### PR TITLE
Per-member card storage paths + DB-enforced slot uniqueness

### DIFF
--- a/.claude/notes/cache-invalidation.md
+++ b/.claude/notes/cache-invalidation.md
@@ -1,0 +1,92 @@
+# Cache invalidation migration — notes for later
+
+Archived from a design conversation. Pick this up _after_ the BE cleanup work
+(kill `reserveCard`, move `fetchDeck` to a view, `setCardImage` dedupe trigger)
+has landed, since those changes simplify the migration surface.
+
+---
+
+## The problem this solves
+
+UI values drift out of sync with the backend. Most pressing: deck `due_count`.
+Also `card_count`, and anything derived-per-deck you add later.
+
+Root cause: **there's no invalidation layer**. The dashboard fetches decks once
+on mount; mutations that happen elsewhere in the tree don't signal back. Known
+drift points today:
+
+- Study session → dashboard: `useStudyModal().start()` is fire-and-forget; the
+  dashboard never learns a review was saved.
+- Deck-view mutations → dashboard: deck-view correctly calls `refetchDeck()`,
+  but the dashboard's `decks` ref isn't touched.
+- Any card edit that shifts a due date: no refetch anywhere.
+
+## The decision
+
+Adopt **TanStack Query (Vue Query)** as the single paradigm for server-state
+interactions. NOT Pinia-for-decks.
+
+**Why not a Pinia store for decks:** decks are _server state_ (fetched, cached,
+potentially stale). Pinia is well-suited to _client state_ (session, theme,
+modal stacks, shortcut registry). Putting server state in Pinia means manually
+re-implementing invalidation, refetch-on-focus, deduping, loading/error — which
+is just a worse query cache.
+
+**Clean split to aim for:**
+
+- Pinia → client state (session, member, theme, shortcuts, ephemeral UI)
+- Query cache → server state (decks, cards, reviews, media)
+
+## Scope
+
+- 35 exported API functions in `src/api/`
+- ~45 call sites across 18 files (5 composables, 7 views, 4 components, 2 stores)
+- ~150 lines of existing cache-adjacent logic (manual refetches, debounces,
+  optimistic inserts)
+- Estimate: one focused 2-week refactor, or ~4 weeks at 50% with normal feature
+  work interleaved
+
+## Suggested migration order (bottom-up by layer)
+
+1. **Set up Vue Query + design query-key convention** upfront
+   (`['decks']`, `['deck', id]`, `['cards', deckId]`, etc.) — ~1 day
+2. **Deck reads + mutations** — this alone fixes the original drift problem,
+   so it validates the pattern end-to-end. ~2 days
+3. **Members + shop** — small, self-contained. ~1 day
+4. **Card CRUD** — biggest call-site density. ~3 days
+5. **Images** — ~2 days
+6. **Hot paths last** (study session `saveReview`, bulk editor `saveCard`) —
+   needs behavioral validation. ~4 days
+7. **Auth** — can likely stay in Pinia since it's identity, not fetched data
+
+Each layer can ship independently. Step 2 is the one that fixes the drift.
+
+## Enforcement while migrating (avoid paradigm-mixing)
+
+Add a CI check from day one: grep for `@/api` imports outside approved query
+and mutation wrappers, and direct `supabase.` usage outside `src/api/`.
+Prevents drift toward a two-paradigm app during the multi-week window.
+
+## Sharp edges to plan for
+
+- **`saveCard` debounces inside the API layer** (`src/api/cards/update.ts`).
+  TanStack expects caller-side debouncing. Pull the debounce out of the API
+  and into the mutation wrapper.
+- **`saveReview` is fire-and-forget** during study sessions. `mutate()`
+  supports this natively but wire up real `onError` handling — today errors
+  are just logged and the session advances anyway.
+- **`reserveCard` as Q/M hybrid** — not a concern, it's being killed during
+  the pre-migration cleanup.
+- **`fetchDeck` coarse invalidation** — by the time this migration starts,
+  `fetchDeck` will be reading from the `decks_with_stats` view. Still worth
+  deciding whether to split query keys: `['deck', id]` vs `['cards', deckId]`
+  - `['reviews', cardId]`. Splitting lets card-level mutations invalidate
+    without refetching the whole deck aggregate.
+
+## Open decisions for when you pick this up
+
+- Keep auth in Pinia, or migrate it too? (Recommendation: keep it in Pinia.)
+- Granularity of query keys for cards/reviews inside a deck — single monolith
+  key vs split. Split is more work but aligns with mutation granularity.
+- Persistence layer for the cache? (localStorage for stale-while-revalidate on
+  reload.) Nice-to-have, not required for v1.

--- a/.claude/rules/learning-log.md
+++ b/.claude/rules/learning-log.md
@@ -30,3 +30,44 @@ After each backend teaching session, list the key concepts covered as touchpoint
 | Nullable ADD COLUMN (zero-downtime)   | 7     |
 | View column snapshotting / recreation | 7     |
 | security_invoker vs security_definer  | 4     |
+
+### 2026-04-16 — decks_with_stats view, cards_with_images retrofit
+
+| Concept                                    | Score |
+| ------------------------------------------ | ----- |
+| Views as a unified read shape              | 3     |
+| security_invoker on views                  | 9     |
+| Correlated subqueries                      | 4     |
+| Views replacing trigger-maintained columns | 8     |
+| View column snapshotting (second exposure) | 8     |
+
+### 2026-04-16 — insert_card RPC, plpgsql, advisory locks
+
+| Concept                                     | Score |
+| ------------------------------------------- | ----- |
+| Plpgsql syntax fundamentals                 | 6     |
+| Function return types as part of signatures | 7     |
+| RETURNING ... INTO                          | 6     |
+| Variable/column disambiguation              | 3     |
+| Advisory locks                              | 6     |
+| Fractional ranks + BE-owned rank            | 3     |
+
+### 2026-04-16 — media slot-dedupe trigger + unique partial index
+
+| Concept                                      | Score |
+| -------------------------------------------- | ----- |
+| Trigger function vs trigger (two-part split) | 8     |
+| NEW / OLD / TG_OP record variables           | 8     |
+| BEFORE vs AFTER triggers                     | 8     |
+| SECURITY INVOKER on trigger functions        | 9     |
+| Partial unique indexes                       | 6     |
+| Trigger (behavior) vs index (invariant)      | 7     |
+
+### 2026-04-16 — storage bucket + storage.objects RLS
+
+| Concept                                               | Score |
+| ----------------------------------------------------- | ----- |
+| storage.buckets declarative config (config.toml)      | 5     |
+| storage.objects RLS with owner column                 | 9     |
+| UPSERT requires SELECT policy (ON CONFLICT DO UPDATE) | 2     |
+| storage.foldername + path-based member isolation      | 8     |

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -5,6 +5,20 @@ paths:
 
 # Writing Tests
 
