### PR TITLE
Text editor simplification + list/grid render perf

### DIFF
--- a/src/components/text-editor/text-editor.vue
+++ b/src/components/text-editor/text-editor.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import { useTemplateRef } from 'vue'
-import { useTextComposer } from '@/composables/use-text-composer'
+import { onMounted, ref, useTemplateRef, watch } from 'vue'
 
-const { disabled, content } = defineProps<{
+type TextEditorProps = {
   disabled?: boolean
   content?: string
   placeholder?: string
   attributes?: CardAttributes
-}>()
+}
+
+const { disabled, content } = defineProps<TextEditorProps>()
 
 const emit = defineEmits<{
   (e: 'update', text: string): void
@@ -15,15 +16,34 @@ const emit = defineEmits<{
   (e: 'blur'): void
 }>()
 
-const text_editor = useTemplateRef('text-editor')
+const text_editor = useTemplateRef<HTMLDivElement>('text-editor')
+const has_content = ref(Boolean(content?.length))
 
-const { has_content, focus } = useTextComposer(text_editor, {
-  content,
-  disabled,
-  onUpdate: (text: string) => emit('update', text),
-  onFocus: () => emit('focus'),
-  onBlur: () => emit('blur')
+onMounted(() => {
+  if (!text_editor.value) return
+  text_editor.value.textContent = content ?? ''
 })
+
+watch(
+  () => content,
+  (next) => {
+    if (!text_editor.value) return
+    const value = next ?? ''
+    if (text_editor.value.textContent === value) return
+    text_editor.value.textContent = value
+    has_content.value = value.length > 0
+  }
+)
+
+function on_input(event: Event) {
+  const text = (event.target as HTMLElement).innerText ?? ''
+  has_content.value = text.length > 0
+  emit('update', text)
+}
+
+function focus() {
+  text_editor.value?.focus()
+}
 
 defineExpose({ focus })
 </script>
@@ -34,24 +54,35 @@ defineExpose({ focus })
       data-testid="text-editor"
       ref="text-editor"
       class="text-editor"
+      :contenteditable="disabled ? 'false' : 'plaintext-only'"
       :class="[
         `text-editor--size-${attributes?.text_size ?? 'large'}`,
         `text-editor--h-${attributes?.horizontal_alignment ?? 'center'}`,
         `text-editor--v-${attributes?.vertical_alignment ?? 'center'}`
       ]"
+      @input="on_input"
+      @focus="emit('focus')"
+      @blur="emit('blur')"
     ></div>
-    <span v-if="!has_content && !disabled" class="text-editor__placeholder">
+    <span
+      v-if="!has_content && !disabled"
+      data-testid="text-editor__placeholder"
+      class="text-editor__placeholder"
+    >
       {{ placeholder }}
     </span>
   </div>
 </template>
 
 <style>
-.text-editor {
+.text-editor,
+.text-editor-container {
   width: 100%;
   height: 100%;
   outline: none;
   color: var(--color-brown-700);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 /* Horizontal alignment */
@@ -97,105 +128,38 @@ defineExpose({ focus })
   color: var(--color-brown-300);
 }
 
-/* Size scale — each tier sets custom properties for p, h3, h2, h1 */
+.text-editor {
+  font-size: var(--editor-p);
+  line-height: var(--editor-p-lh);
+}
+
 .text-editor--size-small {
   --editor-p: var(--text-lg);
   --editor-p-lh: var(--text-lg--line-height);
-  --editor-h3: var(--text-lg);
-  --editor-h3-lh: var(--text-lg--line-height);
-  --editor-h2: var(--text-xl);
-  --editor-h2-lh: var(--text-xl--line-height);
-  --editor-h1: var(--text-2xl);
-  --editor-h1-lh: var(--text-2xl--line-height);
 }
 
 .text-editor--size-medium {
   --editor-p: var(--text-2xl);
   --editor-p-lh: var(--text-2xl--line-height);
-  --editor-h3: var(--text-xl);
-  --editor-h3-lh: var(--text-xl--line-height);
-  --editor-h2: var(--text-2xl);
-  --editor-h2-lh: var(--text-2xl--line-height);
-  --editor-h1: var(--text-3xl);
-  --editor-h1-lh: var(--text-3xl--line-height);
 }
 
 .text-editor--size-large {
   --editor-p: var(--text-4xl);
   --editor-p-lh: var(--text-4xl--line-height);
-  --editor-h3: var(--text-2xl);
-  --editor-h3-lh: var(--text-2xl--line-height);
-  --editor-h2: var(--text-3xl);
-  --editor-h2-lh: var(--text-3xl--line-height);
-  --editor-h1: var(--text-4xl);
-  --editor-h1-lh: var(--text-4xl--line-height);
 }
 
 .text-editor--size-x-large {
   --editor-p: var(--text-5xl);
   --editor-p-lh: var(--text-5xl--line-height);
-  --editor-h3: var(--text-3xl);
-  --editor-h3-lh: var(--text-3xl--line-height);
-  --editor-h2: var(--text-4xl);
-  --editor-h2-lh: var(--text-4xl--line-height);
-  --editor-h1: var(--text-5xl);
-  --editor-h1-lh: var(--text-5xl--line-height);
 }
 
 .text-editor--size-huge {
   --editor-p: var(--text-6xl);
   --editor-p-lh: var(--text-6xl--line-height);
-  --editor-h3: var(--text-4xl);
-  --editor-h3-lh: var(--text-4xl--line-height);
-  --editor-h2: var(--text-5xl);
-  --editor-h2-lh: var(--text-5xl--line-height);
-  --editor-h1: var(--text-6xl);
-  --editor-h1-lh: var(--text-6xl--line-height);
 }
 
 .text-editor--size-ginormous {
   --editor-p: var(--text-7xl);
   --editor-p-lh: var(--text-7xl--line-height);
-  --editor-h3: var(--text-5xl);
-  --editor-h3-lh: var(--text-5xl--line-height);
-  --editor-h2: var(--text-6xl);
-  --editor-h2-lh: var(--text-6xl--line-height);
-  --editor-h1: var(--text-7xl);
-  --editor-h1-lh: var(--text-7xl--line-height);
-}
-
-/* Element rules read from the custom properties */
-.text-editor p {
-  font-size: var(--editor-p);
-  line-height: var(--editor-p-lh);
-}
-
-.text-editor h1 {
-  font-size: var(--editor-h1);
-  line-height: var(--editor-h1-lh);
-}
-
-.text-editor h2 {
-  font-size: var(--editor-h2);
-  line-height: var(--editor-h2-lh);
-}
-
-.text-editor h3 {
-  font-size: var(--editor-h3);
-  line-height: var(--editor-h3-lh);
-}
-
-.text-editor ul {
-  list-style-type: disc;
-  list-style-position: inside;
-}
-
-.text-editor li {
-  font-size: var(--editor-p);
-  line-height: var(--editor-p-lh);
-}
-
-.text-editor li span {
-  margin-left: -8px;
 }
 </style>

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -53,7 +53,7 @@ function onClick(e: MouseEvent) {
   <div
     data-testid="card-list-item"
     :data-id="card.id"
-    class="group/listitem relative grid w-full grid-cols-[1fr_auto_1fr] gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-colors duration-100 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-grey-700"
+    class="group/listitem relative grid w-full grid-cols-[1fr_auto_1fr] gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-colors duration-100 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-grey-700 [content-visibility:auto] [contain-intrinsic-size:auto_407px]"
     :class="{
       'cursor-pointer': mode === 'select',
       'focus-within:bg-brown-300 hover:focus-within:bg-brown-300 dark:focus-within:bg-blue-650 dark:hover:focus-within:bg-blue-650':

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -53,10 +53,10 @@ function onClick(e: MouseEvent) {
   <div
     data-testid="card-list-item"
     :data-id="card.id"
-    class="group/listitem relative grid w-full grid-cols-[1fr_auto_1fr] grid-rows-[auto_auto] gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-colors duration-100 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-grey-700"
+    class="group/listitem relative grid w-full grid-cols-[1fr_auto_1fr] gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-colors duration-100 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-grey-700"
     :class="{
       'cursor-pointer': mode === 'select',
-      'focus-within:gap-y-6 focus-within:bg-brown-300 hover:focus-within:bg-brown-300 dark:focus-within:bg-blue-650 dark:hover:focus-within:bg-blue-650':
+      'focus-within:bg-brown-300 hover:focus-within:bg-brown-300 dark:focus-within:bg-blue-650 dark:hover:focus-within:bg-blue-650':
         mode !== 'select'
     }"
     @mousedown="onClick"
@@ -92,15 +92,6 @@ function onClick(e: MouseEvent) {
       @delete="onDeleteCard?.(card.id!)"
     />
     <ui-radio v-else :checked="selected" />
-
-    <div
-      class="grid-rows-2 h-0 overflow-hidden transition-all duration-75"
-      :class="{
-        'group-focus-within/listitem:flex group-focus-within/listitem:h-10': mode !== 'select'
-      }"
-    >
-      <slot name="toolbar"></slot>
-    </div>
 
     <ui-button
       v-if="mode !== 'select'"

--- a/src/views/deck/card-editor/list.vue
+++ b/src/views/deck/card-editor/list.vue
@@ -2,7 +2,6 @@
 import ListItem from './list-item.vue'
 import { inject } from 'vue'
 import { type CardBulkEditor } from '@/composables/card-bulk-editor'
-import toolbar from '@/components/text-editor/toolbar/index.vue'
 
 const { all_cards, isDuplicate } = inject<CardBulkEditor>('card-editor')!
 </script>
@@ -16,9 +15,6 @@ const { all_cards, isDuplicate } = inject<CardBulkEditor>('card-editor')!
       :card="card"
       :duplicate="isDuplicate(card)"
     >
-      <template #toolbar>
-        <toolbar />
-      </template>
     </list-item>
     <slot></slot>
   </div>

--- a/src/views/deck/card-grid/grid-item.vue
+++ b/src/views/deck/card-grid/grid-item.vue
@@ -43,6 +43,9 @@ const emit = defineEmits<{
 
   max-width: 314px;
   width: 100%;
+
+  content-visibility: auto;
+  contain-intrinsic-size: auto 220px;
 }
 
 .grid-item .grid-item__card {

--- a/tests/integration/components/text-editor/text-editor.test.js
+++ b/tests/integration/components/text-editor/text-editor.test.js
@@ -1,22 +1,6 @@
-import { describe, test, expect, vi } from 'vite-plus/test'
+import { describe, test, expect } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
 import TextEditor from '@/components/text-editor/text-editor.vue'
-
-// ── Hoisted mocks ──────────────────────────────────────────────────────────────
-
-// Shared ref created lazily on first useTextComposer call.
-// Tests set `mockHasContent` before mounting to control placeholder visibility.
-let mockHasContent
-
-vi.mock('@/composables/use-text-composer', async () => {
-  const { ref: vueRef } = await import('vue')
-  return {
-    useTextComposer: () => {
-      mockHasContent = vueRef(false)
-      return { has_content: mockHasContent, focus: vi.fn() }
-    }
-  }
-})
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -26,6 +10,10 @@ function makeEditor(props = {}) {
 
 function getEditorEl(wrapper) {
   return wrapper.find('[data-testid="text-editor"]')
+}
+
+function getPlaceholder(wrapper) {
+  return wrapper.find('[data-testid="text-editor__placeholder"]')
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -125,25 +113,64 @@ describe('TextEditor', () => {
     expect(classes).toContain('text-editor--v-center')
   })
 
+  // ── contenteditable wiring ─────────────────────────────────────────────────
+
+  test('enables plaintext-only contenteditable when not disabled', () => {
+    const wrapper = makeEditor()
+    expect(getEditorEl(wrapper).attributes('contenteditable')).toBe('plaintext-only')
+  })
+
+  test('disables contenteditable when disabled', () => {
+    const wrapper = makeEditor({ disabled: true })
+    expect(getEditorEl(wrapper).attributes('contenteditable')).toBe('false')
+  })
+
+  test('seeds initial textContent from content prop', () => {
+    const wrapper = makeEditor({ content: 'hello' })
+    expect(getEditorEl(wrapper).element.textContent).toBe('hello')
+  })
+
+  test('emits update with current textContent on input', async () => {
+    const wrapper = makeEditor()
+    const el = getEditorEl(wrapper)
+    el.element.textContent = 'typed'
+    await el.trigger('input')
+    expect(wrapper.emitted('update')).toEqual([['typed']])
+  })
+
+  test('emits focus and blur on native focus events', async () => {
+    const wrapper = makeEditor()
+    const el = getEditorEl(wrapper)
+    await el.trigger('focus')
+    await el.trigger('blur')
+    expect(wrapper.emitted('focus')).toHaveLength(1)
+    expect(wrapper.emitted('blur')).toHaveLength(1)
+  })
+
   // ── Placeholder ────────────────────────────────────────────────────────────
 
   test('shows placeholder when no content and not disabled', () => {
     const wrapper = makeEditor({ placeholder: 'Type here...' })
-    // mockHasContent defaults to false on each mount
-    const placeholder = wrapper.find('.text-editor__placeholder')
+    const placeholder = getPlaceholder(wrapper)
     expect(placeholder.exists()).toBe(true)
     expect(placeholder.text()).toBe('Type here...')
   })
 
-  test('hides placeholder when has content', async () => {
+  test('hides placeholder when content prop is set', () => {
+    const wrapper = makeEditor({ placeholder: 'Type here...', content: 'hi' })
+    expect(getPlaceholder(wrapper).exists()).toBe(false)
+  })
+
+  test('hides placeholder after typing', async () => {
     const wrapper = makeEditor({ placeholder: 'Type here...' })
-    mockHasContent.value = true
-    await wrapper.vm.$nextTick()
-    expect(wrapper.find('.text-editor__placeholder').exists()).toBe(false)
+    const el = getEditorEl(wrapper)
+    el.element.textContent = 'typed'
+    await el.trigger('input')
+    expect(getPlaceholder(wrapper).exists()).toBe(false)
   })
 
   test('hides placeholder when disabled', () => {
     const wrapper = makeEditor({ placeholder: 'Type here...', disabled: true })
-    expect(wrapper.find('.text-editor__placeholder').exists()).toBe(false)
+    expect(getPlaceholder(wrapper).exists()).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Two pre-launch UI prep changes bundled together:

- **Text editor** rewritten as a plain `contenteditable` div. Drops the Lexical-based rich-text composer from launch scope (the composer code stays in `src/utils/text-composer/` and `useTextComposer` for post-launch). Uses `contenteditable="plaintext-only"` + `white-space: pre-wrap` so newlines work and pasted content is stripped of formatting. Reads `innerText` to preserve line breaks.
- **`content-visibility: auto`** on `card-list-item` and `.grid-item`. Browser skips paint/layout for offscreen items in long decks. `contain-intrinsic-size: auto 407px` (list) and `auto 220px` (grid) reserve layout space so scrollbar doesn't jump.

## Test plan

- [ ] Open a card editor: type text, press Enter, paste rich text — newlines preserved, formatting stripped.
- [ ] Open a deck with > 50 cards: scroll to the bottom, scroll back. DevTools Performance shows skipped paints for offscreen rows.
- [ ] Find-in-page (Cmd+F) still matches text in offscreen rows.
- [ ] Existing text-editor tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)