### PR TITLE
Button size redesign and deck pagination labels

### DIFF
--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -7,7 +7,7 @@ import type { SfxOptions } from '@/sfx/directive'
 defineOptions({ inheritAttrs: false })
 
 export type ButtonProps = {
-  size?: 'xl' | 'lg' | 'base' | 'sm' | 'xs'
+  size?: 'xl' | 'lg' | 'base' | 'sm'
   variant?: 'solid' | 'outline'
   inverted?: boolean
   iconOnly?: boolean
@@ -108,6 +108,8 @@ const tooltip_active = computed(() => iconOnly && !!slots.default)
   height: var(--btn-height, max-content);
   width: max-content;
 
+  flex-grow: 0;
+
   display: flex;
   gap: var(--btn-gap);
   align-items: center;
@@ -158,7 +160,6 @@ const tooltip_active = computed(() => iconOnly && !!slots.default)
 .ui-kit-btn.ui-kit-btn--icon-only {
   --btn-padding: 8px;
   --btn-border-radius: var(--radius-4);
-  width: auto;
   aspect-ratio: 1/1;
 }
 
@@ -166,58 +167,53 @@ const tooltip_active = computed(() => iconOnly && !!slots.default)
 .ui-kit-btn.ui-kit-btn--xl {
   --btn-font-size: var(--text-xl);
   --btn-font-size--line-height: var(--text-xl--line-height);
-  --btn-border-radius: var(--radius-5_5);
-  --btn-gap: 16px;
+  --btn-border-radius: 22.5px;
+  --btn-gap: 10px;
   --btn-padding: 14px 24px;
   --btn-height: 50px;
+
+  &.ui-kit-btn--icon-only {
+    --btn-padding: 14px;
+  }
 }
 .ui-kit-btn.ui-kit-btn--lg {
-  --btn-font-size: var(--text-lg);
+  --btn-font-size: var(--text-xl);
   --btn-font-size--line-height: var(--text-xl--line-height);
-  --btn-border-radius: var(--radius-5);
-  --btn-gap: 16px;
-  --btn-padding: 14px 20px;
-  --btn-height: 46px;
+  --btn-border-radius: 19px;
+  --btn-gap: 6px;
+  --btn-padding: 10px 20px;
+  --btn-height: 45px;
+  --icon-size: 20px;
 
   &.ui-kit-btn--icon-only {
     --btn-padding: 10px;
   }
 }
 .ui-kit-btn.ui-kit-btn--base {
-  --btn-font-size: var(--text-base);
-  --btn-font-size--line-height: var(--text-base--line-height);
-  --btn-border-radius: var(--radius-4);
-  --btn-gap: 8px;
-  --btn-padding: 6px 10px;
+  --btn-font-size: var(--text-lg);
+  --btn-font-size--line-height: var(--text-lg--line-height);
+  --btn-border-radius: 18px;
+  --btn-gap: 4px;
+  --btn-padding: 6px 14px;
+  --btn-height: 40px;
+  --icon-size: 20px;
   --btn-height: 40px;
 
   &.ui-kit-btn--icon-only {
     --btn-padding: 8px;
-    --btn-border-radius: var(--radius-4_5);
   }
 }
 .ui-kit-btn.ui-kit-btn--sm {
   --btn-font-size: var(--text-base);
   --btn-font-size--line-height: var(--text-base--line-height);
-  --btn-border-radius: var(--radius-4);
-  --btn-gap: 6px;
-  --btn-padding: 4px 6px;
-  --icon-size: 22px;
-
-  &.ui-kit-btn--icon-only {
-    --btn-padding: 6px;
-  }
-}
-.ui-kit-btn.ui-kit-btn--xs {
-  --btn-font-size: var(--text-base);
-  --btn-font-size--line-height: var(--text-base--line-height);
-  --btn-border-radius: var(--radius-3_75);
+  --btn-border-radius: 13px;
   --btn-gap: 3px;
   --btn-padding: 4px 12px;
   --icon-size: 16px;
+  --btn-height: 30px;
 
   &.ui-kit-btn--icon-only {
-    --btn-padding: 8px;
+    --btn-padding: 7px;
   }
 }
 

--- a/src/composables/card-editor/card-carousel.ts
+++ b/src/composables/card-editor/card-carousel.ts
@@ -37,6 +37,13 @@ export function useCardCarousel({ list, cards_query, card_count }: Args) {
   const total_pages = computed(() => Math.max(1, Math.ceil(card_count.value / page_size.value)))
   const can_paginate = computed(() => total_pages.value > 1)
 
+  // 1-based labels for "previous"/"next" buttons. Wrap so the prev label on
+  // page 0 reads as the last page, and next on the last page reads as 1.
+  const prev_page_number = computed(() => (page.value === 0 ? total_pages.value : page.value))
+  const next_page_number = computed(() =>
+    page.value === total_pages.value - 1 ? 1 : page.value + 2
+  )
+
   const visible_cards = computed(() => {
     if (visible_capacity.value === 0) return list.all_cards.value.slice(0, 1)
     const start = page.value * page_size.value
@@ -97,6 +104,8 @@ export function useCardCarousel({ list, cards_query, card_count }: Args) {
     visible_cards,
     is_page_loading,
     can_paginate,
+    prev_page_number,
+    next_page_number,
     setVisibleCapacity,
     prevPage,
     nextPage

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -240,6 +240,8 @@
   "deck-view.actions.study-all": "Study <span>all</span> cards",
   "deck-view.actions.edit-cards": "Edit Cards",
   "deck-view.actions.cancel": "Stop Editing",
+  "deck-view.actions.prev-page": "Page {page}",
+  "deck-view.actions.next-page": "Page {page}",
   "deck-view.add-card": "Add Card",
   "deck-view.no-cards": "No Cards",
   "deck-view.tabs.card-view": "View",

--- a/src/phone/apps/settings/component/billing-settings/payment-methods-section.vue
+++ b/src/phone/apps/settings/component/billing-settings/payment-methods-section.vue
@@ -104,7 +104,7 @@ function openAddCreditCard() {
             v-else
             :data-testid="`billing-settings__payment-method-make-default-${method.id}`"
             data-theme="green-400"
-            size="xs"
+            size="sm"
             variant="outline"
             :loading="set_default_mutation.isLoading.value"
             @click="onSetDefault(method.id)"
@@ -115,7 +115,7 @@ function openAddCreditCard() {
           <ui-button
             :data-testid="`billing-settings__payment-method-detach-${method.id}`"
             data-theme="red-500"
-            size="xs"
+            size="sm"
             variant="outline"
             icon-only
             icon-left="delete"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -76,6 +76,7 @@
   --radius-3_5: --spacing(3.5); /* 14px */
   --radius-3_75: --spacing(3.75); /* 15px */
   --radius-4: --spacing(4); /* 16px */
+  --radius-4_25: --spacing(4.25); /* 17px */
   --radius-4_5: --spacing(4.5); /* 18px */
   --radius-5: --spacing(5); /* 20px */
   --radius-5_5: --spacing(5.5); /* 22px */

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -97,7 +97,7 @@ function onClick(e: MouseEvent) {
       icon-left="add"
       icon-only
       data-theme="brown-100"
-      size="xs"
+      size="sm"
       class="absolute! z-1 top-0 -translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="prependCard(card.id!)"
     />
@@ -107,7 +107,7 @@ function onClick(e: MouseEvent) {
       icon-left="add"
       icon-only
       data-theme="brown-100"
-      size="xs"
+      size="sm"
       class="absolute! z-1 bottom-0 translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="appendCard(card.id!)"
     />

--- a/src/views/deck/deck-hero.vue
+++ b/src/views/deck/deck-hero.vue
@@ -40,9 +40,10 @@ function onToggleEditCards() {
       <template #actions>
         <ui-button
           data-testid="deck-hero__settings-button"
+          data-theme="blue-500"
+          data-theme-dark="blue-650"
           icon-left="build"
           class="absolute! -top-2.5 -left-2.5"
-          size="sm"
           icon-only
           @click="onSettingsClicked"
           >{{ t('deck.settings-modal.title') }}</ui-button

--- a/src/views/deck/index.vue
+++ b/src/views/deck/index.vue
@@ -34,6 +34,16 @@ const mode_components: { [key in CardEditorMode]: any } = {
 }
 
 const is_empty = computed(() => !editor.isLoading.value && editor.list.all_cards.value.length === 0)
+
+const prev_page_number = computed(() => {
+  const { page, total_pages } = editor.carousel
+  return page.value === 0 ? total_pages.value : page.value
+})
+
+const next_page_number = computed(() => {
+  const { page, total_pages } = editor.carousel
+  return page.value === total_pages.value - 1 ? 1 : page.value + 2
+})
 </script>
 
 <template>
@@ -61,7 +71,7 @@ const is_empty = computed(() => !editor.isLoading.value && editor.list.all_cards
         icon-left="arrow-left"
         @click="editor.carousel.prevPage()"
       >
-        {{ t('common.previous') }}
+        {{ t('deck-view.actions.prev-page', { page: prev_page_number }) }}
       </ui-button>
 
       <div v-if="is_empty" data-testid="deck-view__empty" class="row-start-2 col-start-2" />
@@ -75,7 +85,7 @@ const is_empty = computed(() => !editor.isLoading.value && editor.list.all_cards
         icon-left="arrow-right"
         @click="editor.carousel.nextPage()"
       >
-        {{ t('common.next') }}
+        {{ t('deck-view.actions.next-page', { page: next_page_number }) }}
       </ui-button>
     </div>
   </section>

--- a/src/views/deck/index.vue
+++ b/src/views/deck/index.vue
@@ -35,15 +35,7 @@ const mode_components: { [key in CardEditorMode]: any } = {
 
 const is_empty = computed(() => !editor.isLoading.value && editor.list.all_cards.value.length === 0)
 
-const prev_page_number = computed(() => {
-  const { page, total_pages } = editor.carousel
-  return page.value === 0 ? total_pages.value : page.value
-})
-
-const next_page_number = computed(() => {
-  const { page, total_pages } = editor.carousel
-  return page.value === total_pages.value - 1 ? 1 : page.value + 2
-})
+const { prev_page_number, next_page_number } = editor.carousel
 </script>
 
 <template>

--- a/src/views/deck/mode-toolbar/mode-view.vue
+++ b/src/views/deck/mode-toolbar/mode-view.vue
@@ -3,7 +3,7 @@ import toolbarBase from './toolbar-base.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiTag from '@/components/ui-kit/tag.vue'
 import { useI18n } from 'vue-i18n'
-import { inject } from 'vue'
+import { computed, inject } from 'vue'
 import { type CardListController } from '@/composables/card-editor/card-list-controller'
 
 const { t } = useI18n()
@@ -11,6 +11,10 @@ const { t } = useI18n()
 const { list, carousel } = inject<CardListController>('card-editor')!
 const { addCard } = list
 const { page, total_pages, prevPage, nextPage, can_paginate } = carousel
+
+const prev_page_number = computed(() => (page.value === 0 ? total_pages.value : page.value))
+
+const next_page_number = computed(() => (page.value === total_pages.value - 1 ? 1 : page.value + 2))
 </script>
 
 <template>
@@ -20,7 +24,7 @@ const { page, total_pages, prevPage, nextPage, can_paginate } = carousel
         data-testid="mode-view__search-button"
         data-theme="brown-300"
         data-theme-dark="grey-800"
-        size="xs"
+        size="sm"
         icon-left="search"
         icon-only
       >
@@ -31,7 +35,7 @@ const { page, total_pages, prevPage, nextPage, can_paginate } = carousel
         data-testid="mode-view__add-card-button"
         data-theme="blue-500"
         data-theme-dark="blue-650"
-        size="xs"
+        size="sm"
         icon-left="add"
         @click="addCard()"
       >
@@ -45,7 +49,7 @@ const { page, total_pages, prevPage, nextPage, can_paginate } = carousel
           data-testid="mode-view__page-counter"
           data-theme="green-400"
           data-theme-dark="green-800"
-          class="bgx-diagonal-stripes dark:bgx-opacity-10"
+          class="bgx-diagonal-stripes bgx-opacity-10"
         >
           {{ t('deck.mode-view.page-counter', { current: page + 1, total: total_pages }) }}
         </ui-tag>
@@ -55,12 +59,12 @@ const { page, total_pages, prevPage, nextPage, can_paginate } = carousel
           data-theme="brown-300"
           data-theme-dark="grey-800"
           icon-only
-          size="xs"
+          size="sm"
           icon-left="arrow-left"
           :disabled="!can_paginate"
           @click="prevPage"
         >
-          {{ t('common.previous') }}
+          {{ t('deck-view.actions.prev-page', { page: prev_page_number }) }}
         </ui-button>
 
         <ui-button
@@ -68,12 +72,12 @@ const { page, total_pages, prevPage, nextPage, can_paginate } = carousel
           data-theme="brown-300"
           data-theme-dark="grey-800"
           icon-only
-          size="xs"
+          size="sm"
           icon-left="arrow-right"
           :disabled="!can_paginate"
           @click="nextPage"
         >
-          {{ t('common.next') }}
+          {{ t('deck-view.actions.next-page', { page: next_page_number }) }}
         </ui-button>
       </div>
     </template>

--- a/src/views/deck/mode-toolbar/mode-view.vue
+++ b/src/views/deck/mode-toolbar/mode-view.vue
@@ -3,18 +3,15 @@ import toolbarBase from './toolbar-base.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiTag from '@/components/ui-kit/tag.vue'
 import { useI18n } from 'vue-i18n'
-import { computed, inject } from 'vue'
+import { inject } from 'vue'
 import { type CardListController } from '@/composables/card-editor/card-list-controller'
 
 const { t } = useI18n()
 
 const { list, carousel } = inject<CardListController>('card-editor')!
 const { addCard } = list
-const { page, total_pages, prevPage, nextPage, can_paginate } = carousel
-
-const prev_page_number = computed(() => (page.value === 0 ? total_pages.value : page.value))
-
-const next_page_number = computed(() => (page.value === total_pages.value - 1 ? 1 : page.value + 2))
+const { page, total_pages, prev_page_number, next_page_number, prevPage, nextPage, can_paginate } =
+  carousel
 </script>
 
 <template>

--- a/tests/unit/composables/card-editor/card-carousel.test.js
+++ b/tests/unit/composables/card-editor/card-carousel.test.js
@@ -139,6 +139,33 @@ describe('useCardCarousel', () => {
     })
   })
 
+  // ── prev/next page-number labels ─────────────────────────────────────────
+
+  describe('prev_page_number / next_page_number', () => {
+    test('prev wraps to the last page when on page 0', () => {
+      const { carousel } = makeCarousel({ card_count: 30 })
+      carousel.setVisibleCapacity(10) // total_pages = 3
+      expect(carousel.page.value).toBe(0)
+      expect(carousel.prev_page_number.value).toBe(3)
+    })
+
+    test('next wraps to 1 when on the last page', () => {
+      const { carousel } = makeCarousel({ card_count: 30 })
+      carousel.setVisibleCapacity(10) // total_pages = 3
+      carousel.nextPage()
+      carousel.nextPage() // page = 2 (last)
+      expect(carousel.next_page_number.value).toBe(1)
+    })
+
+    test('mid-range labels reflect 1-based neighbors', () => {
+      const { carousel } = makeCarousel({ card_count: 30 })
+      carousel.setVisibleCapacity(10)
+      carousel.nextPage() // page = 1
+      expect(carousel.prev_page_number.value).toBe(1)
+      expect(carousel.next_page_number.value).toBe(3)
+    })
+  })
+
   // ── is_page_loading ──────────────────────────────────────────────────────
 
   describe('is_page_loading', () => {


### PR DESCRIPTION
## Summary

Two unrelated UI tweaks bundled together:

1. **Button size scale redesign** — `ui-kit/button` sizes (`xl`/`lg`/`base`/`sm`) get revised padding, radius, and gap values. The seldom-used `xs` size is removed; the few callers (billing payment methods, card-editor list-item add buttons) move to `sm`. Deck-hero settings button visual tweak.
2. **Deck pagination labels** — the deck view's prev/next page buttons now show the absolute target page number instead of generic "Previous"/"Next", wrapping at the collection ends. Same treatment in the mode-toolbar.

## Changes

- `refactor(ui-kit): redesign button sizes (drop xs)` — `button.vue`, `main.css` (new `--radius-4_25`), consumer migrations.
- `feat(deck): show absolute page numbers in pagination` — `deck/index.vue`, `mode-toolbar/mode-view.vue`, locale strings.