+## Before modifying a failing test
+
+**Highest priority when a test is failing: verify the failure isn't catching a real bug.** A failing test is a signal, not noise — the default assumption should be that the code under test (or a recently changed dependency) regressed, not that the test is wrong.
+
+Before touching the test file:
+
+1. Read the assertion that failed and the source code it exercises.
+2. Check whether recent changes to the source could have broken the behaviour the test was asserting.
+3. Run the test in isolation and confirm the failure mode (stale fixture, missing mock, actual regression).
+
+**If there's even a chance the test is catching a real bug, stop. Surface a concise message to the user** — name the test, the assertion, and your best read of the suspected bug — and wait for confirmation before proceeding. Do not edit the test, update fixtures, or add mocks on your own initiative when the failure might be meaningful.
+
+Only edit the test after you've either verified the source is correct and the test expectation is outdated, or the user has explicitly confirmed to proceed.
+
 ## Test type selection
 
 | Priority | Type            | Environment        | When to use                                                           |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ vp test          # run tests with coverage
 vp check         # format + lint + type-check
 ```
 
-Local Supabase runs on port 54321 (API) and 54322 (Postgres). Start it with `supabase start`, then seed storage buckets with `supabase seed buckets --local`. See [Supabase setup](docs/src/supabase/index.md) for details.
+Local Supabase runs on port 54321 (API) and 54322 (Postgres). Start it with `supabase start` and apply migrations with `supabase migration up`. See [Supabase setup](docs/src/supabase/index.md) for details.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ vp test          # run tests with coverage
 vp check         # format + lint + type-check
 ```
 
-Local Supabase runs on port 54321 (API) and 54322 (Postgres). Start it with `supabase start`.
+Local Supabase runs on port 54321 (API) and 54322 (Postgres). Start it with `supabase start`, then seed storage buckets with `supabase seed buckets --local`. See [Supabase setup](docs/src/supabase/index.md) for details.
 
 ---
 

--- a/docs/src/supabase/index.md
+++ b/docs/src/supabase/index.md
@@ -39,38 +39,18 @@ supabase migration up
 
 ---
 
-## Provision storage buckets
+## Storage buckets
 
-Storage buckets are declared in `supabase/config.toml` under
-`[storage.buckets.<name>]` blocks — for example:
+Buckets are provisioned via SQL migrations (not `config.toml`), so
+`supabase migration up` creates them in every environment — local,
+staging, production — with no separate step.
 
-```toml
-[storage.buckets.cards]
-public = true
-file_size_limit = "10MiB"
-allowed_mime_types = ["image/png", "image/jpeg", "image/webp", "image/gif"]
-```
+See `supabase/migrations/20260416000007_cards-bucket.sql` as the pattern:
+a single `INSERT ... ON CONFLICT (id) DO UPDATE` on `storage.buckets`.
+The `ON CONFLICT` clause makes it idempotent and lets follow-up migrations
+edit settings (public flag, file-size limit, MIME allowlist) by writing
+new INSERTs against the same `id`.
 
-**Local**
-
-`supabase start` does **not** auto-provision declarative buckets. After the
-initial `supabase start`, and any time you wipe the local stack (e.g.
-`supabase stop` + fresh volume), run:
-
-```bash
-supabase seed buckets --local
-```
-
-This reads `config.toml` and creates any missing buckets. Requires Supabase
-CLI ≥ 2.90. If you hit `Bucket not found` during an upload in local dev,
-this is the first thing to try.
-
-Bucket-scoped RLS policies on `storage.objects` are tracked as normal SQL
-migrations (e.g. `20260416000005_cards-bucket-storage-policies.sql`) and
-apply via `supabase migrations up`.
-
-**Staging / Production**
-
-Buckets in linked projects are managed in the Supabase dashboard (Storage
-tab) and don't require the `seed` command. Keep `config.toml` as the source
-of truth and mirror the settings manually in the dashboard.
+Bucket-scoped RLS policies on `storage.objects` live in adjacent migrations
+(e.g. `20260416000005_cards-bucket-storage-policies.sql`) and apply
+through the same `migration up` flow.

