### PR TITLE
Stripe upgrade flow: payment element checkout and settings UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "vp dev",
     "dev:host": "vp dev --host",
+    "dev:full": "run-p -l vite stripe",
+    "vite": "vp dev",
+    "stripe": "stripe listen --forward-to http://localhost:54321/functions/v1/stripe-webhook",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vp preview",
     "test": "vp test run --coverage",
@@ -29,7 +32,7 @@
     "@lexical/selection": "^0.41.0",
     "@lexical/utils": "^0.41.0",
     "@pinia/colada": "^1.1.0",
-    "@stripe/stripe-js": "^8.11.0",
+    "@stripe/stripe-js": "^9.2.0",
     "@supabase/supabase-js": "^2.101.1",
     "@types/howler": "^2.2.12",
     "body-scroll-lock": "4.0.0-beta.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(pinia@3.0.4(typescript@5.8.3)(vue@3.5.31(typescript@5.8.3)))(vue@3.5.31(typescript@5.8.3))
       '@stripe/stripe-js':
-        specifier: ^8.11.0
-        version: 8.11.0
+        specifier: ^9.2.0
+        version: 9.2.0
       '@supabase/supabase-js':
         specifier: ^2.101.1
         version: 2.101.1
@@ -1272,8 +1272,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@stripe/stripe-js@8.11.0':
-    resolution: {integrity: sha512-3fVF4z3efsgwgyj64nFK+6F4/vMw0mUXD2TBbOfftJtKVNx4JNv3CSfe1fY4DCtCk0JFp8/YPNcRkzgV0HJ8cg==}
+  '@stripe/stripe-js@9.2.0':
+    resolution: {integrity: sha512-YSzLC0t6VS9MDdPTynSMqU8IxrItFUjkDORALFT6sSMR/XZ5Vgm3RDp/Gk7z727MC4A9s4MFVel0gF0c7+kdrg==}
     engines: {node: '>=12.16'}
 
   '@supabase/auth-js@2.101.1':
@@ -4611,7 +4611,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stripe/stripe-js@8.11.0': {}
+  '@stripe/stripe-js@9.2.0': {}
 
   '@supabase/auth-js@2.101.1':
     dependencies:

--- a/src/api/billing/db/index.ts
+++ b/src/api/billing/db/index.ts
@@ -1,0 +1,43 @@
+import { supabase } from '@/supabase-client'
+import logger from '@/utils/logger'
+
+export type CreateSubscriptionArgs = { planId: string }
+export type CreateSubscriptionResult = {
+  clientSecret: string
+  subscriptionId: string
+}
+
+export async function createSubscription(
+  args: CreateSubscriptionArgs
+): Promise<CreateSubscriptionResult> {
+  const { data, error } = await supabase.functions.invoke<CreateSubscriptionResult>(
+    'create-subscription',
+    { body: args }
+  )
+
+  if (error || !data?.clientSecret) {
+    logger.error(error?.message ?? 'create-subscription returned no clientSecret')
+    throw error ?? new Error('No clientSecret returned')
+  }
+
+  return data
+}
+
+export type CreatePortalSessionArgs = { returnUrl: string }
+export type CreatePortalSessionResult = { url: string }
+
+export async function createPortalSession(
+  args: CreatePortalSessionArgs
+): Promise<CreatePortalSessionResult> {
+  const { data, error } = await supabase.functions.invoke<CreatePortalSessionResult>(
+    'create-portal-session',
+    { body: args }
+  )
+
+  if (error || !data?.url) {
+    logger.error(error?.message ?? 'create-portal-session returned no url')
+    throw error ?? new Error('No url returned')
+  }
+
+  return data
+}

--- a/src/api/billing/index.ts
+++ b/src/api/billing/index.ts
@@ -1,0 +1,1 @@
+export * from './mutations'

--- a/src/api/billing/mutations/create-portal-session.ts
+++ b/src/api/billing/mutations/create-portal-session.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@pinia/colada'
+import { createPortalSession, type CreatePortalSessionArgs } from '../db'
+
+export function useCreatePortalSessionMutation() {
+  return useMutation({
+    mutation: (args: CreatePortalSessionArgs) => createPortalSession(args)
+  })
+}

--- a/src/api/billing/mutations/create-subscription.ts
+++ b/src/api/billing/mutations/create-subscription.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@pinia/colada'
+import { createSubscription, type CreateSubscriptionArgs } from '../db'
+
+export function useCreateSubscriptionMutation() {
+  return useMutation({
+    mutation: (args: CreateSubscriptionArgs) => createSubscription(args)
+  })
+}

--- a/src/api/billing/mutations/index.ts
+++ b/src/api/billing/mutations/index.ts
@@ -1,0 +1,2 @@
+export * from './create-subscription'
+export * from './create-portal-session'

--- a/src/components/modals/checkout.vue
+++ b/src/components/modals/checkout.vue
@@ -1,69 +1,189 @@
 <script setup lang="ts">
-import { supabase } from '@/supabase-client'
-import { loadStripe, type StripeElements } from '@stripe/stripe-js'
-import { onMounted, ref } from 'vue'
-import { useSessionStore } from '@/stores/session'
+import { onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useQueryCache } from '@pinia/colada'
+import {
+  loadStripe,
+  type Stripe,
+  type StripeElements,
+  type StripePaymentElement
+} from '@stripe/stripe-js'
+import mobileSheet from '@/components/layout-kit/modal/mobile-sheet.vue'
+import UiButton from '@/components/ui-kit/button.vue'
+import { useCreateSubscriptionMutation } from '@/api/billing'
+import logger from '@/utils/logger'
 
