### PR TITLE
Member roles and plan

### DIFF
--- a/src/composables/use-can.ts
+++ b/src/composables/use-can.ts
@@ -1,0 +1,33 @@
+import { useMemberStore } from '@/stores/member'
+
+/**
+ * Capability checks for the current member.
+ *
+ * Name capabilities by the feature, not by the role that currently has access.
+ *
+ *   Bad:  `can.administrate()`  — implies "because they're an admin"
+ *   Good: `can.manageUsers()`   — implies "because they need to manage users"
+ *
+ * When a policy changes (e.g. paid users should now export analytics), edit
+ * the single line in this file — every call site picks up the new behavior
+ * automatically. Call sites should never ask "is this user an admin?"; they
+ * should ask "is this user allowed to do X?" and let `useCan` answer.
+ *
+ * Rule of thumb: if renaming a capability would feel wrong when the policy
+ * changes, the name is wrong.
+ *
+ * @example
+ * const can = useCan()
+ * if (can.useProFeature()) { ... }
+ */
+export function useCan() {
+  const member = useMemberStore()
+
+  const isPaid = () => member.plan === 'paid'
+  const _isModerator = () => member.role === 'moderator' || member.role === 'admin'
+  const _isAdmin = () => member.role === 'admin'
+
+  return {
+    useProFeature: isPaid // this is an example
+  }
+}

