### PR TITLE
Component-owned editor state for auto-save

### DIFF
--- a/.claude/notes/card-editor-refactor.md
+++ b/.claude/notes/card-editor-refactor.md
@@ -93,53 +93,29 @@ vue-tsc: 0 errors. Format: clean.
 
 Ordered by impact ÷ effort. Pick up from the top in a fresh session.
 
-### 1. [HIGH] Optimistic rollback on updateCard
+### 1. [DONE] ~~Optimistic rollback on updateCard~~ — solved by component-owned editor state
 
-`src/composables/card-mutations.ts` — `updateCard` path for real cards:
+Shipped in PR #143 (`refactor/card-editor-auto-save`). The original plan was
+optimistic apply + snapshot rollback inside the mutation layer. That path
+was attempted and rejected mid-session: rollback coordinated correctly
+across debounce supersessions, but refetches from `invalidateDeck` still
+clobbered in-flight edits because the cache was driving the editor input
+directly.
 
-```ts
-saving.value = true
-try {
-  await save_mutation.mutateAsync({ card, values })
-} finally {
-  saving.value = false
-}
-```
+Final shape:
 
-The save mutation internally mutates `card` in place before the network call.
-If the network call fails, the local card object is already mutated — UI
-shows the new value but the DB has the old one, and a future refetch will
-silently revert the user's edit.
+- `saveCard` (db) is pure — no `Object.assign` on its arg.
+- `useSaveCardMutation` no longer invalidates the deck on settle. Bulk ops
+  still invalidate explicitly.
+- `list-item-card.vue` owns local `front_text` / `back_text` / `save_failed`
+  refs. The text editor renders from local state, immune to cache updates.
+- Save failures surface as a red outline on the failing card via a new
+  `error` prop on `Card`; the next edit clears it.
+- Architecture rule added: `src/api/` functions must not mutate their args
+  (`.claude/rules/architecture.md`).
 
-If the user edits the same card twice quickly while the first save is
-in-flight, the second `save_mutation.mutateAsync` runs against the already-
-mutated card. The first mutation's `onSettled` invalidates the cache, which
-may refetch the pre-edit-2 state and clobber edit-2 on the next render.
-
-**Fix**: add `onMutate` / `onError` around `save_mutation`:
-
-```ts
-return useMutation({
-  mutation: ({ card, values }) => saveCard(card, values),
-  onMutate: ({ card, values }) => {
-    const rollback = { ...card } // snapshot
-    Object.assign(card, values) // optimistic apply
-    return rollback
-  },
-  onError: (_err, { card }, rollback) => {
-    if (rollback) Object.assign(card, rollback)
-  },
-  onSettled: (_data, _err, _vars, _ctx, { queryCache }) => {
-    invalidateDeck(queryCache, deck_id)
-  }
-})
-```
-
-Likely lives inside `src/api/cards/mutations/save.ts`, not in the composable
-layer. Verify the Pinia Colada mutation signature for context parameter shape.
-
-Tests: add cases for "updateCard rolls back local card on network failure",
-"concurrent edits don't drop the later value".
+No more rollback machinery. Local state is the source of truth while the
+component is mounted; the cache is persistence-only for the editor flow.
 
 ---
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -67,3 +67,20 @@ Rules of thumb:
 - **Reactive state (refs, lifecycle, provide/inject)** → `src/composables/`.
 
 Prefer a directory under `src/utils/` over a flat `src/utils/foo.ts` when more than one file is likely, so helpers stay co-located with their domain.
+
+## `src/api/` functions must not mutate their arguments
+
+API-layer functions are thin network adapters. They must not mutate their input parameters — callers can't tell from the signature which fields are now stale, and optimistic-UI rollback becomes impossible because the "before" state is already gone by the time the network fails. Optimistic apply belongs in the composable that calls the mutation, not in the network adapter.
+
+```ts
+// Bad — mutates `card` before the network call
+export async function saveCard(card: Card, values: Partial<Card>) {
+  Object.assign(card, values)
+  await upsertCard(buildCardPayload(card))
+}
+
+// Good — builds an immutable payload, leaves `card` untouched
+export async function saveCard(card: Card, values: Partial<Card>) {
+  await upsertCard(buildCardPayload({ ...card, ...values }))
+}
+```

--- a/src/api/cards/db/update.ts
+++ b/src/api/cards/db/update.ts
@@ -4,20 +4,19 @@ import { isoNow } from '@/utils/date'
 import { uploadImage, insertMedia } from '@/api/media/db'
 import { useMemberStore } from '@/stores/member'
 import uid from '@/utils/uid'
