### PR TITLE
Study sessions no longer refetch the deck per rating

### DIFF
--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: prepare-pr
 description: Prepare a branch for PR by rewriting commit messages into release-notes-friendly Conventional Commits, renaming the branch if it no longer fits the changes, splitting unrelated or oversized work into a stack of smaller PRs, drafting a PR title and body, and opening the GitHub "create PR" page pre-filled. Use when a feature branch is code-complete and ready for review.
 allowed-tools: Read, Edit, Write, Bash, Glob, Grep
-lastUpdated: 2026-04-15T16:54:40-07:00
+lastUpdated: 2026-04-17T01:40:00Z
 ---
 
 ## Why this skill exists
@@ -15,7 +15,7 @@ The output is:
 2. Commits renamed into **Conventional Commits** format (see style guide below).
 3. Branches renamed if their slugs no longer fit.
 4. Branches pushed (force-with-lease if rewritten, fresh push if new).
-5. GitHub "create PR" pages opened in the browser with title + body pre-filled via `gh pr create --web`, one per PR, each with the correct base branch for stacked reviews.
+5. Each PR submitted via `gh pr create` — created directly (no browser) when the plan has multiple PRs, or opened pre-filled in the browser when there's a single PR.
 
 History may have been published — **the user has pre-authorised force-pushing on this branch**, so don't block on upstream state. Still surface what you're about to do before you do it.
 
@@ -309,22 +309,35 @@ If `.github/pull_request_template.md` exists, use its structure instead and fill
 
 Keep the body tight. One short paragraph + a handful of bullets beats a wall of text.
 
-### Step 10 — Open pre-filled PR page (per PR)
+### Step 10 — Submit or open each PR
 
-For each branch, open the GitHub create-PR page with base set correctly:
+Behaviour depends on how many PRs the plan produced:
+
+**Multiple PRs → create each one directly, no browser.** Spawning N create-PR tabs in a stack is annoying; for stacked reviews the user also needs parent PR numbers resolved before stacked children can reference them.
 
 ```sh
-gh pr create --web \
+gh pr create \
   --base <base-branch> \
   --title "<title from Step 9>" \
   --body "<body from Step 9>"
 ```
 
-`<base-branch>` is `master` for the root PR and the parent PR's branch name for stacked PRs. `--web` opens the browser on the GitHub "create pull request" form with the fields pre-filled. The user clicks "Create pull request" when satisfied.
+Run parents before children. Capture the URL each invocation prints — needed for the Step 11 report and for substituting `#N` references into stacked-child bodies before their own create call.
 
-Open root PRs first so their PR numbers exist by the time stacked PRs are drafted (lets you reference `#N` in the body).
+**Single PR → open the pre-filled create page in the browser.**
 
-If `gh` isn't available or auth failed in Step 1: skip this command and print the title and body as fenced blocks so the user can paste them manually.
+```sh
+gh pr create --web \
+  --base master \
+  --title "<title from Step 9>" \
+  --body "<body from Step 9>"
+```
+
+`--web` opens the GitHub "create pull request" form with the fields pre-filled. The user clicks "Create pull request" when satisfied.
+
+`<base-branch>` is `master` for the root PR and the parent PR's branch name for stacked PRs.
+
+If `gh` isn't available or auth failed in Step 1: skip these commands and print each PR's title, body, and base as fenced blocks so the user can create them manually.
 
 ### Step 11 — Report
 
@@ -332,13 +345,18 @@ Output a summary per PR:
 
 ```
 PR 1: <branch>   (base: master)   (was: <old-name>)   # omit "was" if unchanged
+  <url-or-draft-note>
   <new log — short>
 
 PR 2: <branch>   (base: <parent-branch>) [stacked]
+  <url>
   <new log — short>
-
-All PR draft pages opened in browser.
 ```
+
+The line under the header:
+
+- **Multiple-PR runs**: the URL returned by each `gh pr create` call (e.g. `https://github.com/org/repo/pull/123`).
+- **Single-PR runs**: `Draft opened in browser — submit when ready.`
 
 If anything was skipped (split declined, rename declined, gh unavailable, push blocked), list it under **Deferred items** so it's not forgotten.
 