-type SubscriptionData = {
-  clientSecret: string
-  subscriptionId: string
-  customerId: string
+export type CheckoutResponse = { upgraded: boolean }
+
+const { close } = defineProps<{
+  close: (response?: CheckoutResponse) => void
+}>()
+
+const { t } = useI18n()
+const queryCache = useQueryCache()
+const { mutateAsync: createSubscription } = useCreateSubscriptionMutation()
+
+const container_ref = useTemplateRef<HTMLDivElement>('container')
+
+const is_loading = ref(true)
+const is_submitting = ref(false)
+const is_ready = ref(false)
+const load_error = ref(false)
+const submit_error = ref<string | null>(null)
+
+let stripe: Stripe | null = null
+let elements: StripeElements | null = null
+let payment_element: StripePaymentElement | null = null
+
+const APPEARANCE = {
+  theme: 'stripe' as const,
+  variables: {
+    colorPrimary: '#6f9b80',
+    colorBackground: '#f9f8f5',
+    colorText: '#744e2a',
+    colorDanger: '#dc2626',
+    colorTextPlaceholder: '#b8b1a9',
+    fontFamily: 'Tilt Neon, sans-serif',
+    spacingUnit: '4px',
+    borderRadius: '8px'
+  },
+  rules: {
+    '.Input': {
+      border: '1px solid #e7e0d5',
+      boxShadow: 'none'
+    },
+    '.Input:focus': {
+      border: '1px solid #6f9b80',
+      boxShadow: '0 0 0 3px rgba(111, 155, 128, 0.25)'
+    },
+    '.Label': {
+      color: '#744e2a',
+      fontWeight: '500'
+    },
+    '.Tab': {
+      border: '1px solid #e7e0d5',
+      backgroundColor: '#f9f8f5'
+    },
+    '.Tab:hover': {
+      backgroundColor: '#ede9df'
+    },
+    '.Tab--selected': {
+      borderColor: '#6f9b80',
+      backgroundColor: '#f3f1ea'
+    }
+  }
 }
 
-const session = useSessionStore()
-
-const stripe_elements = ref<StripeElements | null>(null)
-const payment_element = ref<any | null>(null)
-const subscription_data = ref<SubscriptionData | null>(null)
-
 onMounted(async () => {
-  const res = await supabase.functions.invoke<SubscriptionData>('create-subscription', {
-    body: {
-      priceId: import.meta.env.VITE_MEMBERSHIP_PRICE_ID,
-      email: session.user?.email
-    }
-  })
+  try {
+    const [subscription, stripeInstance] = await Promise.all([
+      createSubscription({ planId: 'paid' }),
+      loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY)
+    ])
+    if (!stripeInstance) throw new Error('Stripe.js failed to load')
+    stripe = stripeInstance
 
-  subscription_data.value = res.data
+    elements = stripe.elements({
+      clientSecret: subscription.clientSecret,
+      appearance: APPEARANCE,
+      fonts: [{ cssSrc: 'https://fonts.googleapis.com/css2?family=Tilt+Neon&display=swap' }]
+    })
 
-  if (!subscription_data.value) return
+    payment_element = elements.create('payment', { layout: 'tabs' })
+    payment_element.on('ready', () => {
+      is_ready.value = true
+    })
 
-  const stripe = await loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY)
-
-  if (!stripe) return
-
-  stripe_elements.value = stripe.elements({
-    clientSecret: subscription_data.value.clientSecret,
-    appearance: {
-      theme: 'flat',
-      variables: {
-        fontFamily: 'Tilt Neon, sans-serif',
-        colorBackground: '#f3f1ea',
-        colorText: '#744e2a'
-      }
-    }
-  })
-
-  payment_element.value = stripe_elements.value.create('payment')
-  payment_element.value.mount('#payment-element')
+    if (container_ref.value) payment_element.mount(container_ref.value)
+  } catch (err) {
+    logger.error((err as Error).message)
+    load_error.value = true
+  } finally {
+    is_loading.value = false
+  }
 })
+
+onBeforeUnmount(() => {
+  payment_element?.destroy()
+})
+
+async function onSubmit() {
+  if (!stripe || !elements) return
+  is_submitting.value = true
+  submit_error.value = null
+
+  const result = await stripe.confirmPayment({
+    elements,
+    confirmParams: {
+      return_url: window.location.origin
+    },
+    redirect: 'if_required'
+  })
+
+  if (result.error) {
+    submit_error.value = result.error.message ?? t('billing.checkout.submit-error')
+    is_submitting.value = false
+    return
+  }
+
+  if (result.paymentIntent?.status === 'succeeded') {
+    queryCache.invalidateQueries({ key: ['member'] })
+    close({ upgraded: true })
+    return
+  }
+
+  submit_error.value = t('billing.checkout.submit-error')
+  is_submitting.value = false
+}
 </script>
 
 <template>
-  <div class="w-150 h-100 p-6">
-    <h1 class="text-xl font-semibold mb-4">Subscribe</h1>
-
-    <div>
-      <!-- Stripe mounts the Payment Element here -->
-      <div id="payment-element" class="mb-4"></div>
-
-      <button
-        type="button"
-        class="px-4 py-2 rounded bg-black text-white disabled:opacity-60"
-        :disabled="!stripe_elements"
+  <mobile-sheet
+    data-testid="checkout"
+    class="sm:max-w-130! max-h-[95dvh]"
+    :title="t('billing.checkout.title')"
+    theme="green-400"
+    @close="close()"
+  >
+    <template #body>
+      <div
+        data-testid="checkout__body"
+        class="overflow-y-auto max-h-[65dvh] px-6 pb-2 flex flex-col gap-4"
       >
-        Start subscription
-      </button>
-    </div>
-  </div>
+        <p
+          v-if="is_loading"
+          data-testid="checkout__loading"
+          class="text-brown-700 py-10 text-center"
+        >
+          {{ t('billing.checkout.loading') }}
+        </p>
+        <p
+          v-else-if="load_error"
+          data-testid="checkout__error"
+          class="py-10 text-center text-red-500"
+        >
+          {{ t('billing.checkout.error') }}
+        </p>
+        <div ref="container" data-testid="checkout__payment-element"></div>
+        <p v-if="submit_error" data-testid="checkout__submit-error" class="text-sm text-red-500">
+          {{ submit_error }}
+        </p>
+      </div>
+    </template>
+    <template #footer>
+      <div v-if="!is_loading && !load_error" data-testid="checkout__footer" class="px-6 pb-6 pt-2">
+        <ui-button
+          data-testid="checkout__submit"
+          theme="green-400"
+          full-width
+          size="lg"
+          :loading="is_submitting"
+          :disabled="!is_ready"
+          @click="onSubmit"
+        >
+          {{ t('billing.checkout.submit') }}
+        </ui-button>
+      </div>
+    </template>
+  </mobile-sheet>
 </template>

--- a/src/composables/deck/use-deck-actions.ts
+++ b/src/composables/deck/use-deck-actions.ts
@@ -1,25 +1,35 @@
 import { useI18n } from 'vue-i18n'
 import { useMemberDeckCountQuery, useUpsertDeckMutation } from '@/api/decks'
 import { useAlert } from '@/composables/alert'
+import { useModal } from '@/composables/modal'
 import { useCan } from '@/composables/use-can'