-import { buildCardPayload, hasCardChanges } from '@/utils/card/payload'
+import { buildCardPayload } from '@/utils/card/payload'
 import { type CardBase } from '@type/card'
 
 /**
- * In-place update + upsert for an existing card. Skips the network round-trip
- * if `values` introduces no actual change. Caller-side debouncing lives in
- * the `useSaveCardMutation` wrapper, not here.
+ * Upserts a card with `values` merged over the current state. Leaves `card`
+ * untouched — optimistic apply and rollback are the caller's concern.
+ * Caller-side debouncing lives in the `useSaveCardMutation` wrapper, and the
+ * no-change short-circuit lives in the composable that calls it (both must
+ * happen before any optimistic mutation is applied to `card`).
  */
 export async function saveCard(card: Card, values: Partial<Card>): Promise<void> {
   if (!card.id) return
-  if (!hasCardChanges(card, values)) return
-
-  Object.assign(card, values)
-  await upsertCard(buildCardPayload(card))
+  await upsertCard(buildCardPayload({ ...card, ...values }))
 }
 
 export async function upsertCard(card: Partial<CardBase>): Promise<Card> {

--- a/src/api/cards/mutations/save.ts
+++ b/src/api/cards/mutations/save.ts
@@ -1,7 +1,6 @@
-import { useMutation, useQueryCache } from '@pinia/colada'
+import { useMutation } from '@pinia/colada'
 import { debounce } from '@/utils/debounce'
 import { saveCard } from '../db'
-import { invalidateDeck } from './_invalidate'
 
 type SaveCardVars = {
   card: Card
@@ -11,14 +10,14 @@ type SaveCardVars = {
 /**
  * Debounce is keyed by card id so concurrent edits to different cards don't
  * supersede each other. Superseded calls resolve with undefined.
+ *
+ * Intentionally does not invalidate the deck on settle: the calling component
+ * owns the authoritative editor state, so a self-triggered refetch would fight
+ * it. Bulk ops (delete, move, deck change) still invalidate explicitly.
  */
 export function useSaveCardMutation() {
-  const queryCache = useQueryCache()
   return useMutation({
     mutation: ({ card, values }: SaveCardVars) =>
-      debounce(() => saveCard(card, values), { key: `card-${card.id}` }),
-    onSettled: (_data, _error, { card }) => {
-      invalidateDeck(queryCache, card.deck_id)
-    }
+      debounce(() => saveCard(card, values), { key: `card-${card.id}` })
   })
 }

--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -37,6 +37,10 @@ const { image, text } = defineProps<{
   outline: 2px solid var(--color-blue-500);
 }
 
+.card-container[data-error] .card-face {
+  outline: 2px solid var(--color-red-500);
+}
+
 .card-face[data-mode='edit'][data-image='false'] {
   grid-template-rows: auto 1fr;
 }

--- a/src/components/card/index.vue
+++ b/src/components/card/index.vue
@@ -16,6 +16,7 @@ type CardProps = Partial<CardBase> & {
   card_attributes?: DeckCardAttributes
   face_classes?: string
   sfx?: SfxOptions
+  error?: boolean
 }
 
 const emit = defineEmits<{
@@ -29,7 +30,8 @@ const {
   cover_config,
   card_attributes,
   front_image_path,
-  back_image_path
+  back_image_path,
+  error = false
 } = defineProps<CardProps>()
 
 const front_image_url = computed(() => {
@@ -78,6 +80,7 @@ function onLeave(el: Element, done: () => void) {
     translate="no"
     class="card-container"
     :class="`card-container--${size} card-container--${mode}`"
+    :data-error="error || undefined"
     v-sfx="sfx"
   >
     <slot></slot>

--- a/src/composables/card-mutations.ts
+++ b/src/composables/card-mutations.ts
@@ -50,7 +50,8 @@ export function useCardMutations(opts: Options) {
       return
     }
 
-    // Real card path — debounced in-place save.
+    // Real card path — debounced save. Editor state lives on the component,
+    // so there's nothing to reconcile here: we just write through.
     const card = list.findCard(id)
     if (!card) return
 

--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -24,16 +24,28 @@ const front_input = useTemplateRef('front-input')
 const focused = ref(false)
 const focusOutPromise = ref<Promise<void> | null>(null)
 
+// Local editor state is the source of truth while the component is mounted.
+// Initialised from the card prop; later cache updates are ignored so
+// incoming refetches can't clobber what the user has typed.
+const front_text = ref(card.front_text ?? '')
+const back_text = ref(card.back_text ?? '')
+const save_failed = ref(false)
+
 const { mode, updateCard, card_attributes } = inject<CardListController>('card-editor')!
 const set_image_mutation = useSetCardImageMutation()
 const delete_image_mutation = useDeleteCardImageMutation()
 
-function onUpdate(side: 'front' | 'back', text: string) {
-  const update: Partial<Card> = {
-    [`${side}_text`]: text
-  }
+async function onUpdate(side: 'front' | 'back', text: string) {
+  if (side === 'front') front_text.value = text
+  else back_text.value = text
 
-  updateCard(card.id, update)
+  save_failed.value = false
+
+  try {
+    await updateCard(card.id, { [`${side}_text`]: text })
+  } catch {
+    save_failed.value = true
+  }
 }
 
 function focusEditor() {
@@ -101,6 +113,7 @@ defineExpose({ focusEditor, hasFocusWithin })
       size="xl"
       mode="edit"
       v-bind="card"
+      :error="save_failed"
       class="group/card"
       :class="{ 'pointer-events-none': mode === 'select' }"
     >
@@ -116,7 +129,7 @@ defineExpose({ focusEditor, hasFocusWithin })
       <template #editor>
         <text-editor
           ref="front-input"
-          :content="card.front_text"
+          :content="front_text"
           :attributes="card_attributes.front"
           :placeholder="t('common.front')"
           class="w-full h-full"
@@ -134,6 +147,7 @@ defineExpose({ focusEditor, hasFocusWithin })
       size="xl"
       mode="edit"
       v-bind="card"
+      :error="save_failed"
       class="group/card"
       :class="{ 'pointer-events-none': mode === 'select' }"
     >
@@ -149,7 +163,7 @@ defineExpose({ focusEditor, hasFocusWithin })
       <template #editor>
         <text-editor
           ref="back-input"
-          :content="card.back_text"
+          :content="back_text"
           :attributes="card_attributes.back"
           :placeholder="t('common.back')"
           class="w-full h-full"

--- a/tests/integration/components/card/index.test.js
+++ b/tests/integration/components/card/index.test.js
@@ -41,4 +41,23 @@ describe('Card (cover side)', () => {
     const coverStub = wrapper.findComponent({ name: 'CardCover' })
     expect(coverStub.props('cover')).toBeUndefined()
   })
+
+  // ── error prop → data-error attribute (drives red outline in CSS) ────────────
+
+  test('does not set data-error on the root when error is false', () => {
+    const wrapper = mountCard({ error: false })
+    expect(wrapper.find('[data-testid="card"]').attributes('data-error')).toBeUndefined()
+  })
+
+  test('does not set data-error on the root when error is omitted (defaults to false)', () => {
+    const wrapper = mountCard()
+    expect(wrapper.find('[data-testid="card"]').attributes('data-error')).toBeUndefined()
+  })
+
+  test('sets data-error on the root when error is true', () => {
+    const wrapper = mountCard({ error: true })
+    // Binding uses `error || undefined` so the attribute is absent when false
+    // and present when true; we don't assert a specific value string.
+    expect(wrapper.find('[data-testid="card"]').attributes('data-error')).toBeDefined()
+  })
 })

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -1,14 +1,14 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
-import { shallowMount } from '@vue/test-utils'
-import { defineComponent, h, ref } from 'vue'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h, ref, useAttrs } from 'vue'
 
 // Stub Card so its default + editor slots render — otherwise ImageButton
 // (which lives inside the card's default slot) is unreachable under shallowMount.
 // Forward attrs so `data-testid="front-input"` / `back-input` make it through.
-import { useAttrs } from 'vue'
 const CardStub = defineComponent({
   name: 'Card',
   inheritAttrs: false,
+  props: { error: { type: Boolean, default: false } },
   setup(_props, { slots }) {
     const attrs = useAttrs()
     return () => h('div', attrs, [slots.default?.(), slots.editor?.()])
@@ -41,6 +41,7 @@ vi.mock('@/composables/toast', () => ({
 
 import ListItemCard from '@/views/deck/card-editor/list-item-card.vue'
 import ImageButton from '@/views/deck/image-button.vue'
+import textEditor from '@/components/text-editor/text-editor.vue'
 
 function mount(props = {}) {
   return shallowMount(ListItemCard, {
@@ -75,6 +76,7 @@ beforeEach(() => {
   mocks.deleteCardImageMock.mockReset()
   mocks.deleteCardImageMock.mockResolvedValue(undefined)
   mocks.updateCardMock.mockReset()
+  mocks.updateCardMock.mockResolvedValue(undefined)
   mocks.emitSfxMock.mockReset()
 })
 
@@ -144,5 +146,48 @@ describe('ListItemCard', () => {
       deck_id: 10,
       side: 'front'
     })
+  })
+
+  // ── Auto-save wiring ──────────────────────────────────────────────────────
+
+  test('forwards text-editor updates to updateCard with the matching side key', async () => {
+    const wrapper = mount({ card: { id: 42 } })
+    const editors = wrapper.findAllComponents(textEditor)
+    await editors[0].vm.$emit('update', 'new front')
+    expect(mocks.updateCardMock).toHaveBeenCalledWith(42, { front_text: 'new front' })
+
+    await editors[1].vm.$emit('update', 'new back')
+    expect(mocks.updateCardMock).toHaveBeenLastCalledWith(42, { back_text: 'new back' })
+  })
+
+  // ── Error state — red outline from local save failure ─────────────────────
+
+  test('starts with error=false on both faces', () => {
+    const wrapper = mount({ card: { id: 42 } })
+    const cards = wrapper.findAllComponents(CardStub)
+    expect(cards[0].props('error')).toBe(false)
+    expect(cards[1].props('error')).toBe(false)
+  })
+
+  test('sets error=true on both faces when updateCard rejects', async () => {
+    mocks.updateCardMock.mockRejectedValueOnce(new Error('boom'))
+    const wrapper = mount({ card: { id: 42 } })
+    await wrapper.findAllComponents(textEditor)[0].vm.$emit('update', 'X')
+    await flushPromises()
+    const cards = wrapper.findAllComponents(CardStub)
+    expect(cards[0].props('error')).toBe(true)
+    expect(cards[1].props('error')).toBe(true)
+  })
+
+  test('clears error on the next update', async () => {
+    mocks.updateCardMock.mockRejectedValueOnce(new Error('boom'))
+    const wrapper = mount({ card: { id: 42 } })
+    await wrapper.findAllComponents(textEditor)[0].vm.$emit('update', 'X')
+    await flushPromises()
+    expect(wrapper.findAllComponents(CardStub)[0].props('error')).toBe(true)
+
+    await wrapper.findAllComponents(textEditor)[0].vm.$emit('update', 'XY')
+    await flushPromises()
+    expect(wrapper.findAllComponents(CardStub)[0].props('error')).toBe(false)
   })
 })

--- a/tests/unit/api/cards/mutations/save.test.js
+++ b/tests/unit/api/cards/mutations/save.test.js
@@ -1,8 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 
-const { useMutationSpy, invalidateSpy, saveCardMock, debounceMock } = vi.hoisted(() => ({
+const { useMutationSpy, saveCardMock, debounceMock } = vi.hoisted(() => ({
   useMutationSpy: vi.fn((cfg) => cfg),
-  invalidateSpy: vi.fn(),
   saveCardMock: vi.fn().mockResolvedValue(undefined),
   // Call the debounced fn immediately so the mutation resolves synchronously
   // in tests. We still assert on the debounce call shape.
@@ -10,8 +9,7 @@ const { useMutationSpy, invalidateSpy, saveCardMock, debounceMock } = vi.hoisted
 }))
 
 vi.mock('@pinia/colada', () => ({
-  useMutation: useMutationSpy,
-  useQueryCache: () => ({ invalidateQueries: invalidateSpy })
+  useMutation: useMutationSpy
 }))
 
 vi.mock('@/api/cards/db', () => ({
@@ -26,7 +24,6 @@ import { useSaveCardMutation } from '@/api/cards/mutations/save'
 
 beforeEach(() => {
   useMutationSpy.mockClear()
-  invalidateSpy.mockClear()
   saveCardMock.mockClear()
   saveCardMock.mockResolvedValue(undefined)
   debounceMock.mockClear()
@@ -57,20 +54,10 @@ describe('useSaveCardMutation', () => {
     expect(saveCardMock).toHaveBeenCalledWith(card, values)
   })
 
-  test("onSettled invalidates the card's deck (list + detail)", () => {
-    const { onSettled } = configFrom()
-
-    onSettled(undefined, undefined, { card: { id: 5, deck_id: 10 }, values: {} })
-
-    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['deck', 10] })
-    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 10] })
-  })
-
-  test('onSettled no-ops invalidation when the card has no deck_id', () => {
-    const { onSettled } = configFrom()
-
-    onSettled(undefined, undefined, { card: { id: 5 }, values: {} })
-
-    expect(invalidateSpy).not.toHaveBeenCalled()
+  test('does not install an onSettled handler — deck cache is not invalidated on self-save', () => {
+    // Refetch after a self-save would clobber the component-owned editor
+    // state that's driving the input. Bulk ops invalidate explicitly.
+    const config = configFrom()
+    expect(config.onSettled).toBeUndefined()
   })
 })

--- a/tests/unit/api/cards/update.test.js
+++ b/tests/unit/api/cards/update.test.js
@@ -93,17 +93,19 @@ beforeEach(() => {
 })
 
 describe('saveCard', () => {
-  test('mutates card in place and upserts when values change', async () => {
+  test('upserts with values merged over the current card state when values change', async () => {
     const card = makeCard()
     await saveCard(card, { front_text: 'Updated' })
-    expect(card.front_text).toBe('Updated')
     expect(mocks.singleMock).toHaveBeenCalled()
+    const { data } = mocks.singleMock.mock.calls[0][0]
+    expect(data.front_text).toBe('Updated')
   })
 
-  test('skips upsert when values are unchanged', async () => {
+  test('does not mutate the input card', async () => {
     const card = makeCard()
-    await saveCard(card, { front_text: card.front_text })
-    expect(mocks.singleMock).not.toHaveBeenCalled()
+    const before = { ...card }
+    await saveCard(card, { front_text: 'Updated' })
+    expect(card).toEqual(before)
   })
 
   test('skips upsert when card has no id', async () => {

--- a/tests/unit/composables/card-mutations.test.js
+++ b/tests/unit/composables/card-mutations.test.js
@@ -155,6 +155,14 @@ describe('useCardMutations', () => {
       expect(saveCardMock).not.toHaveBeenCalled()
     })
 
+    test("does not mutate the card passed to saveCard — optimistic apply is the caller's job", async () => {
+      const realCard = makeCard({ id: 42, front_text: 'before' })
+      const list = makeList({ persisted: [realCard], findCard: () => realCard })
+      const m = makeMutations({ list })
+      await m.updateCard(42, { front_text: 'after' })
+      expect(realCard.front_text).toBe('before')
+    })
+
     test('toggles saving=true during the async save and back to false afterward', async () => {
       const realCard = makeCard({ id: 1 })
       const list = makeList({ findCard: () => realCard })
@@ -168,7 +176,7 @@ describe('useCardMutations', () => {
       expect(m.saving.value).toBe(false)
     })
 
-    test('resets saving to false when saveCard rejects', async () => {
+    test('resets saving to false when saveCard rejects and propagates the rejection', async () => {
       const realCard = makeCard({ id: 1 })
       const list = makeList({ findCard: () => realCard })
       saveCardMock.mockRejectedValueOnce(new Error('boom'))
@@ -216,12 +224,9 @@ describe('useCardMutations', () => {
     })
 
     test('does not clear selection state (controller owns that)', async () => {
-      // The mutation layer is deliberately selection-agnostic after the
-      // refactor — verify it doesn't touch anything beyond the network call.
       const m = makeMutations()
       await m.deleteCards({ cards: [makeCard({ id: 1 })] })
       expect(deleteCardsMock).toHaveBeenCalledOnce()
-      // No selection-layer assertion needed; mutation takes no selection dep.
     })
   })
 


### PR DESCRIPTION
> Stacked on #142. Review against the parent branch on the **Files changed** tab, or after the base PR merges.

## Summary

Reshapes the auto-save flow so the component owns what the user is typing. Fixes a clobber bug where rapid typing caused refetches to overwrite in-flight edits.

The previous design optimistically mutated the cached card and invalidated the deck on every save settle (including debounce supersessions). Refetches kicked off mid-typing and replaced the card objects the editor was rendering. A short-lived attempt to coordinate with snapshot-rollback didn't hold up because the cache was driving the input directly.

## Changes

- `src/api/cards/db/update.ts` — `saveCard` no longer mutates its `card` argument; builds an immutable payload via spread.
- `src/api/cards/mutations/save.ts` — drops `onSettled` invalidation. Bulk ops still invalidate explicitly.
- `src/composables/card-mutations.ts` — `updateCard` is now a thin passthrough; no optimistic apply, no snapshot map, no rollback.
- `src/views/deck/card-editor/list-item-card.vue` — local `front_text` / `back_text` / `save_failed` refs. Text editor renders from local state. On save reject, `save_failed` flips true; cleared on the next edit.
- `src/components/card/{index,card-face}.vue` — new `error` prop on `Card`, drives a red outline via `data-error` attribute.
- `.claude/rules/architecture.md` — new rule: `src/api/` functions must not mutate their arguments.

## Test plan

- [ ] Type continuously into a card; text never reverts
- [ ] Type with Network blocked in DevTools — red outline appears, clears on next edit
- [ ] Bulk delete / move / select-all still refetch correctly
- [ ] Temp-card creation: type in a new card, wait for promotion, continue editing — no focus loss or text drop