### PR TITLE
OAuth popup reliability + mobile fallback

### DIFF
--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -68,10 +68,26 @@ export async function signupEmail(
   return data?.session
 }
 
+function prefersFullRedirect(): boolean {
+  return window.matchMedia('(pointer: coarse)').matches || window.innerWidth < 768
+}
+
 export async function signInOAuth(
   provider: OAuthProvider,
   options?: SignupOAuthOptions
 ): Promise<void> {
+  if (prefersFullRedirect()) {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: {
+        redirectTo: AUTH_REDIRECT_URL,
+        ...options
+      }
+    })
+    if (error) throw error
+    return
+  }
+
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider,
     options: {
@@ -85,33 +101,37 @@ export async function signInOAuth(
     throw error ?? new Error('No URL returned')
   }
 
-  // Calculate centered position
   const width = 500
   const height = 600
   const left = window.screenX + (window.outerWidth - width) / 2
   const top = window.screenY + (window.outerHeight - height) / 2
-
   const popupFeatures = `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
 
-  // Check if window.open is supported and not blocked
   const popup = window.open(data.url, 'googleAuth', popupFeatures)
 
   if (!popup || popup.closed || typeof popup.closed === 'undefined') {
-    // Fallback: redirect the current tab instead
     window.location.href = data.url
     return
   }
 
-  return new Promise((resolve, reject) => {
-    window.addEventListener(
-      'message',
-      async (event) => {
-        if (event.origin !== window.location.origin) reject(new Error('Invalid origin'))
-        if (event.data !== 'auth_complete') reject(new Error('Invalid message'))
+  const TIMEOUT_MS = 5 * 60 * 1000
 
+  return new Promise<void>((resolve, reject) => {
+    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        cleanup()
         resolve()
-      },
-      { once: true }
-    )
+      }
+    })
+
+    const timeout = window.setTimeout(() => {
+      cleanup()
+      reject(new Error('OAuth timed out'))
+    }, TIMEOUT_MS)
+
+    function cleanup() {
+      sub.subscription.unsubscribe()
+      window.clearTimeout(timeout)
+    }
   })
 }

--- a/src/components/ui-kit/icon.vue
+++ b/src/components/ui-kit/icon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type Component, ref, watchEffect } from 'vue'
+import { type Component, shallowRef, watchEffect } from 'vue'
 import logger from '@/utils/logger'
 
 const { src } = defineProps<{
@@ -22,7 +22,7 @@ const lazyIcons: Record<string, () => Promise<Component>> = import.meta.glob(
   }
 )
 
-const iconComponent = ref<Component | undefined>()
+const iconComponent = shallowRef<Component | undefined>()
 
 watchEffect(async () => {
   const key = `../../assets/icons/${src}.svg`

--- a/src/views/auth/callback.vue
+++ b/src/views/auth/callback.vue
@@ -1,14 +1,18 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { supabase } from '@/supabase-client'
 
-onMounted(async () => {
-  await supabase.auth.exchangeCodeForSession(window.location.href)
+const router = useRouter()
 
-  if (window.opener) {
-    window.opener.postMessage('auth_complete', window.location.origin)
+onMounted(async () => {
+  await supabase.auth.getSession()
+
+  if (window.opener && window.opener !== window) {
+    window.close()
+    return
   }
 
-  window.close()
+  router.push({ name: 'dashboard' })
 })
 </script>

--- a/tests/integration/views/auth/callback.test.js
+++ b/tests/integration/views/auth/callback.test.js
@@ -1,0 +1,83 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  push: vi.fn()
+}))
+
+vi.mock('@/supabase-client', () => ({
+  supabase: { auth: { getSession: mocks.getSession } }
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: mocks.push })
+}))
+
+import Callback from '@/views/auth/callback.vue'
+
+function setOpener(value) {
+  Object.defineProperty(window, 'opener', {
+    configurable: true,
+    get: () => value
+  })
+}
+
+describe('auth/callback', () => {
+  let closeSpy
+  let originalOpenerDescriptor
+
+  beforeEach(() => {
+    mocks.getSession.mockReset()
+    mocks.getSession.mockResolvedValue({ data: { session: null }, error: null })
+    mocks.push.mockReset()
+    originalOpenerDescriptor = Object.getOwnPropertyDescriptor(window, 'opener')
+    closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    closeSpy.mockRestore()
+    if (originalOpenerDescriptor) {
+      Object.defineProperty(window, 'opener', originalOpenerDescriptor)
+    } else {
+      // Best-effort reset when browser has no own descriptor for opener.
+      try {
+        // eslint-disable-next-line no-self-assign
+        delete window.opener
+      } catch {
+        setOpener(null)
+      }
+    }
+  })
+
+  test('awaits getSession on mount', async () => {
+    setOpener(null)
+    mount(Callback)
+    await flushPromises()
+    expect(mocks.getSession).toHaveBeenCalledTimes(1)
+  })
+
+  test('pushes to the dashboard route when not running inside a popup', async () => {
+    setOpener(null)
+    mount(Callback)
+    await flushPromises()
+    expect(mocks.push).toHaveBeenCalledWith({ name: 'dashboard' })
+    expect(closeSpy).not.toHaveBeenCalled()
+  })
+
+  test('closes the window when running inside a popup and does not navigate', async () => {
+    setOpener({})
+    mount(Callback)
+    await flushPromises()
+    expect(closeSpy).toHaveBeenCalledTimes(1)
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+
+  test('ignores a self-referential opener (same window) and routes to dashboard', async () => {
+    setOpener(window)
+    mount(Callback)
+    await flushPromises()
+    expect(closeSpy).not.toHaveBeenCalled()
+    expect(mocks.push).toHaveBeenCalledWith({ name: 'dashboard' })
+  })
+})

--- a/tests/unit/api/session.test.js
+++ b/tests/unit/api/session.test.js
@@ -1,0 +1,304 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  signInWithPassword: vi.fn(),
+  signOut: vi.fn(),
+  signUp: vi.fn(),
+  signInWithOAuth: vi.fn(),
+  onAuthStateChange: vi.fn()
+}))
+
+vi.mock('@/supabase-client', () => ({
+  supabase: {
+    auth: {
+      getSession: mocks.getSession,
+      signInWithPassword: mocks.signInWithPassword,
+      signOut: mocks.signOut,
+      signUp: mocks.signUp,
+      signInWithOAuth: mocks.signInWithOAuth,
+      onAuthStateChange: mocks.onAuthStateChange
+    }
+  }
+}))
+
+import { getSession, login, logout, signupEmail, signInOAuth } from '@/api/session'
+
+beforeEach(() => {
+  Object.values(mocks).forEach((m) => m.mockReset())
+  global.__matchMedia.matches = false
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1024 })
+})
+
+describe('getSession', () => {
+  test('returns the session on success', async () => {
+    const session = { user: { id: 'u1' } }
+    mocks.getSession.mockResolvedValueOnce({ data: { session }, error: null })
+    await expect(getSession()).resolves.toEqual(session)
+  })
+
+  test('returns null when no session is present', async () => {
+    mocks.getSession.mockResolvedValueOnce({ data: { session: null }, error: null })
+    await expect(getSession()).resolves.toBeNull()
+  })
+
+  test('throws when supabase returns an error', async () => {
+    mocks.getSession.mockResolvedValueOnce({ data: null, error: { message: 'nope' } })
+    await expect(getSession()).rejects.toThrow('nope')
+  })
+})
+
+describe('login', () => {
+  test('returns the session on success', async () => {
+    const session = { user: { id: 'u1' } }
+    mocks.signInWithPassword.mockResolvedValueOnce({ data: { session }, error: null })
+    await expect(login('e@x.com', 'pw')).resolves.toEqual(session)
+    expect(mocks.signInWithPassword).toHaveBeenCalledWith({ email: 'e@x.com', password: 'pw' })
+  })
+
+  test('throws when supabase returns an error', async () => {
+    mocks.signInWithPassword.mockResolvedValueOnce({ data: null, error: { message: 'bad creds' } })
+    await expect(login('e@x.com', 'pw')).rejects.toThrow('bad creds')
+  })
+})
+
+describe('logout', () => {
+  test('resolves when signOut succeeds', async () => {
+    mocks.signOut.mockResolvedValueOnce({ error: null })
+    await expect(logout()).resolves.toBeUndefined()
+  })
+
+  test('throws when signOut errors', async () => {
+    mocks.signOut.mockResolvedValueOnce({ error: { message: 'offline' } })
+    await expect(logout()).rejects.toThrow('offline')
+  })
+})
+
+describe('signupEmail', () => {
+  test('passes display_name through options.data', async () => {
+    const session = { user: { id: 'u1' } }
+    mocks.signUp.mockResolvedValueOnce({ data: { session }, error: null })
+    await expect(signupEmail('e@x.com', 'pw', { display_name: 'Alice' })).resolves.toEqual(session)
+    expect(mocks.signUp).toHaveBeenCalledWith({
+      email: 'e@x.com',
+      password: 'pw',
+      options: { data: { display_name: 'Alice' } }
+    })
+  })
+
+  test('throws the raw error from supabase', async () => {
+    const err = { message: 'dup', status: 422 }
+    mocks.signUp.mockResolvedValueOnce({ data: null, error: err })
+    await expect(signupEmail('e@x.com', 'pw')).rejects.toBe(err)
+  })
+})
+
+describe('signInOAuth', () => {
+  let openSpy
+
+  beforeEach(() => {
+    openSpy = vi.fn()
+    vi.stubGlobal('open', openSpy)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  describe('full-redirect path', () => {
+    test('uses the full redirect when pointer is coarse', async () => {
+      global.__matchMedia.matches = true
+      mocks.signInWithOAuth.mockResolvedValueOnce({ data: null, error: null })
+
+      await signInOAuth('google')
+
+      expect(mocks.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'google',
+        options: expect.not.objectContaining({ skipBrowserRedirect: true })
+      })
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    test('uses the full redirect when viewport is narrow', async () => {
+      window.innerWidth = 600
+      mocks.signInWithOAuth.mockResolvedValueOnce({ data: null, error: null })
+
+      await signInOAuth('google')
+
+      expect(mocks.signInWithOAuth).toHaveBeenCalledTimes(1)
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    test('merges caller-provided options over defaults', async () => {
+      global.__matchMedia.matches = true
+      mocks.signInWithOAuth.mockResolvedValueOnce({ data: null, error: null })
+
+      await signInOAuth('google', { redirectTo: '/custom' })
+
+      const [arg] = mocks.signInWithOAuth.mock.calls[0]
+      expect(arg.options.redirectTo).toBe('/custom')
+    })
+
+    test('throws when the redirect call errors', async () => {
+      global.__matchMedia.matches = true
+      mocks.signInWithOAuth.mockResolvedValueOnce({ data: null, error: new Error('boom') })
+      await expect(signInOAuth('google')).rejects.toThrow('boom')
+    })
+  })
+
+  describe('popup path', () => {
+    function captureAuthCallback() {
+      let cb
+      const unsubscribe = vi.fn()
+      mocks.onAuthStateChange.mockImplementationOnce((fn) => {
+        cb = fn
+        return { data: { subscription: { unsubscribe } } }
+      })
+      return { get: () => cb, unsubscribe }
+    }
+
+    test('passes skipBrowserRedirect=true and opens the popup', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({
+        data: { url: 'https://auth.x/login' },
+        error: null
+      })
+      const popup = { closed: false }
+      openSpy.mockReturnValue(popup)
+      captureAuthCallback()
+
+      signInOAuth('google')
+      await Promise.resolve()
+
+      expect(mocks.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'google',
+        options: expect.objectContaining({ skipBrowserRedirect: true })
+      })
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://auth.x/login',
+        'googleAuth',
+        expect.stringContaining('width=500')
+      )
+    })
+
+    test('resolves when onAuthStateChange fires SIGNED_IN with a session', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({
+        data: { url: 'https://auth.x' },
+        error: null
+      })
+      openSpy.mockReturnValue({ closed: false })
+      const cb = captureAuthCallback()
+
+      const promise = signInOAuth('google')
+      await Promise.resolve()
+
+      cb.get()('SIGNED_IN', { user: { id: 'u1' } })
+
+      await expect(promise).resolves.toBeUndefined()
+      expect(cb.unsubscribe).toHaveBeenCalled()
+    })
+
+    test('ignores onAuthStateChange events that are not SIGNED_IN', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({
+        data: { url: 'https://auth.x' },
+        error: null
+      })
+      openSpy.mockReturnValue({ closed: false })
+      const cb = captureAuthCallback()
+
+      const promise = signInOAuth('google')
+      await Promise.resolve()
+
+      cb.get()('TOKEN_REFRESHED', { user: { id: 'u1' } })
+      cb.get()('SIGNED_OUT', null)
+
+      let settled = false
+      promise.then(() => (settled = true))
+      await Promise.resolve()
+      expect(settled).toBe(false)
+
+      cb.get()('SIGNED_IN', { user: { id: 'u1' } })
+      await expect(promise).resolves.toBeUndefined()
+    })
+
+    test('ignores SIGNED_IN when the session is null', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({
+        data: { url: 'https://auth.x' },
+        error: null
+      })
+      openSpy.mockReturnValue({ closed: false })
+      const cb = captureAuthCallback()
+
+      const promise = signInOAuth('google')
+      await Promise.resolve()
+
+      cb.get()('SIGNED_IN', null)
+
+      let settled = false
+      promise.then(() => (settled = true))
+      await Promise.resolve()
+      expect(settled).toBe(false)
+
+      cb.get()('SIGNED_IN', { user: { id: 'u1' } })
+      await expect(promise).resolves.toBeUndefined()
+    })
+
+    test('rejects after the 5-minute timeout', async () => {
+      vi.useFakeTimers()
+      mocks.signInWithOAuth.mockResolvedValueOnce({
+        data: { url: 'https://auth.x' },
+        error: null
+      })
+      openSpy.mockReturnValue({ closed: false })
+      const cb = captureAuthCallback()
+
+      const promise = signInOAuth('google')
+      promise.catch(() => {})
+      await Promise.resolve()
+
+      vi.advanceTimersByTime(5 * 60 * 1000)
+
+      await expect(promise).rejects.toThrow('OAuth timed out')
+      expect(cb.unsubscribe).toHaveBeenCalled()
+    })
+
+    test('falls back to full-tab redirect when window.open is blocked (null)', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({
+        data: { url: 'https://auth.x' },
+        error: null
+      })
+      openSpy.mockReturnValue(null)
+      const locationStub = { href: '' }
+      vi.stubGlobal('location', locationStub)
+
+      await signInOAuth('google')
+
+      expect(locationStub.href).toBe('https://auth.x')
+      expect(mocks.onAuthStateChange).not.toHaveBeenCalled()
+    })
+
+    test('falls back to full-tab redirect when popup is immediately closed', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({
+        data: { url: 'https://auth.x' },
+        error: null
+      })
+      openSpy.mockReturnValue({ closed: true })
+      const locationStub = { href: '' }
+      vi.stubGlobal('location', locationStub)
+
+      await signInOAuth('google')
+
+      expect(locationStub.href).toBe('https://auth.x')
+    })
+
+    test('throws when signInWithOAuth returns an error', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({ data: null, error: new Error('oauth fail') })
+      await expect(signInOAuth('google')).rejects.toThrow('oauth fail')
+    })
+
+    test('throws when signInWithOAuth returns no url', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({ data: {}, error: null })
+      await expect(signInOAuth('google')).rejects.toThrow('No URL returned')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

OAuth popup flow was breaking in stage/prod: popup navigated to `/dashboard` inside itself instead of closing, and had no mobile support. Root cause was a double code exchange (Supabase's default `detectSessionInUrl` + a manual one in `callback.vue`) throwing before `window.close()`, plus a parent-side postMessage flow that broke under COOP severance and had a bug where it rejected then still resolved.

Parent now resolves via `supabase.auth.onAuthStateChange` — localStorage broadcast survives COOP, no opener access, no postMessage. Callback view drops the duplicate exchange, self-closes in popup context, otherwise routes to `/dashboard`. Mobile / coarse-pointer / narrow-viewport devices use the full-page redirect flow (popup unreliable on iOS).

Bundles a small unrelated perf tweak (`ref` → `shallowRef` on dynamically-loaded icon component).

## Changes

- `signInOAuth`: detect mobile / coarse pointer / narrow viewport → full redirect; desktop → popup resolved via auth state change, 5-min timeout, fallback to full-tab redirect when popup blocked
- `auth/callback.vue`: drop manual `exchangeCodeForSession`; self-close in popup, route to dashboard otherwise
- Unit tests (22) for `src/api/session.ts` + integration tests (4) for `callback.vue`
- `icon.vue`: `ref` → `shallowRef` for dynamically-loaded component