--- a/src/stores/member.ts
+++ b/src/stores/member.ts
@@ -10,6 +10,8 @@ export const useMemberStore = defineStore('member', () => {
   const id = ref<Member['id']>()
   const avatar_url = ref<Member['avatar_url']>()
   const updated_at = ref<Member['updated_at']>()
+  const role = ref<Member['role']>()
+  const plan = ref<Member['plan']>()
 
   async function fetchMember(user_id: string): Promise<void> {
     const fetched_member = await fetchMemberById(user_id)
@@ -22,6 +24,8 @@ export const useMemberStore = defineStore('member', () => {
     id.value = fetched_member.id
     avatar_url.value = fetched_member.avatar_url
     updated_at.value = fetched_member.updated_at
+    role.value = fetched_member.role
+    plan.value = fetched_member.plan
   }
 
   const has_member = computed(() => Boolean(id.value))
@@ -35,6 +39,8 @@ export const useMemberStore = defineStore('member', () => {
     created_at,
     id,
     avatar_url,
-    updated_at
+    updated_at,
+    role,
+    plan
   }
 })

--- a/src/views/welcome/sign-up/plan-selector.vue
+++ b/src/views/welcome/sign-up/plan-selector.vue
@@ -4,11 +4,11 @@ import { useI18n } from 'vue-i18n'
 import PlanOption from './plan-option.vue'
 
 defineProps<{
-  selected_plan: MemberType
+  selected_plan: MemberPlan
 }>()
 
 const emit = defineEmits<{
-  (e: 'select', plan: MemberType): void
+  (e: 'select', plan: MemberPlan): void
 }>()
 
 const { t } = useI18n()

--- a/supabase/migrations/20260415000000_member-roles-and-plan.sql
+++ b/supabase/migrations/20260415000000_member-roles-and-plan.sql
@@ -1,0 +1,78 @@
+-- Add `role` and `plan` to members.
+--
+-- Two orthogonal axes:
+--   role: staff status      (user | moderator | admin)
+--   plan: billing status    (free | paid)
+--
+-- Both columns are NOT NULL with a default, so existing rows get backfilled
+-- automatically — no separate UPDATE needed. (Frontend analogy: like adding a
+-- prop with a default value — existing usages keep working without changes.)
+
+create type member_role as enum ('user', 'moderator', 'admin');
+create type member_plan as enum ('free', 'paid');
+
+alter table public.members
+  add column role member_role not null default 'user',
+  add column plan member_plan not null default 'free';
+
+-- Helper for RLS policies. SECURITY DEFINER lets it bypass RLS to read the
+-- caller's own member row (otherwise the policy would recurse into itself
+-- when checking permissions on `members`).
+--
+-- Frontend analogy: this is like a `useCurrentUserRole()` composable — call
+-- it anywhere and get back the active user's role. The DB version is just
+-- callable from inside SQL policies and RPCs.
+create or replace function public.auth_role()
+returns member_role
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select role from public.members where id = auth.uid()
+$$;
+
+create or replace function public.auth_plan()
+returns member_plan
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select plan from public.members where id = auth.uid()
+$$;
+
+-- Lock down `role` and `plan` so users can't promote themselves.
+--
+-- The existing UPDATE policy ("matching auth id") would otherwise let any
+-- authenticated user run `update members set role = 'admin' where id = auth.uid()`.
+--
+-- We can't easily add a per-column rule to an existing policy, so the cleanest
+-- fix is: tighten the existing policy with a WITH CHECK that compares the new
+-- row to the old row. If `role` or `plan` changed, the update is rejected.
+--
+-- Frontend analogy: this is like a form validator that runs on submit and
+-- rejects the payload if certain fields were touched — except it's enforced
+-- by the database, so no client (or server route) can bypass it.
+
+drop policy if exists "Enable update for authenticated users with matching auth id" on public.members;
+
+create policy "members can update their own non-privileged fields"
+on public.members
+for update
+to authenticated
+using (auth.uid() = id)
+with check (
+  auth.uid() = id
+  and role = (select role from public.members where id = auth.uid())
+  and plan = (select plan from public.members where id = auth.uid())
+);
+
+-- Admins can change anyone's role or plan. Moderators intentionally cannot —
+-- promoting users is an admin-only concern.
+create policy "admins can update any member"
+on public.members
+for update
+to authenticated
+using (auth_role() = 'admin')
+with check (auth_role() = 'admin');

--- a/supabase/tests/00008_member_roles_and_plan.sql
+++ b/supabase/tests/00008_member_roles_and_plan.sql
@@ -1,0 +1,141 @@
+-- =============================================================================
+-- Member role + plan: column defaults, auth helpers, and privilege escalation
+-- guards introduced in 20260415000000_member-roles-and-plan.sql
+--
+--   - Defaults: new members get role='user' and plan='free'
+--   - auth_role() / auth_plan() reflect the caller's own row
+--   - Users CANNOT update their own role or plan (privilege escalation block)
+--   - Admins CAN update another member's role and plan
+--   - Moderators CANNOT update another member's role or plan
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(10);
+
+-- ── Setup (as postgres superuser) ─────────────────────────────────────────────
+SELECT tests.create_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, 'alice');
+SELECT tests.create_user('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, 'bob');
+SELECT tests.create_user('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'carol_admin');
+SELECT tests.create_user('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid, 'dan_mod');
+
+-- Promote carol to admin, dan to moderator (bypassing RLS as superuser).
+UPDATE public.members SET role = 'admin'
+  WHERE id = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+UPDATE public.members SET role = 'moderator'
+  WHERE id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+
+-- Test 1: default role is 'user' for new rows
+SELECT is(
+  (SELECT role::text FROM public.members WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  'user',
+  'new members get role=user by default'
+);
+
+-- Test 2: default plan is 'free' for new rows
+SELECT is(
+  (SELECT plan::text FROM public.members WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  'free',
+  'new members get plan=free by default'
+);
+
+
+-- ── Act as Alice (plain user) ─────────────────────────────────────────────────
+SELECT tests.set_claims('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 3: auth_role() returns the caller's role
+SELECT is(
+  (SELECT public.auth_role()::text),
+  'user',
+  'auth_role() returns caller role'
+);
+
+-- Test 4: auth_plan() returns the caller's plan
+SELECT is(
+  (SELECT public.auth_plan()::text),
+  'free',
+  'auth_plan() returns caller plan'
+);
+
+-- Test 5: Alice can update her own non-privileged fields
+SELECT lives_ok(
+  $$
+    UPDATE public.members
+    SET description = 'new bio'
+    WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+  $$,
+  'Alice can update non-privileged fields on her own row'
+);
+
+-- Test 6: Alice CANNOT promote herself to admin
+SELECT throws_ok(
+  $$
+    UPDATE public.members
+    SET role = 'admin'
+    WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+  $$,
+  NULL,
+  NULL,
+  'Alice cannot escalate her own role'
+);
+
+-- Test 7: Alice CANNOT upgrade her own plan
+SELECT throws_ok(
+  $$
+    UPDATE public.members
+    SET plan = 'paid'
+    WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+  $$,
+  NULL,
+  NULL,
+  'Alice cannot upgrade her own plan'
+);
+
+
+-- ── Act as Dan (moderator) ────────────────────────────────────────────────────
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 8: Moderator cannot change another user's role (row is invisible to UPDATE).
+UPDATE public.members
+SET role = 'admin'
+WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+SET LOCAL role = 'postgres';
+SELECT is(
+  (SELECT role::text FROM public.members WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+  'user',
+  'moderator cannot promote another user'
+);
+
+
+-- ── Act as Carol (admin) ──────────────────────────────────────────────────────
+SELECT tests.set_claims('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 9: Admin can change another user's role
+SELECT lives_ok(
+  $$
+    UPDATE public.members
+    SET role = 'moderator'
+    WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+  $$,
+  'admin can change another user''s role'
+);
+
+-- Test 10: Admin can change another user's plan
+SELECT lives_ok(
+  $$
+    UPDATE public.members
+    SET plan = 'paid'
+    WHERE id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+  $$,
+  'admin can change another user''s plan'
+);
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/unit/composables/use-can.test.js
+++ b/tests/unit/composables/use-can.test.js
@@ -1,0 +1,42 @@
+import { describe, test, expect, beforeEach } from 'vite-plus/test'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCan } from '@/composables/use-can'
+import { useMemberStore } from '@/stores/member'
+
+describe('useCan', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('useProFeature', () => {
+    test('returns true when member plan is paid', () => {
+      const member = useMemberStore()
+      member.plan = 'paid'
+      const can = useCan()
+      expect(can.useProFeature()).toBe(true)
+    })
+
+    test('returns false when member plan is free', () => {
+      const member = useMemberStore()
+      member.plan = 'free'
+      const can = useCan()
+      expect(can.useProFeature()).toBe(false)
+    })
+
+    test('returns false when member plan is not set', () => {
+      const can = useCan()
+      expect(can.useProFeature()).toBe(false)
+    })
+
+    test('reflects live store state (not captured at call time)', () => {
+      const member = useMemberStore()
+      const can = useCan()
+
+      member.plan = 'free'
+      expect(can.useProFeature()).toBe(false)
+
+      member.plan = 'paid'
+      expect(can.useProFeature()).toBe(true)
+    })
+  })
+})

--- a/tests/unit/stores/member.test.js
+++ b/tests/unit/stores/member.test.js
@@ -1,0 +1,73 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('@/api/members', () => ({
+  fetchMemberById: vi.fn()
+}))
+
+import { useMemberStore } from '@/stores/member'
+import { fetchMemberById } from '@/api/members'
+
+describe('useMemberStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(fetchMemberById).mockReset()
+  })
+
+  test('initializes with all fields undefined and has_member false', () => {
+    const store = useMemberStore()
+    expect(store.id).toBeUndefined()
+    expect(store.display_name).toBeUndefined()
+    expect(store.email).toBeUndefined()
+    expect(store.role).toBeUndefined()
+    expect(store.plan).toBeUndefined()
+    expect(store.has_member).toBe(false)
+  })
+
+  test('has_member is true once an id is set', () => {
+    const store = useMemberStore()
+    store.id = 'abc'
+    expect(store.has_member).toBe(true)
+  })
+
+  test('fetchMember hydrates every field from the api result', async () => {
+    vi.mocked(fetchMemberById).mockResolvedValue({
+      id: 'user-1',
+      display_name: 'Alice',
+      description: 'hi',
+      email: 'a@test.com',
+      created_at: '2026-01-01',
+      avatar_url: 'https://avatar',
+      updated_at: '2026-01-02',
+      role: 'admin',
+      plan: 'paid'
+    })
+
+    const store = useMemberStore()
+    await store.fetchMember('user-1')
+
+    expect(fetchMemberById).toHaveBeenCalledWith('user-1')
+    expect(store.id).toBe('user-1')
+    expect(store.display_name).toBe('Alice')
+    expect(store.description).toBe('hi')
+    expect(store.email).toBe('a@test.com')
+    expect(store.created_at).toBe('2026-01-01')
+    expect(store.avatar_url).toBe('https://avatar')
+    expect(store.updated_at).toBe('2026-01-02')
+    expect(store.role).toBe('admin')
+    expect(store.plan).toBe('paid')
+    expect(store.has_member).toBe(true)
+  })
+
+  test('fetchMember leaves store untouched when api returns null', async () => {
+    vi.mocked(fetchMemberById).mockResolvedValue(null)
+
+    const store = useMemberStore()
+    await store.fetchMember('user-1')
+
+    expect(store.id).toBeUndefined()
+    expect(store.role).toBeUndefined()
+    expect(store.plan).toBeUndefined()
+    expect(store.has_member).toBe(false)
+  })
+})

--- a/types/member.d.ts
+++ b/types/member.d.ts
@@ -6,7 +6,12 @@ type Member = {
   email?: string
   avatar_url?: string
   updated_at?: string
+  role?: MemberRole
+  plan?: MemberPlan
 }
+
+declare type MemberRole = 'user' | 'moderator' | 'admin'
+declare type MemberPlan = 'free' | 'paid'
 
 type MemberTheme =
   | 'blue-500'
@@ -31,5 +36,3 @@ type MemberTheme =
   | 'grey-900'
   | 'grey-400'
   | 'white'
-
-declare type MemberType = 'free' | 'paid'


### PR DESCRIPTION
## Summary

Adds `role` and `plan` columns to the member profile and a `useCan` composable for capability checks driven by them.

## Changes

- Migration `20260415000000_member-roles-and-plan.sql` adds the new columns and supporting policy/defaults
- `src/composables/use-can.ts` — capability-check composable backed by member role/plan
- `src/stores/member.ts` + `types/member.d.ts` — surface role and plan on the member profile
- `src/views/welcome/sign-up/plan-selector.vue` — wire selector to the new plan field

## Test plan

- [ ] Apply migration locally with `supabase migrations up` and confirm new columns exist
- [ ] Sign up a new member; verify default role/plan persist on the profile
- [ ] Use the plan selector during sign-up and confirm the chosen plan is saved
- [ ] Exercise `useCan` against a permitted vs. denied capability