### PR TITLE
Resume audio after tab or background wake

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,8 +4,9 @@ import { useToast } from '@/composables/toast'
 import UiToast from '@/components/ui-kit/toast.vue'
 import UiModal from '@/components/ui-kit/modal.vue'
 import audio_player from '@/sfx/player'
+import { installAudioLifecycle } from '@/sfx/lifecycle'
 import { useSessionStore } from '@/stores/session'
-import { onMounted } from 'vue'
+import { onMounted, onBeforeUnmount } from 'vue'
 import logger from '@/utils/logger'
 import { useThemeStore } from '@/stores/theme'
 import { useRouter } from 'vue-router'
@@ -24,16 +25,23 @@ const removeGuard = router.afterEach((to) => {
   }
 })
 
+let teardownAudioLifecycle: (() => void) | undefined
+
 onMounted(async () => {
   try {
     theme.load()
     session.startLoading()
     await audio_player.setup()
+    teardownAudioLifecycle = installAudioLifecycle()
   } catch (e: any) {
     logger.error(e.message, e)
   } finally {
     session.stopLoading()
   }
+})
+
+onBeforeUnmount(() => {
+  teardownAudioLifecycle?.()
 })
 </script>
 

--- a/src/sfx/lifecycle.ts
+++ b/src/sfx/lifecycle.ts
@@ -1,0 +1,68 @@
+import { Howler } from 'howler'
+
+let installed = false
+let gestureArmed = false
+
+const GESTURE_EVENTS = ['pointerdown', 'keydown', 'touchend'] as const
+
+export function installAudioLifecycle(): () => void {
+  if (installed || typeof window === 'undefined') return () => {}
+  installed = true
+
+  const tryResume = async () => {
+    const ctx = Howler.ctx
+    if (!ctx) return
+    if (ctx.state === 'suspended') {
+      try {
+        await ctx.resume()
+      } catch {
+        armGestureRetry()
+        return
+      }
+    }
+    if (ctx.state !== 'running') armGestureRetry()
+  }
+
+  const gestureResume = async () => {
+    removeGestureListeners()
+    gestureArmed = false
+    const ctx = Howler.ctx
+    if (!ctx) return
+    try {
+      await ctx.resume()
+    } catch {
+      // Gesture didn't satisfy the browser; next gesture will rearm.
+    }
+  }
+
+  const armGestureRetry = () => {
+    if (gestureArmed) return
+    gestureArmed = true
+    for (const ev of GESTURE_EVENTS) {
+      window.addEventListener(ev, gestureResume, { once: true, passive: true })
+    }
+  }
+
+  const removeGestureListeners = () => {
+    for (const ev of GESTURE_EVENTS) {
+      window.removeEventListener(ev, gestureResume)
+    }
+  }
+
+  const onVisibility = () => {
+    if (document.visibilityState === 'visible') void tryResume()
+  }
+
+  document.addEventListener('visibilitychange', onVisibility)
+  window.addEventListener('pageshow', tryResume)
+  window.addEventListener('focus', tryResume)
+
+  return () => {
+    document.removeEventListener('visibilitychange', onVisibility)
+    window.removeEventListener('pageshow', tryResume)
+    window.removeEventListener('focus', tryResume)
+    removeGestureListeners()
+    installed = false
+    gestureArmed = false
+  }
+}

--- a/src/sfx/lifecycle.ts
+++ b/src/sfx/lifecycle.ts
@@ -1,3 +1,14 @@
+/**
+ * Keeps Howler's `AudioContext` running across page visibility, focus, and
+ * restoration events.
+ *
+ * Mobile browsers suspend the AudioContext when the tab hides or the device
+ * locks; Chrome does the same after long-idle background tabs. Once
+ * suspended, Howler's internal unlock flag doesn't re-fire, so subsequent
+ * plays silently hang. This module re-resumes the context when the page
+ * comes back, and falls back to the next user gesture on platforms that
+ * require one (iOS Safari).
+ */
 import { Howler } from 'howler'
 
 let installed = false
@@ -5,6 +16,17 @@ let gestureArmed = false
 
 const GESTURE_EVENTS = ['pointerdown', 'keydown', 'touchend'] as const
 
