### PR TITLE
Compute deck counts via decks_with_stats view

### DIFF
--- a/src/api/decks.ts
+++ b/src/api/decks.ts
@@ -4,10 +4,10 @@ import logger from '@/utils/logger'
 import { DateTime } from 'luxon'
 
 export async function fetchMemberDecks(): Promise<Deck[]> {
-  const { data, error } = await supabase.rpc('get_member_decks_with_due_count', {
-    p_member_id: useMemberStore().id,
-    p_now: DateTime.now().toISO()
-  })
+  const { data, error } = await supabase
+    .from('decks_with_stats')
+    .select('*')
+    .eq('member_id', useMemberStore().id)
 
   if (error) {
     logger.error(error.message)
@@ -19,7 +19,7 @@ export async function fetchMemberDecks(): Promise<Deck[]> {
 
 export async function fetchDeck(id: number): Promise<Deck> {
   const { data, error } = await supabase
-    .from('decks')
+    .from('decks_with_stats')
     .select('*, cards:cards_with_images(*, review:reviews(*)), member:members(display_name)')
     .eq('id', id)
     .order('rank', { ascending: true, referencedTable: 'cards_with_images' })

--- a/supabase/migrations/20260416000000_decks-with-stats-view.sql
+++ b/supabase/migrations/20260416000000_decks-with-stats-view.sql
@@ -1,0 +1,52 @@
+-- =============================================================================
+-- decks_with_stats view
+-- =============================================================================
+--
+-- Replaces two things at once:
+--   1. The `get_member_decks_with_due_count(uuid, timestamptz)` RPC — used by
+--      `fetchMemberDecks()` to list decks on the dashboard.
+--   2. The `decks.card_count` column (populated by a trigger) — used by
+--      `fetchDeck()` for the single-deck card count.
+--
+-- By exposing both `card_count` and `due_count` as computed-at-read columns on
+-- a view, we get one shape that serves both reads, and the FE can stop
+-- coordinating two different state representations.
+-- =============================================================================
+
+BEGIN;
+
+-- Columns are listed explicitly rather than via `d.*` because the decks
+-- table still has a (soon-to-be-dropped) `card_count` smallint column
+-- maintained by the old trigger. `d.*` would expand to include it and
+-- collide with the computed column of the same name. Once Phase 2.2 drops
+-- the column, the view can be recreated with `d.*`.
+CREATE OR REPLACE VIEW public.decks_with_stats
+WITH (security_invoker = true) AS
+SELECT
+  d.id,
+  d.created_at,
+  d.updated_at,
+  d.description,
+  d.is_public,
+  d.title,
+  d.member_id,
+  d.tags,
+  d.has_image,
+  d.study_config,
+  d.cover_config,
+  d.card_attributes,
+  (
+    SELECT count(*)::int
+    FROM public.cards c
+    WHERE c.deck_id = d.id
+  ) AS card_count,
+  (
+    SELECT count(*)::int
+    FROM public.cards c
+    LEFT JOIN public.reviews r ON r.card_id = c.id
+    WHERE c.deck_id = d.id
+      AND (r.due IS NULL OR r.due <= now())
+  ) AS due_count
+FROM public.decks d;
+
+COMMIT;

--- a/supabase/migrations/20260416000001_cards-with-images-security-invoker.sql
+++ b/supabase/migrations/20260416000001_cards-with-images-security-invoker.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- Set security_invoker on cards_with_images
+-- =============================================================================
+--
+-- The cards_with_images view was created without the `security_invoker = true`
+-- option, so by default it runs with the view owner's privileges (the role
+-- that created it, typically `postgres`). That means queries against the view
+-- bypass RLS on the underlying `cards` and `media` tables — a potential
+-- information leak that's only accidentally mitigated today by the fact that
+-- PostgREST always filters by the caller's member_id in client queries.
+--
+-- `ALTER VIEW ... SET (...)` lets us flip the option without having to drop
+-- and recreate the view — useful because `cards_with_images` has many
+-- callers and recreating it would require coordinating column ordering.
+-- =============================================================================
+
+BEGIN;
+
+ALTER VIEW public.cards_with_images SET (security_invoker = true);
+
+COMMIT;

--- a/supabase/migrations/20260416000002_drop-deck-card-count-column.sql
+++ b/supabase/migrations/20260416000002_drop-deck-card-count-column.sql
@@ -1,0 +1,31 @@
+-- =============================================================================
+-- Drop deprecated deck card_count column, trigger, and list RPC
+-- =============================================================================
+--
+-- Now that `decks_with_stats` is live and the FE reads counts through it,
+-- the old trigger-maintained `decks.card_count` column and the
+-- `get_member_decks_with_due_count` RPC are both dead. This migration cleans
+-- them up.
+--
+-- Order matters:
+--   1. Drop the trigger FIRST so no future inserts try to update the column.
+--   2. Drop the trigger's function (nothing else calls it).
+--   3. Drop the list RPC (replaced by the view + .select() from client).
+--   4. Drop the column itself.
+--
+-- We don't touch `get_member_card_count` — it's a cross-deck aggregate
+-- (total cards or due cards for a member) used by the free-tier limit check,
+-- and the view can't replace it because the view is per-deck.
+-- =============================================================================
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_card_insert_update_count ON public.cards;
+
+DROP FUNCTION IF EXISTS public.update_deck_card_count();
+
+DROP FUNCTION IF EXISTS public.get_member_decks_with_due_count(uuid, timestamp with time zone);
+
+ALTER TABLE public.decks DROP COLUMN IF EXISTS card_count;
+
+COMMIT;

--- a/supabase/tests/00006_triggers.sql
+++ b/supabase/tests/00006_triggers.sql
@@ -1,10 +1,14 @@
 -- =============================================================================
--- Trigger tests: set_member_id, update_deck_card_count
+-- Trigger tests: set_member_id
+--
+-- The update_deck_card_count trigger + decks.card_count column were removed
+-- in 20260416000002_drop-deck-card-count-column.sql — per-deck counts are
+-- now computed live in the decks_with_stats view (see 00009_decks_with_stats.sql).
 -- =============================================================================
 
 BEGIN;
 
-SELECT plan(5);
+SELECT plan(2);
 
 -- ── Setup ─────────────────────────────────────────────────────────────────────
 
@@ -35,45 +39,6 @@ SELECT is(
   (SELECT member_id FROM public.cards WHERE id = 1000),
   '11111111-1111-1111-1111-111111111111'::uuid,
   'set_member_id trigger stamps auth.uid() on card insert'
-);
-
-
--- ── update_deck_card_count trigger ────────────────────────────────────────────
-
--- Test 3: card_count is correct after insert
-SELECT is(
-  (SELECT card_count FROM public.decks WHERE id = 100)::int,
-  1,
-  'card_count is 1 after inserting one card'
-);
-
--- Test 4: card_count increments
-SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
-SET LOCAL role = 'authenticated';
-
-INSERT INTO public.cards (id, deck_id, front_text, back_text, rank)
-VALUES (1001, 100, 'Q2', 'A2', 2000);
-
-SET LOCAL role = 'postgres';
-
-SELECT is(
-  (SELECT card_count FROM public.decks WHERE id = 100)::int,
-  2,
-  'card_count incremented to 2 after second card insert'
-);
-
--- Test 5: card_count decrements on delete
-SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
-SET LOCAL role = 'authenticated';
-
-DELETE FROM public.cards WHERE id = 1001;
-
-SET LOCAL role = 'postgres';
-
-SELECT is(
-  (SELECT card_count FROM public.decks WHERE id = 100)::int,
-  1,
-  'card_count decremented to 1 after deleting a card'
 );
 
 

--- a/supabase/tests/00007_card_attributes.sql
+++ b/supabase/tests/00007_card_attributes.sql
@@ -1,10 +1,10 @@
 -- =============================================================================
--- Tests for the card_defaults → card_attributes rename and the RPC projection
--- that exposes it to the dashboard.
+-- Tests for the card_defaults → card_attributes rename and the view
+-- projection that exposes it to the dashboard.
 --
 -- Covers:
 --   1. The column was renamed (old name gone, new name present).
---   2. get_member_decks_with_due_count returns card_attributes.
+--   2. decks_with_stats returns card_attributes.
 --   3. The projection survives round-tripping a nested {front,back} shape.
 -- =============================================================================
 
@@ -25,7 +25,7 @@ SELECT has_column(
 );
 
 
--- ── RPC: includes card_attributes in projection ───────────────────────────────
+-- ── View: includes card_attributes in projection ──────────────────────────────
 
 SELECT tests.create_user('33333333-3333-3333-3333-333333333333'::uuid, 'charlie_attrs');
 SELECT tests.set_claims('33333333-3333-3333-3333-333333333333'::uuid);
@@ -46,7 +46,7 @@ SET LOCAL role = 'authenticated';
 SELECT results_eq(
   $$
     SELECT card_attributes
-    FROM public.get_member_decks_with_due_count('33333333-3333-3333-3333-333333333333'::uuid)
+    FROM public.decks_with_stats
     WHERE id = 900
   $$,
   $$
@@ -57,7 +57,7 @@ SELECT results_eq(
       )
     )
   $$,
-  'get_member_decks_with_due_count returns the nested {front,back} card_attributes shape'
+  'decks_with_stats returns the nested {front,back} card_attributes shape'
 );
 
 -- Null card_attributes should surface as null (not crash the projection)
@@ -66,16 +66,17 @@ SET LOCAL role = 'postgres';
 INSERT INTO public.decks (id, title, is_public, card_attributes)
 VALUES (901, 'No Attrs', false, NULL);
 
+SELECT tests.set_claims('33333333-3333-3333-3333-333333333333'::uuid);
 SET LOCAL role = 'authenticated';
 
 SELECT results_eq(
   $$
     SELECT card_attributes IS NULL
-    FROM public.get_member_decks_with_due_count('33333333-3333-3333-3333-333333333333'::uuid)
+    FROM public.decks_with_stats
     WHERE id = 901
   $$,
   $$ VALUES (true) $$,
-  'RPC returns NULL card_attributes when the column is NULL'
+  'decks_with_stats returns NULL card_attributes when the column is NULL'
 );
 
 

--- a/supabase/tests/00009_decks_with_stats.sql
+++ b/supabase/tests/00009_decks_with_stats.sql
@@ -1,0 +1,119 @@
+-- =============================================================================
+-- decks_with_stats view + cards_with_images security_invoker
+--
+-- Covers:
+--   1. security_invoker = true on the new view (Alice cannot read Bob's decks).
+--   2. card_count column is accurate.
+--   3. due_count column is accurate both before and after a review is written.
+--   4. No join-duplication in the view row count.
+--   5. Retrofit: cards_with_images now respects RLS (Bob can't see Alice's
+--      private cards through the view).
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(8);
+
+-- ── Setup ─────────────────────────────────────────────────────────────────────
+
+SELECT tests.create_user('11111111-1111-1111-1111-111111111111'::uuid, 'alice_stats');
+SELECT tests.create_user('22222222-2222-2222-2222-222222222222'::uuid, 'bob_stats');
+
+-- Alice: one private deck (100) with 2 cards, one public deck (101) with 1 card.
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+INSERT INTO public.decks (id, title, is_public) VALUES
+  (100, 'Alice Private Deck', false),
+  (101, 'Alice Public Deck',  true);
+INSERT INTO public.cards (id, deck_id, front_text, back_text, rank) VALUES
+  (1000, 100, 'Q1', 'A1', 1000),
+  (1001, 100, 'Q2', 'A2', 2000),
+  (1100, 101, 'Q3', 'A3', 1000);
+
+-- Card 1001 has a review due in the future (NOT due).
+-- Cards 1000 and 1100 have no review row → considered due.
+INSERT INTO public.reviews (id, card_id, due, stability, difficulty)
+VALUES (300, 1001, now() + interval '7 days', 1.0, 5.0);
+
+-- Bob: one private deck, one card.
+SELECT tests.set_claims('22222222-2222-2222-2222-222222222222'::uuid);
+INSERT INTO public.decks (id, title, is_public) VALUES (200, 'Bob Private Deck', false);
+INSERT INTO public.cards (id, deck_id, front_text, back_text, rank) VALUES
+  (2000, 200, 'Bob Q', 'Bob A', 1000);
+
+
+-- ── Act as Alice ──────────────────────────────────────────────────────────────
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 1: Alice can read her own decks through the view.
+SELECT lives_ok(
+  $$ SELECT * FROM public.decks_with_stats WHERE id IN (100, 101) $$,
+  'Alice can read her own decks via decks_with_stats'
+);
+
+-- Test 2: card_count is accurate on Alice's private deck (2 cards).
+SELECT is(
+  (SELECT card_count FROM public.decks_with_stats WHERE id = 100),
+  2,
+  'card_count on deck 100 equals 2'
+);
+
+-- Test 3: due_count on deck 100 is 1 — card 1000 is due (no review),
+-- card 1001 is not (review.due is in the future).
+SELECT is(
+  (SELECT due_count FROM public.decks_with_stats WHERE id = 100),
+  1,
+  'due_count on deck 100 equals 1 (only card 1000 is currently due)'
+);
+
+-- Test 4: due_count on Alice's public deck 101 is 1 — card 1100 has no review.
+SELECT is(
+  (SELECT due_count FROM public.decks_with_stats WHERE id = 101),
+  1,
+  'due_count on deck 101 equals 1 (card 1100 has no review, so it is due)'
+);
+
+-- Test 5: Alice does not see Bob's private deck through the view.
+-- If security_invoker were not set, the view would run as postgres and
+-- return Bob's row — this assertion would fail.
+SELECT is(
+  (SELECT count(*) FROM public.decks_with_stats WHERE id = 200)::int,
+  0,
+  'security_invoker: Alice cannot read Bob''s private deck via decks_with_stats'
+);
+
+-- Test 6: Alice's view row count equals her visible-deck count.
+-- Catches accidental join-style duplication where a deck with N cards
+-- would return N rows.
+SELECT is(
+  (SELECT count(*) FROM public.decks_with_stats WHERE member_id = '11111111-1111-1111-1111-111111111111')::int,
+  2,
+  'view row count equals member deck count (no join duplication)'
+);
+
+
+-- ── Act as Bob — test cards_with_images RLS retrofit ─────────────────────────
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims('22222222-2222-2222-2222-222222222222'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 7: Bob cannot see Alice's private card (1000) via cards_with_images.
+-- Before the security_invoker retrofit this would return the row.
+SELECT is(
+  (SELECT count(*) FROM public.cards_with_images WHERE id = 1000)::int,
+  0,
+  'security_invoker (retrofit): Bob cannot see Alice''s private card via cards_with_images'
+);
+
+-- Test 8: Bob CAN see Alice's public card (1100) via cards_with_images —
+-- confirms the retrofit only closes the leak and doesn't break the
+-- "public decks are readable" path.
+SELECT is(
+  (SELECT count(*) FROM public.cards_with_images WHERE id = 1100)::int,
+  1,
+  'Bob can still see Alice''s public deck card via cards_with_images'
+);
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/unit/api/decks.test.js
+++ b/tests/unit/api/decks.test.js
@@ -1,0 +1,147 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+
+const { queryMock, capturedTables } = vi.hoisted(() => {
+  const queryMock = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    order: vi.fn(),
+    single: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn()
+  }
+  return { queryMock, capturedTables: [] }
+})
+
+vi.mock('@/supabase-client', () => ({
+  supabase: {
+    from: vi.fn((table) => {
+      capturedTables.push(table)
+      return queryMock
+    })
+  }
+}))
+
+vi.mock('@/stores/member', () => ({
+  useMemberStore: () => ({ id: 'member-uuid-1' })
+}))
+
+vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
+
+import { supabase } from '@/supabase-client'
+import {
+  fetchMemberDecks,
+  fetchDeck,
+  fetchMemberDeckCount,
+  upsertDeck,
+  deleteDeck
+} from '@/api/decks'
+
+beforeEach(() => {
+  Object.values(queryMock).forEach((fn) => fn.mockReset?.())
+  queryMock.select.mockReturnValue(queryMock)
+  queryMock.eq.mockReturnValue(queryMock)
+  queryMock.order.mockReturnValue(queryMock)
+  queryMock.delete.mockReturnValue(queryMock)
+  capturedTables.length = 0
+  supabase.from.mockClear()
+})
+
+describe('fetchMemberDecks', () => {
+  test('reads from decks_with_stats filtered by current member', async () => {
+    queryMock.eq.mockResolvedValueOnce({ data: [{ id: 1 }], error: null })
+    const result = await fetchMemberDecks()
+    expect(capturedTables[0]).toBe('decks_with_stats')
+    expect(queryMock.eq).toHaveBeenCalledWith('member_id', 'member-uuid-1')
+    expect(result).toEqual([{ id: 1 }])
+  })
+
+  test('throws when the query errors', async () => {
+    const err = new Error('denied')
+    queryMock.eq.mockResolvedValueOnce({ data: null, error: err })
+    await expect(fetchMemberDecks()).rejects.toBe(err)
+  })
+})
+
+describe('fetchDeck', () => {
+  test('reads from decks_with_stats with the nested cards + member embed', async () => {
+    queryMock.single.mockResolvedValueOnce({ data: { id: 5 }, error: null })
+    await fetchDeck(5)
+    expect(capturedTables[0]).toBe('decks_with_stats')
+    const [selectArg] = queryMock.select.mock.calls[0]
+    expect(selectArg).toContain('cards:cards_with_images')
+    expect(selectArg).toContain('member:members(display_name)')
+    expect(queryMock.eq).toHaveBeenCalledWith('id', 5)
+  })
+
+  test('orders embedded cards by rank ascending', async () => {
+    queryMock.single.mockResolvedValueOnce({ data: {}, error: null })
+    await fetchDeck(5)
+    expect(queryMock.order).toHaveBeenCalledWith('rank', {
+      ascending: true,
+      referencedTable: 'cards_with_images'
+    })
+  })
+
+  test('throws when the query errors', async () => {
+    const err = new Error('missing')
+    queryMock.single.mockResolvedValueOnce({ data: null, error: err })
+    await expect(fetchDeck(5)).rejects.toBe(err)
+  })
+})
+
+describe('fetchMemberDeckCount', () => {
+  test('returns the exact count for the current member', async () => {
+    queryMock.eq.mockResolvedValueOnce({ count: 3, error: null })
+    const n = await fetchMemberDeckCount()
+    expect(capturedTables[0]).toBe('decks')
+    expect(queryMock.select).toHaveBeenCalledWith('*', { count: 'exact', head: true })
+    expect(queryMock.eq).toHaveBeenCalledWith('member_id', 'member-uuid-1')
+    expect(n).toBe(3)
+  })
+
+  test('returns 0 when count is null', async () => {
+    queryMock.eq.mockResolvedValueOnce({ count: null, error: null })
+    const n = await fetchMemberDeckCount()
+    expect(n).toBe(0)
+  })
+
+  test('throws when the query errors', async () => {
+    const err = new Error('boom')
+    queryMock.eq.mockResolvedValueOnce({ count: null, error: err })
+    await expect(fetchMemberDeckCount()).rejects.toBe(err)
+  })
+})
+
+describe('upsertDeck', () => {
+  test('upserts on the decks table and stamps updated_at', async () => {
+    queryMock.upsert.mockResolvedValueOnce({ error: null })
+    const deck = { id: 1, title: 'T' }
+    await upsertDeck(deck)
+    expect(capturedTables[0]).toBe('decks')
+    const [payload, opts] = queryMock.upsert.mock.calls[0]
+    expect(payload.updated_at).toBeTruthy()
+    expect(opts).toEqual({ onConflict: 'id' })
+  })
+
+  test('throws when the upsert fails', async () => {
+    const err = new Error('dup')
+    queryMock.upsert.mockResolvedValueOnce({ error: err })
+    await expect(upsertDeck({ id: 1 })).rejects.toBe(err)
+  })
+})
+
+describe('deleteDeck', () => {
+  test('deletes the given deck by id', async () => {
+    queryMock.eq.mockResolvedValueOnce({ error: null })
+    await deleteDeck(42)
+    expect(capturedTables[0]).toBe('decks')
+    expect(queryMock.delete).toHaveBeenCalled()
+    expect(queryMock.eq).toHaveBeenCalledWith('id', 42)
+  })
+
+  test('throws when the delete fails', async () => {
+    const err = new Error('denied')
+    queryMock.eq.mockResolvedValueOnce({ error: err })
+    await expect(deleteDeck(42)).rejects.toBe(err)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -80,7 +80,6 @@ export default defineConfig({
         '**/main.ts',
         '**/supabase-client.ts',
         '**/router/**',
-        '**/src/api/**',
         '**/src/components/ui-kit/_index.ts',
         '**/types/**',
         '**/src/utils/logger.ts',


### PR DESCRIPTION
## Summary

Replaces the trigger-maintained `decks.card_count` column and the `get_member_decks_with_due_count` RPC with a single `decks_with_stats` view that computes both `card_count` and `due_count` at read time. Both list (`fetchMemberDecks`) and single-deck (`fetchDeck`) code paths now read the same shape, setting up a consistent surface for a future query-cache migration.

Also retrofits `security_invoker = true` onto `cards_with_images`, closing a pre-existing RLS hole where the view ran as its owner and effectively bypassed per-member isolation.

## Changes

- New migration `20260416000000_decks-with-stats-view.sql` — `security_invoker` view with correlated-subquery counts, `now()` server-side
- New migration `20260416000001_cards-with-images-security-invoker.sql` — retrofit via `ALTER VIEW ... SET (security_invoker = true)`
- New migration `20260416000002_drop-deck-card-count-column.sql` — drops the old trigger, function, RPC, and column
- `src/api/decks.ts` — `fetchMemberDecks` and `fetchDeck` now read from the view
- `vite.config.ts` — removes `**/src/api/**` from the coverage exclude list so the new `decks.ts` coverage counts
- New `supabase/tests/00009_decks_with_stats.sql` — 8 pgTAP tests covering count accuracy, `security_invoker` isolation, and the `cards_with_images` retrofit
- New `tests/unit/api/decks.test.js` — 12 unit tests covering all 5 `src/api/decks.ts` exports

## Test plan

- [ ] `vp check` passes
- [ ] `vp test` passes (unit + integration)
- [ ] `supabase test db` passes (pgTAP)
- [ ] Dashboard loads with correct deck counts
- [ ] Open a deck → overview-panel shows correct `card_count`
- [ ] Rate a card → `due_count` drops by 1 on next dashboard load