--- a/src/api/reviews/mutations/save.ts
+++ b/src/api/reviews/mutations/save.ts
@@ -13,10 +13,16 @@ export function useSaveReviewMutation() {
   const queryCache = useQueryCache()
   return useMutation({
     mutation: (vars: SaveReviewVars) => saveReview(vars.card_id, vars.card, vars.log),
-    onSettled: (_data, _error, vars) => {
+    onSettled: () => {
       queryCache.invalidateQueries({ key: ['decks'] })
-      queryCache.invalidateQueries({ key: ['deck', vars.deck_id] })
-      queryCache.invalidateQueries({ key: ['cards', vars.deck_id] })
     }
   })
+}
+
+export function useFlushDeckReviews() {
+  const queryCache = useQueryCache()
+  return (deck_id: number) => {
+    queryCache.invalidateQueries({ key: ['deck', deck_id] })
+    queryCache.invalidateQueries({ key: ['cards', deck_id] })
+  }
 }

--- a/src/components/modals/study-session/session-flashcard.vue
+++ b/src/components/modals/study-session/session-flashcard.vue
@@ -15,6 +15,7 @@ import { type Grade } from 'ts-fsrs'
 import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 import Card from '@/components/card/index.vue'
 import { useCardsInDeckQuery } from '@/api/cards'
+import { useFlushDeckReviews } from '@/api/reviews'
 import { emitSfx } from '@/sfx/bus'
 
 const { deck, config_override } = defineProps<{
@@ -76,6 +77,7 @@ const card_view = computed<'skeleton' | 'edit' | 'read'>(() => {
 })
 
 const cards_query = useCardsInDeckQuery(() => deck.id!)
+const flushDeckReviews = useFlushDeckReviews()
 
 onMounted(() => {
   if (!deck.id) emit('closed')
@@ -103,10 +105,15 @@ function requestClose() {
     return
   }
 
+  mode.value = 'completed'
+}
+
+function onFinishAnimationDone() {
+  if (deck.id) flushDeckReviews(deck.id)
   emit(
     'finished',
     num_correct.value,
-    reviewed_count.value,
+    cards.value.length,
     remaining_due_count.value,
     config.study_all_cards
   )
@@ -229,8 +236,5 @@ async function onCardReviewed(grade?: Grade) {
     />
   </div>
 
-  <finish-animation
-    v-if="mode === 'completed'"
-    @done="emit('finished', num_correct, cards.length, remaining_due_count, config.study_all_cards)"
-  />
+  <finish-animation v-if="mode === 'completed'" @done="onFinishAnimationDone" />
 </template>

--- a/tests/integration/components/modals/study-session/session-flashcard.test.js
+++ b/tests/integration/components/modals/study-session/session-flashcard.test.js
@@ -60,8 +60,11 @@ vi.mock('@/api/cards', () => {
   }
 })
 
+const { mockFlushDeckReviews } = vi.hoisted(() => ({ mockFlushDeckReviews: vi.fn() }))
+
 vi.mock('@/api/reviews', () => ({
-  useSaveReviewMutation: () => ({ mutate: mockSaveReview, mutateAsync: mockSaveReview })
+  useSaveReviewMutation: () => ({ mutate: mockSaveReview, mutateAsync: mockSaveReview }),
+  useFlushDeckReviews: () => mockFlushDeckReviews
 }))
 
 // ── Card stub ─────────────────────────────────────────────────────────────────
@@ -151,6 +154,7 @@ describe('Session', () => {
     mockEmitSfx.mockClear()
     cardsDataRef.value = undefined
     mockSaveReview.mockClear()
+    mockFlushDeckReviews.mockClear()
   })
 
   // ── Loading behavior ───────────────────────────────────────────────────────
@@ -573,7 +577,7 @@ describe('Session', () => {
       expect(wrapper.emitted('finished')).toBeFalsy()
     })
 
-    test('requestClose after reviewing a card emits "finished" with stats', async () => {
+    test('requestClose after reviewing a card routes through finish-animation and emits "finished"', async () => {
       const wrapper = makeSession(2)
       await waitForLoad(wrapper)
 
@@ -585,9 +589,108 @@ describe('Session', () => {
       await flushPromises()
 
       wrapper.vm.requestClose()
+      await flushPromises()
 
       expect(wrapper.emitted('finished')).toHaveLength(1)
       expect(wrapper.emitted('closed')).toBeFalsy()
+    })
+
+    // requestClose during an active session no longer emits 'finished' directly —
+    // it flips mode to 'completed' so the finish animation gets to play, and the
+    // animation's @done handler is the single emitter of 'finished'.
+    test('early close with 1 review of 2 cards: total reports cards.length, not reviewed_count', async () => {
+      const wrapper = makeSession(2)
+      await waitForLoad(wrapper)
+
+      await startSession(wrapper)
+      await wrapper.find('[data-testid="rating-buttons__show"]').trigger('click')
+      await wrapper.find('[data-testid="rating-buttons__good"]').trigger('click')
+      await flushPromises()
+      fireTransitionEnd(wrapper)
+      await flushPromises()
+
+      wrapper.vm.requestClose()
+      await flushPromises()
+
+      const [, total] = wrapper.emitted('finished')[0]
+      expect(total).toBe(2)
+    })
+  })
+
+  // ── Deck cache flush (post-migration to end-of-session invalidation) ───────
+
+  describe('deck cache flush', () => {
+    test('flushDeckReviews is not called during per-review saves', async () => {
+      const wrapper = makeSession(3)
+      await waitForLoad(wrapper)
+
+      await startSession(wrapper)
+      await wrapper.find('[data-testid="rating-buttons__show"]').trigger('click')
+      await wrapper.find('[data-testid="rating-buttons__good"]').trigger('click')
+      await flushPromises()
+      fireTransitionEnd(wrapper)
+      await flushPromises()
+
+      expect(mockSaveReview).toHaveBeenCalledTimes(1)
+      expect(mockFlushDeckReviews).not.toHaveBeenCalled()
+    })
+
+    test('flushDeckReviews fires with deck.id on natural completion (last card reviewed)', async () => {
+      const wrapper = makeSession(1)
+      await waitForLoad(wrapper)
+
+      await startSession(wrapper)
+      await wrapper.find('[data-testid="rating-buttons__show"]').trigger('click')
+      await wrapper.find('[data-testid="rating-buttons__good"]').trigger('click')
+      await flushPromises()
+      fireTransitionEnd(wrapper)
+      await flushPromises()
+
+      expect(mockFlushDeckReviews).toHaveBeenCalledTimes(1)
+      expect(mockFlushDeckReviews).toHaveBeenCalledWith(1)
+    })
+
+    test('flushDeckReviews fires when requestClose is invoked after ≥1 review', async () => {
+      const wrapper = makeSession(2)
+      await waitForLoad(wrapper)
+
+      await startSession(wrapper)
+      await wrapper.find('[data-testid="rating-buttons__show"]').trigger('click')
+      await wrapper.find('[data-testid="rating-buttons__good"]').trigger('click')
+      await flushPromises()
+      fireTransitionEnd(wrapper)
+      await flushPromises()
+
+      expect(mockFlushDeckReviews).not.toHaveBeenCalled()
+
+      wrapper.vm.requestClose()
+      await flushPromises()
+
+      expect(mockFlushDeckReviews).toHaveBeenCalledTimes(1)
+      expect(mockFlushDeckReviews).toHaveBeenCalledWith(1)
+    })
+
+    test('flushDeckReviews is NOT called when requestClose from cover state emits "closed"', async () => {
+      const wrapper = makeSession(2)
+      await waitForLoad(wrapper)
+
+      wrapper.vm.requestClose()
+      await flushPromises()
+
+      expect(wrapper.emitted('closed')).toHaveLength(1)
+      expect(mockFlushDeckReviews).not.toHaveBeenCalled()
+    })
+
+    test('flushDeckReviews is NOT called when requestClose after starting but before any review', async () => {
+      const wrapper = makeSession(2)
+      await waitForLoad(wrapper)
+
+      await startSession(wrapper)
+      wrapper.vm.requestClose()
+      await flushPromises()
+
+      expect(wrapper.emitted('closed')).toHaveLength(1)
+      expect(mockFlushDeckReviews).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/api/reviews/mutations/save.test.js
+++ b/tests/unit/api/reviews/mutations/save.test.js
@@ -15,7 +15,7 @@ vi.mock('@/api/reviews/db', () => ({
   saveReview: saveReviewMock
 }))
 
-import { useSaveReviewMutation } from '@/api/reviews/mutations/save'
+import { useSaveReviewMutation, useFlushDeckReviews } from '@/api/reviews/mutations/save'
 
 beforeEach(() => {
   useMutationSpy.mockClear()
@@ -53,35 +53,43 @@ describe('useSaveReviewMutation', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'] })
   })
 
-  test('onSettled invalidates ["deck", deck_id] so the detail view refetches', () => {
+  // Per-review saves must not invalidate ["deck", id] or ["cards", id]: those
+  // are active during a study session and refetching on every rating churns
+  // the full deck+cards join. The session flushes them once on close instead.
+  test('onSettled fires exactly one invalidation per review (no deck/cards refetch mid-session)', () => {
     const { onSettled } = configFrom(useSaveReviewMutation)
 
     onSettled(undefined, undefined, { card_id: 1, deck_id: 7, card: {}, log: {} })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['deck', 7] })
+    expect(invalidateSpy).toHaveBeenCalledTimes(1)
   })
 
-  test('onSettled invalidates ["cards", deck_id] so the cards-in-deck query refetches', () => {
-    const { onSettled } = configFrom(useSaveReviewMutation)
-
-    onSettled(undefined, undefined, { card_id: 1, deck_id: 7, card: {}, log: {} })
-
-    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 7] })
-  })
-
-  test('onSettled fires exactly three invalidations (no accidental over-invalidation)', () => {
-    const { onSettled } = configFrom(useSaveReviewMutation)
-
-    onSettled(undefined, undefined, { card_id: 1, deck_id: 7, card: {}, log: {} })
-
-    expect(invalidateSpy).toHaveBeenCalledTimes(3)
-  })
-
-  test('invalidations still fire when the mutation itself errored', () => {
+  test('invalidation still fires when the mutation itself errored', () => {
     const { onSettled } = configFrom(useSaveReviewMutation)
 
     onSettled(undefined, new Error('network'), { card_id: 1, deck_id: 7, card: {}, log: {} })
 
-    expect(invalidateSpy).toHaveBeenCalledTimes(3)
+    expect(invalidateSpy).toHaveBeenCalledTimes(1)
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'] })
+  })
+})
+
+describe('useFlushDeckReviews', () => {
+  test('invalidates ["deck", deck_id] and ["cards", deck_id]', () => {
+    const flush = useFlushDeckReviews()
+
+    flush(7)
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['deck', 7] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 7] })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not invalidate ["decks"] — that is handled by the per-review mutation', () => {
+    const flush = useFlushDeckReviews()
+
+    flush(7)
+
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ key: ['decks'] })
   })
 })


### PR DESCRIPTION
## Summary

After migrating to Pinia Colada, every saved review invalidated `['deck', id]` and `['cards', id]` alongside `['decks']`. Both are active queries during a study session (deck-view is mounted behind the modal; session-flashcard subscribes to cards-in-deck), so every rating triggered a refetch of the full deck+cards+reviews join. This PR keeps the per-review `['decks']` invalidation so the dashboard due count stays correct, and defers deck/cards invalidation to a single `useFlushDeckReviews` call that fires once when the session ends (natural finish or early close with ≥1 review). Early close now routes through the finish animation so `finished` has a single emission path.

Also includes a prepare-pr skill update: multi-PR runs now create each PR directly via `gh pr create` (parents first) instead of spawning N browser tabs via `--web`.