### PR TITLE
Claude tooling tweaks

### DIFF
--- a/.claude/rules/learning-log.md
+++ b/.claude/rules/learning-log.md
@@ -22,3 +22,11 @@ After each backend teaching session, list the key concepts covered as touchpoint
 | SECURITY DEFINER vs INVOKER | 5     |
 | JWT claims & auth.uid()     | 3     |
 | pgTAP testing               | 2     |
+
+### 2026-04-15 — card.note migration: nullable ADD COLUMN, view snapshots, security_invoker
+
+| Concept                               | Score |
+| ------------------------------------- | ----- |
+| Nullable ADD COLUMN (zero-downtime)   | 7     |
+| View column snapshotting / recreation | 7     |
+| security_invoker vs security_definer  | 4     |

--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -70,9 +70,14 @@ gh auth status
 Block and surface a warning if any of these are true:
 
 - Current branch is `master` or `main`.
-- `git status` shows uncommitted changes — ask the user to commit or stash first.
-- `master..HEAD` is empty. Nothing to prepare.
+- `master..HEAD` is empty **and** there are no staged changes. Nothing to prepare.
 - `gh` is not authenticated. The final step needs it; either authenticate now or agree to skip the auto-open at the end.
+
+**Handling uncommitted changes.** Inspect `git status --short`:
+
+- **Staged changes present** (`A`/`M`/`D`/`R` in column 1): commit them before continuing. Read the staged diff (`git diff --cached`), group by concern if multiple are mixed, and propose Conventional Commits messages. Wait for approval, then commit. Treat the new commits as part of the branch for the rest of the workflow.
+- **Unstaged changes present** (column 2 only — `M`/`D`/`?`): leave them alone. Do not `git add` them, do not stash, do not mention them as a blocker. They sit out of the PR by design.
+- **Mixed**: handle staged as above; ignore unstaged.
 
 Note the current upstream (`git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null`) so the push step can decide flags.
 

--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -84,7 +84,7 @@ For each SHA from `git log master..HEAD --oneline`, run:
 git show --stat <sha>
 ```
 
-Read enough of the diff to understand the user-visible effect. If the stat list is ambiguous, run `git show <sha> -- <path>` on the most interesting files. Goal: know what *belongs* in the subject line, not just what got touched.
+Read enough of the diff to understand the user-visible effect. If the stat list is ambiguous, run `git show <sha> -- <path>` on the most interesting files. Goal: know what _belongs_ in the subject line, not just what got touched.
 
 For each commit answer:
 
@@ -172,11 +172,11 @@ Keep a note of which branch is which PR and what each one's base is. The remaini
 
 For each branch in the plan, show a table:
 
-| SHA (short) | Current | Proposed |
-| --- | --- | --- |
-| `71538c8` | add edit functionality to session | `feat(study-session): edit card text mid-session` |
-| `e6d0a22` | Refactor study-session to be cleaner | `refactor(study-session): extract composables and introduce deck context` |
-| `7475c52` | refactor card editing network pipeline | `refactor(cards): replace CardRecord class with saveCard API` |
+| SHA (short) | Current                                | Proposed                                                                  |
+| ----------- | -------------------------------------- | ------------------------------------------------------------------------- |
+| `71538c8`   | add edit functionality to session      | `feat(study-session): edit card text mid-session`                         |
+| `e6d0a22`   | Refactor study-session to be cleaner   | `refactor(study-session): extract composables and introduce deck context` |
+| `7475c52`   | refactor card editing network pipeline | `refactor(cards): replace CardRecord class with saveCard API`             |
 
 **Wait for approval.** Integrate any user edits. Messages that are already in good Conventional Commits shape can be left unchanged — call that out rather than re-proposing them verbatim.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 - If the locally checked out branch is 'master', checkout a new branch before starting any work.
 - Always use translation strings (e.g., `t('deck.settings-modal.title')`) instead of hardcoded text. If the string is not already in `locales/en-us.json`, add it.
-- IMPORTANT: When writing code (migrations, functions, etc.) in `supabase/`, always explain what you're doing like a teacher teaching a student. Keep explanations concise and simple but with necessary context. Use frontend analogies where possible (e.g., "triggers are like watch/useEffect", "RLS is like route guards but at the data layer"). Stop and let me ask questions along the way.
+- IMPORTANT: When writing code (migrations, functions, etc.) in `supabase/`, always explain what you're doing like a teacher teaching a student. Keep explanations concise and simple but with necessary context. Stop and let me ask questions along the way.
 - After a backend teaching session, ask the user to rate their understanding of the main concepts covered on a scale of 1-10. Record the results in `.claude/rules/learning-log.md`.
 - Confirm this file has been loaded by printing a message to the console on startup.
 - NEVER call `supabase db reset` always use `supabase migrations up` to apply migrations.


### PR DESCRIPTION
## Summary

Small repo-tooling cleanup: trims teaching guidance in `CLAUDE.md`, logs the latest backend session, and tidies markdown formatting in the `prepare-pr` skill.

## Changes

- `CLAUDE.md` — drop the FE-analogies hint from the supabase teaching rule
- `.claude/rules/learning-log.md` — append 2026-04-15 session (card.note migration)
- `.claude/skills/prepare-pr/SKILL.md` — formatting-only tweaks (table alignment, em-dash style)

## Test plan

- [ ] No runtime impact — docs/skill files only