+/**
+ * Wires `visibilitychange`, `pageshow`, and `focus` listeners that call
+ * `Howler.ctx.resume()`. If the browser refuses to resume without a user
+ * gesture, arms a one-shot `pointerdown`/`keydown`/`touchend` listener that
+ * retries on the next interaction.
+ *
+ * Returns a teardown function that removes every listener it registered.
+ * Calling `installAudioLifecycle` while already installed is a no-op and
+ * returns a no-op teardown — the original teardown remains the only way to
+ * uninstall.
+ */
 export function installAudioLifecycle(): () => void {
   if (installed || typeof window === 'undefined') return () => {}
   installed = true

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -1,4 +1,4 @@
-import { Howl } from 'howler'
+import { Howl, Howler } from 'howler'
 import { debounce } from '@/utils/debounce'
 import {
   AUDIO_CONFIG,
@@ -70,17 +70,43 @@ class AudioPlayer {
       return
     }
 
+    const sound = this.loaded_sounds.get(key)
+
+    if (!sound) {
+      throw new Error(`Sound "${key}" not loaded.`)
+    }
+
+    await this._ensureContextRunning()
+
+    if (Howler.ctx && Howler.ctx.state !== 'running') {
+      return
+    }
+
     return new Promise((resolve) => {
-      const sound = this.loaded_sounds.get(key)
-
-      if (!sound) {
-        throw new Error(`Sound "${key}" not loaded.`)
+      const done = () => {
+        sound.off('end', done)
+        sound.off('playerror', done)
+        clearTimeout(timer)
+        resolve()
       }
+      const fallbackMs = Math.ceil((sound.duration() || 1) * 1000) + 500
+      const timer = setTimeout(done, fallbackMs)
 
+      sound.once('end', done)
+      sound.once('playerror', done)
       sound.volume(options.volume ?? sound.volume())
-      sound.once('end', () => resolve())
       sound.play()
     })
+  }
+
+  private _ensureContextRunning = async (): Promise<void> => {
+    const ctx = Howler.ctx
+    if (!ctx || ctx.state === 'running') return
+    try {
+      await ctx.resume()
+    } catch {
+      // Suspension recovery needs a user gesture; lifecycle watcher handles it.
+    }
   }
 
   private async _setupAudioCategory(

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -83,17 +83,34 @@ class AudioPlayer {
     }
 
     return new Promise((resolve) => {
-      const done = () => {
-        sound.off('end', done)
-        sound.off('playerror', done)
+      // The returned Promise must settle in exactly one of three ways:
+      //   1. 'end'       — Howler's normal completion event.
+      //   2. 'playerror' — Howler failed to decode/play (e.g. autoplay policy).
+      //   3. Timer       — neither of the above fired in time.
+      //
+      // (3) is the safety net: if the AudioContext suspends mid-play (tab hides
+      // right after play, device locks) Howler never emits 'end' and the
+      // promise would hang forever, stalling any caller that awaits emitSfx().
+      //
+      // Whichever path wins, settle() cancels the other two: clearing the
+      // timer and off()-ing both handlers. The off() calls matter because
+      // Howl.once() only auto-removes a handler when it fires — if the timer
+      // wins, the 'end'/'playerror' subscriptions would otherwise leak,
+      // holding resolve + timer references for the lifetime of the Howl.
+      let settled = false
+      const settle = () => {
+        if (settled) return
+        settled = true
+        sound.off('end', settle)
+        sound.off('playerror', settle)
         clearTimeout(timer)
         resolve()
       }
       const fallbackMs = Math.ceil((sound.duration() || 1) * 1000) + 500
-      const timer = setTimeout(done, fallbackMs)
+      const timer = setTimeout(settle, fallbackMs)
 
-      sound.once('end', done)
-      sound.once('playerror', done)
+      sound.once('end', settle)
+      sound.once('playerror', settle)
       sound.volume(options.volume ?? sound.volume())
       sound.play()
     })

--- a/tests/unit/sfx/lifecycle.test.js
+++ b/tests/unit/sfx/lifecycle.test.js
@@ -1,0 +1,228 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+
+const mockCtx = {
+  state: 'running',
+  resume: vi.fn()
+}
+
+vi.mock('howler', () => ({
+  Howler: {
+    get ctx() {
+      return mockCtx
+    }
+  }
+}))
+
+async function loadLifecycle() {
+  const mod = await import('@/sfx/lifecycle')
+  return mod.installAudioLifecycle
+}
+
+function fireVisibility(state) {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('installAudioLifecycle', () => {
+  let teardown
+
+  beforeEach(async () => {
+    vi.resetModules()
+    mockCtx.state = 'running'
+    mockCtx.resume = vi.fn().mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    teardown?.()
+    teardown = undefined
+  })
+
+  test('resumes suspended context when tab becomes visible', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockImplementation(async () => {
+      mockCtx.state = 'running'
+    })
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireVisibility('visible')
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+  })
+
+  test('ignores visibility change when tab hides', async () => {
+    mockCtx.state = 'suspended'
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireVisibility('hidden')
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).not.toHaveBeenCalled()
+  })
+
+  test('resumes context on pageshow', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockImplementation(async () => {
+      mockCtx.state = 'running'
+    })
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    window.dispatchEvent(new Event('pageshow'))
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+  })
+
+  test('resumes context on window focus', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockImplementation(async () => {
+      mockCtx.state = 'running'
+    })
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    window.dispatchEvent(new Event('focus'))
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+  })
+
+  test('skips resume when context already running', async () => {
+    mockCtx.state = 'running'
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireVisibility('visible')
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).not.toHaveBeenCalled()
+  })
+
+  test('arms gesture retry when resume rejects', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockRejectedValueOnce(new Error('needs gesture'))
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireVisibility('visible')
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+
+    mockCtx.resume.mockResolvedValueOnce(undefined)
+    window.dispatchEvent(new Event('pointerdown'))
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(2)
+  })
+
+  test('arms gesture retry when context stays suspended after resume', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockResolvedValue(undefined)
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireVisibility('visible')
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+
+    mockCtx.resume.mockImplementationOnce(async () => {
+      mockCtx.state = 'running'
+    })
+    window.dispatchEvent(new KeyboardEvent('keydown'))
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(2)
+  })
+
+  test('gesture retry listener fires only once across event types', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockResolvedValue(undefined)
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireVisibility('visible')
+    await flushMicrotasks()
+
+    mockCtx.resume.mockClear()
+    mockCtx.resume.mockResolvedValue(undefined)
+
+    window.dispatchEvent(new Event('pointerdown'))
+    window.dispatchEvent(new KeyboardEvent('keydown'))
+    window.dispatchEvent(new Event('touchend'))
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+  })
+
+  test('teardown removes listeners', async () => {
+    mockCtx.state = 'suspended'
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    teardown()
+    teardown = undefined
+
+    fireVisibility('visible')
+    window.dispatchEvent(new Event('pageshow'))
+    window.dispatchEvent(new Event('focus'))
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).not.toHaveBeenCalled()
+  })
+
+  test('second install without teardown is a noop', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockResolvedValue(undefined)
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+    const noopTeardown = installAudioLifecycle()
+
+    fireVisibility('visible')
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+    expect(typeof noopTeardown).toBe('function')
+    noopTeardown()
+  })
+
+  test('handles missing AudioContext gracefully', async () => {
+    const originalCtx = mockCtx.state
+    Object.defineProperty(mockCtx, 'state', {
+      configurable: true,
+      get: () => undefined
+    })
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireVisibility('visible')
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).not.toHaveBeenCalled()
+
+    Object.defineProperty(mockCtx, 'state', {
+      configurable: true,
+      writable: true,
+      value: originalCtx
+    })
+  })
+})

