### PR TITLE
Free-plan deck limit with capability gate

### DIFF
--- a/src/api/decks.ts
+++ b/src/api/decks.ts
@@ -33,6 +33,20 @@ export async function fetchDeck(id: number): Promise<Deck> {
   return data
 }
 
+export async function fetchMemberDeckCount(): Promise<number> {
+  const { count, error } = await supabase
+    .from('decks')
+    .select('*', { count: 'exact', head: true })
+    .eq('member_id', useMemberStore().id)
+
+  if (error) {
+    logger.error(error.message)
+    throw error
+  }
+
+  return count ?? 0
+}
+
 export async function upsertDeck(deck: Deck): Promise<void> {
   deck.updated_at = DateTime.now().toISO()
   const { error } = await supabase.from('decks').upsert(deck, { onConflict: 'id' })

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -54,8 +54,8 @@ function cycleTab() {
 }
 
 async function onSave() {
-  await saveDeck()
-  close(true)
+  const saved = await saveDeck()
+  if (saved) close(true)
 }
 </script>
 

--- a/src/composables/deck-editor.ts
+++ b/src/composables/deck-editor.ts
@@ -1,6 +1,7 @@
 import { reactive, ref } from 'vue'
-import { deleteDeck as upstreamDeleteDeck, upsertDeck } from '@/api/decks'
+import { deleteDeck as upstreamDeleteDeck } from '@/api/decks'
 import { uploadImage as uploadImageToStorage } from '@/api/media'
+import { useDeckActions } from '@/composables/deck/use-deck-actions'
 import type { ImageUploadPayload } from '@/components/image-uploader.vue'
 
 export function useDeckEditor(deck?: Deck) {
@@ -30,8 +31,10 @@ export function useDeckEditor(deck?: Deck) {
   const cover_image_preview = ref<string | undefined>(deck?.cover_config?.bg_image)
   const cover_image_loading = ref(false)
 
-  async function saveDeck() {
-    await upsertDeck({
+  const deck_actions = useDeckActions()
+
+  async function saveDeck(): Promise<boolean> {
+    const payload: Deck = {
       ...settings,
       study_config: { ...config },
       cover_config: { ...cover },
@@ -39,7 +42,10 @@ export function useDeckEditor(deck?: Deck) {
         front: { ...card_attributes.front },
         back: { ...card_attributes.back }
       }
-    })
+    }
+    return settings.id
+      ? await deck_actions.updateDeck(payload)
+      : await deck_actions.createDeck(payload)
   }
 
   async function deleteDeck() {

--- a/src/composables/deck/use-deck-actions.ts
+++ b/src/composables/deck/use-deck-actions.ts
@@ -1,0 +1,30 @@
+import { useI18n } from 'vue-i18n'
+import { fetchMemberDeckCount, upsertDeck } from '@/api/decks'
+import { useAlert } from '@/composables/alert'
+import { useCan } from '@/composables/use-can'
+
+export function useDeckActions() {
+  const { t } = useI18n()
+  const alert = useAlert()
+  const can = useCan()
+
+  async function createDeck(deck: Deck): Promise<boolean> {
+    const count = await fetchMemberDeckCount()
+    if (!can.createDeck(count)) {
+      await alert.warn({
+        title: t('errors.deck-limit-reached.title'),
+        message: t('errors.deck-limit-reached.message')
+      }).response
+      return false
+    }
+    await upsertDeck(deck)
+    return true
+  }
+
+  async function updateDeck(deck: Deck): Promise<boolean> {
+    await upsertDeck(deck)
+    return true
+  }
+
+  return { createDeck, updateDeck }
+}

--- a/src/composables/use-can.ts
+++ b/src/composables/use-can.ts
@@ -1,4 +1,5 @@
 import { useMemberStore } from '@/stores/member'
+import { PLANS } from '@/config/plans'
 
 /**
  * Capability checks for the current member.
@@ -28,6 +29,10 @@ export function useCan() {
   const _isAdmin = () => member.role === 'admin'
 
   return {
-    useProFeature: isPaid // this is an example
+    useProFeature: isPaid, // this is an example
+    createDeck: (currentDeckCount: number) => {
+      const limit = PLANS[member.plan ?? 'free'].deckLimit
+      return limit === null || currentDeckCount < limit
+    }
   }
 }

--- a/src/config/plans.ts
+++ b/src/config/plans.ts
@@ -1,0 +1,8 @@
+type PlanConfig = {
+  deckLimit: number | null
+}
+
+export const PLANS: Record<MemberPlan, PlanConfig> = {
+  free: { deckLimit: 5 },
+  paid: { deckLimit: null }
+}

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -150,6 +150,9 @@
   "dashboard.all": "All Decks",
   "dashboard.create-deck": "Make a New Deck",
 
+  "errors.deck-limit-reached.title": "Deck limit reached",
+  "errors.deck-limit-reached.message": "You've reached your plan's deck limit. Upgrade to create more.",
+
   "deck.description-placeholder": "Add a short description to your deck.",
   "deck.title-placeholder": "Deck Name",
   "deck.settings-modal.title": "Deck Configuration",

--- a/src/views/dashboard/dashboard.vue
+++ b/src/views/dashboard/dashboard.vue
@@ -10,9 +10,13 @@ import UiButton from '@/components/ui-kit/button.vue'
 import { useMediaQuery } from '@/composables/use-media-query'
 import ReviewInbox from './review-inbox.vue'
 import { useDeckSettingsModal } from '@/composables/modals/use-deck-settings-modal'
+import { useAlert } from '@/composables/alert'
+import { useCan } from '@/composables/use-can'
 
 const { t } = useI18n()
 const toast = useToast()
+const alert = useAlert()
+const can = useCan()
 const router = useRouter()
 const is_md = useMediaQuery('md')
 
@@ -44,6 +48,14 @@ function onDeckClicked(deck: Deck) {
 }
 
 async function onCreateDeckClicked() {
+  if (!can.createDeck(decks.value.length)) {
+    alert.warn({
+      title: t('errors.deck-limit-reached.title'),
+      message: t('errors.deck-limit-reached.message')
+    })
+    return
+  }
+
   const { response: deck_created } = deck_settings_modal.open()
 
   if (await deck_created) {

--- a/tests/integration/components/modals/deck-settings/index.test.js
+++ b/tests/integration/components/modals/deck-settings/index.test.js
@@ -6,7 +6,7 @@ import DeckSettings from '@/components/modals/deck-settings/index.vue'
 // ── Hoisted mocks ──────────────────────────────────────────────────────────────
 
 const { mockSaveDeck } = vi.hoisted(() => ({
-  mockSaveDeck: vi.fn().mockResolvedValue(undefined)
+  mockSaveDeck: vi.fn().mockResolvedValue(true)
 }))
 
 vi.mock('@/composables/deck-editor', async () => {
@@ -97,7 +97,7 @@ function makeDeck(overrides = {}) {
 describe('DeckSettings', () => {
   beforeEach(() => {
     mockSaveDeck.mockClear()
-    mockSaveDeck.mockResolvedValue(undefined)
+    mockSaveDeck.mockResolvedValue(true)
   })
 
   // ── Structure ──────────────────────────────────────────────────────────────
@@ -158,6 +158,18 @@ describe('DeckSettings', () => {
     await flushPromises()
     expect(mockSaveDeck).toHaveBeenCalledOnce()
     expect(close).toHaveBeenCalledWith(true)
+  })
+
+  test('save button does not close the modal when saveDeck returns false', async () => {
+    mockSaveDeck.mockResolvedValueOnce(false)
+    const close = vi.fn()
+    const wrapper = makeDeckSettings({ deck: makeDeck(), close })
+    await wrapper
+      .find('[data-testid="deck-settings__footer"] [data-testid="ui-button-stub"]')
+      .trigger('click')
+    await flushPromises()
+    expect(mockSaveDeck).toHaveBeenCalledOnce()
+    expect(close).not.toHaveBeenCalled()
   })
 
   // ── Close behaviour ────────────────────────────────────────────────────────

--- a/tests/unit/composables/deck-editor.test.js
+++ b/tests/unit/composables/deck-editor.test.js
@@ -3,8 +3,9 @@ import { useDeckEditor } from '@/composables/deck-editor'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { mockUpsertDeck } = vi.hoisted(() => ({
-  mockUpsertDeck: vi.fn().mockResolvedValue(undefined)
+const { mockCreateDeck, mockUpdateDeck } = vi.hoisted(() => ({
+  mockCreateDeck: vi.fn().mockResolvedValue(true),
+  mockUpdateDeck: vi.fn().mockResolvedValue(true)
 }))
 
 const { mockDeleteDeck } = vi.hoisted(() => ({
@@ -16,8 +17,14 @@ const { mockUploadImage } = vi.hoisted(() => ({
 }))
 
 vi.mock('@/api/decks', () => ({
-  upsertDeck: mockUpsertDeck,
   deleteDeck: mockDeleteDeck
+}))
+
+vi.mock('@/composables/deck/use-deck-actions', () => ({
+  useDeckActions: () => ({
+    createDeck: mockCreateDeck,
+    updateDeck: mockUpdateDeck
+  })
 }))
 
 vi.mock('@/api/media', () => ({
@@ -43,7 +50,10 @@ function makeDeck(overrides = {}) {
 
 describe('useDeckEditor', () => {
   beforeEach(() => {
-    mockUpsertDeck.mockClear()
+    mockCreateDeck.mockClear()
+    mockCreateDeck.mockResolvedValue(true)
+    mockUpdateDeck.mockClear()
+    mockUpdateDeck.mockResolvedValue(true)
     mockDeleteDeck.mockClear()
     mockUploadImage.mockClear()
     mockUploadImage.mockResolvedValue('https://cdn.example.com/cover.jpg')
@@ -113,8 +123,8 @@ describe('useDeckEditor', () => {
 
       await saveDeck()
 
-      expect(mockUpsertDeck).toHaveBeenCalledOnce()
-      const [arg] = mockUpsertDeck.mock.calls[0]
+      expect(mockUpdateDeck).toHaveBeenCalledOnce()
+      const [arg] = mockUpdateDeck.mock.calls[0]
       expect(arg.study_config).toEqual({ study_all_cards: true, retry_failed_cards: false })
     })
 
@@ -124,8 +134,8 @@ describe('useDeckEditor', () => {
 
       await saveDeck()
 
-      expect(mockUpsertDeck).toHaveBeenCalledOnce()
-      const [arg] = mockUpsertDeck.mock.calls[0]
+      expect(mockUpdateDeck).toHaveBeenCalledOnce()
+      const [arg] = mockUpdateDeck.mock.calls[0]
       expect(arg.cover_config).toEqual({ color: '#ff0000' })
     })
 
@@ -135,7 +145,7 @@ describe('useDeckEditor', () => {
 
       await saveDeck()
 
-      const [arg] = mockUpsertDeck.mock.calls[0]
+      const [arg] = mockUpdateDeck.mock.calls[0]
       expect(arg.title).toBe('Updated Title')
       expect(arg.is_public).toBe(false)
     })
@@ -150,8 +160,39 @@ describe('useDeckEditor', () => {
 
       await saveDeck()
 
-      const [arg] = mockUpsertDeck.mock.calls[0]
+      const [arg] = mockUpdateDeck.mock.calls[0]
       expect(arg.study_config.study_all_cards).toBe(true)
+    })
+
+    test('routes to createDeck when the deck has no id', async () => {
+      const { saveDeck } = useDeckEditor()
+
+      await saveDeck()
+
+      expect(mockCreateDeck).toHaveBeenCalledOnce()
+      expect(mockUpdateDeck).not.toHaveBeenCalled()
+    })
+
+    test('routes to updateDeck when the deck has an id', async () => {
+      const { saveDeck } = useDeckEditor(makeDeck({ id: 42 }))
+
+      await saveDeck()
+
+      expect(mockUpdateDeck).toHaveBeenCalledOnce()
+      expect(mockCreateDeck).not.toHaveBeenCalled()
+    })
+
+    test('returns the boolean result from the action', async () => {
+      mockCreateDeck.mockResolvedValueOnce(false)
+      const { saveDeck } = useDeckEditor()
+
+      await expect(saveDeck()).resolves.toBe(false)
+    })
+
+    test('returns true from updateDeck by default', async () => {
+      const { saveDeck } = useDeckEditor(makeDeck({ id: 1 }))
+
+      await expect(saveDeck()).resolves.toBe(true)
     })
   })
 
@@ -196,7 +237,7 @@ describe('useDeckEditor', () => {
 
       await saveDeck()
 
-      const [arg] = mockUpsertDeck.mock.calls[0]
+      const [arg] = mockUpdateDeck.mock.calls[0]
       expect(arg.card_attributes).toEqual({
         front: { text_size: 'ginormous', vertical_alignment: 'bottom' },
         back: { text_size: 'medium' }
@@ -215,7 +256,7 @@ describe('useDeckEditor', () => {
 
       await saveDeck()
 
-      const [arg] = mockUpsertDeck.mock.calls[0]
+      const [arg] = mockUpdateDeck.mock.calls[0]
       expect(arg.card_attributes.front.text_size).toBe('x-large')
       expect(arg.card_attributes.front.horizontal_alignment).toBe('right')
       expect(arg.card_attributes.back.vertical_alignment).toBe('top')

--- a/tests/unit/composables/deck/use-deck-actions.test.js
+++ b/tests/unit/composables/deck/use-deck-actions.test.js
@@ -1,0 +1,122 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { useDeckActions } from '@/composables/deck/use-deck-actions'
+
+const { mockFetchMemberDeckCount, mockUpsertDeck, mockCreateDeckCapability, mockWarn } =
+  vi.hoisted(() => ({
+    mockFetchMemberDeckCount: vi.fn(),
+    mockUpsertDeck: vi.fn().mockResolvedValue(undefined),
+    mockCreateDeckCapability: vi.fn(),
+    mockWarn: vi.fn()
+  }))
+
+vi.mock('@/api/decks', () => ({
+  fetchMemberDeckCount: mockFetchMemberDeckCount,
+  upsertDeck: mockUpsertDeck
+}))
+
+vi.mock('@/composables/use-can', () => ({
+  useCan: () => ({ createDeck: mockCreateDeckCapability })
+}))
+
+vi.mock('@/composables/alert', () => ({
+  useAlert: () => ({
+    warn: mockWarn
+  })
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key) => key })
+}))
+
+function makeAlertResponse(promise = Promise.resolve(undefined)) {
+  return { response: promise }
+}
+
+describe('useDeckActions', () => {
+  beforeEach(() => {
+    mockFetchMemberDeckCount.mockReset()
+    mockUpsertDeck.mockReset()
+    mockUpsertDeck.mockResolvedValue(undefined)
+    mockCreateDeckCapability.mockReset()
+    mockWarn.mockReset()
+    mockWarn.mockReturnValue(makeAlertResponse())
+  })
+
+  describe('createDeck', () => {
+    test('calls upsertDeck and returns true when capability check passes', async () => {
+      mockFetchMemberDeckCount.mockResolvedValue(2)
+      mockCreateDeckCapability.mockReturnValue(true)
+
+      const { createDeck } = useDeckActions()
+      const result = await createDeck({ title: 'New Deck' })
+
+      expect(mockCreateDeckCapability).toHaveBeenCalledWith(2)
+      expect(mockUpsertDeck).toHaveBeenCalledWith({ title: 'New Deck' })
+      expect(mockWarn).not.toHaveBeenCalled()
+      expect(result).toBe(true)
+    })
+
+    test('opens warn alert and returns false when capability check fails', async () => {
+      mockFetchMemberDeckCount.mockResolvedValue(5)
+      mockCreateDeckCapability.mockReturnValue(false)
+
+      const { createDeck } = useDeckActions()
+      const result = await createDeck({ title: 'Blocked Deck' })
+
+      expect(mockWarn).toHaveBeenCalledWith({
+        title: 'errors.deck-limit-reached.title',
+        message: 'errors.deck-limit-reached.message'
+      })
+      expect(mockUpsertDeck).not.toHaveBeenCalled()
+      expect(result).toBe(false)
+    })
+
+    test('awaits the alert response before resolving', async () => {
+      mockFetchMemberDeckCount.mockResolvedValue(5)
+      mockCreateDeckCapability.mockReturnValue(false)
+
+      let resolveAlert
+      mockWarn.mockReturnValue(
+        makeAlertResponse(
+          new Promise((r) => {
+            resolveAlert = r
+          })
+        )
+      )
+
+      const { createDeck } = useDeckActions()
+      const pending = createDeck({ title: 'Blocked' })
+
+      let settled = false
+      pending.then(() => {
+        settled = true
+      })
+
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(settled).toBe(false)
+
+      resolveAlert()
+      await pending
+      expect(settled).toBe(true)
+    })
+  })
+
+  describe('updateDeck', () => {
+    test('calls upsertDeck and returns true', async () => {
+      const { updateDeck } = useDeckActions()
+      const result = await updateDeck({ id: 1, title: 'Updated' })
+
+      expect(mockUpsertDeck).toHaveBeenCalledWith({ id: 1, title: 'Updated' })
+      expect(result).toBe(true)
+    })
+
+    test('does not check capability or fetch count', async () => {
+      const { updateDeck } = useDeckActions()
+      await updateDeck({ id: 1, title: 'Updated' })
+
+      expect(mockFetchMemberDeckCount).not.toHaveBeenCalled()
+      expect(mockCreateDeckCapability).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/composables/use-can.test.js
+++ b/tests/unit/composables/use-can.test.js
@@ -39,4 +39,36 @@ describe('useCan', () => {
       expect(can.useProFeature()).toBe(true)
     })
   })
+
+  describe('createDeck', () => {
+    test('allows free user under the limit', () => {
+      const member = useMemberStore()
+      member.plan = 'free'
+      const can = useCan()
+      expect(can.createDeck(0)).toBe(true)
+      expect(can.createDeck(4)).toBe(true)
+    })
+
+    test('blocks free user at the limit', () => {
+      const member = useMemberStore()
+      member.plan = 'free'
+      const can = useCan()
+      expect(can.createDeck(5)).toBe(false)
+      expect(can.createDeck(99)).toBe(false)
+    })
+
+    test('allows paid user regardless of count', () => {
+      const member = useMemberStore()
+      member.plan = 'paid'
+      const can = useCan()
+      expect(can.createDeck(0)).toBe(true)
+      expect(can.createDeck(1_000_000)).toBe(true)
+    })
+
+    test('treats unset plan as free', () => {
+      const can = useCan()
+      expect(can.createDeck(4)).toBe(true)
+      expect(can.createDeck(5)).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Caps free-plan members at 5 decks. Paid plan remains unlimited. The cap is enforced at two points in the UI: the dashboard "create deck" button shows a warn alert up-front when over the limit, and the deck-settings modal save falls back through the same alert if it somehow slips through (e.g. stale deck count).

## Changes

- New `src/config/plans.ts` declares per-plan caps (`deckLimit`) keyed by `MemberPlan`.
- `useCan` grows a `createDeck(currentDeckCount)` capability that reads from `PLANS` so limits change in one place.
- New `useDeckActions` composable (`src/composables/deck/use-deck-actions.ts`) orchestrates the capability check and alert; `useDeckEditor.saveDeck` now routes through it and returns a boolean so the modal only closes on success.
- `fetchMemberDeckCount` added to the decks API so the capability check has authoritative state independent of whatever's in the dashboard view.
- Dashboard gates the create button with the same capability + alert flow.

## Test plan

- [ ] As a free member with 5 decks, clicking "Make a New Deck" on the dashboard opens the warn alert and does not open the settings modal.
- [ ] As a free member with <5 decks, the button opens the modal; saving creates a deck and refetches.
- [ ] As a paid member, the limit never triggers regardless of deck count.
- [ ] Unit suite: `vp test tests/unit/composables/use-can.test.js tests/unit/composables/deck/use-deck-actions.test.js tests/unit/composables/deck-editor.test.js`.
- [ ] Integration: `vp test tests/integration/components/modals/deck-settings/index.test.js`.