### PR TITLE
Defer new-card creation until first keystroke

### DIFF
--- a/src/api/cards/insert.ts
+++ b/src/api/cards/insert.ts
@@ -1,15 +1,21 @@
 import { supabase } from '@/supabase-client'
 import logger from '@/utils/logger'
 
-export async function reserveCard(
-  deck_id: number,
-  left_card_id?: number,
-  right_card_id?: number
-): Promise<{ out_rank: number; out_id: number }> {
-  const { data, error } = await supabase.rpc('reserve_card', {
-    p_deck_id: deck_id,
-    p_left_card_id: left_card_id ?? null,
-    p_right_card_id: right_card_id ?? null
+export type InsertCardParams = {
+  deck_id: number
+  left_card_id: number | null
+  right_card_id: number | null
+  front_text: string
+  back_text: string
+}
+
+export async function insertCard(params: InsertCardParams): Promise<{ id: number; rank: number }> {
+  const { data, error } = await supabase.rpc('insert_card', {
+    p_deck_id: params.deck_id,
+    p_left_card_id: params.left_card_id,
+    p_right_card_id: params.right_card_id,
+    p_front_text: params.front_text,
+    p_back_text: params.back_text
   })
 
   if (error) {

--- a/src/composables/card-bulk-editor.ts
+++ b/src/composables/card-bulk-editor.ts
@@ -1,12 +1,20 @@
 import { computed, ref } from 'vue'
 import { deleteCards as upstreamDeleteCards } from '@/api/cards'
-import { reserveCard } from '@/api/cards'
+import { insertCard } from '@/api/cards'
 import { saveCard } from '@/api/cards'
 
 // TODO: Add error handling for all async functions
 
 export type CardEditorMode = 'view' | 'select' | 'edit'
 export type CardBulkEditor = ReturnType<typeof useCardBulkEditor>
+
+// Monotonically decreasing counter for in-memory-only cards. Negative IDs
+// cannot collide with real bigserial IDs from Postgres (which are always
+// positive), so `card.id < 0` is a reliable "not yet persisted" sentinel.
+let temp_id_counter = 0
+function nextTempId(): number {
+  return --temp_id_counter
+}
 
 export function useCardBulkEditor(initial_cards: Card[], _deck_id: number) {
   const all_cards = ref<Card[]>([...initial_cards])
@@ -24,8 +32,57 @@ export function useCardBulkEditor(initial_cards: Card[], _deck_id: number) {
     if (!card) return
 
     saving.value = true
-    await saveCard(card, values)
-    saving.value = false
+    try {
+      if (card.id < 0) {
+        // First save of a temp card — insert on the server, then swap the
+        // temp id for the real one. Neighbors are derived from the array's
+        // current order (skipping other temp cards).
+        const { left_card_id, right_card_id } = findRealNeighbors(card.id)
+        const inserted = await insertCard({
+          deck_id: deck_id.value!,
+          left_card_id,
+          right_card_id,
+          front_text: values.front_text ?? card.front_text ?? '',
+          back_text: values.back_text ?? card.back_text ?? ''
+        })
+        card.id = inserted.id
+        card.rank = inserted.rank
+        Object.assign(card, values)
+      } else {
+        await saveCard(card, values)
+      }
+    } finally {
+      saving.value = false
+    }
+  }
+
+  // Walks the local array outward from a temp card to find its nearest
+  // persisted neighbors on either side. Neighbors that are themselves temp
+  // (id < 0) are skipped — only real IDs can be sent to the server.
+  function findRealNeighbors(temp_id: number): {
+    left_card_id: number | null
+    right_card_id: number | null
+  } {
+    const idx = all_cards.value.findIndex((c) => c.id === temp_id)
+    let left_card_id: number | null = null
+    let right_card_id: number | null = null
+
+    for (let i = idx - 1; i >= 0; i--) {
+      const id = all_cards.value[i].id
+      if (id !== undefined && id > 0) {
+        left_card_id = id
+        break
+      }
+    }
+    for (let i = idx + 1; i < all_cards.value.length; i++) {
+      const id = all_cards.value[i].id
+      if (id !== undefined && id > 0) {
+        right_card_id = id
+        break
+      }
+    }
+
+    return { left_card_id, right_card_id }
   }
 
   function selectCard(id: number) {
@@ -95,28 +152,41 @@ export function useCardBulkEditor(initial_cards: Card[], _deck_id: number) {
     )
   }
 
-  async function appendCard(card_id: number) {
+  function appendCard(card_id: number) {
     const other_card = all_cards.value[all_cards.value.findIndex((c) => c.id === card_id) + 1]
-    await addCard(other_card?.id, card_id)
+    addCard(card_id, other_card?.id)
   }
 
-  async function prependCard(card_id: number) {
+  function prependCard(card_id: number) {
     const other_card = all_cards.value[all_cards.value.findIndex((c) => c.id === card_id) - 1]
-    await addCard(card_id, other_card?.id)
+    addCard(other_card?.id, card_id)
   }
 
-  async function addCard(left_card_id?: number, right_card_id?: number) {
+  // In-memory only. No network call until the user types into the card
+  // and `updateCard` promotes the temp row to a real INSERT (see above).
+  function addCard(left_card_id?: number, right_card_id?: number) {
     if (!left_card_id && !right_card_id) {
-      const last_card = all_cards.value?.at(-1)
-      left_card_id = last_card?.id
+      left_card_id = all_cards.value.at(-1)?.id
     }
 
-    const { out_id, out_rank } = await reserveCard(deck_id.value!, left_card_id, right_card_id)
-    const new_card: Card = { id: out_id, rank: out_rank, deck_id: deck_id.value }
+    const new_card: Card = {
+      id: nextTempId(),
+      rank: 0,
+      deck_id: deck_id.value,
+      front_text: '',
+      back_text: ''
+    }
 
-    let index = all_cards.value.findIndex((card) => card.rank! > new_card.rank!)
-    if (index === -1) {
-      index = all_cards.value.length // append at end
+    // Position by neighbor id, not rank — a temp card has no real rank yet.
+    let index: number
+    if (left_card_id !== undefined) {
+      const left_idx = all_cards.value.findIndex((c) => c.id === left_card_id)
+      index = left_idx >= 0 ? left_idx + 1 : all_cards.value.length
+    } else if (right_card_id !== undefined) {
+      const right_idx = all_cards.value.findIndex((c) => c.id === right_card_id)
+      index = right_idx >= 0 ? right_idx : 0
+    } else {
+      index = all_cards.value.length
     }
 
     all_cards.value.splice(index, 0, new_card)

--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -104,6 +104,7 @@ defineExpose({ focusEditor, hasFocusWithin })
       :class="{ 'pointer-events-none': mode === 'select' }"
     >
       <image-button
+        v-if="card.id > 0"
         class="absolute! -top-2 -left-2 opacity-0 transition-opacity duration-100 ease-in-out group-hover/card:opacity-100"
         :image="card.front_image_path"
         @image-uploaded="onImageUpload('front', $event)"
@@ -136,6 +137,7 @@ defineExpose({ focusEditor, hasFocusWithin })
       :class="{ 'pointer-events-none': mode === 'select' }"
     >
       <image-button
+        v-if="card.id > 0"
         class="absolute! -top-2 -right-2 opacity-0 transition-opacity duration-100 ease-in-out group-hover/card:opacity-100"
         :image="card.back_image_path"
         @image-uploaded="onImageUpload('back', $event)"

--- a/supabase/migrations/20260416000003_insert-card-rpc.sql
+++ b/supabase/migrations/20260416000003_insert-card-rpc.sql
@@ -1,0 +1,82 @@
+-- =============================================================================
+-- insert_card RPC
+-- =============================================================================
+--
+-- Replaces the reserve_card workflow. Where reserve_card created an empty
+-- placeholder row on the server when the user clicked "add card", insert_card
+-- is only called once the user has actually typed something — so every row
+-- in the cards table corresponds to a real, non-empty card.
+--
+-- The FE no longer computes rank. It creates cards in-memory with a negative
+-- temp id, and on the first save passes the surrounding card IDs as left/
+-- right neighbors. Postgres then computes the rank between them using the
+-- existing card_rank_between function.
+--
+-- Column names `id` and `rank` on the RETURNS TABLE clash with the cards
+-- table's columns, so references inside the function body are always fully
+-- qualified (public.cards.id, public.decks.id, etc.) to keep the
+-- variable-vs-column resolution unambiguous.
+--
+-- reserve_card is left in place for one release cycle so we have a rollback
+-- path. A later migration drops it.
+-- =============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.insert_card(
+  p_deck_id bigint,
+  p_left_card_id bigint,
+  p_right_card_id bigint,
+  p_front_text text,
+  p_back_text text
+)
+RETURNS TABLE(id bigint, rank numeric)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_rank numeric;
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Ownership check: caller must own the deck.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.decks
+    WHERE public.decks.id = p_deck_id AND public.decks.member_id = v_uid
+  ) THEN
+    RAISE EXCEPTION 'Deck not found or not owned by user';
+  END IF;
+
+  -- Serialize rank computation within this deck to avoid rank collisions
+  -- if two requests land concurrently.
+  PERFORM pg_advisory_xact_lock(p_deck_id);
+
+  -- Compute the rank between the two given neighbors. If card_rank_between
+  -- raises P0001 (the neighbors are too close together for further bisection),
+  -- reindex the deck and retry once.
+  BEGIN
+    v_rank := public.card_rank_between(p_deck_id, p_left_card_id, p_right_card_id);
+  EXCEPTION
+    WHEN SQLSTATE 'P0001' THEN
+      PERFORM public.reindex_deck_ranks(p_deck_id);
+      v_rank := public.card_rank_between(p_deck_id, p_left_card_id, p_right_card_id);
+  END;
+
+  INSERT INTO public.cards (member_id, deck_id, rank, front_text, back_text)
+  VALUES (
+    v_uid,
+    p_deck_id,
+    v_rank,
+    COALESCE(p_front_text, ''),
+    COALESCE(p_back_text, '')
+  )
+  RETURNING public.cards.id, public.cards.rank
+  INTO id, rank;
+
+  RETURN NEXT;
+END;
+$$;
+
+COMMIT;

--- a/supabase/tests/00005_rpc_functions.sql
+++ b/supabase/tests/00005_rpc_functions.sql
@@ -1,10 +1,10 @@
 -- =============================================================================
--- RPC function tests: save_review, reserve_card, reorder_card
+-- RPC function tests: save_review, reserve_card, reorder_card, insert_card
 -- =============================================================================
 
 BEGIN;
 
-SELECT plan(8);
+SELECT plan(12);
 
 -- ── Setup ─────────────────────────────────────────────────────────────────────
 
@@ -121,6 +121,50 @@ SELECT throws_ok(
   $$,
   'Card not found or not owned by user',
   'Alice cannot reorder Bob''s card'
+);
+
+
+-- ── insert_card ───────────────────────────────────────────────────────────────
+-- Alice's deck 100 has cards at ranks 1000 and 2000 (ids 1000 and 1001).
+
+-- Test 9: Alice can insert a card bisecting two existing cards and gets
+-- a rank strictly between them.
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+SET LOCAL role = 'authenticated';
+
+SELECT public.insert_card(100, 1000, 1001, 'Bisect Q', 'Bisect A');
+
+SELECT ok(
+  (SELECT rank > 1000 AND rank < 2000 FROM public.cards WHERE front_text = 'Bisect Q'),
+  'insert_card bisects: rank is between the left and right neighbors'
+);
+
+-- Test 10: Appending with right_card_id = NULL gives a rank greater than
+-- the deck's current max.
+SELECT public.insert_card(100, 1001, NULL, 'Append Q', 'Append A');
+
+SELECT ok(
+  (SELECT rank > 2000 FROM public.cards WHERE front_text = 'Append Q'),
+  'insert_card appends when right neighbor is NULL: rank > max existing'
+);
+
+-- Test 11: Alice cannot insert a card into Bob's deck.
+SELECT throws_ok(
+  $$
+    SELECT public.insert_card(200, NULL, NULL, 'Sneaky Q', 'Sneaky A')
+  $$,
+  'Deck not found or not owned by user',
+  'Alice cannot insert a card into Bob''s deck'
+);
+
+-- Test 12: NULL front_text is coerced to empty string (COALESCE in function).
+SELECT public.insert_card(100, 1001, NULL, NULL, 'Only back');
+
+SET LOCAL role = 'postgres';
+SELECT is(
+  (SELECT front_text FROM public.cards WHERE back_text = 'Only back'),
+  '',
+  'insert_card coerces NULL front_text to empty string'
 );
 
 

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -1,0 +1,128 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h, ref } from 'vue'
+
+// Stub Card so its default + editor slots render — otherwise ImageButton
+// (which lives inside the card's default slot) is unreachable under shallowMount.
+// Forward attrs so `data-testid="front-input"` / `back-input` make it through.
+import { useAttrs } from 'vue'
+const CardStub = defineComponent({
+  name: 'Card',
+  inheritAttrs: false,
+  setup(_props, { slots }) {
+    const attrs = useAttrs()
+    return () => h('div', attrs, [slots.default?.(), slots.editor?.()])
+  }
+})
+
+const mocks = vi.hoisted(() => ({
+  setCardImageMock: vi.fn(),
+  deleteCardImageMock: vi.fn(),
+  updateCardMock: vi.fn(),
+  emitSfxMock: vi.fn()
+}))
+
+vi.mock('@/api/cards', () => ({
+  setCardImage: mocks.setCardImageMock,
+  deleteCardImage: mocks.deleteCardImageMock
+}))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mocks.emitSfxMock }))
+
+vi.mock('@/composables/toast', () => ({
+  useToast: () => ({ error: vi.fn(), success: vi.fn(), warn: vi.fn() })
+}))
+
+import ListItemCard from '@/views/deck/card-editor/list-item-card.vue'
+import ImageButton from '@/views/deck/image-button.vue'
+
+function mount(props = {}) {
+  return shallowMount(ListItemCard, {
+    props: {
+      card: {
+        id: 1,
+        deck_id: 10,
+        front_text: 'Q',
+        back_text: 'A',
+        rank: 1000,
+        ...props.card
+      },
+      duplicate: false,
+      ...props
+    },
+    global: {
+      stubs: { Card: CardStub },
+      provide: {
+        'card-editor': {
+          mode: ref('edit'),
+          updateCard: mocks.updateCardMock
+        },
+        'card-attributes': { front: {}, back: {} }
+      }
+    }
+  })
+}
+
+beforeEach(() => {
+  mocks.setCardImageMock.mockReset()
+  mocks.setCardImageMock.mockResolvedValue(undefined)
+  mocks.deleteCardImageMock.mockReset()
+  mocks.deleteCardImageMock.mockResolvedValue(undefined)
+  mocks.updateCardMock.mockReset()
+  mocks.emitSfxMock.mockReset()
+})
+
+describe('ListItemCard', () => {
+  // ── Image buttons visibility (the temp-id fix) ─────────────────────────────
+
+  test('renders image buttons on both sides when the card has a real id', () => {
+    const wrapper = mount({ card: { id: 42 } })
+    const buttons = wrapper.findAllComponents(ImageButton)
+    expect(buttons).toHaveLength(2)
+  })
+
+  test('hides image buttons on both sides when the card has a temp id (id < 0)', () => {
+    const wrapper = mount({ card: { id: -1 } })
+    const buttons = wrapper.findAllComponents(ImageButton)
+    expect(buttons).toHaveLength(0)
+  })
+
+  test('hides image buttons when id is 0 (not yet assigned)', () => {
+    const wrapper = mount({ card: { id: 0 } })
+    const buttons = wrapper.findAllComponents(ImageButton)
+    expect(buttons).toHaveLength(0)
+  })
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  test('renders a front and a back card', () => {
+    const wrapper = mount()
+    expect(wrapper.find('[data-testid="front-input"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="back-input"]').exists()).toBe(true)
+  })
+
+  // ── Image upload / delete wiring ──────────────────────────────────────────
+
+  test('passes the uploaded file to setCardImage when the front image button emits', async () => {
+    const wrapper = mount({ card: { id: 42 } })
+    const file = new File(['x'], 'a.png', { type: 'image/png' })
+    const frontButton = wrapper.findAllComponents(ImageButton)[0]
+    await frontButton.vm.$emit('image-uploaded', file)
+    expect(mocks.setCardImageMock).toHaveBeenCalledWith(42, file, 'front')
+  })
+
+  test('passes the side to setCardImage when the back image button emits', async () => {
+    const wrapper = mount({ card: { id: 42 } })
+    const file = new File(['x'], 'b.png', { type: 'image/png' })
+    const backButton = wrapper.findAllComponents(ImageButton)[1]
+    await backButton.vm.$emit('image-uploaded', file)
+    expect(mocks.setCardImageMock).toHaveBeenCalledWith(42, file, 'back')
+  })
+
+  test('deletes the front image when the front image button emits image-deleted', async () => {
+    const wrapper = mount({ card: { id: 42 } })
+    const frontButton = wrapper.findAllComponents(ImageButton)[0]
+    await frontButton.vm.$emit('image-deleted')
+    expect(mocks.deleteCardImageMock).toHaveBeenCalledWith(42, 'front')
+  })
+})

--- a/tests/unit/api/cards/insert.test.js
+++ b/tests/unit/api/cards/insert.test.js
@@ -1,0 +1,84 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+
+const { rpcMock } = vi.hoisted(() => ({
+  rpcMock: vi.fn()
+}))
+
+vi.mock('@/supabase-client', () => ({
+  supabase: { rpc: rpcMock }
+}))
+
+vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
+
+import { insertCard } from '@/api/cards/insert'
+
+describe('insertCard', () => {
+  beforeEach(() => {
+    rpcMock.mockReset()
+  })
+
+  test('calls the insert_card RPC with the expected param shape', async () => {
+    rpcMock.mockResolvedValueOnce({ data: [{ id: 1, rank: 1500 }], error: null })
+
+    await insertCard({
+      deck_id: 10,
+      left_card_id: 1,
+      right_card_id: 2,
+      front_text: 'Q',
+      back_text: 'A'
+    })
+
+    expect(rpcMock).toHaveBeenCalledWith('insert_card', {
+      p_deck_id: 10,
+      p_left_card_id: 1,
+      p_right_card_id: 2,
+      p_front_text: 'Q',
+      p_back_text: 'A'
+    })
+  })
+
+  test('returns the first row (id + rank) from the RPC response', async () => {
+    rpcMock.mockResolvedValueOnce({ data: [{ id: 42, rank: 2500 }], error: null })
+
+    const result = await insertCard({
+      deck_id: 10,
+      left_card_id: null,
+      right_card_id: null,
+      front_text: '',
+      back_text: ''
+    })
+
+    expect(result).toEqual({ id: 42, rank: 2500 })
+  })
+
+  test('forwards null neighbors unchanged (used for empty-deck inserts)', async () => {
+    rpcMock.mockResolvedValueOnce({ data: [{ id: 1, rank: 1000 }], error: null })
+
+    await insertCard({
+      deck_id: 10,
+      left_card_id: null,
+      right_card_id: null,
+      front_text: 'Q',
+      back_text: 'A'
+    })
+
+    const [, args] = rpcMock.mock.calls[0]
+    expect(args.p_left_card_id).toBeNull()
+    expect(args.p_right_card_id).toBeNull()
+  })
+
+  test('throws when the RPC returns an error', async () => {
+    const err = new Error('deck not found')
+    rpcMock.mockResolvedValueOnce({ data: null, error: err })
+
+    await expect(
+      insertCard({
+        deck_id: 10,
+        left_card_id: null,
+        right_card_id: null,
+        front_text: '',
+        back_text: ''
+      })
+    ).rejects.toBe(err)
+  })
+})

--- a/tests/unit/composables/card-bulk-editor.test.js
+++ b/tests/unit/composables/card-bulk-editor.test.js
@@ -1,0 +1,382 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { card } from '@tests/fixtures/card'
+
+const { insertCardMock, saveCardMock, deleteCardsMock } = vi.hoisted(() => ({
+  insertCardMock: vi.fn(),
+  saveCardMock: vi.fn(),
+  deleteCardsMock: vi.fn()
+}))
+
+vi.mock('@/api/cards', () => ({
+  insertCard: insertCardMock,
+  saveCard: saveCardMock,
+  deleteCards: deleteCardsMock
+}))
+
+import { useCardBulkEditor } from '@/composables/card-bulk-editor'
+
+function makeCard(overrides = {}) {
+  return card.one({ overrides })
+}
+
+describe('useCardBulkEditor', () => {
+  beforeEach(() => {
+    insertCardMock.mockReset()
+    insertCardMock.mockResolvedValue({ id: 9999, rank: 1500 })
+    saveCardMock.mockReset()
+    saveCardMock.mockResolvedValue(undefined)
+    deleteCardsMock.mockReset()
+    deleteCardsMock.mockResolvedValue(undefined)
+  })
+
+  // ── Initialization ─────────────────────────────────────────────────────────
+
+  describe('initialization', () => {
+    test('seeds all_cards from the initial array', () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 })]
+      const { all_cards } = useCardBulkEditor(initial, 10)
+      expect(all_cards.value).toHaveLength(2)
+      expect(all_cards.value.map((c) => c.id)).toEqual([1, 2])
+    })
+
+    test('does not mutate the caller-provided array', () => {
+      const initial = [makeCard({ id: 1 })]
+      const { addCard } = useCardBulkEditor(initial, 10)
+      addCard()
+      expect(initial).toHaveLength(1)
+    })
+
+    test('starts in view mode with no selection', () => {
+      const { mode, selected_card_ids, saving } = useCardBulkEditor([], 10)
+      expect(mode.value).toBe('view')
+      expect(selected_card_ids.value).toEqual([])
+      expect(saving.value).toBe(false)
+    })
+  })
+
+  // ── addCard (in-memory only, no network) ───────────────────────────────────
+
+  describe('addCard', () => {
+    test('appends to the end by default and does not hit the network', () => {
+      const { all_cards, addCard } = useCardBulkEditor([makeCard({ id: 1 })], 10)
+      addCard()
+      expect(all_cards.value).toHaveLength(2)
+      expect(insertCardMock).not.toHaveBeenCalled()
+      expect(saveCardMock).not.toHaveBeenCalled()
+    })
+
+    test('assigns a negative temp id so the card is distinguishable from persisted rows', () => {
+      const { all_cards, addCard } = useCardBulkEditor([], 10)
+      addCard()
+      expect(all_cards.value[0].id).toBeLessThan(0)
+    })
+
+    test('assigns unique temp ids to successive adds', () => {
+      const { all_cards, addCard } = useCardBulkEditor([], 10)
+      addCard()
+      addCard()
+      expect(all_cards.value[0].id).not.toBe(all_cards.value[1].id)
+    })
+
+    test('inserts after the given left neighbor', () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 }), makeCard({ id: 3 })]
+      const { all_cards, addCard } = useCardBulkEditor(initial, 10)
+      addCard(1) // insert after card 1
+      expect(all_cards.value.map((c) => c.id)).toEqual([1, all_cards.value[1].id, 2, 3])
+    })
+
+    test('inserts before the given right neighbor when no left neighbor', () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 })]
+      const { all_cards, addCard } = useCardBulkEditor(initial, 10)
+      addCard(undefined, 2) // insert before card 2
+      expect(all_cards.value.map((c) => c.id)).toEqual([1, all_cards.value[1].id, 2])
+    })
+
+    test('appends when neither neighbor matches an existing card', () => {
+      const initial = [makeCard({ id: 1 })]
+      const { all_cards, addCard } = useCardBulkEditor(initial, 10)
+      addCard(999, 888)
+      expect(all_cards.value).toHaveLength(2)
+      expect(all_cards.value[1].id).toBeLessThan(0)
+    })
+
+    test('initializes front/back text to empty strings', () => {
+      const { all_cards, addCard } = useCardBulkEditor([], 10)
+      addCard()
+      expect(all_cards.value[0].front_text).toBe('')
+      expect(all_cards.value[0].back_text).toBe('')
+    })
+  })
+
+  // ── appendCard / prependCard ───────────────────────────────────────────────
+
+  describe('appendCard / prependCard', () => {
+    test('appendCard inserts after the target and before the next real card', () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 })]
+      const { all_cards, appendCard } = useCardBulkEditor(initial, 10)
+      appendCard(1)
+      expect(all_cards.value.map((c) => c.id)).toEqual([1, all_cards.value[1].id, 2])
+    })
+
+    test('prependCard inserts before the target and after the previous real card', () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 })]
+      const { all_cards, prependCard } = useCardBulkEditor(initial, 10)
+      prependCard(2)
+      expect(all_cards.value.map((c) => c.id)).toEqual([1, all_cards.value[1].id, 2])
+    })
+  })
+
+  // ── updateCard — routing between insertCard (temp) and saveCard (real) ─────
+
+  describe('updateCard', () => {
+    test('routes to saveCard for an existing (real-id) card', async () => {
+      const real = makeCard({ id: 42 })
+      const { updateCard } = useCardBulkEditor([real], 10)
+      await updateCard(42, { front_text: 'Updated' })
+      expect(saveCardMock).toHaveBeenCalledOnce()
+      expect(insertCardMock).not.toHaveBeenCalled()
+    })
+
+    test('routes to insertCard on first save of a temp card', async () => {
+      const { addCard, all_cards, updateCard } = useCardBulkEditor([], 10)
+      addCard()
+      const temp_id = all_cards.value[0].id
+      await updateCard(temp_id, { front_text: 'Q', back_text: 'A' })
+      expect(insertCardMock).toHaveBeenCalledOnce()
+      expect(saveCardMock).not.toHaveBeenCalled()
+    })
+
+    test('swaps temp id for the real id returned by insertCard', async () => {
+      insertCardMock.mockResolvedValueOnce({ id: 777, rank: 1234 })
+      const { addCard, all_cards, updateCard } = useCardBulkEditor([], 10)
+      addCard()
+      const temp_id = all_cards.value[0].id
+      await updateCard(temp_id, { front_text: 'X' })
+      expect(all_cards.value[0].id).toBe(777)
+      expect(all_cards.value[0].rank).toBe(1234)
+    })
+
+    test('sends null neighbors when the temp card is the only card', async () => {
+      const { addCard, all_cards, updateCard } = useCardBulkEditor([], 10)
+      addCard()
+      await updateCard(all_cards.value[0].id, { front_text: 'X' })
+      const [args] = insertCardMock.mock.calls[0]
+      expect(args.left_card_id).toBeNull()
+      expect(args.right_card_id).toBeNull()
+    })
+
+    test('finds real neighbors on either side of a temp card', async () => {
+      const initial = [makeCard({ id: 100 }), makeCard({ id: 200 })]
+      const { addCard, all_cards, updateCard } = useCardBulkEditor(initial, 10)
+      addCard(100, 200) // insert between 100 and 200
+      const temp_id = all_cards.value[1].id
+      await updateCard(temp_id, { front_text: 'X' })
+      const [args] = insertCardMock.mock.calls[0]
+      expect(args.left_card_id).toBe(100)
+      expect(args.right_card_id).toBe(200)
+    })
+
+    test('skips adjacent temp cards when resolving neighbors', async () => {
+      const initial = [makeCard({ id: 100 }), makeCard({ id: 200 })]
+      const { addCard, all_cards, updateCard } = useCardBulkEditor(initial, 10)
+      addCard(100) // temp A between 100 and 200
+      addCard(all_cards.value[1].id) // temp B after temp A, before 200
+      const temp_b_id = all_cards.value[2].id
+      await updateCard(temp_b_id, { front_text: 'X' })
+      const [args] = insertCardMock.mock.calls[0]
+      // A (negative id) is skipped, so the left neighbor resolves to 100 (real).
+      expect(args.left_card_id).toBe(100)
+      expect(args.right_card_id).toBe(200)
+    })
+
+    test('passes front/back text to insertCard, preferring values over card state', async () => {
+      const { addCard, all_cards, updateCard } = useCardBulkEditor([], 10)
+      addCard()
+      await updateCard(all_cards.value[0].id, { front_text: 'from values' })
+      const [args] = insertCardMock.mock.calls[0]
+      expect(args.front_text).toBe('from values')
+      expect(args.back_text).toBe('')
+    })
+
+    test('is a no-op when the id is not found', async () => {
+      const { updateCard } = useCardBulkEditor([], 10)
+      await updateCard(999, { front_text: 'X' })
+      expect(insertCardMock).not.toHaveBeenCalled()
+      expect(saveCardMock).not.toHaveBeenCalled()
+    })
+
+    test('toggles saving around the async work', async () => {
+      let resolveSave
+      saveCardMock.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveSave = r
+        })
+      )
+      const { updateCard, saving } = useCardBulkEditor([makeCard({ id: 1 })], 10)
+      const promise = updateCard(1, { front_text: 'X' })
+      expect(saving.value).toBe(true)
+      resolveSave()
+      await promise
+      expect(saving.value).toBe(false)
+    })
+
+    test('resets saving even if saveCard rejects', async () => {
+      saveCardMock.mockRejectedValueOnce(new Error('boom'))
+      const { updateCard, saving } = useCardBulkEditor([makeCard({ id: 1 })], 10)
+      await expect(updateCard(1, { front_text: 'X' })).rejects.toThrow('boom')
+      expect(saving.value).toBe(false)
+    })
+  })
+
+  // ── selection ──────────────────────────────────────────────────────────────
+
+  describe('selection', () => {
+    test('selectCard adds an id once (no duplicates)', () => {
+      const { selectCard, selected_card_ids } = useCardBulkEditor([], 10)
+      selectCard(1)
+      selectCard(1)
+      expect(selected_card_ids.value).toEqual([1])
+    })
+
+    test('deselectCard removes an id', () => {
+      const { selectCard, deselectCard, selected_card_ids } = useCardBulkEditor([], 10)
+      selectCard(1)
+      selectCard(2)
+      deselectCard(1)
+      expect(selected_card_ids.value).toEqual([2])
+    })
+
+    test('toggleSelectCard flips selection state', () => {
+      const { toggleSelectCard, selected_card_ids } = useCardBulkEditor([], 10)
+      toggleSelectCard(1)
+      expect(selected_card_ids.value).toEqual([1])
+      toggleSelectCard(1)
+      expect(selected_card_ids.value).toEqual([])
+    })
+
+    test('selectAllCards selects every card with a defined id', () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 }), makeCard({ id: 3 })]
+      const { selectAllCards, selected_card_ids } = useCardBulkEditor(initial, 10)
+      selectAllCards()
+      expect(selected_card_ids.value.sort()).toEqual([1, 2, 3])
+    })
+
+    test('clearSelectedCards empties the selection', () => {
+      const { selectCard, clearSelectedCards, selected_card_ids } = useCardBulkEditor([], 10)
+      selectCard(1)
+      clearSelectedCards()
+      expect(selected_card_ids.value).toEqual([])
+    })
+
+    test('toggleSelectAll selects everything when nothing is selected', () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 })]
+      const { toggleSelectAll, selected_card_ids } = useCardBulkEditor(initial, 10)
+      toggleSelectAll()
+      expect(selected_card_ids.value).toHaveLength(2)
+    })
+
+    test('toggleSelectAll clears the selection when everything is selected', () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 })]
+      const { toggleSelectAll, selected_card_ids } = useCardBulkEditor(initial, 10)
+      toggleSelectAll()
+      toggleSelectAll()
+      expect(selected_card_ids.value).toEqual([])
+    })
+
+    test('all_cards_selected reflects full selection', () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 })]
+      const { selectAllCards, all_cards_selected } = useCardBulkEditor(initial, 10)
+      expect(all_cards_selected.value).toBe(false)
+      selectAllCards()
+      expect(all_cards_selected.value).toBe(true)
+    })
+  })
+
+  // ── getSelectedCards ───────────────────────────────────────────────────────
+
+  describe('getSelectedCards', () => {
+    test('returns selected cards with review stripped by default', () => {
+      const initial = [makeCard({ id: 1, review: { due: new Date() } }), makeCard({ id: 2 })]
+      const { selectCard, getSelectedCards } = useCardBulkEditor(initial, 10)
+      selectCard(1)
+      const [c] = getSelectedCards()
+      expect('review' in c).toBe(false)
+    })
+
+    test('preserves review when clean=false', () => {
+      const initial = [makeCard({ id: 1, review: { due: new Date() } })]
+      const { selectCard, getSelectedCards } = useCardBulkEditor(initial, 10)
+      selectCard(1)
+      const [c] = getSelectedCards(false)
+      expect('review' in c).toBe(true)
+    })
+  })
+
+  // ── deleteCards ────────────────────────────────────────────────────────────
+
+  describe('deleteCards', () => {
+    test('forwards selected cards to the API and clears selection', async () => {
+      const initial = [makeCard({ id: 1 }), makeCard({ id: 2 })]
+      const { selectCard, deleteCards, selected_card_ids } = useCardBulkEditor(initial, 10)
+      selectCard(1)
+      await deleteCards()
+      expect(deleteCardsMock).toHaveBeenCalledOnce()
+      expect(deleteCardsMock.mock.calls[0][0]).toHaveLength(1)
+      expect(selected_card_ids.value).toEqual([])
+    })
+
+    test('is a no-op when nothing is selected', async () => {
+      const { deleteCards } = useCardBulkEditor([makeCard({ id: 1 })], 10)
+      await deleteCards()
+      expect(deleteCardsMock).not.toHaveBeenCalled()
+    })
+
+    test('still clears selection when the API call rejects', async () => {
+      deleteCardsMock.mockRejectedValueOnce(new Error('boom'))
+      const { selectCard, deleteCards, selected_card_ids } = useCardBulkEditor(
+        [makeCard({ id: 1 })],
+        10
+      )
+      selectCard(1)
+      await deleteCards()
+      expect(selected_card_ids.value).toEqual([])
+    })
+  })
+
+  // ── resetCards / setMode / isDuplicate ─────────────────────────────────────
+
+  describe('resetCards / setMode / isDuplicate', () => {
+    test('resetCards replaces all_cards and optionally updates deck_id', async () => {
+      const { all_cards, resetCards, addCard } = useCardBulkEditor([makeCard({ id: 1 })], 10)
+      resetCards([makeCard({ id: 2 }), makeCard({ id: 3 })], 99)
+      expect(all_cards.value.map((c) => c.id)).toEqual([2, 3])
+      // deck_id updates are reflected in future addCard calls (via new_card.deck_id)
+      addCard()
+      expect(all_cards.value.at(-1).deck_id).toBe(99)
+    })
+
+    test('setMode updates the mode ref', () => {
+      const { mode, setMode } = useCardBulkEditor([], 10)
+      setMode('edit')
+      expect(mode.value).toBe('edit')
+    })
+
+    test('isDuplicate returns true when front_text matches another card', () => {
+      const initial = [
+        makeCard({ id: 1, front_text: 'same' }),
+        makeCard({ id: 2, front_text: 'same' })
+      ]
+      const { isDuplicate } = useCardBulkEditor(initial, 10)
+      expect(isDuplicate(initial[0])).toBe(true)
+    })
+
+    test('isDuplicate ignores empty cards', () => {
+      const initial = [
+        makeCard({ id: 1, front_text: '', back_text: '' }),
+        makeCard({ id: 2, front_text: '', back_text: '' })
+      ]
+      const { isDuplicate } = useCardBulkEditor(initial, 10)
+      expect(isDuplicate(initial[0])).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
> Stacked on \`refactor/decks-with-stats-view\`. Review after the base PR merges, or review the diff against the parent branch on the \"Files changed\" tab.

## Summary

Adding a card no longer creates an empty placeholder row on the server. The FE splices a card in-memory with a negative temp id; the first save routes through a new \`insert_card\` RPC that computes rank from neighbor IDs via \`card_rank_between\` inside an advisory lock keyed on the deck.

Net effect: empty rows no longer accumulate in the \`cards\` table from clicks that never get typed into, and there's no network round-trip just to \"click +\".

## Changes

- New migration \`20260416000003_insert-card-rpc.sql\` — \`insert_card(p_deck_id, p_left_card_id, p_right_card_id, p_front_text, p_back_text)\` with ownership check and advisory lock
- \`src/api/cards/insert.ts\` — replaces \`reserveCard\` with \`insertCard\`
- \`src/composables/card-bulk-editor.ts\` — \`addCard\` becomes in-memory (no network); \`updateCard\` routes to \`insertCard\` on temp IDs with \`findRealNeighbors\` skipping adjacent temps
- **Fix**: \`appendCard\`/\`prependCard\` had inverted left/right neighbor args. Was previously hidden because the old \`reserve_card\` RPC raised \`P0001\` on the bad ordering — under the new FE-first flow, this surfaced as \"new card appears in the wrong spot,\" matching a long-standing UX bug. Fixed here.
- \`src/views/deck/card-editor/list-item-card.vue\` — hides image upload buttons on temp cards (storage.media FK needs a persisted card)
- Extended pgTAP in \`00005_rpc_functions.sql\` — 4 new tests for \`insert_card\`
- New \`tests/unit/composables/card-bulk-editor.test.js\` — 39 unit tests (full coverage; the ones that failed against the broken \`appendCard\`/\`prependCard\` are what surfaced the bug)
- New \`tests/unit/api/cards/insert.test.js\` — 4 unit tests
- New \`tests/integration/views/deck/card-editor/list-item-card.test.js\` — 7 integration tests focused on the hidden-image-button behavior

## Test plan

- [ ] \`vp check\` / \`vp test\` / \`supabase test db\` all green
- [ ] Add a card, don't type, refresh → card vanishes (new behavior)
- [ ] Add A → type → add B between existing cards → type → ordering correct
- [ ] Add multiple temp cards, type into them out of order → neighbors resolve to real IDs
- [ ] Image upload button is hidden on a freshly-added temp card; appears after first keystroke