--- a/tests/unit/sfx/player.test.js
+++ b/tests/unit/sfx/player.test.js
@@ -1,0 +1,157 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+const mockCtx = {
+  state: 'running',
+  resume: vi.fn()
+}
+
+vi.mock('howler', () => ({
+  Howl: vi.fn(),
+  Howler: {
+    get ctx() {
+      return mockCtx
+    }
+  }
+}))
+
+vi.mock('@/utils/debounce', () => ({
+  debounce: (fn) => Promise.resolve(fn())
+}))
+
+const { default: audio_player } = await import('@/sfx/player')
+
+function makeFakeSound() {
+  const handlers = { end: [], playerror: [] }
+  const sound = {
+    volume: vi.fn().mockReturnValue(0.5),
+    play: vi.fn(),
+    duration: vi.fn(() => 0.2),
+    once: vi.fn((evt, cb) => {
+      handlers[evt]?.push(cb)
+    }),
+    off: vi.fn((evt, cb) => {
+      const list = handlers[evt]
+      if (!list) return
+      const i = list.indexOf(cb)
+      if (i !== -1) list.splice(i, 1)
+    }),
+    _fire(evt) {
+      handlers[evt]?.slice().forEach((cb) => cb())
+    }
+  }
+  return sound
+}
+
+describe('audio_player._play', () => {
+  beforeEach(() => {
+    mockCtx.state = 'running'
+    mockCtx.resume = vi.fn().mockResolvedValue(undefined)
+    audio_player.loaded_sounds.clear()
+    audio_player.unlocked = true
+    audio_player.queued_sound = undefined
+    vi.useRealTimers()
+  })
+
+  test('resumes suspended context before playing', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockImplementation(async () => {
+      mockCtx.state = 'running'
+    })
+    const sound = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.click', sound)
+
+    const promise = audio_player.play('ui.click')
+    await Promise.resolve()
+    sound._fire('end')
+    await promise
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+    expect(sound.play).toHaveBeenCalledTimes(1)
+  })
+
+  test('skips play when context stays suspended after resume', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockRejectedValue(new Error('needs gesture'))
+    const sound = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.click', sound)
+
+    await audio_player.play('ui.click')
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+    expect(sound.play).not.toHaveBeenCalled()
+  })
+
+  test('resolves when end event fires', async () => {
+    const sound = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.click', sound)
+
+    const promise = audio_player.play('ui.click')
+    await Promise.resolve()
+    sound._fire('end')
+
+    await expect(promise).resolves.toBeUndefined()
+    expect(sound.off).toHaveBeenCalledWith('end', expect.any(Function))
+    expect(sound.off).toHaveBeenCalledWith('playerror', expect.any(Function))
+  })
+
+  test('resolves when playerror fires so promise does not hang', async () => {
+    const sound = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.click', sound)
+
+    const promise = audio_player.play('ui.click')
+    await Promise.resolve()
+    sound._fire('playerror')
+
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  test('resolves via duration timeout fallback when no event fires', async () => {
+    vi.useFakeTimers()
+    const sound = makeFakeSound()
+    sound.duration = vi.fn(() => 0.1)
+    audio_player.loaded_sounds.set('ui.click', sound)
+
+    let settled = false
+    const promise = audio_player.play('ui.click').then(() => {
+      settled = true
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(700)
+    await promise
+
+    expect(settled).toBe(true)
+  })
+
+  test('enqueues when audio system not yet unlocked', async () => {
+    audio_player.unlocked = false
+    const sound = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.click', sound)
+
+    await audio_player.play('ui.click')
+
+    expect(sound.play).not.toHaveBeenCalled()
+    expect(audio_player.queued_sound).toEqual({
+      key: 'ui.click',
+      options: {}
+    })
+  })
+
+  test('throws when sound not loaded', async () => {
+    await expect(audio_player.play('ui.missing')).rejects.toThrow('Sound "ui.missing" not loaded.')
+  })
+
+  test('applies volume option before playing', async () => {
+    const sound = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.click', sound)
+
+    const promise = audio_player.play('ui.click', { volume: 0.9 })
+    await Promise.resolve()
+    sound._fire('end')
+    await promise
+
+    expect(sound.volume).toHaveBeenCalledWith(0.9)
+    expect(sound.play).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes audio going silent on mobile after the phone locks or a tab switch, and on Chrome desktop after a background tab returns to the foreground.

Root cause: browsers suspend the Web Audio `AudioContext` when the page hides. The local `unlocked` latch in `audio_player` was set once on initial unlock and never reset, so later `sound.play()` calls ran against a suspended context and the `end` promise never resolved.

## Changes

- `_ensureContextRunning` awaits `Howler.ctx.resume()` before every play; if the context stays suspended, the play is skipped instead of hanging.
- `_play` now also settles on `playerror` and on a duration-based timeout so promises never wedge the caller.
- New `src/sfx/lifecycle.ts` listens for `visibilitychange`, `pageshow`, and `focus`, resumes the context, and falls back to a one-shot `pointerdown`/`keydown`/`touchend` retry when the browser still requires a user gesture (iOS).
- Wired `installAudioLifecycle()` into `App.vue` with teardown in `onBeforeUnmount`.
- Unit coverage for both the lifecycle watcher and the player resume/timeout paths.