+import Checkout from '@/components/modals/checkout.vue'
 
 export function useDeckActions() {
   const { t } = useI18n()
   const alert = useAlert()
+  const modal = useModal()
   const can = useCan()
   const deck_count_query = useMemberDeckCountQuery()
   const upsert_mutation = useUpsertDeckMutation()
 
-  async function createDeck(deck: Deck): Promise<boolean> {
+  async function guardCreateDeck(): Promise<boolean> {
     await deck_count_query.refresh()
-    const count = deck_count_query.data.value ?? 0
-    if (!can.createDeck(count)) {
-      await alert.warn({
-        title: t('errors.deck-limit-reached.title'),
-        message: t('errors.deck-limit-reached.message')
-      }).response
-      return false
+    if (can.createDeck.value) return true
+
+    const confirmed = await alert.warn({
+      title: t('errors.deck-limit-reached.title'),
+      message: t('errors.deck-limit-reached.message'),
+      confirmLabel: t('errors.deck-limit-reached.upgrade-cta')
+    }).response
+    if (confirmed) {
+      modal.open(Checkout, { mode: 'mobile-sheet', backdrop: true })
     }
+    return false
+  }
+
+  async function createDeck(deck: Deck): Promise<boolean> {
+    if (!(await guardCreateDeck())) return false
     await upsert_mutation.mutateAsync(deck)
     return true
   }
@@ -29,5 +39,5 @@ export function useDeckActions() {
     return true
   }
 
-  return { createDeck, updateDeck }
+  return { guardCreateDeck, createDeck, updateDeck }
 }

--- a/src/composables/use-can.ts
+++ b/src/composables/use-can.ts
@@ -1,38 +1,38 @@
+import { computed } from 'vue'
 import { useMemberStore } from '@/stores/member'
+import { useMemberDeckCountQuery } from '@/api/decks'
 import { PLANS } from '@/config/plans'
 
 /**
  * Capability checks for the current member.
  *
+ * Every capability is a ComputedRef so templates and computeds downstream
+ * re-evaluate automatically when member/plan/deck-count state changes.
+ *
  * Name capabilities by the feature, not by the role that currently has access.
  *
- *   Bad:  `can.administrate()`  — implies "because they're an admin"
- *   Good: `can.manageUsers()`   — implies "because they need to manage users"
+ *   Bad:  `can.administrate`  — implies "because they're an admin"
+ *   Good: `can.manageUsers`   — implies "because they need to manage users"
  *
  * When a policy changes (e.g. paid users should now export analytics), edit
  * the single line in this file — every call site picks up the new behavior
- * automatically. Call sites should never ask "is this user an admin?"; they
- * should ask "is this user allowed to do X?" and let `useCan` answer.
- *
- * Rule of thumb: if renaming a capability would feel wrong when the policy
- * changes, the name is wrong.
+ * automatically.
  *
  * @example
  * const can = useCan()
- * if (can.useProFeature()) { ... }
+ * if (!can.createDeck.value) { ... }
  */
 export function useCan() {
   const member = useMemberStore()
+  const deckCount = useMemberDeckCountQuery()
 
-  const isPaid = () => member.plan === 'paid'
-  const _isModerator = () => member.role === 'moderator' || member.role === 'admin'
-  const _isAdmin = () => member.role === 'admin'
+  const useProFeature = computed(() => member.plan === 'paid')
 
-  return {
-    useProFeature: isPaid, // this is an example
-    createDeck: (currentDeckCount: number) => {
-      const limit = PLANS[member.plan ?? 'free'].deckLimit
-      return limit === null || currentDeckCount < limit
-    }
-  }
+  const createDeck = computed(() => {
+    const limit = PLANS[member.plan ?? 'free'].deckLimit
+    const count = deckCount.data.value ?? 0
+    return limit === null || count < limit
+  })
+
+  return { useProFeature, createDeck }
 }

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -99,6 +99,12 @@
   "settings.member-settings.title": "Member Settings",
   "settings.member-settings.general.label": "General",
   "settings.member-settings.subscription.label": "Subscription",
+  "settings.member-settings.subscription.free.status": "Free plan",
+  "settings.member-settings.subscription.free.usage": "{used} of {limit} decks used",
+  "settings.member-settings.subscription.free.upgrade": "Upgrade",
+  "settings.member-settings.subscription.paid.status": "Paid plan — active",
+  "settings.member-settings.subscription.paid.manage": "Manage billing",
+  "settings.member-settings.subscription.portal-error": "Couldn't open the billing portal. Please try again.",
   "settings.notification-settings.title": "Notification Settings",
 
   "alert.generic-title": "Continue?",
@@ -152,6 +158,13 @@
 
   "errors.deck-limit-reached.title": "Deck limit reached",
   "errors.deck-limit-reached.message": "You've reached your plan's deck limit. Upgrade to create more.",
+  "errors.deck-limit-reached.upgrade-cta": "Upgrade plan",
+
+  "billing.checkout.title": "Upgrade your plan",
+  "billing.checkout.loading": "Loading checkout…",
+  "billing.checkout.error": "Couldn't load checkout. Please try again.",
+  "billing.checkout.submit": "Subscribe",
+  "billing.checkout.submit-error": "Something went wrong. Please try again.",
 
   "deck.description-placeholder": "Add a short description to your deck.",
   "deck.title-placeholder": "Deck Name",

--- a/src/phone/apps/settings/component/member-settings.vue
+++ b/src/phone/apps/settings/component/member-settings.vue
@@ -3,13 +3,42 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import SectionHeader from './section-header.vue'
 import UiInput from '@/components/ui-kit/input.vue'
+import UiButton from '@/components/ui-kit/button.vue'
 import { useMemberStore } from '@/stores/member'
+import { useMemberDeckCountQuery } from '@/api/decks'
+import { useCreatePortalSessionMutation } from '@/api/billing'
+import { useModal } from '@/composables/modal'
+import { useToast } from '@/composables/toast'
+import { PLANS } from '@/config/plans'
+import Checkout from '@/components/modals/checkout.vue'
 
 const { t } = useI18n()
 const member_store = useMemberStore()
+const deck_count_query = useMemberDeckCountQuery()
+const portal_mutation = useCreatePortalSessionMutation()
+const modal = useModal()
+const toast = useToast()
 
 const display_name = ref(member_store.display_name)
 const email = ref(member_store.email)
+const portal_loading = ref(false)
+
+function openUpgradeModal() {
+  modal.open(Checkout, { mode: 'mobile-sheet', backdrop: true })
+}
+
+async function openBillingPortal() {
+  portal_loading.value = true
+  try {
+    const { url } = await portal_mutation.mutateAsync({
+      returnUrl: window.location.href
+    })
+    window.location.href = url
+  } catch {
+    portal_loading.value = false
+    toast.error(t('settings.member-settings.subscription.portal-error'))
+  }
+}
 </script>
 
 <template>
@@ -32,6 +61,67 @@ const email = ref(member_store.email)
 
     <div data-testid="member-settings__subscription" class="flex flex-col gap-8">
       <section-header>{{ t('settings.member-settings.subscription.label') }}</section-header>
+
+      <div
+        v-if="member_store.plan === 'paid'"
+        data-testid="member-settings__subscription-paid"
+        class="grid grid-cols-[200px_1fr] gap-6 items-center"
+      >
+        <h2
+          data-testid="member-settings__subscription-status"
+          class="text-brown-700 dark:text-brown-300 text-lg"
+        >
+          {{ t('settings.member-settings.subscription.paid.status') }}
+        </h2>
+        <div>
+          <ui-button
+            data-testid="member-settings__subscription-manage"
+            theme="green-400"
+            size="sm"
+            :loading="portal_loading"
+            @click="openBillingPortal"
+          >
+            {{ t('settings.member-settings.subscription.paid.manage') }}
+          </ui-button>
+        </div>
+      </div>
+
+      <div
+        v-else
+        data-testid="member-settings__subscription-free"
+        class="grid grid-cols-[200px_1fr] gap-6 items-start"
+      >
+        <h2
+          data-testid="member-settings__subscription-status"
+          class="text-brown-700 dark:text-brown-300 text-lg"
+        >
+          {{ t('settings.member-settings.subscription.free.status') }}
+        </h2>
+        <div data-testid="member-settings__subscription-free-body" class="flex flex-col gap-3">
+          <p
+            data-testid="member-settings__subscription-usage"
+            class="text-brown-500 dark:text-brown-400"
+          >
+            {{
+              t('settings.member-settings.subscription.free.usage', {
+                used: deck_count_query.data.value ?? 0,
+                limit: PLANS.free.deckLimit
+              })
+            }}
+          </p>
+          <div>
+            <ui-button
+              data-testid="member-settings__subscription-upgrade"
+              theme="green-400"
+              size="sm"
+              icon-left="sparkles"
+              @click="openUpgradeModal"
+            >
+              {{ t('settings.member-settings.subscription.free.upgrade') }}
+            </ui-button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/src/views/dashboard/dashboard.vue
+++ b/src/views/dashboard/dashboard.vue
@@ -9,17 +9,15 @@ import UiButton from '@/components/ui-kit/button.vue'
 import { useMediaQuery } from '@/composables/use-media-query'
 import ReviewInbox from './review-inbox.vue'
 import { useDeckSettingsModal } from '@/composables/modals/use-deck-settings-modal'
-import { useAlert } from '@/composables/alert'
-import { useCan } from '@/composables/use-can'
+import { useDeckActions } from '@/composables/deck/use-deck-actions'
 
 const { t } = useI18n()
 const toast = useToast()
-const alert = useAlert()
-const can = useCan()
 const router = useRouter()
 const is_md = useMediaQuery('md')
 
 const deck_settings_modal = useDeckSettingsModal()
+const deck_actions = useDeckActions()
 const { data: decks_data, error: decks_error } = useMemberDecksQuery()
 const decks = computed(() => decks_data.value ?? [])
 watch(decks_error, (err) => {
@@ -34,16 +32,10 @@ function onDeckClicked(deck: Deck) {
   router.push({ name: 'deck', params: { id: deck.id } })
 }
 
-function onCreateDeckClicked() {
-  if (!can.createDeck(decks.value.length)) {
-    alert.warn({
-      title: t('errors.deck-limit-reached.title'),
-      message: t('errors.deck-limit-reached.message')
-    })
-    return
+async function onCreateDeckClicked() {
+  if (await deck_actions.guardCreateDeck()) {
+    deck_settings_modal.open()
   }
-
-  deck_settings_modal.open()
 }
 </script>
 

--- a/tests/integration/components/modals/checkout.test.js
+++ b/tests/integration/components/modals/checkout.test.js
@@ -1,0 +1,243 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h, useAttrs } from 'vue'
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const {
+  mockCreateSubscription,
+  mockInvalidateQueries,
+  mockConfirmPayment,
+  mockElementMount,
+  mockElementDestroy,
+  elementHandlers,
+  mockLoadStripe,
+  stripeInstance
+} = vi.hoisted(() => {
+  const handlers = new Map()
+  return {
+    mockCreateSubscription: vi.fn().mockResolvedValue({
+      clientSecret: 'pi_secret_x',
+      subscriptionId: 'sub_1'
+    }),
+    mockInvalidateQueries: vi.fn(),
+    mockConfirmPayment: vi.fn(),
+    mockElementMount: vi.fn(),
+    mockElementDestroy: vi.fn(),
+    elementHandlers: handlers,
+    mockLoadStripe: vi.fn(),
+    stripeInstance: null
+  }
+})
+
+vi.mock('@stripe/stripe-js', () => {
+  return {
+    loadStripe: mockLoadStripe
+  }
+})
+
+vi.mock('@/api/billing', () => ({
+  useCreateSubscriptionMutation: () => ({ mutateAsync: mockCreateSubscription })
+}))
+
+vi.mock('@pinia/colada', () => ({
+  useQueryCache: () => ({ invalidateQueries: mockInvalidateQueries })
+}))
+
+vi.mock('@/utils/logger', () => ({
+  default: { error: vi.fn() }
+}))
+
+// ── Stubs ──────────────────────────────────────────────────────────────────────
+
+const MobileSheetStub = defineComponent({
+  name: 'MobileSheet',
+  emits: ['close'],
+  setup(_props, { slots }) {
+    return () =>
+      h('div', { 'data-testid': 'mobile-sheet-stub' }, [slots.body?.(), slots.footer?.()])
+  }
+})
+
+const UiButtonStub = defineComponent({
+  name: 'UiButton',
+  inheritAttrs: false,
+  emits: ['click'],
+  setup(_props, { slots, emit }) {
+    const attrs = useAttrs()
+    return () =>
+      h('button', { ...attrs, onClick: () => emit('click') }, slots.default?.())
+  }
+})
+
+// ── Fake Stripe SDK (configurable per test) ────────────────────────────────────
+
+function makeStripe() {
+  const fakePaymentElement = {
+    on: vi.fn((event, handler) => elementHandlers.set(event, handler)),
+    mount: mockElementMount,
+    destroy: mockElementDestroy
+  }
+  const fakeElements = {
+    create: vi.fn(() => fakePaymentElement)
+  }
+  return {
+    elements: vi.fn(() => fakeElements),
+    confirmPayment: mockConfirmPayment
+  }
+}
+
+// ── Component-under-test loader ────────────────────────────────────────────────
+
+async function makeCheckout({ close = vi.fn() } = {}) {
+  const Checkout = (await import('@/components/modals/checkout.vue')).default
+
+  const wrapper = shallowMount(Checkout, {
+    props: { close },
+    global: {
+      stubs: {
+        MobileSheet: MobileSheetStub,
+        UiButton: UiButtonStub
+      }
+    }
+  })
+  return { wrapper, close }
+}
+
+// Fires the stored 'ready' handler from the Payment Element so is_ready flips.
+function fireReady() {
+  elementHandlers.get('ready')?.()
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockCreateSubscription.mockReset()
+  mockCreateSubscription.mockResolvedValue({
+    clientSecret: 'pi_secret_x',
+    subscriptionId: 'sub_1'
+  })
+  mockInvalidateQueries.mockReset()
+  mockConfirmPayment.mockReset()
+  mockElementMount.mockReset()
+  mockElementDestroy.mockReset()
+  elementHandlers.clear()
+  mockLoadStripe.mockReset()
+  mockLoadStripe.mockResolvedValue(makeStripe())
+})
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('checkout modal', () => {
+  test('shows a loading indicator before Stripe.js initializes', async () => {
+    let resolveStripe
+    mockLoadStripe.mockReturnValue(
+      new Promise((r) => {
+        resolveStripe = r
+      })
+    )
+    const { wrapper } = await makeCheckout()
+
+    expect(wrapper.find('[data-testid="checkout__loading"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="checkout__footer"]').exists()).toBe(false)
+
+    resolveStripe(makeStripe())
+    await flushPromises()
+  })
+
+  test('mounts the Payment Element once Stripe resolves', async () => {
+    const { wrapper } = await makeCheckout()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="checkout__payment-element"]').exists()).toBe(true)
+    expect(mockElementMount).toHaveBeenCalledTimes(1)
+  })
+
+  test('submit button is disabled until the Payment Element fires "ready"', async () => {
+    const { wrapper } = await makeCheckout()
+    await flushPromises()
+
+    const submit = wrapper.find('[data-testid="checkout__submit"]')
+    expect(submit.attributes('disabled')).toBeDefined()
+
+    fireReady()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="checkout__submit"]').attributes('disabled')).toBeUndefined()
+  })
+
+  test('renders the error state when createSubscription rejects', async () => {
+    mockCreateSubscription.mockRejectedValue(new Error('api down'))
+    const { wrapper } = await makeCheckout()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="checkout__error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="checkout__footer"]').exists()).toBe(false)
+  })
+
+  test('renders the error state when Stripe.js fails to load', async () => {
+    mockLoadStripe.mockResolvedValue(null)
+    const { wrapper } = await makeCheckout()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="checkout__error"]').exists()).toBe(true)
+  })
+
+  test('on successful payment, invalidates member cache and closes the modal', async () => {
+    mockConfirmPayment.mockResolvedValue({
+      paymentIntent: { status: 'succeeded' }
+    })
+    const { wrapper, close } = await makeCheckout()
+    await flushPromises()
+    fireReady()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="checkout__submit"]').trigger('click')
+    await flushPromises()
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ key: ['member'] })
+    expect(close).toHaveBeenCalledWith({ upgraded: true })
+  })
+
+  test('shows the submit error when confirmPayment returns an error', async () => {
+    mockConfirmPayment.mockResolvedValue({
+      error: { message: 'Your card was declined.' }
+    })
+    const { wrapper, close } = await makeCheckout()
+    await flushPromises()
+    fireReady()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="checkout__submit"]').trigger('click')
+    await flushPromises()
+
+    const err = wrapper.find('[data-testid="checkout__submit-error"]')
+    expect(err.exists()).toBe(true)
+    expect(err.text()).toBe('Your card was declined.')
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  test('falls back to a generic submit error when paymentIntent status is non-success', async () => {
+    mockConfirmPayment.mockResolvedValue({
+      paymentIntent: { status: 'requires_action' }
+    })
+    const { wrapper, close } = await makeCheckout()
+    await flushPromises()
+    fireReady()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="checkout__submit"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="checkout__submit-error"]').exists()).toBe(true)
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  test('destroys the Payment Element on unmount', async () => {
+    const { wrapper } = await makeCheckout()
+    await flushPromises()
+
+    wrapper.unmount()
+    expect(mockElementDestroy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/integration/phone/apps/settings/component/member-settings.test.js
+++ b/tests/integration/phone/apps/settings/component/member-settings.test.js
@@ -1,0 +1,209 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h, useAttrs } from 'vue'
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const { mockPortalMutate, mockModalOpen, mockToastError, state } = vi.hoisted(() => ({
+  mockPortalMutate: vi.fn(),
+  mockModalOpen: vi.fn(),
+  mockToastError: vi.fn(),
+  state: { plan: 'free', deckCount: 0 }
+}))
+
+vi.mock('@/stores/member', () => ({
+  useMemberStore: () => ({
+    get plan() {
+      return state.plan
+    },
+    display_name: 'Alice',
+    email: 'alice@example.com'
+  })
+}))
+
+vi.mock('@/api/decks', async () => {
+  const { ref } = await vi.importActual('vue')
+  return {
+    useMemberDeckCountQuery: () => ({
+      data: {
+        get value() {
+          return state.deckCount
+        }
+      }
+    })
+  }
+})
+
+vi.mock('@/api/billing', () => ({
+  useCreatePortalSessionMutation: () => ({ mutateAsync: mockPortalMutate })
+}))
+
+vi.mock('@/composables/modal', () => ({
+  useModal: () => ({ open: mockModalOpen })
+}))
+
+vi.mock('@/composables/toast', () => ({
+  useToast: () => ({ error: mockToastError })
+}))
+
+vi.mock('@/components/modals/checkout.vue', () => ({
+  default: { name: 'Checkout' }
+}))
+
+// ── Stubs (render functions — no runtime compiler in browser mode) ────────────
+
+const SectionHeaderStub = defineComponent({
+  name: 'SectionHeader',
+  inheritAttrs: false,
+  setup(_props, { slots }) {
+    const attrs = useAttrs()
+    return () => h('div', { ...attrs, 'data-testid': 'section-header-stub' }, slots.default?.())
+  }
+})
+
+const UiInputStub = defineComponent({
+  name: 'UiInput',
+  props: ['value'],
+  setup() {
+    return () => h('input', { 'data-testid': 'ui-input-stub' })
+  }
+})
+
+const UiButtonStub = defineComponent({
+  name: 'UiButton',
+  inheritAttrs: false,
+  emits: ['click'],
+  setup(_props, { slots, emit }) {
+    const attrs = useAttrs()
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          onClick: () => emit('click')
+        },
+        slots.default?.()
+      )
+  }
+})
+
+// ── Component-under-test loader ────────────────────────────────────────────────
+
+async function makeMemberSettings() {
+  const MemberSettings = (
+    await import('@/phone/apps/settings/component/member-settings.vue')
+  ).default
+
+  return shallowMount(MemberSettings, {
+    global: {
+      stubs: {
+        SectionHeader: SectionHeaderStub,
+        UiInput: UiInputStub,
+        UiButton: UiButtonStub
+      }
+    }
+  })
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  state.plan = 'free'
+  state.deckCount = 0
+  mockPortalMutate.mockReset()
+  mockModalOpen.mockReset()
+  mockToastError.mockReset()
+})
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('member-settings subscription section', () => {
+  describe('free plan', () => {
+    beforeEach(() => {
+      state.plan = 'free'
+      state.deckCount = 3
+    })
+
+    test('renders the free-plan subsection', async () => {
+      const wrapper = await makeMemberSettings()
+      expect(wrapper.find('[data-testid="member-settings__subscription-free"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="member-settings__subscription-paid"]').exists()).toBe(
+        false
+      )
+    })
+
+    test('shows an Upgrade button', async () => {
+      const wrapper = await makeMemberSettings()
+      expect(
+        wrapper.find('[data-testid="member-settings__subscription-upgrade"]').exists()
+      ).toBe(true)
+    })
+
+    test('displays the current deck usage', async () => {
+      const wrapper = await makeMemberSettings()
+      const usage = wrapper.find('[data-testid="member-settings__subscription-usage"]')
+      expect(usage.exists()).toBe(true)
+      expect(usage.text()).toContain('3')
+      expect(usage.text()).toContain('5')
+    })
+
+    test('clicking Upgrade opens the Checkout modal as a mobile sheet with backdrop', async () => {
+      const wrapper = await makeMemberSettings()
+      await wrapper
+        .find('[data-testid="member-settings__subscription-upgrade"]')
+        .trigger('click')
+
+      expect(mockModalOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Checkout' }),
+        { mode: 'mobile-sheet', backdrop: true }
+      )
+    })
+  })
+
+  describe('paid plan', () => {
+    beforeEach(() => {
+      state.plan = 'paid'
+    })
+
+    test('renders the paid-plan subsection', async () => {
+      const wrapper = await makeMemberSettings()
+      expect(wrapper.find('[data-testid="member-settings__subscription-paid"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="member-settings__subscription-free"]').exists()).toBe(
+        false
+      )
+    })
+
+    test('shows a Manage billing button', async () => {
+      const wrapper = await makeMemberSettings()
+      expect(wrapper.find('[data-testid="member-settings__subscription-manage"]').exists()).toBe(
+        true
+      )
+    })
+
+    test('clicking Manage billing creates a portal session with the current URL as returnUrl', async () => {
+      mockPortalMutate.mockResolvedValue({ url: 'https://portal.stripe.com/session_x' })
+      const wrapper = await makeMemberSettings()
+
+      await wrapper
+        .find('[data-testid="member-settings__subscription-manage"]')
+        .trigger('click')
+
+      expect(mockPortalMutate).toHaveBeenCalledWith({
+        returnUrl: window.location.href
+      })
+    })
+
+    test('shows a toast when the portal session fails', async () => {
+      mockPortalMutate.mockRejectedValue(new Error('network down'))
+      const wrapper = await makeMemberSettings()
+
+      await wrapper
+        .find('[data-testid="member-settings__subscription-manage"]')
+        .trigger('click')
+      await flushPromises()
+
+      expect(mockToastError).toHaveBeenCalledTimes(1)
+      expect(mockToastError.mock.calls[0][0]).toContain('billing portal')
+    })
+  })
+})

--- a/tests/integration/phone/apps/settings/component/member-settings.test.js
+++ b/tests/integration/phone/apps/settings/component/member-settings.test.js
@@ -181,7 +181,10 @@ describe('member-settings subscription section', () => {
     })
 
     test('clicking Manage billing creates a portal session with the current URL as returnUrl', async () => {
-      mockPortalMutate.mockResolvedValue({ url: 'https://portal.stripe.com/session_x' })
+      // Never resolves — the component redirects via `window.location.href = url`
+      // on success, which navigates the test iframe away and trips Vitest's
+      // iframe-connect watchdog. We only need to assert the mutation arg here.
+      mockPortalMutate.mockReturnValue(new Promise(() => {}))
       const wrapper = await makeMemberSettings()
 
       await wrapper

--- a/tests/unit/api/billing/mutations.test.js
+++ b/tests/unit/api/billing/mutations.test.js
@@ -1,0 +1,59 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+const { useMutationSpy, createSubscriptionMock, createPortalSessionMock } = vi.hoisted(() => ({
+  useMutationSpy: vi.fn((cfg) => cfg),
+  createSubscriptionMock: vi.fn().mockResolvedValue({
+    clientSecret: 'pi_secret_x',
+    subscriptionId: 'sub_1'
+  }),
+  createPortalSessionMock: vi.fn().mockResolvedValue({ url: 'https://portal' })
+}))
+
+vi.mock('@pinia/colada', () => ({ useMutation: useMutationSpy }))
+
+vi.mock('@/api/billing/db', () => ({
+  createSubscription: createSubscriptionMock,
+  createPortalSession: createPortalSessionMock
+}))
+
+import { useCreateSubscriptionMutation } from '@/api/billing/mutations/create-subscription'
+import { useCreatePortalSessionMutation } from '@/api/billing/mutations/create-portal-session'
+
+beforeEach(() => {
+  useMutationSpy.mockClear()
+  createSubscriptionMock.mockClear()
+  createPortalSessionMock.mockClear()
+})
+
+function configFrom(hook) {
+  hook()
+  return useMutationSpy.mock.calls.at(-1)[0]
+}
+
+describe('useCreateSubscriptionMutation', () => {
+  test('delegates to createSubscription with the caller args', async () => {
+    const { mutation } = configFrom(useCreateSubscriptionMutation)
+    await mutation({ planId: 'paid' })
+    expect(createSubscriptionMock).toHaveBeenCalledWith({ planId: 'paid' })
+  })
+
+  test('returns whatever createSubscription resolved with', async () => {
+    const { mutation } = configFrom(useCreateSubscriptionMutation)
+    const result = await mutation({ planId: 'paid' })
+    expect(result).toEqual({ clientSecret: 'pi_secret_x', subscriptionId: 'sub_1' })
+  })
+})
+
+describe('useCreatePortalSessionMutation', () => {
+  test('delegates to createPortalSession with the caller args', async () => {
+    const { mutation } = configFrom(useCreatePortalSessionMutation)
+    await mutation({ returnUrl: 'https://app' })
+    expect(createPortalSessionMock).toHaveBeenCalledWith({ returnUrl: 'https://app' })
+  })
+
+  test('returns the portal url', async () => {
+    const { mutation } = configFrom(useCreatePortalSessionMutation)
+    const result = await mutation({ returnUrl: 'https://app' })
+    expect(result).toEqual({ url: 'https://portal' })
+  })
+})

--- a/tests/unit/composables/deck/use-deck-actions.test.js
+++ b/tests/unit/composables/deck/use-deck-actions.test.js
@@ -1,40 +1,39 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
-import { useDeckActions } from '@/composables/deck/use-deck-actions'
 
-const { refreshMock, upsertMock, countRef, mockCreateDeckCapability, mockWarn } = vi.hoisted(
-  () => ({
-    refreshMock: vi.fn().mockResolvedValue(undefined),
-    upsertMock: vi.fn().mockResolvedValue(undefined),
-    countRef: { value: 0 },
-    mockCreateDeckCapability: vi.fn(),
-    mockWarn: vi.fn()
-  })
-)
+const { refreshMock, upsertMock, canCreateDeck, mockWarn, mockModalOpen } = vi.hoisted(() => ({
+  refreshMock: vi.fn().mockResolvedValue(undefined),
+  upsertMock: vi.fn().mockResolvedValue(undefined),
+  canCreateDeck: { value: true },
+  mockWarn: vi.fn(),
+  mockModalOpen: vi.fn()
+}))
 
 vi.mock('@/api/decks', () => ({
-  useMemberDeckCountQuery: () => ({
-    refresh: refreshMock,
-    data: countRef
-  }),
-  useUpsertDeckMutation: () => ({
-    mutate: upsertMock,
-    mutateAsync: upsertMock
-  })
+  useMemberDeckCountQuery: () => ({ refresh: refreshMock, data: { value: 0 } }),
+  useUpsertDeckMutation: () => ({ mutate: upsertMock, mutateAsync: upsertMock })
 }))
 
 vi.mock('@/composables/use-can', () => ({
-  useCan: () => ({ createDeck: mockCreateDeckCapability })
+  useCan: () => ({ createDeck: canCreateDeck })
 }))
 
 vi.mock('@/composables/alert', () => ({
-  useAlert: () => ({
-    warn: mockWarn
-  })
+  useAlert: () => ({ warn: mockWarn })
+}))
+
+vi.mock('@/composables/modal', () => ({
+  useModal: () => ({ open: mockModalOpen })
+}))
+
+vi.mock('@/components/modals/checkout.vue', () => ({
+  default: { name: 'Checkout' }
 }))
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key) => key })
 }))