--- a/docs/src/supabase/index.md
+++ b/docs/src/supabase/index.md
@@ -36,3 +36,41 @@ Link the CLI to the project, then push:
 supabase link --project-ref <project-ref>
 supabase migration up
 ```
+
+---
+
+## Provision storage buckets
+
+Storage buckets are declared in `supabase/config.toml` under
+`[storage.buckets.<name>]` blocks — for example:
+
+```toml
+[storage.buckets.cards]
+public = true
+file_size_limit = "10MiB"
+allowed_mime_types = ["image/png", "image/jpeg", "image/webp", "image/gif"]
+```
+
+**Local**
+
+`supabase start` does **not** auto-provision declarative buckets. After the
+initial `supabase start`, and any time you wipe the local stack (e.g.
+`supabase stop` + fresh volume), run:
+
+```bash
+supabase seed buckets --local
+```
+
+This reads `config.toml` and creates any missing buckets. Requires Supabase
+CLI ≥ 2.90. If you hit `Bucket not found` during an upload in local dev,
+this is the first thing to try.
+
+Bucket-scoped RLS policies on `storage.objects` are tracked as normal SQL
+migrations (e.g. `20260416000005_cards-bucket-storage-policies.sql`) and
+apply via `supabase migrations up`.
+
+**Staging / Production**
+
+Buckets in linked projects are managed in the Supabase dashboard (Storage
+tab) and don't require the `seed` command. Keep `config.toml` as the source
+of truth and mirror the settings manually in the dashboard.

--- a/src/api/cards/update.ts
+++ b/src/api/cards/update.ts
@@ -1,7 +1,8 @@
 import { supabase } from '@/supabase-client'
 import logger from '@/utils/logger'
 import { DateTime } from 'luxon'
-import { uploadImage, insertMedia, deleteMediaByPath, deduplicateSlotMedia } from '@/api/media'
+import { uploadImage, insertMedia } from '@/api/media'
+import { useMemberStore } from '@/stores/member'
 import uid from '@/utils/uid'
 import { debounce } from '@/utils/debounce'
 import { buildCardPayload, hasCardChanges } from '@/utils/card/payload'
@@ -93,31 +94,21 @@ export async function moveCardsToDeck(cards: CardBase[], deck_id: number): Promi
 }
 
 export async function setCardImage(card_id: number, file: File, side: 'front' | 'back') {
+  const member_id = useMemberStore().id
+  if (!member_id) throw new Error('Not authenticated')
+
   const bucket = 'cards'
   const slot = `card_${side}` as const
-  const path = `${card_id}/${side}/${uid()}.${file.type.split('/')[1]}`
+  // Path includes member_id so any viewer (not just the owner) builds a
+  // correct storage URL. The storage policies enforce that only the owner
+  // can INSERT/UPDATE/DELETE under their own folder.
+  const path = `${member_id}/${card_id}/${side}/${uid()}.${file.type.split('/')[1]}`
 
-  // Insert the DB record first. If the upload then fails we can easily delete
-  // this row — it's safer than orphaning a storage file with no DB record.
+  // Upload first so we don't soft-delete the previous image (via the DB
+  // trigger on insertMedia) until the new file is actually in storage.
+  // Failure mode: upload fails → nothing changed.
+  //                insertMedia fails → storage file is orphaned, reaped by
+  //                cleanup-media cron.
+  await uploadImage(bucket, path, file)
   await insertMedia({ bucket, path, card_id, slot })
-
-  try {
-    await uploadImage(bucket, path, file)
-  } catch (e) {
-    // Upload failed — roll back the DB record. Log if the rollback itself fails
-    // so the dangling row is visible in logs.
-    deleteMediaByPath(card_id, path).catch((rollbackErr) =>
-      logger.error(
-        `Failed to rollback media record after upload failure — path: ${path}`,
-        rollbackErr
-      )
-    )
-    throw e
-  }
-
-  // Soft-delete previous records for this slot so card_with_images doesn't
-  // return duplicate rows when joining on (card_id, slot, deleted_at IS NULL).
-  await deduplicateSlotMedia(card_id, slot, path).catch((err) =>
-    logger.error('Failed to dedup slot media after upload:', err)
-  )
 }

--- a/src/api/media.ts
+++ b/src/api/media.ts
@@ -1,17 +1,8 @@
 import { supabase } from '@/supabase-client'
-import { useMemberStore } from '@/stores/member'
 import logger from '@/utils/logger'
 
 export async function uploadImage(bucket: string, path: string, file: File): Promise<string> {
-  const member_id = useMemberStore().id
-
-  if (!member_id) {
-    throw new Error('Not authenticated')
-  }
-
-  const full_path = `${member_id}/${path}`
-
-  const { error } = await supabase.storage.from(bucket).upload(full_path, file, { upsert: true })
+  const { error } = await supabase.storage.from(bucket).upload(path, file, { upsert: true })
 
   if (error) {
     logger.error(`Error uploading file: ${error.message}`)
@@ -22,14 +13,7 @@ export async function uploadImage(bucket: string, path: string, file: File): Pro
 }
 
 export async function deleteImage(bucket: string, path: string): Promise<void> {
-  const member_id = useMemberStore().id
-
-  if (!member_id) {
-    throw new Error('Not authenticated')
-  }
-
-  const full_path = `${member_id}/${path}`
-  const { error } = await supabase.storage.from(bucket).remove([full_path])
+  const { error } = await supabase.storage.from(bucket).remove([path])
 
   if (error) {
     logger.error(`Error deleting file: ${error.message}`)
@@ -38,15 +22,7 @@ export async function deleteImage(bucket: string, path: string): Promise<void> {
 }
 
 export function getImageUrl(bucket: string, path: string): string {
-  const member_id = useMemberStore().id
-
-  if (!member_id) {
-    throw new Error('Not authenticated')
-  }
-
-  const full_path = `${member_id}/${path}`
-
-  return supabase.storage.from(bucket).getPublicUrl(full_path).data.publicUrl
+  return supabase.storage.from(bucket).getPublicUrl(path).data.publicUrl
 }
 
 export async function insertMedia(params: Media): Promise<void> {
@@ -67,39 +43,6 @@ export async function deleteMedia(id: string): Promise<void> {
 
   if (error) {
     logger.error(`Failed to delete media: ${error}`)
-    throw error
-  }
-}
-
-// Hard-deletes a specific media record by card + storage path.
-// Used to roll back an insertMedia when a subsequent upload fails.
-export async function deleteMediaByPath(card_id: number, path: string): Promise<void> {
-  const { error } = await supabase.from('media').delete().eq('card_id', card_id).eq('path', path)
-
-  if (error) {
-    logger.error(`Failed to delete media by path: ${error}`)
-    throw error
-  }
-}
-
-// Soft-deletes all active media records for a given card slot except the one
-// at keep_path. Prevents the card_with_images view from joining multiple active
-// rows for the same slot and returning duplicate cards.
-export async function deduplicateSlotMedia(
-  card_id: number,
-  slot: string,
-  keep_path: string
-): Promise<void> {
-  const { error } = await supabase
-    .from('media')
-    .update({ deleted_at: new Date().toISOString() })
-    .eq('card_id', card_id)
-    .eq('slot', slot)
-    .neq('path', keep_path)
-    .is('deleted_at', null)
-
-  if (error) {
-    logger.error(`Failed to dedup slot media: ${error}`)
     throw error
   }
 }

--- a/src/composables/deck-editor.ts
+++ b/src/composables/deck-editor.ts
@@ -2,6 +2,7 @@ import { reactive, ref } from 'vue'
 import { deleteDeck as upstreamDeleteDeck } from '@/api/decks'
 import { uploadImage as uploadImageToStorage } from '@/api/media'
 import { useDeckActions } from '@/composables/deck/use-deck-actions'
+import { useMemberStore } from '@/stores/member'
 import type { ImageUploadPayload } from '@/components/image-uploader.vue'
 
 export function useDeckEditor(deck?: Deck) {
@@ -70,8 +71,11 @@ export function useDeckEditor(deck?: Deck) {
     cover_image_preview.value = payload.preview
     cover_image_loading.value = true
     try {
+      const member_id = useMemberStore().id
+      if (!member_id) throw new Error('Not authenticated')
       const deck_id = settings.id
-      const path = deck_id ? `covers/${deck_id}` : `covers/draft-${crypto.randomUUID()}`
+      const leaf = deck_id ? `covers/${deck_id}` : `covers/draft-${crypto.randomUUID()}`
+      const path = `${member_id}/${leaf}`
       const url = await uploadImageToStorage('decks', path, payload.file)
       cover.bg_image = url
       cover_image_preview.value = url

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -109,6 +109,11 @@ file_size_limit = "50MiB"
 # allowed_mime_types = ["image/png", "image/jpeg"]
 # objects_path = "./images"
 
+[storage.buckets.cards]
+public = true
+file_size_limit = "10MiB"
+allowed_mime_types = ["image/png", "image/jpeg", "image/webp", "image/gif"]
+
 [auth]
 enabled = true
 site_url = "http://localhost:5173"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -109,10 +109,10 @@ file_size_limit = "50MiB"
 # allowed_mime_types = ["image/png", "image/jpeg"]
 # objects_path = "./images"
 
-[storage.buckets.cards]
-public = true
-file_size_limit = "10MiB"
-allowed_mime_types = ["image/png", "image/jpeg", "image/webp", "image/gif"]
+# Storage buckets are provisioned via SQL migrations (see
+# supabase/migrations/20260416000007_cards-bucket.sql) rather than the
+# declarative config above, so a single `supabase migration up` covers
+# local, staging, and production consistently.
 
 [auth]
 enabled = true

--- a/supabase/migrations/20260416000004_media-slot-dedupe-trigger.sql
+++ b/supabase/migrations/20260416000004_media-slot-dedupe-trigger.sql
@@ -1,0 +1,63 @@
+-- =============================================================================
+-- media slot-dedupe trigger + unique partial index
+-- =============================================================================
+--
+-- Enforces the invariant that at most one *active* (non-soft-deleted) media
+-- row exists per (card_id, slot). Previously enforced by convention in the
+-- client-side setCardImage function. Moving the rule into the DB means:
+--
+--   1. The invariant holds regardless of which code path inserts media —
+--      client, edge function, admin SQL, or a future API endpoint.
+--   2. setCardImage on the FE becomes a single insert instead of three
+--      coordinated operations.
+--
+-- Two complementary mechanisms:
+--
+--   - A BEFORE INSERT trigger that soft-deletes prior rows before the new
+--     row lands. This is the "graceful" enforcement: callers just insert,
+--     the old row gets retired automatically.
+--
+--   - A unique partial index as belt-and-suspenders: if any code path
+--     bypasses the trigger (e.g. ALTER TRIGGER ... DISABLE) or races past
+--     it, a duplicate insert fails with a unique-constraint violation
+--     instead of silently producing two active rows.
+--
+-- BEFORE INSERT (not AFTER) is required because the unique index check
+-- fires before AFTER triggers. With AFTER INSERT the second upload would
+-- error on the index check before the trigger had a chance to retire the
+-- first row. BEFORE INSERT runs before the check, so it can soft-delete
+-- the prior row into a state where the new insert passes uniqueness.
+-- =============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.dedupe_media_slot_on_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+  IF NEW.card_id IS NOT NULL AND NEW.slot IS NOT NULL THEN
+    UPDATE public.media
+    SET deleted_at = now()
+    WHERE card_id = NEW.card_id
+      AND slot = NEW.slot
+      AND deleted_at IS NULL;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_media_dedupe_slot
+  BEFORE INSERT ON public.media
+  FOR EACH ROW
+  EXECUTE FUNCTION public.dedupe_media_slot_on_insert();
+
+-- The non-unique performance index at 20260411000003 stays; this adds
+-- uniqueness as the enforced invariant.
+CREATE UNIQUE INDEX IF NOT EXISTS media_card_slot_active_uniq
+  ON public.media (card_id, slot)
+  WHERE deleted_at IS NULL AND card_id IS NOT NULL;
+
+COMMIT;

--- a/supabase/migrations/20260416000005_cards-bucket-storage-policies.sql
+++ b/supabase/migrations/20260416000005_cards-bucket-storage-policies.sql
@@ -1,0 +1,70 @@
+-- =============================================================================
+-- storage.objects RLS policies for the `cards` bucket
+-- =============================================================================
+--
+-- Path shape: `<member_id>/<card_id>/<side>/<uid>.<ext>` — set in
+-- src/api/media.ts:setCardImage. The first path segment is the uploader's
+-- member_id; `storage.foldername(name)[1]` extracts it.
+--
+-- Four policies (SELECT/INSERT/UPDATE/DELETE) all gated on
+-- `auth.uid()::text = foldername[1]`, enforcing per-member isolation end
+-- to end.
+--
+-- The SELECT policy is load-bearing even for non-SELECT operations:
+-- supabase-js's upload-with-upsert emits `INSERT ... ON CONFLICT DO UPDATE`,
+-- which requires SELECT permission for the conflict check. Without it,
+-- every upload fails with a generic "new row violates RLS" error.
+--
+-- DROP IF EXISTS is at the top so this migration re-applies cleanly after
+-- a `migration repair --status reverted` (only while the branch is still
+-- in development — see the "editing migrations" rule).
+-- =============================================================================
+
+BEGIN;
+
+DROP POLICY IF EXISTS "cards_bucket_authenticated_select" ON storage.objects;
+DROP POLICY IF EXISTS "cards_bucket_authenticated_insert" ON storage.objects;
+DROP POLICY IF EXISTS "cards_bucket_authenticated_update" ON storage.objects;
+DROP POLICY IF EXISTS "cards_bucket_authenticated_delete" ON storage.objects;
+
+CREATE POLICY "cards_bucket_authenticated_select"
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (
+  bucket_id = 'cards'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "cards_bucket_authenticated_insert"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'cards'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "cards_bucket_authenticated_update"
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'cards'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+)
+WITH CHECK (
+  bucket_id = 'cards'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "cards_bucket_authenticated_delete"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'cards'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+);
+
+COMMIT;

--- a/supabase/migrations/20260416000006_media-path-include-member-id.sql
+++ b/supabase/migrations/20260416000006_media-path-include-member-id.sql
@@ -1,0 +1,31 @@
+-- =============================================================================
+-- Backfill media.path to match the storage key (prepend member_id)
+-- =============================================================================
+--
+-- Historically the FE stored `media.path` as `<card_id>/<side>/<uid>.<ext>`
+-- but uploaded to storage at `<member_id>/<card_id>/<side>/<uid>.<ext>`.
+-- getImageUrl() compensated by prepending the CURRENT viewer's member_id —
+-- which breaks when viewing another member's public deck (viewer id ≠
+-- owner id, URL 404s).
+--
+-- Fix: media.path should hold the full storage key. This migration
+-- backfills existing rows so media.path == the actual storage location.
+-- Going forward, the FE writes the full path on insert (see updated
+-- setCardImage).
+--
+-- Scope: only card-scoped media (card_id IS NOT NULL). Deck cover images
+-- use the `decks` bucket with a different path convention and aren't
+-- affected.
+--
+-- Idempotent: skips rows whose path already starts with member_id/.
+-- =============================================================================
+
+BEGIN;
+
+UPDATE public.media
+SET path = member_id::text || '/' || path
+WHERE card_id IS NOT NULL
+  AND member_id IS NOT NULL
+  AND path NOT LIKE member_id::text || '/%';
+
+COMMIT;

--- a/supabase/migrations/20260416000007_cards-bucket.sql
+++ b/supabase/migrations/20260416000007_cards-bucket.sql
@@ -1,0 +1,31 @@
+-- =============================================================================
+-- Create the `cards` storage bucket
+-- =============================================================================
+--
+-- Lives in a migration (not config.toml) so a single `supabase migration up`
+-- provisions the bucket in any environment — local, staging, or production.
+-- `config.toml`'s [storage.buckets.X] syntax requires a separate
+-- `supabase seed buckets` command and doesn't apply on deploy, which made
+-- stage/prod environments diverge.
+--
+-- Idempotent via ON CONFLICT DO UPDATE: re-running the migration is a no-op
+-- when settings match, and propagates changes when a new migration edits
+-- the VALUES clause or adds a follow-up UPDATE.
+-- =============================================================================
+
+BEGIN;
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'cards',
+  'cards',
+  true,
+  10485760, -- 10 MiB
+  ARRAY['image/png', 'image/jpeg', 'image/webp', 'image/gif']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public             = EXCLUDED.public,
+  file_size_limit    = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+COMMIT;

--- a/supabase/tests/00006_triggers.sql
+++ b/supabase/tests/00006_triggers.sql
@@ -1,5 +1,5 @@
 -- =============================================================================
--- Trigger tests: set_member_id
+-- Trigger tests: set_member_id, dedupe_media_slot_on_insert
 --
 -- The update_deck_card_count trigger + decks.card_count column were removed
 -- in 20260416000002_drop-deck-card-count-column.sql — per-deck counts are
@@ -8,7 +8,7 @@
 
 BEGIN;
 
-SELECT plan(2);
+SELECT plan(5);
 
 -- ── Setup ─────────────────────────────────────────────────────────────────────
 
@@ -40,6 +40,72 @@ SELECT is(
   '11111111-1111-1111-1111-111111111111'::uuid,
   'set_member_id trigger stamps auth.uid() on card insert'
 );
+
+
+-- ── dedupe_media_slot_on_insert trigger ───────────────────────────────────────
+
+-- Setup: insert two media rows for the same (card_id, slot) back-to-back
+-- as the authenticated user (the set_member_id_on_media trigger needs
+-- auth.uid() to stamp member_id). The first should be soft-deleted by the
+-- dedupe trigger when the second row lands.
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+SET LOCAL role = 'authenticated';
+
+INSERT INTO public.media (card_id, slot, bucket, path)
+VALUES (1000, 'card_front'::public.media_slot, 'cards', 'first.png');
+
+INSERT INTO public.media (card_id, slot, bucket, path)
+VALUES (1000, 'card_front'::public.media_slot, 'cards', 'second.png');
+
+SET LOCAL role = 'postgres';
+
+-- Test 3: Exactly one active row remains per (card_id, slot)
+SELECT is(
+  (SELECT count(*) FROM public.media
+   WHERE card_id = 1000
+     AND slot = 'card_front'::public.media_slot
+     AND deleted_at IS NULL)::int,
+  1,
+  'exactly one active media row remains after second insert on same (card_id, slot)'
+);
+
+-- Test 4: Different slots are independent — inserting card_back doesn't
+-- touch card_front.
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+SET LOCAL role = 'authenticated';
+
+INSERT INTO public.media (card_id, slot, bucket, path)
+VALUES (1000, 'card_back'::public.media_slot, 'cards', 'back.png');
+
+SET LOCAL role = 'postgres';
+
+SELECT is(
+  (SELECT count(*) FROM public.media
+   WHERE card_id = 1000 AND deleted_at IS NULL)::int,
+  2,
+  'card_front and card_back are independent — no cross-slot dedupe'
+);
+
+-- Test 5: If the trigger is bypassed, the unique partial index catches the
+-- duplicate. Disable the trigger, then try to insert a second active row
+-- for the same (card_id, slot) — expect a unique-violation error (SQLSTATE 23505).
+ALTER TABLE public.media DISABLE TRIGGER trg_media_dedupe_slot;
+
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+SET LOCAL role = 'authenticated';
+
+SELECT throws_ok(
+  $$
+    INSERT INTO public.media (card_id, slot, bucket, path)
+    VALUES (1000, 'card_front'::public.media_slot, 'cards', 'bypass.png')
+  $$,
+  '23505',
+  NULL,
+  'unique partial index blocks a duplicate active row when the trigger is bypassed'
+);
+
+SET LOCAL role = 'postgres';
+ALTER TABLE public.media ENABLE TRIGGER trg_media_dedupe_slot;
 
 
 SELECT * FROM finish();

--- a/supabase/tests/00010_cards_bucket_storage_rls.sql
+++ b/supabase/tests/00010_cards_bucket_storage_rls.sql
@@ -1,0 +1,112 @@
+-- =============================================================================
+-- RLS tests: storage.objects policies for the `cards` bucket
+--
+-- Enforces per-member isolation via owner::text = foldername[1]. The SELECT
+-- policy is required even on pure INSERTs because supabase-js's
+-- upload-with-upsert flow emits INSERT ... ON CONFLICT DO UPDATE, which
+-- needs SELECT privilege for the conflict-check step.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(5);
+
+-- ── Setup ─────────────────────────────────────────────────────────────────────
+
+SELECT tests.create_user('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid, 'alice_storage');
+SELECT tests.create_user('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid, 'bob_storage');
+
+
+-- ── Act as Alice ──────────────────────────────────────────────────────────────
+SELECT tests.set_claims('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 1: Alice can INSERT into her own folder.
+SELECT lives_ok(
+  $$
+    INSERT INTO storage.objects (bucket_id, name, owner, owner_id)
+    VALUES (
+      'cards',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    )
+  $$,
+  'Alice can INSERT into her own member-scoped folder'
+);
+
+-- Test 2: Alice cannot INSERT into Bob's folder (owner::text ≠ foldername[1]).
+SELECT throws_ok(
+  $$
+    INSERT INTO storage.objects (bucket_id, name, owner, owner_id)
+    VALUES (
+      'cards',
+      'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb/42/front/hack.png',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    )
+  $$,
+  '42501',
+  NULL,
+  'Alice cannot INSERT into Bob''s folder — policy rejects mismatched owner/path'
+);
+
+-- Test 3: UPSERT (INSERT ... ON CONFLICT DO UPDATE) succeeds for Alice's own
+-- row. This is the shape supabase-js emits when upload({ upsert: true }) is
+-- called. Without the SELECT policy this would fail even with no conflicting
+-- row, because Postgres needs SELECT for the conflict check.
+SELECT lives_ok(
+  $$
+    INSERT INTO storage.objects (bucket_id, name, owner, owner_id, version)
+    VALUES (
+      'cards',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      'v2'
+    )
+    ON CONFLICT (name, bucket_id) DO UPDATE SET version = EXCLUDED.version
+  $$,
+  'UPSERT into Alice''s own folder succeeds (SELECT policy permits conflict check)'
+);
+
+
+-- ── Act as Bob — confirm cross-member isolation ──────────────────────────────
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 4: Bob does not see Alice's object via storage.objects SELECT.
+-- (Public-URL fetches bypass RLS; that path is unaffected. This covers the
+-- programmatic SELECT path used by list()/download()/upsert-conflict-check.)
+SELECT is(
+  (SELECT count(*) FROM storage.objects
+   WHERE name = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png'
+     AND bucket_id = 'cards')::int,
+  0,
+  'Bob cannot SELECT Alice''s object through storage.objects RLS'
+);
+
+-- Test 5: Bob cannot UPDATE a row in Alice's folder.
+UPDATE storage.objects
+SET version = 'hacked'
+WHERE name = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png'
+  AND bucket_id = 'cards';
+
+SET LOCAL role = 'postgres';
+SELECT isnt(
+  (SELECT version FROM storage.objects
+   WHERE name = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png'
+     AND bucket_id = 'cards'),
+  'hacked',
+  'Bob cannot UPDATE rows in Alice''s folder'
+);
+
+-- Direct DELETE against storage.objects is globally blocked by Supabase's
+-- `storage.protect_delete` trigger regardless of RLS, so DELETE policy
+-- enforcement has to be verified at the integration layer (manual upload
+-- replacement test), not in pgTAP.
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/unit/api/cards/update.test.js
+++ b/tests/unit/api/cards/update.test.js
@@ -1,39 +1,74 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 
-const { singleMock } = vi.hoisted(() => ({
-  singleMock: vi.fn().mockResolvedValue({ data: {}, error: null })
+const mocks = vi.hoisted(() => ({
+  singleMock: vi.fn(),
+  selectMock: vi.fn(),
+  upsertMock: vi.fn(),
+  rpcMock: vi.fn(),
+  uploadImageMock: vi.fn(),
+  insertMediaMock: vi.fn(),
+  memberIdRef: { value: 'member-uuid-1' }
 }))
 
-// Fake supabase client that captures the upsert payload via the `single()` mock.
+// Minimal supabase mock:
+// - `from('cards').upsert(payload, opts?)` returns a chainable object whose
+//   `.select().single()` resolves via `singleMock` and whose `.select()` alone
+//   resolves via `selectMock`. Bare `.upsert(...)` (no chain) resolves via
+//   `upsertMock`.
+// - `rpc(name, params)` resolves via `rpcMock`.
 vi.mock('@/supabase-client', () => ({
   supabase: {
     from: () => ({
-      upsert: (payload) => {
-        singleMock.__lastPayload = payload
-        return {
-          select: () => ({
-            single: () => singleMock({ data: payload, error: null })
-          })
+      upsert: (payload, opts) => {
+        const chain = {
+          select: () => {
+            mocks.selectMock.__payload = payload
+            const withSingle = {
+              single: () => mocks.singleMock({ data: payload, error: null, opts })
+            }
+            // The upsertCards path doesn't chain .single(), so thenify the
+            // select() result itself.
+            return Object.assign(withSingle, {
+              then: (resolve, reject) =>
+                mocks.selectMock({ data: payload, error: null, opts }).then(resolve, reject)
+            })
+          },
+          then: (resolve, reject) => mocks.upsertMock({ payload, opts }).then(resolve, reject)
         }
+        return chain
       }
-    })
+    }),
+    rpc: (...args) => mocks.rpcMock(...args)
   }
 }))
 
-vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
 vi.mock('@/api/media', () => ({
-  uploadImage: vi.fn(),
-  insertMedia: vi.fn(),
-  deleteMediaByPath: vi.fn(),
-  deduplicateSlotMedia: vi.fn()
+  uploadImage: mocks.uploadImageMock,
+  insertMedia: mocks.insertMediaMock
 }))
+
+vi.mock('@/stores/member', () => ({
+  useMemberStore: () => ({ id: mocks.memberIdRef.value })
+}))
+
+vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
 
 // Call the debounced fn immediately so saveCard resolves synchronously.
 vi.mock('@/utils/debounce', () => ({
   debounce: vi.fn((fn) => fn())
 }))
 
-import { saveCard } from '@/api/cards/update'
+// Deterministic uid so path assertions are stable.
+vi.mock('@/utils/uid', () => ({ default: () => 'FIXED_UID' }))
+
+import {
+  saveCard,
+  upsertCard,
+  upsertCards,
+  reorderCard,
+  moveCardsToDeck,
+  setCardImage
+} from '@/api/cards/update'
 import { debounce } from '@/utils/debounce'
 
 function makeCard(overrides = {}) {
@@ -48,34 +83,41 @@ function makeCard(overrides = {}) {
   }
 }
 
-function lastUpsertPayload() {
-  return singleMock.__lastPayload
-}
+beforeEach(() => {
+  mocks.singleMock.mockReset()
+  mocks.singleMock.mockResolvedValue({ data: {}, error: null })
+  mocks.selectMock.mockReset()
+  mocks.selectMock.mockResolvedValue({ data: [], error: null })
+  mocks.upsertMock.mockReset()
+  mocks.upsertMock.mockResolvedValue({ error: null })
+  mocks.rpcMock.mockReset()
+  mocks.rpcMock.mockResolvedValue({ error: null })
+  mocks.uploadImageMock.mockReset()
+  mocks.uploadImageMock.mockResolvedValue('https://cdn/x')
+  mocks.insertMediaMock.mockReset()
+  mocks.insertMediaMock.mockResolvedValue(undefined)
+  mocks.memberIdRef.value = 'member-uuid-1'
+  vi.mocked(debounce).mockClear()
+})
 
 describe('saveCard', () => {
-  beforeEach(() => {
-    singleMock.mockClear()
-    singleMock.__lastPayload = undefined
-    vi.mocked(debounce).mockClear()
-  })
-
   test('mutates card in place and upserts when values change', async () => {
     const card = makeCard()
     await saveCard(card, { front_text: 'Updated' })
     expect(card.front_text).toBe('Updated')
-    expect(singleMock).toHaveBeenCalled()
+    expect(mocks.singleMock).toHaveBeenCalled()
   })
 
   test('skips upsert when values are unchanged', async () => {
     const card = makeCard()
     await saveCard(card, { front_text: card.front_text })
-    expect(singleMock).not.toHaveBeenCalled()
+    expect(mocks.singleMock).not.toHaveBeenCalled()
   })
 
   test('skips upsert when card has no id', async () => {
     const card = makeCard({ id: 0 })
     await saveCard(card, { front_text: 'New' })
-    expect(singleMock).not.toHaveBeenCalled()
+    expect(mocks.singleMock).not.toHaveBeenCalled()
   })
 
   test('keys the debounce by card id so concurrent card edits do not supersede each other', async () => {
@@ -84,11 +126,129 @@ describe('saveCard', () => {
     expect(debounce).toHaveBeenCalledWith(expect.any(Function), { key: `card-${card.id}` })
   })
 
-  test('sends the built payload (runtime-only fields stripped)', async () => {
+  test('strips runtime-only fields (review, state) from the upsert payload', async () => {
     const card = { ...makeCard(), review: { due: new Date() }, state: 'unreviewed' }
     await saveCard(card, { front_text: 'X' })
-    const payload = lastUpsertPayload()
+    const payload = mocks.selectMock.__payload
     expect('review' in payload).toBe(false)
     expect('state' in payload).toBe(false)
+  })
+})
+
+describe('upsertCard', () => {
+  test('upserts a single card on the cards table with onConflict: id', async () => {
+    await upsertCard(makeCard({ front_text: 'New' }))
+    expect(mocks.singleMock).toHaveBeenCalled()
+    const { opts } = mocks.singleMock.mock.calls[0][0]
+    expect(opts).toEqual({ onConflict: 'id' })
+  })
+
+  test('stamps updated_at on the payload', async () => {
+    await upsertCard(makeCard())
+    const { data } = mocks.singleMock.mock.calls[0][0]
+    expect(data.updated_at).toBeTruthy()
+  })
+
+  test('throws when the DB returns an error', async () => {
+    mocks.singleMock.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+    await expect(upsertCard(makeCard())).rejects.toThrow('boom')
+  })
+})
+
+describe('upsertCards', () => {
+  test('stamps updated_at on every card in the batch', async () => {
+    await upsertCards([makeCard({ id: 1 }), makeCard({ id: 2 })])
+    const payload = mocks.selectMock.__payload
+    expect(payload).toHaveLength(2)
+    expect(payload.every((c) => c.updated_at)).toBe(true)
+  })
+
+  test('throws when the DB returns an error', async () => {
+    mocks.selectMock.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+    await expect(upsertCards([makeCard()])).rejects.toThrow('boom')
+  })
+})
+
+describe('reorderCard', () => {
+  test('calls reorder_card RPC with the neighbor IDs', async () => {
+    await reorderCard(42, 10, 20)
+    expect(mocks.rpcMock).toHaveBeenCalledWith('reorder_card', {
+      p_card_id: 42,
+      p_left_card_id: 10,
+      p_right_card_id: 20
+    })
+  })
+
+  test('coerces undefined neighbors to null for the RPC', async () => {
+    await reorderCard(42)
+    const [, args] = mocks.rpcMock.mock.calls[0]
+    expect(args.p_left_card_id).toBeNull()
+    expect(args.p_right_card_id).toBeNull()
+  })
+
+  test('throws when the RPC returns an error', async () => {
+    mocks.rpcMock.mockResolvedValueOnce({ error: { message: 'denied' } })
+    await expect(reorderCard(42)).rejects.toThrow('denied')
+  })
+})
+
+describe('moveCardsToDeck', () => {
+  test('sets deck_id on every card and upserts the batch', async () => {
+    await moveCardsToDeck([makeCard({ id: 1 }), makeCard({ id: 2 })], 99)
+    const { payload } = mocks.upsertMock.mock.calls[0][0]
+    expect(payload).toHaveLength(2)
+    expect(payload.every((c) => c.deck_id === 99)).toBe(true)
+  })
+
+  test('throws when the upsert fails', async () => {
+    mocks.upsertMock.mockResolvedValueOnce({ error: { message: 'rls' } })
+    await expect(moveCardsToDeck([makeCard()], 99)).rejects.toThrow('rls')
+  })
+})
+
+describe('setCardImage', () => {
+  test('builds the path with member_id/card_id/side/uid.ext and uploads first, then inserts media', async () => {
+    const call_order = []
+    mocks.uploadImageMock.mockImplementationOnce(async () => call_order.push('upload'))
+    mocks.insertMediaMock.mockImplementationOnce(async () => call_order.push('insert'))
+
+    const file = new File(['x'], 'f.png', { type: 'image/png' })
+    await setCardImage(42, file, 'front')
+
+    expect(mocks.uploadImageMock).toHaveBeenCalledWith(
+      'cards',
+      'member-uuid-1/42/front/FIXED_UID.png',
+      file
+    )
+    expect(mocks.insertMediaMock).toHaveBeenCalledWith({
+      bucket: 'cards',
+      path: 'member-uuid-1/42/front/FIXED_UID.png',
+      card_id: 42,
+      slot: 'card_front'
+    })
+    expect(call_order).toEqual(['upload', 'insert'])
+  })
+
+  test('uses card_back slot for back images', async () => {
+    const file = new File(['x'], 'f.png', { type: 'image/png' })
+    await setCardImage(42, file, 'back')
+    const [, path] = mocks.uploadImageMock.mock.calls[0]
+    expect(path).toContain('/back/')
+    const [params] = mocks.insertMediaMock.mock.calls[0]
+    expect(params.slot).toBe('card_back')
+  })
+
+  test('throws before touching storage when the member is not authenticated', async () => {
+    mocks.memberIdRef.value = undefined
+    const file = new File(['x'], 'f.png', { type: 'image/png' })
+    await expect(setCardImage(42, file, 'front')).rejects.toThrow(/Not authenticated/)
+    expect(mocks.uploadImageMock).not.toHaveBeenCalled()
+  })
+
+  test('does not call insertMedia when upload fails (old image stays intact)', async () => {
+    mocks.uploadImageMock.mockRejectedValueOnce(new Error('upload failed'))
+    const file = new File(['x'], 'f.png', { type: 'image/png' })
+    await expect(setCardImage(42, file, 'front')).rejects.toThrow('upload failed')
+    expect(mocks.insertMediaMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/api/media.test.js
+++ b/tests/unit/api/media.test.js
@@ -1,0 +1,153 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+
+const mocks = vi.hoisted(() => ({
+  uploadMock: vi.fn(),
+  removeMock: vi.fn(),
+  getPublicUrlMock: vi.fn(),
+  insertMock: vi.fn(),
+  updateMock: vi.fn(),
+  eqMock: vi.fn()
+}))
+
+vi.mock('@/supabase-client', () => ({
+  supabase: {
+    storage: {
+      from: vi.fn(() => ({
+        upload: mocks.uploadMock,
+        remove: mocks.removeMock,
+        getPublicUrl: mocks.getPublicUrlMock
+      }))
+    },
+    from: vi.fn(() => ({
+      insert: mocks.insertMock,
+      update: mocks.updateMock
+    }))
+  }
+}))
+
+vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
+
+import { supabase } from '@/supabase-client'
+import { uploadImage, deleteImage, getImageUrl, insertMedia, deleteMedia } from '@/api/media'
+
+describe('uploadImage', () => {
+  beforeEach(() => {
+    mocks.uploadMock.mockReset()
+    mocks.getPublicUrlMock.mockReset()
+    mocks.getPublicUrlMock.mockReturnValue({ data: { publicUrl: 'https://cdn/p' } })
+    supabase.storage.from.mockClear()
+  })
+
+  test('uploads the file at the given path with upsert=true and returns the public URL', async () => {
+    mocks.uploadMock.mockResolvedValueOnce({ error: null })
+    const file = new File(['x'], 'a.png', { type: 'image/png' })
+    const url = await uploadImage('cards', 'member/card/front/abc.png', file)
+    expect(supabase.storage.from).toHaveBeenCalledWith('cards')
+    expect(mocks.uploadMock).toHaveBeenCalledWith('member/card/front/abc.png', file, {
+      upsert: true
+    })
+    expect(url).toBe('https://cdn/p')
+  })
+
+  test('does not prepend anything to the caller-provided path', async () => {
+    mocks.uploadMock.mockResolvedValueOnce({ error: null })
+    const file = new File(['x'], 'a.png', { type: 'image/png' })
+    await uploadImage('cards', 'already/fully/qualified.png', file)
+    const [path] = mocks.uploadMock.mock.calls[0]
+    expect(path).toBe('already/fully/qualified.png')
+  })
+
+  test('throws when the upload fails', async () => {
+    mocks.uploadMock.mockResolvedValueOnce({ error: { message: 'bucket not found' } })
+    const file = new File(['x'], 'a.png', { type: 'image/png' })
+    await expect(uploadImage('cards', 'p', file)).rejects.toThrow('bucket not found')
+  })
+})
+
+describe('deleteImage', () => {
+  beforeEach(() => {
+    mocks.removeMock.mockReset()
+  })
+
+  test('removes the given path from the bucket', async () => {
+    mocks.removeMock.mockResolvedValueOnce({ error: null })
+    await deleteImage('cards', 'member/file.png')
+    expect(mocks.removeMock).toHaveBeenCalledWith(['member/file.png'])
+  })
+
+  test('throws when the remove fails', async () => {
+    mocks.removeMock.mockResolvedValueOnce({ error: { message: 'denied' } })
+    await expect(deleteImage('cards', 'p')).rejects.toThrow('denied')
+  })
+})
+
+describe('getImageUrl', () => {
+  beforeEach(() => {
+    mocks.getPublicUrlMock.mockReset()
+  })
+
+  test('returns the public URL for the given path with no prepending', () => {
+    mocks.getPublicUrlMock.mockReturnValueOnce({ data: { publicUrl: 'https://cdn/x' } })
+    const url = getImageUrl('cards', 'member/card/front/abc.png')
+    expect(mocks.getPublicUrlMock).toHaveBeenCalledWith('member/card/front/abc.png')
+    expect(url).toBe('https://cdn/x')
+  })
+})
+
+describe('insertMedia', () => {
+  beforeEach(() => {
+    mocks.insertMock.mockReset()
+    supabase.from.mockClear()
+  })
+
+  test('inserts into the media table with the full payload', async () => {
+    mocks.insertMock.mockResolvedValueOnce({ error: null })
+    const params = { bucket: 'cards', path: 'p', card_id: 1, slot: 'card_front' }
+    await insertMedia(params)
+    expect(supabase.from).toHaveBeenCalledWith('media')
+    expect(mocks.insertMock).toHaveBeenCalledWith(params)
+  })
+
+  test('throws synchronously when neither card_id nor deck_id is provided', async () => {
+    await expect(insertMedia({ bucket: 'cards', path: 'p' })).rejects.toThrow(
+      /requires either card_id or deck_id/
+    )
+    expect(mocks.insertMock).not.toHaveBeenCalled()
+  })
+
+  test('accepts deck_id alone (deck covers, no card)', async () => {
+    mocks.insertMock.mockResolvedValueOnce({ error: null })
+    await insertMedia({ bucket: 'decks', path: 'p', deck_id: 7 })
+    expect(mocks.insertMock).toHaveBeenCalled()
+  })
+
+  test('throws when the insert fails', async () => {
+    const err = { message: 'rls' }
+    mocks.insertMock.mockResolvedValueOnce({ error: err })
+    await expect(insertMedia({ bucket: 'cards', path: 'p', card_id: 1 })).rejects.toBe(err)
+  })
+})
+
+describe('deleteMedia', () => {
+  beforeEach(() => {
+    mocks.updateMock.mockReset()
+    mocks.eqMock.mockReset()
+    mocks.updateMock.mockReturnValue({ eq: mocks.eqMock })
+    supabase.from.mockClear()
+  })
+
+  test('soft-deletes by setting deleted_at and filtering by id', async () => {
+    mocks.eqMock.mockResolvedValueOnce({ error: null })
+    await deleteMedia('abc')
+    expect(supabase.from).toHaveBeenCalledWith('media')
+    const [patch] = mocks.updateMock.mock.calls[0]
+    expect(patch.deleted_at).toBeInstanceOf(Date)
+    expect(mocks.eqMock).toHaveBeenCalledWith('id', 'abc')
+  })
+
+  test('throws when the update fails', async () => {
+    const err = { message: 'denied' }
+    mocks.eqMock.mockResolvedValueOnce({ error: err })
+    await expect(deleteMedia('abc')).rejects.toBe(err)
+  })
+})

--- a/tests/unit/composables/deck-editor.test.js
+++ b/tests/unit/composables/deck-editor.test.js
@@ -16,6 +16,8 @@ const { mockUploadImage } = vi.hoisted(() => ({
   mockUploadImage: vi.fn().mockResolvedValue('https://cdn.example.com/cover.jpg')
 }))
 
+const TEST_MEMBER_ID = '11111111-1111-1111-1111-111111111111'
+
 vi.mock('@/api/decks', () => ({
   deleteDeck: mockDeleteDeck
 }))
@@ -29,6 +31,10 @@ vi.mock('@/composables/deck/use-deck-actions', () => ({
 
 vi.mock('@/api/media', () => ({
   uploadImage: mockUploadImage
+}))
+
+vi.mock('@/stores/member', () => ({
+  useMemberStore: () => ({ id: TEST_MEMBER_ID })
 }))
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -421,7 +427,11 @@ describe('useDeckEditor', () => {
 
       await setCoverImage(makePayload())
 
-      expect(mockUploadImage).toHaveBeenCalledWith('decks', 'covers/42', expect.any(File))
+      expect(mockUploadImage).toHaveBeenCalledWith(
+        'decks',
+        `${TEST_MEMBER_ID}/covers/42`,
+        expect.any(File)
+      )
     })
 
     test('uses draft path when deck has no id', async () => {
@@ -431,7 +441,7 @@ describe('useDeckEditor', () => {
       await setCoverImage(makePayload())
 
       const [, path] = mockUploadImage.mock.calls[0]
-      expect(path).toMatch(/^covers\/draft-/)
+      expect(path).toMatch(new RegExp(`^${TEST_MEMBER_ID}/covers/draft-`))
     })
   })
 


### PR DESCRIPTION
> Stacked on \`refactor/defer-card-creation\`. Review after the base PR merges, or review the diff against the parent branch on the \"Files changed\" tab.

## Summary

Three coordinated storage changes:

1. **Dedupe moves to the DB.** The \"one active media row per (card_id, slot)\" invariant was enforced by a three-step client-side flow in \`setCardImage\`. Replaced by a BEFORE INSERT trigger + partial unique index. \`setCardImage\` becomes a single \`uploadImage\` + \`insertMedia\`.
2. **Media paths include member_id.** \`media.path\` now stores the full storage key, so \`getImageUrl\` produces correct URLs for any viewer — not just the owner. Fixes a latent bug where viewing another member's public deck produced 404s.
3. **Cards bucket gets real storage RLS.** Declarative \`[storage.buckets.cards]\` in \`config.toml\`, plus \`storage.objects\` policies (SELECT/INSERT/UPDATE/DELETE) gated on \`auth.uid()\` matching the path's first segment. The SELECT policy is load-bearing even for plain uploads: \`supabase-js\`'s upsert flow emits \`INSERT ... ON CONFLICT DO UPDATE\`, which needs SELECT for the conflict check.

## Changes

- New migration \`20260416000004_media-slot-dedupe-trigger.sql\` — BEFORE INSERT trigger + \`SECURITY INVOKER\` function + unique partial index
- New migration \`20260416000005_cards-bucket-storage-policies.sql\` — four RLS policies on \`storage.objects\` for the \`cards\` bucket
- New migration \`20260416000006_media-path-include-member-id.sql\` — idempotent backfill prefixing existing \`media.path\` rows with \`member_id\`
- \`supabase/config.toml\` — declarative \`[storage.buckets.cards]\`
- \`src/api/cards/update.ts:setCardImage\` — simplified to \`uploadImage\` → \`insertMedia\`; path built with member_id
- \`src/api/media.ts\` — helpers no longer auto-prepend member_id; callers pass full paths. Removes \`deduplicateSlotMedia\` and \`deleteMediaByPath\` (dead)
- \`src/composables/deck-editor.ts:setCoverImage\` — builds full path with member_id to preserve storage layout
- Extended pgTAP in \`00006_triggers.sql\` — 3 new tests for the media dedupe trigger
- New \`supabase/tests/00010_cards_bucket_storage_rls.sql\` — 5 pgTAP tests covering per-member isolation + UPSERT/SELECT interaction
- \`tests/unit/api/cards/update.test.js\` — extended from 5 → 19 unit tests
- New \`tests/unit/api/media.test.js\` — 12 unit tests
- \`tests/unit/composables/deck-editor.test.js\` — updated assertions for the new path shape
- Also bundles \`docs:\` and \`chore:\` commits (docs for \`supabase seed buckets --local\`, harness-rule updates)

## Notes for review

- Devs pulling this branch for the first time need to run \`supabase seed buckets --local\` once — declarative buckets don't auto-provision on \`supabase start\`. Called out in \`docs/src/supabase/index.md\`.
- The \`storage.protect_delete\` system trigger blocks direct SQL DELETE on \`storage.objects\`, so the DELETE arm of the policy isn't pgTAP-testable; verified via manual UI upload-replacement.

## Test plan

- [ ] \`vp check\` / \`vp test\` / \`supabase test db\` all green
- [ ] Upload an image to a card → old image soft-deleted, new one visible
- [ ] Upload the back image → both slots render correctly (no cross-slot dedupe)
- [ ] Force an upload failure (throttle) → previous image intact
- [ ] View another member's public deck → card images render correctly (the latent-bug fix)