### PR TITLE
Smooth first-open modal animation

### DIFF
--- a/src/components/ui-kit/modal.vue
+++ b/src/components/ui-kit/modal.vue
@@ -57,14 +57,27 @@ function getModeConfig(el: Element) {
   return MODAL_MODE_CONFIG[mode]
 }
 
+function onBeforeEnter(el: Element) {
+  ;(el as HTMLElement).style.willChange = 'transform, opacity'
+}
+
 function onEnter(el: Element, done: () => void) {
   const config = getModeConfig(el)
-  config.enter(el, is_desktop_size.value, done)
+  const html_el = el as HTMLElement
+  config.enter(el, is_desktop_size.value, () => {
+    html_el.style.willChange = ''
+    done()
+  })
 }
 
 function onLeave(el: Element, done: () => void) {
   const config = getModeConfig(el)
-  config.leave(el, is_desktop_size.value, done)
+  const html_el = el as HTMLElement
+  html_el.style.willChange = 'transform, opacity'
+  config.leave(el, is_desktop_size.value, () => {
+    html_el.style.willChange = ''
+    done()
+  })
 }
 </script>
 
@@ -90,6 +103,7 @@ function onLeave(el: Element, done: () => void) {
 
   <transition-group
     :css="false"
+    @before-enter="onBeforeEnter"
     @enter="onEnter"
     @leave="onLeave"
     data-testid="ui-kit-modal-container"

--- a/src/composables/modals/use-deck-settings-modal.ts
+++ b/src/composables/modals/use-deck-settings-modal.ts
@@ -1,8 +1,11 @@
+import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-import DeckSettings, {
-  type DeckSettingsResponse
-} from '@/components/modals/deck-settings/index.vue'
+import type { DeckSettingsResponse } from '@/components/modals/deck-settings/index.vue'
+
+const DeckSettings = defineAsyncComponent(
+  () => import('@/components/modals/deck-settings/index.vue')
+)
 
 export function useDeckSettingsModal() {
   const modal = useModal()

--- a/src/composables/modals/use-study-modal.ts
+++ b/src/composables/modals/use-study-modal.ts
@@ -1,9 +1,14 @@
+import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-import StudySession, {
-  type StudySessionResponse
-} from '@/components/modals/study-session/index.vue'
-import SessionComplete from '@/components/modals/study-session/session-complete.vue'
+import type { StudySessionResponse } from '@/components/modals/study-session/index.vue'
+
+const StudySession = defineAsyncComponent(
+  () => import('@/components/modals/study-session/index.vue')
+)
+const SessionComplete = defineAsyncComponent(
+  () => import('@/components/modals/study-session/session-complete.vue')
+)
 
 export type SecondaryAction = 'study-more' | 'study-all' | 'study-again'
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,10 @@ import { PiniaColada } from '@pinia/colada'
 import { createI18n } from 'vue-i18n'
 import messages from '@intlify/unplugin-vue-i18n/messages'
 import { vSfx } from '@/sfx/directive'
+import { warmupAnimations } from '@/utils/animations/warmup'
 
 loadFont()
+warmupAnimations()
 
 const i18n = createI18n({
   locale: 'en-us',

--- a/src/utils/animations/modal.ts
+++ b/src/utils/animations/modal.ts
@@ -1,11 +1,17 @@
 import { gsap } from 'gsap'
 
+const ENTER_SETTLE_DELAY = 0.033
+
 export function slideUpFadeIn(el: Element, done: () => void) {
-  gsap.fromTo(
-    el,
-    { translateY: '200px', opacity: 0 },
-    { translateY: 0, opacity: 1, duration: 0.2, ease: 'expo.out', onComplete: done }
-  )
+  gsap.set(el, { translateY: '200px', opacity: 0 })
+  gsap.to(el, {
+    translateY: 0,
+    opacity: 1,
+    duration: 0.2,
+    delay: ENTER_SETTLE_DELAY,
+    ease: 'expo.out',
+    onComplete: done
+  })
 }
 
 export function slideDownFadeOut(el: Element, done: () => void) {
@@ -19,11 +25,14 @@ export function slideDownFadeOut(el: Element, done: () => void) {
 }
 
 export function slideUpFromEdge(el: Element, done: () => void) {
-  gsap.fromTo(
-    el,
-    { translateY: '100%' },
-    { translateY: 0, duration: 0.2, ease: 'expo.out', onComplete: done }
-  )
+  gsap.set(el, { translateY: '100%' })
+  gsap.to(el, {
+    translateY: 0,
+    duration: 0.2,
+    delay: ENTER_SETTLE_DELAY,
+    ease: 'expo.out',
+    onComplete: done
+  })
 }
 
 export function slideDownToEdge(el: Element, done: () => void) {
@@ -31,11 +40,15 @@ export function slideDownToEdge(el: Element, done: () => void) {
 }
 
 export function springScaleIn(el: Element, done: () => void) {
-  gsap.fromTo(
-    el,
-    { scale: 0.8, opacity: 0 },
-    { scale: 1, opacity: 1, duration: 0.1, ease: 'back.out(1.7)', onComplete: done }
-  )
+  gsap.set(el, { scale: 0.8, opacity: 0 })
+  gsap.to(el, {
+    scale: 1,
+    opacity: 1,
+    duration: 0.1,
+    delay: ENTER_SETTLE_DELAY,
+    ease: 'back.out(1.7)',
+    onComplete: done
+  })
 }
 
 export function scaleFadeOut(el: Element, done: () => void) {

--- a/src/utils/animations/warmup.ts
+++ b/src/utils/animations/warmup.ts
@@ -1,0 +1,39 @@
+import { gsap } from 'gsap'
+
+type IdleCallback = (cb: () => void) => void
+
+const scheduleIdle: IdleCallback =
+  typeof window !== 'undefined' && 'requestIdleCallback' in window
+    ? (cb) => (window as any).requestIdleCallback(cb, { timeout: 2000 })
+    : (cb) => setTimeout(cb, 500)
+
+export function warmupAnimations() {
+  gsap.to({ _: 0 }, { _: 1, duration: 0, ease: 'expo.out' })
+  gsap.to({ _: 0 }, { _: 1, duration: 0, ease: 'back.out(1.7)' })
+
+  const el = document.createElement('div')
+  el.setAttribute('aria-hidden', 'true')
+  el.style.cssText = [
+    'position:fixed',
+    'top:0',
+    'left:0',
+    'width:1px',
+    'height:1px',
+    'pointer-events:none',
+    'opacity:0',
+    'backdrop-filter:blur(4px)',
+    '-webkit-backdrop-filter:blur(4px)',
+    'contain:strict'
+  ].join(';')
+  document.body.appendChild(el)
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => el.remove())
+  })
+
+  scheduleIdle(() => {
+    void import('@/components/modals/study-session/index.vue')
+    void import('@/components/modals/study-session/session-complete.vue')
+    void import('@/components/modals/deck-settings/index.vue')
+  })
+}

--- a/tests/integration/components/ui-kit/modal.test.js
+++ b/tests/integration/components/ui-kit/modal.test.js
@@ -34,6 +34,7 @@ vi.mock('@/composables/use-shortcuts', () => ({
 // The mock must call onComplete so transition-group JS hooks finish in browser mode.
 vi.mock('gsap', () => ({
   gsap: {
+    set: vi.fn(),
     fromTo: vi.fn((_el, _from, to) => to?.onComplete?.()),
     to: vi.fn((_el, opts) => opts?.onComplete?.())
   }

--- a/tests/unit/composables/use-deck-settings-modal.test.js
+++ b/tests/unit/composables/use-deck-settings-modal.test.js
@@ -1,0 +1,85 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { flushPromises } from '@vue/test-utils'
+import { useDeckSettingsModal } from '@/composables/modals/use-deck-settings-modal'
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+const { mockOpen } = vi.hoisted(() => ({ mockOpen: vi.fn() }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+
+vi.mock('@/composables/modal', () => ({
+  useModal: vi.fn(() => ({ open: mockOpen }))
+}))
+
+// DeckSettings is wrapped with defineAsyncComponent inside the composable, so
+// the component identity doesn't match the raw .vue import. Assert on shape.
+const asyncComponentMatcher = expect.objectContaining({ __asyncLoader: expect.any(Function) })
+
+function makeModalResult(value) {
+  return { response: Promise.resolve(value) }
+}
+
+describe('useDeckSettingsModal', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+    mockOpen.mockReset()
+  })
+
+  test('plays camera-reel sfx when opening', () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useDeckSettingsModal()
+    open()
+
+    expect(mockEmitSfx).toHaveBeenCalled()
+  })
+
+  test('opens modal with backdrop, mobile-sheet mode, and the deck prop', () => {
+    const deck = { id: 42, title: 'A' }
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useDeckSettingsModal()
+    open(deck)
+
+    expect(mockOpen).toHaveBeenCalledWith(asyncComponentMatcher, {
+      backdrop: true,
+      mode: 'mobile-sheet',
+      props: { deck }
+    })
+  })
+
+  test('passes undefined deck when called without an argument', () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useDeckSettingsModal()
+    open()
+
+    expect(mockOpen).toHaveBeenCalledWith(asyncComponentMatcher, {
+      backdrop: true,
+      mode: 'mobile-sheet',
+      props: { deck: undefined }
+    })
+  })
+
+  test('returns the result of modal.open unchanged', () => {
+    const result = makeModalResult('x')
+    mockOpen.mockReturnValueOnce(result)
+
+    const { open } = useDeckSettingsModal()
+    const returned = open()
+
+    expect(returned).toBe(result)
+  })
+
+  test('plays card-drop sfx after the modal closes', async () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useDeckSettingsModal()
+    open()
+    const openSfxCount = mockEmitSfx.mock.calls.length
+
+    await flushPromises()
+
+    expect(mockEmitSfx.mock.calls.length).toBeGreaterThan(openSfxCount)
+  })
+})

--- a/tests/unit/composables/use-study-modal.test.js
+++ b/tests/unit/composables/use-study-modal.test.js
@@ -1,8 +1,11 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { flushPromises } from '@vue/test-utils'
 import { useStudyModal } from '@/composables/modals/use-study-modal'
-import StudySession from '@/components/modals/study-session/index.vue'
-import SessionComplete from '@/components/modals/study-session/session-complete.vue'
+
+// StudySession and SessionComplete are wrapped with defineAsyncComponent inside
+// the composable, so the component identity doesn't match the raw .vue import.
+// We assert on the wrapper object shape instead.
+const asyncComponentMatcher = expect.objectContaining({ __asyncLoader: expect.any(Function) })
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
@@ -62,10 +65,10 @@ describe('useStudyModal', () => {
     const { start } = useStudyModal()
     const startPromise = start(DECK)
 
-    expect(mockOpen).toHaveBeenCalledWith(StudySession, {
+    expect(mockOpen).toHaveBeenCalledWith(asyncComponentMatcher, {
       backdrop: true,
       mode: 'mobile-sheet',
-      props: { deck: DECK }
+      props: { deck: DECK, config_override: undefined }
     })
 
     resolveSession(undefined)
@@ -138,10 +141,10 @@ describe('useStudyModal', () => {
     vi.advanceTimersByTime(300)
     await flushPromises()
 
-    expect(mockOpen).toHaveBeenNthCalledWith(2, SessionComplete, {
+    expect(mockOpen).toHaveBeenNthCalledWith(2, asyncComponentMatcher, {
       backdrop: true,
       mode: 'mobile-sheet',
-      props: { score: 3, total: 5, secondary_action: 'study-all' }
+      props: { score: 3, total: 5, secondary_action: 'study-all', theme: undefined }
     })
 
     resolveComplete(undefined)

--- a/tests/unit/utils/animations/modal.test.js
+++ b/tests/unit/utils/animations/modal.test.js
@@ -1,13 +1,11 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 
-// ── Hoisted mocks ─────────────────────────────────────────────────────────────
-
-const { mockFromTo, mockTo } = vi.hoisted(() => ({
-  mockFromTo: vi.fn(),
+const { mockSet, mockTo } = vi.hoisted(() => ({
+  mockSet: vi.fn(),
   mockTo: vi.fn()
 }))
 
-vi.mock('gsap', () => ({ gsap: { fromTo: mockFromTo, to: mockTo } }))
+vi.mock('gsap', () => ({ gsap: { set: mockSet, to: mockTo } }))
 
 import {
   slideUpFadeIn,
@@ -18,12 +16,8 @@ import {
   scaleFadeOut
 } from '@/utils/animations/modal'
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
 const el = document.createElement('div')
 const done = vi.fn()
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('modal animations', () => {
   beforeEach(() => {
@@ -31,24 +25,36 @@ describe('modal animations', () => {
   })
 
   describe('slideUpFadeIn', () => {
-    test('slides in from 200px below with fade', () => {
+    test('primes initial state at 200px below with opacity 0', () => {
       slideUpFadeIn(el, done)
 
-      expect(mockFromTo).toHaveBeenCalledWith(
+      expect(mockSet).toHaveBeenCalledWith(el, { translateY: '200px', opacity: 0 })
+    })
+
+    test('tweens to rest position with opacity 1', () => {
+      slideUpFadeIn(el, done)
+
+      expect(mockTo).toHaveBeenCalledWith(
         el,
-        { translateY: '200px', opacity: 0 },
         expect.objectContaining({ translateY: 0, opacity: 1 })
       )
+    })
+
+    test('applies a settle delay before tweening', () => {
+      slideUpFadeIn(el, done)
+
+      expect(mockTo).toHaveBeenCalledWith(
+        el,
+        expect.objectContaining({ delay: expect.any(Number) })
+      )
+      const { delay } = mockTo.mock.calls[0][1]
+      expect(delay).toBeGreaterThan(0)
     })
 
     test('calls done via onComplete', () => {
       slideUpFadeIn(el, done)
 
-      expect(mockFromTo).toHaveBeenCalledWith(
-        el,
-        expect.anything(),
-        expect.objectContaining({ onComplete: done })
-      )
+      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ onComplete: done }))
     })
   })
 
@@ -62,6 +68,12 @@ describe('modal animations', () => {
       )
     })
 
+    test('does not prime with gsap.set (leave animation)', () => {
+      slideDownFadeOut(el, done)
+
+      expect(mockSet).not.toHaveBeenCalled()
+    })
+
     test('calls done via onComplete', () => {
       slideDownFadeOut(el, done)
 
@@ -70,32 +82,43 @@ describe('modal animations', () => {
   })
 
   describe('slideUpFromEdge', () => {
-    test('slides in from 100% (full-height edge)', () => {
+    test('primes initial state at 100% translateY', () => {
       slideUpFromEdge(el, done)
 
-      expect(mockFromTo).toHaveBeenCalledWith(
-        el,
-        { translateY: '100%' },
-        expect.objectContaining({ translateY: 0 })
-      )
+      expect(mockSet).toHaveBeenCalledWith(el, { translateY: '100%' })
+    })
+
+    test('tweens to rest position', () => {
+      slideUpFromEdge(el, done)
+
+      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ translateY: 0 }))
+    })
+
+    test('applies a settle delay before tweening', () => {
+      slideUpFromEdge(el, done)
+
+      const { delay } = mockTo.mock.calls[0][1]
+      expect(delay).toBeGreaterThan(0)
     })
 
     test('calls done via onComplete', () => {
       slideUpFromEdge(el, done)
 
-      expect(mockFromTo).toHaveBeenCalledWith(
-        el,
-        expect.anything(),
-        expect.objectContaining({ onComplete: done })
-      )
+      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ onComplete: done }))
     })
   })
 
   describe('slideDownToEdge', () => {
-    test('slides out to 100% (full-height edge)', () => {
+    test('slides out to 100% translateY', () => {
       slideDownToEdge(el, done)
 
       expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ translateY: '100%' }))
+    })
+
+    test('does not prime with gsap.set (leave animation)', () => {
+      slideDownToEdge(el, done)
+
+      expect(mockSet).not.toHaveBeenCalled()
     })
 
     test('calls done via onComplete', () => {
@@ -106,24 +129,32 @@ describe('modal animations', () => {
   })
 
   describe('springScaleIn', () => {
-    test('scales in from 0.8 with spring ease', () => {
+    test('primes initial state at scale 0.8 with opacity 0', () => {
       springScaleIn(el, done)
 
-      expect(mockFromTo).toHaveBeenCalledWith(
+      expect(mockSet).toHaveBeenCalledWith(el, { scale: 0.8, opacity: 0 })
+    })
+
+    test('tweens to scale 1 with opacity 1 using spring ease', () => {
+      springScaleIn(el, done)
+
+      expect(mockTo).toHaveBeenCalledWith(
         el,
-        { scale: 0.8, opacity: 0 },
         expect.objectContaining({ scale: 1, opacity: 1, ease: 'back.out(1.7)' })
       )
+    })
+
+    test('applies a settle delay before tweening', () => {
+      springScaleIn(el, done)
+
+      const { delay } = mockTo.mock.calls[0][1]
+      expect(delay).toBeGreaterThan(0)
     })
 
     test('calls done via onComplete', () => {
       springScaleIn(el, done)
 
-      expect(mockFromTo).toHaveBeenCalledWith(
-        el,
-        expect.anything(),
-        expect.objectContaining({ onComplete: done })
-      )
+      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ onComplete: done }))
     })
   })
 
@@ -132,6 +163,12 @@ describe('modal animations', () => {
       scaleFadeOut(el, done)
 
       expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ scale: 0.8, opacity: 0 }))
+    })
+
+    test('does not prime with gsap.set (leave animation)', () => {
+      scaleFadeOut(el, done)
+
+      expect(mockSet).not.toHaveBeenCalled()
     })
 
     test('calls done via onComplete', () => {

--- a/tests/unit/utils/animations/warmup.test.js
+++ b/tests/unit/utils/animations/warmup.test.js
@@ -1,0 +1,88 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+
+const { mockGsapTo } = vi.hoisted(() => ({ mockGsapTo: vi.fn() }))
+
+vi.mock('gsap', () => ({ gsap: { to: mockGsapTo } }))
+
+// Stub out dynamic imports performed on idle so the real modal modules aren't
+// pulled into the jsdom runtime during this unit test.
+vi.mock('@/components/modals/study-session/index.vue', () => ({ default: {} }))
+vi.mock('@/components/modals/study-session/session-complete.vue', () => ({ default: {} }))
+vi.mock('@/components/modals/deck-settings/index.vue', () => ({ default: {} }))
+
+import { warmupAnimations } from '@/utils/animations/warmup'
+
+describe('warmupAnimations', () => {
+  let rafSpy
+  let rafCallbacks
+  let idleSpy
+
+  beforeEach(() => {
+    mockGsapTo.mockClear()
+    rafCallbacks = []
+    rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+
+    if ('requestIdleCallback' in window) {
+      idleSpy = vi.spyOn(window, 'requestIdleCallback').mockImplementation((cb) => {
+        cb()
+        return 1
+      })
+    }
+
+    // Remove any leaked warmup elements from prior tests.
+    document.querySelectorAll('div[aria-hidden="true"]').forEach((el) => el.remove())
+  })
+
+  afterEach(() => {
+    rafSpy.mockRestore()
+    idleSpy?.mockRestore()
+  })
+
+  test('runs gsap priming tweens for the eases used by modal animations', () => {
+    warmupAnimations()
+
+    expect(mockGsapTo).toHaveBeenCalledTimes(2)
+
+    const eases = mockGsapTo.mock.calls.map((c) => c[1]?.ease)
+    expect(eases).toContain('expo.out')
+    expect(eases).toContain('back.out(1.7)')
+  })
+
+  test('mounts a hidden backdrop-filter probe element', () => {
+    warmupAnimations()
+
+    const probes = [...document.body.querySelectorAll('div[aria-hidden="true"]')]
+
+    expect(probes).toHaveLength(1)
+    const probe = probes[0]
+    expect(probe.getAttribute('aria-hidden')).toBe('true')
+    expect(probe.style.opacity).toBe('0')
+  })
+
+  test('removes the probe element after two animation frames', () => {
+    warmupAnimations()
+
+    const findProbes = () => [...document.body.querySelectorAll('div[aria-hidden="true"]')]
+
+    expect(findProbes()).toHaveLength(1)
+
+    // Flush the first RAF — probe should still be present.
+    rafCallbacks.shift()?.()
+    expect(findProbes()).toHaveLength(1)
+
+    // Flush the second RAF — probe is now removed.
+    rafCallbacks.shift()?.()
+    expect(findProbes()).toHaveLength(0)
+  })
+
+  test('schedules a preload pass via requestIdleCallback when available', () => {
+    if (!idleSpy) return
+
+    warmupAnimations()
+
+    expect(idleSpy).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

First-open modal paint jank was driven by three collisions on the mount frame: GSAP cold-start, backdrop-filter layer creation, and heavy modal-child mount under the same tween tick. This change masks those behind a boot-time warmup, an async-loaded modal tree, and a split of `fromTo` into `set` + `to` with a 33ms settle delay so the browser has time to absorb mount/layout before the tween advances.

## Changes

- `warmupAnimations()` runs at boot: dummy GSAP tweens prime the ease cache, a 1px probe element compiles the `backdrop-filter` compositor layer, and an idle callback kicks off dynamic imports for the study-session and deck-settings modal chunks.
- `src/utils/animations/modal.ts`: enter animations now use `gsap.set` for the from-state and `gsap.to` with `delay: 0.033` for the tween, so each animation self-primes and no longer races the Vue mount frame. Leave animations unchanged.
- `src/components/ui-kit/modal.vue`: `@before-enter` sets `will-change: transform, opacity` on the element; enter/leave callbacks clear it on completion.
- `use-study-modal.ts` and `use-deck-settings-modal.ts`: heavy modal components wrapped in `defineAsyncComponent`.

## Test plan

- [ ] Cold-reload the app and open the study-session modal — enter animation should be smooth from the first frame.
- [ ] Open the deck-settings modal on a fresh load — same smoothness expectation.
- [ ] Open an alert with a backdrop on fresh load — backdrop blur should not cause a visible paint hitch.
- [ ] Mobile mobile-sheet modal (`slideUpFromEdge`) should animate fully from the bottom; no leftover `opacity: 0` on the slotted content after the animation settles.
- [ ] `vp test` — unit + integration suites green (animation, warmup, use-study-modal, use-deck-settings-modal, modal.vue).