+
+import { useDeckActions } from '@/composables/deck/use-deck-actions'
 
 function makeAlertResponse(promise = Promise.resolve(undefined)) {
   return { response: promise }
@@ -42,91 +41,97 @@ function makeAlertResponse(promise = Promise.resolve(undefined)) {
 
 describe('useDeckActions', () => {
   beforeEach(() => {
-    refreshMock.mockReset()
-    refreshMock.mockResolvedValue(undefined)
-    upsertMock.mockReset()
-    upsertMock.mockResolvedValue(undefined)
-    countRef.value = 0
-    mockCreateDeckCapability.mockReset()
+    refreshMock.mockClear()
+    upsertMock.mockClear()
     mockWarn.mockReset()
     mockWarn.mockReturnValue(makeAlertResponse())
+    mockModalOpen.mockClear()
+    canCreateDeck.value = true
+  })
+
+  describe('guardCreateDeck', () => {
+    test('refreshes the deck-count query before checking capability', async () => {
+      const { guardCreateDeck } = useDeckActions()
+      await guardCreateDeck()
+      expect(refreshMock).toHaveBeenCalledTimes(1)
+    })
+
+    test('returns true when allowed, without prompting', async () => {
+      canCreateDeck.value = true
+      const { guardCreateDeck } = useDeckActions()
+      const result = await guardCreateDeck()
+      expect(result).toBe(true)
+      expect(mockWarn).not.toHaveBeenCalled()
+      expect(mockModalOpen).not.toHaveBeenCalled()
+    })
+
+    test('shows the upgrade alert when blocked', async () => {
+      canCreateDeck.value = false
+      const { guardCreateDeck } = useDeckActions()
+      await guardCreateDeck()
+      expect(mockWarn).toHaveBeenCalledWith({
+        title: 'errors.deck-limit-reached.title',
+        message: 'errors.deck-limit-reached.message',
+        confirmLabel: 'errors.deck-limit-reached.upgrade-cta'
+      })
+    })
+
+    test('opens checkout modal when user confirms upgrade', async () => {
+      canCreateDeck.value = false
+      mockWarn.mockReturnValue(makeAlertResponse(Promise.resolve(true)))
+
+      const { guardCreateDeck } = useDeckActions()
+      const result = await guardCreateDeck()
+
+      expect(result).toBe(false)
+      expect(mockModalOpen).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Checkout' }),
+        { mode: 'mobile-sheet', backdrop: true }
+      )
+    })
+
+    test('does not open checkout when user cancels the alert', async () => {
+      canCreateDeck.value = false
+      mockWarn.mockReturnValue(makeAlertResponse(Promise.resolve(false)))
+
+      const { guardCreateDeck } = useDeckActions()
+      const result = await guardCreateDeck()
+
+      expect(result).toBe(false)
+      expect(mockModalOpen).not.toHaveBeenCalled()
+    })
   })
 
   describe('createDeck', () => {
-    test('calls upsertDeck and returns true when capability check passes', async () => {
-      countRef.value = 2
-      mockCreateDeckCapability.mockReturnValue(true)
-
+    test('upserts the deck when guard passes', async () => {
+      canCreateDeck.value = true
       const { createDeck } = useDeckActions()
       const result = await createDeck({ title: 'New Deck' })
 
-      expect(mockCreateDeckCapability).toHaveBeenCalledWith(2)
       expect(upsertMock).toHaveBeenCalledWith({ title: 'New Deck' })
-      expect(mockWarn).not.toHaveBeenCalled()
       expect(result).toBe(true)
     })
 
-    test('opens warn alert and returns false when capability check fails', async () => {
-      countRef.value = 5
-      mockCreateDeckCapability.mockReturnValue(false)
-
+    test('returns false and skips upsert when guard blocks', async () => {
+      canCreateDeck.value = false
       const { createDeck } = useDeckActions()
       const result = await createDeck({ title: 'Blocked Deck' })
 
-      expect(mockWarn).toHaveBeenCalledWith({
-        title: 'errors.deck-limit-reached.title',
-        message: 'errors.deck-limit-reached.message'
-      })
       expect(upsertMock).not.toHaveBeenCalled()
       expect(result).toBe(false)
-    })
-
-    test('awaits the alert response before resolving', async () => {
-      countRef.value = 5
-      mockCreateDeckCapability.mockReturnValue(false)
-
-      let resolveAlert
-      mockWarn.mockReturnValue(
-        makeAlertResponse(
-          new Promise((r) => {
-            resolveAlert = r
-          })
-        )
-      )
-
-      const { createDeck } = useDeckActions()
-      const pending = createDeck({ title: 'Blocked' })
-
-      let settled = false
-      pending.then(() => {
-        settled = true
-      })
-
-      await Promise.resolve()
-      await Promise.resolve()
-      expect(settled).toBe(false)
-
-      resolveAlert()
-      await pending
-      expect(settled).toBe(true)
     })
   })
 
   describe('updateDeck', () => {
-    test('calls upsertDeck and returns true', async () => {
+    test('upserts without running the guard', async () => {
+      canCreateDeck.value = false // guard would block — prove update bypasses it
       const { updateDeck } = useDeckActions()
       const result = await updateDeck({ id: 1, title: 'Updated' })
 
+      expect(refreshMock).not.toHaveBeenCalled()
+      expect(mockWarn).not.toHaveBeenCalled()
       expect(upsertMock).toHaveBeenCalledWith({ id: 1, title: 'Updated' })
       expect(result).toBe(true)
-    })
-
-    test('does not check capability or call refresh', async () => {
-      const { updateDeck } = useDeckActions()
-      await updateDeck({ id: 1, title: 'Updated' })
-
-      expect(refreshMock).not.toHaveBeenCalled()
-      expect(mockCreateDeckCapability).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/composables/use-can.test.js
+++ b/tests/unit/composables/use-can.test.js
@@ -1,90 +1,103 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 
-const state = vi.hoisted(() => ({ member: null }))
+let planRef
+let deckCountRef
 
-vi.mock('@/stores/member', () => ({
-  useMemberStore: () => ({
-    get id() {
-      return state.member?.id
-    },
-    get plan() {
-      return state.member?.plan
-    },
-    get role() {
-      return state.member?.role
-    },
-    get has_member() {
-      return Boolean(state.member?.id)
-    }
-  })
-}))
+vi.mock('@/stores/member', async () => {
+  const { ref } = await vi.importActual('vue')
+  planRef = ref(null)
+  return {
+    useMemberStore: () => ({
+      get plan() {
+        return planRef.value
+      }
+    })
+  }
+})
 
-import { useCan } from '@/composables/use-can'
+vi.mock('@/api/decks', async () => {
+  const { ref } = await vi.importActual('vue')
+  deckCountRef = ref(0)
+  return {
+    useMemberDeckCountQuery: () => ({ data: deckCountRef })
+  }
+})
 
-function setMember(patch) {
-  state.member = { id: 'm1', ...patch }
-}
+const { useCan } = await import('@/composables/use-can')
 
 describe('useCan', () => {
   beforeEach(() => {
-    state.member = null
+    planRef.value = null
+    deckCountRef.value = 0
   })
 
   describe('useProFeature', () => {
-    test('returns true when member plan is paid', () => {
-      setMember({ plan: 'paid' })
-      const can = useCan()
-      expect(can.useProFeature()).toBe(true)
+    test('true when plan is paid', () => {
+      planRef.value = 'paid'
+      expect(useCan().useProFeature.value).toBe(true)
     })
 
-    test('returns false when member plan is free', () => {
-      setMember({ plan: 'free' })
-      const can = useCan()
-      expect(can.useProFeature()).toBe(false)
+    test('false when plan is free', () => {
+      planRef.value = 'free'
+      expect(useCan().useProFeature.value).toBe(false)
     })
 
-    test('returns false when member plan is not set', () => {
-      const can = useCan()
-      expect(can.useProFeature()).toBe(false)
+    test('false when plan is unset', () => {
+      expect(useCan().useProFeature.value).toBe(false)
     })
 
-    test('reflects live store state (not captured at call time)', () => {
+    test('reactively updates when plan changes', () => {
       const can = useCan()
-
-      setMember({ plan: 'free' })
-      expect(can.useProFeature()).toBe(false)
-
-      setMember({ plan: 'paid' })
-      expect(can.useProFeature()).toBe(true)
+      planRef.value = 'free'
+      expect(can.useProFeature.value).toBe(false)
+      planRef.value = 'paid'
+      expect(can.useProFeature.value).toBe(true)
     })
   })
 
   describe('createDeck', () => {
     test('allows free user under the limit', () => {
-      setMember({ plan: 'free' })
+      planRef.value = 'free'
       const can = useCan()
-      expect(can.createDeck(0)).toBe(true)
-      expect(can.createDeck(4)).toBe(true)
+      deckCountRef.value = 0
+      expect(can.createDeck.value).toBe(true)
+      deckCountRef.value = 4
+      expect(can.createDeck.value).toBe(true)
     })
 
     test('blocks free user at the limit', () => {
-      setMember({ plan: 'free' })
+      planRef.value = 'free'
       const can = useCan()
-      expect(can.createDeck(5)).toBe(false)
-      expect(can.createDeck(99)).toBe(false)
+      deckCountRef.value = 5
+      expect(can.createDeck.value).toBe(false)
+      deckCountRef.value = 99
+      expect(can.createDeck.value).toBe(false)
     })
 
     test('allows paid user regardless of count', () => {
-      setMember({ plan: 'paid' })
+      planRef.value = 'paid'
       const can = useCan()
-      expect(can.createDeck(0)).toBe(true)
-      expect(can.createDeck(1_000_000)).toBe(true)
+      deckCountRef.value = 0
+      expect(can.createDeck.value).toBe(true)
+      deckCountRef.value = 1_000_000
+      expect(can.createDeck.value).toBe(true)
     })
 
     test('treats unset plan as free', () => {
       const can = useCan()
-      expect(can.createDeck(4)).toBe(true)
-      expect(can.createDeck(5)).toBe(false)
+      deckCountRef.value = 4
+      expect(can.createDeck.value).toBe(true)
+      deckCountRef.value = 5
+      expect(can.createDeck.value).toBe(false)
+    })
+
+    test('reactively updates when plan flips free → paid', () => {
+      const can = useCan()
+      planRef.value = 'free'
+      deckCountRef.value = 10
+      expect(can.createDeck.value).toBe(false)
+      planRef.value = 'paid'
+      expect(can.createDeck.value).toBe(true)
     })
   })
 })


### PR DESCRIPTION
> Stacked on #131. Review after the base PR merges, or view the diff against \`feat/stripe-backend\` on the "Files changed" tab.

## Summary

Frontend for the Stripe subscription flow. Adds an in-app Payment Element checkout modal and wires it into the two places a user can upgrade: hitting the 5-deck limit and the settings subscription section. Paid members get a "Manage billing" button that opens the hosted Stripe portal.

## Changes

- **`src/api/billing/`** — new domain with `db/` + `mutations/` following the existing topology. Exposes `useCreateSubscriptionMutation` and `useCreatePortalSessionMutation`.
- **Checkout modal** — rewritten as a `mobile-sheet` hosting the Stripe Payment Element. Appearance API tuned to the app palette (sage button, brown labels, Tilt Neon). Handles 3DS inline via \`redirect: 'if_required'\`; invalidates the member query on success.
- **`useDeckActions.guardCreateDeck`** — centralises the deck-limit gate. When blocked, the alert offers "Upgrade plan" which opens the checkout modal. Both `dashboard.vue` and the existing `createDeck` flow delegate to this single guard.
- **`useCan`** refactored to return `ComputedRef` values (was imperative function calls). Templates now pick up plan/deck-count changes reactively after a successful checkout.
- **Settings → subscription section** — free members see usage + Upgrade; paid members see Manage billing (redirects through \`create-portal-session\`).
- **Tests** — unit tests for billing mutations, reactive capability logic, and the guardCreateDeck flow; integration tests (browser mode) for the checkout modal (mocked Stripe.js) and the settings subscription section.
- **Dev ergonomics** — \`pnpm dev:full\` runs vite and \`stripe listen\` concurrently via \`npm-run-all\`. \`@stripe/stripe-js\` bumped 8.11 → 9.2.