### PR TITLE
feat(card-grid): click-to-flip items + dark-theme menu

### DIFF
--- a/src/components/card/index.vue
+++ b/src/components/card/index.vue
@@ -195,8 +195,8 @@ function onLeave(el: Element, done: () => void) {
 }
 
 [data-theme='dark'] .card-container {
-  --card-bg-color: var(--color-grey-750);
-  --card-text-color: var(--color-brown-100);
+  --card-bg-color: var(--color-brown-500);
+  --card-text-color: var(--color-brown-800);
   --card-text-color--placeholder: var(--color-brown-500);
 }
 </style>

--- a/src/views/deck/card-grid/grid-item-menu.vue
+++ b/src/views/deck/card-grid/grid-item-menu.vue
@@ -4,6 +4,8 @@ import UiButton from '@/components/ui-kit/button.vue'
 import UiActionMenu from '@/components/ui-kit/action-menu.vue'
 
 const { t } = useI18n()
+
+defineOptions({ inheritAttrs: false })
 </script>
 
 <template>
@@ -17,10 +19,11 @@ const { t } = useI18n()
     <template #trigger="{ toggle, is_open }">
       <ui-button
         data-theme="brown-300"
-        size="sm"
+        data-theme-dark="grey-800"
         icon-only
         icon-right="more"
         data-testid="grid-item__menu-trigger"
+        v-bind="$attrs"
         :class="{
           'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto':
             !is_open
@@ -29,19 +32,43 @@ const { t } = useI18n()
       />
     </template>
 
-    <ui-button data-theme="brown-300" size="sm" icon-right="edit" class="shadow-xs">
+    <ui-button
+      data-theme="brown-300"
+      data-theme-dark="grey-800"
+      size="sm"
+      icon-right="edit"
+      class="shadow-xs"
+    >
       {{ t('deck-view.item-options.edit') }}
     </ui-button>
-    <ui-button data-theme="brown-300" size="sm" icon-right="move-item" class="shadow-xs">
+    <ui-button
+      data-theme="brown-300"
+      data-theme-dark="grey-800"
+      size="sm"
+      icon-right="move-item"
+      class="shadow-xs"
+    >
       {{ t('deck-view.item-options.move') }}
     </ui-button>
-    <ui-button data-theme="brown-300" size="sm" icon-right="reorder" class="shadow-xs">
+    <ui-button
+      data-theme="brown-300"
+      data-theme-dark="grey-800"
+      size="sm"
+      icon-right="reorder"
+      class="shadow-xs"
+    >
       {{ t('deck-view.item-options.reorder') }}
     </ui-button>
-    <ui-button data-theme="brown-300" size="sm" class="shadow-xs">
+    <ui-button data-theme="brown-300" data-theme-dark="grey-800" size="sm" class="shadow-xs">
       {{ t('deck-view.item-options.select') }}
     </ui-button>
-    <ui-button data-theme="red-500" size="sm" icon-right="delete" class="shadow-xs">
+    <ui-button
+      data-theme="red-500"
+      data-theme-dark="red-600"
+      size="sm"
+      icon-right="delete"
+      class="shadow-xs"
+    >
       {{ t('deck-view.item-options.delete') }}
     </ui-button>
   </ui-action-menu>

--- a/src/views/deck/card-grid/grid-item.vue
+++ b/src/views/deck/card-grid/grid-item.vue
@@ -2,6 +2,8 @@
 import Card from '@/components/card/index.vue'
 import UiRadio from '@/components/ui-kit/radio.vue'
 import GridItemMenu from './grid-item-menu.vue'
+import { emitSfx } from '@/sfx/bus'
+import { ref } from 'vue'
 
 const { card, side, is_selecting } = defineProps<{
   card: Card
@@ -14,28 +16,33 @@ const { card, side, is_selecting } = defineProps<{
 const emit = defineEmits<{
   (e: 'card-selected'): void
 }>()
+
+const active_side = ref(side)
+
+function onCardClick() {
+  if (is_selecting) return
+  active_side.value = active_side.value === 'front' ? 'back' : 'front'
+  emitSfx(active_side.value === 'back' ? 'ui.transition_up' : 'ui.transition_down')
+}
 </script>
 
 <template>
-  <div class="group relative w-full max-w-78.5" data-testid="grid-item-wrapper">
-    <div
-      class="grid-item relative aspect-card w-full overflow-hidden [content-visibility:auto] [contain-intrinsic-size:auto_220px]"
+  <div data-testid="grid-item" class="grid-item relative aspect-card w-full group">
+    <card
+      v-bind="card"
+      :class="{
+        'hover:[&>.card-face]:border-purple-500!': is_selecting
+      }"
+      class="grid-item__card cursor-pointer"
+      size="xl"
+      :side="active_side"
+      :card_attributes="card_attributes"
+      @click="onCardClick"
     >
-      <card
-        v-bind="card"
-        :class="{
-          'cursor-pointer hover:[&>.card-face]:border-purple-500!': is_selecting
-        }"
-        class="grid-item__card"
-        size="xl"
-        :side="side"
-        :card_attributes="card_attributes"
-      >
-        <div v-if="is_selecting" class="absolute top-0 right-0">
-          <ui-radio :checked="selected" @click.stop="emit('card-selected')" />
-        </div>
-      </card>
-    </div>
+      <div v-if="is_selecting" class="absolute top-0 right-0">
+        <ui-radio :checked="selected" @click.stop="emit('card-selected')" />
+      </div>
+    </card>
 
     <grid-item-menu v-if="!is_selecting" />
   </div>

--- a/src/views/deck/card-grid/index.vue
+++ b/src/views/deck/card-grid/index.vue
@@ -55,13 +55,9 @@ const emit = defineEmits<{
 <template>
   <div
     data-testid="card-grid-container"
-    class="flex flex-col items-center w-full md:flex-1 md:min-h-0 md:overflow-hidden"
+    class="flex flex-col items-center w-full md:flex-1 md:min-h-0"
   >
-    <div
-      ref="grid_wrapper"
-      data-testid="card-grid__wrapper"
-      class="w-full md:flex-1 md:min-h-0 md:overflow-hidden"
-    >
+    <div ref="grid_wrapper" data-testid="card-grid__wrapper" class="w-full md:flex-1 md:min-h-0">
       <Transition
         :css="false"
         mode="out-in"
@@ -87,6 +83,7 @@ const emit = defineEmits<{
               @card-selected="emit('card-selected', card.id!)"
             ></grid-item>
           </template>
+
           <template v-else>
             <div
               v-for="n in Math.max(capacity, page_size, 1)"
@@ -98,6 +95,7 @@ const emit = defineEmits<{
         </div>
       </Transition>
     </div>
+
     <div
       v-if="!isMd && hasNextPage"
       ref="sentinel"

--- a/tests/integration/views/deck/card-grid/grid-item.test.js
+++ b/tests/integration/views/deck/card-grid/grid-item.test.js
@@ -1,0 +1,149 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, useAttrs } from 'vue'
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+
+const CardStub = defineComponent({
+  name: 'Card',
+  inheritAttrs: false,
+  props: ['side'],
+  setup(props, { slots }) {
+    const attrs = useAttrs()
+    return () =>
+      h(
+        'div',
+        {
+          'data-testid': 'card-stub',
+          'data-side': props.side,
+          onClick: attrs.onClick
+        },
+        slots.default?.()
+      )
+  }
+})
+
+const UiRadioStub = defineComponent({
+  name: 'UiRadio',
+  props: ['checked'],
+  emits: ['click'],
+  setup(props, { emit }) {
+    return () =>
+      h('button', {
+        'data-testid': 'ui-radio-stub',
+        'data-checked': String(props.checked),
+        onClick: (e) => emit('click', e)
+      })
+  }
+})
+
+const GridItemMenuStub = defineComponent({
+  name: 'GridItemMenu',
+  setup() {
+    return () => h('div', { 'data-testid': 'grid-item-menu-stub' })
+  }
+})
+
+import GridItem from '@/views/deck/card-grid/grid-item.vue'
+
+function mountGridItem(props = {}) {
+  return mount(GridItem, {
+    props: {
+      card: { id: 1, front_text: 'q', back_text: 'a' },
+      side: 'front',
+      is_selecting: false,
+      selected: false,
+      ...props
+    },
+    attachTo: document.body,
+    global: {
+      stubs: {
+        Card: CardStub,
+        UiRadio: UiRadioStub,
+        GridItemMenu: GridItemMenuStub
+      }
+    }
+  })
+}
+
+describe('GridItem (card-grid/grid-item.vue)', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+  })
+
+  test('renders root with data-testid="grid-item"', () => {
+    const wrapper = mountGridItem()
+    expect(wrapper.find('[data-testid="grid-item"]').exists()).toBe(true)
+  })
+
+  test('initial side comes from the side prop', () => {
+    const wrapper = mountGridItem({ side: 'back' })
+    expect(wrapper.find('[data-testid="card-stub"]').attributes('data-side')).toBe('back')
+  })
+
+  test('clicking the card flips front → back and emits transition_up sfx', async () => {
+    const wrapper = mountGridItem({ side: 'front' })
+    await wrapper.find('[data-testid="card-stub"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="card-stub"]').attributes('data-side')).toBe('back')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.transition_up')
+  })
+
+  test('clicking again flips back → front and emits transition_down sfx', async () => {
+    const wrapper = mountGridItem({ side: 'front' })
+    const card = wrapper.find('[data-testid="card-stub"]')
+
+    await card.trigger('click')
+    mockEmitSfx.mockClear()
+
+    await card.trigger('click')
+    expect(card.attributes('data-side')).toBe('front')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.transition_down')
+  })
+
+  test('does not flip or emit sfx when is_selecting is true', async () => {
+    const wrapper = mountGridItem({ side: 'front', is_selecting: true })
+    await wrapper.find('[data-testid="card-stub"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="card-stub"]').attributes('data-side')).toBe('front')
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+  })
+
+  test('renders ui-radio inside the card while selecting', () => {
+    const wrapper = mountGridItem({ is_selecting: true, selected: false })
+    const radio = wrapper.find('[data-testid="ui-radio-stub"]')
+    expect(radio.exists()).toBe(true)
+    expect(radio.attributes('data-checked')).toBe('false')
+  })
+
+  test('forwards the selected prop to the radio', () => {
+    const wrapper = mountGridItem({ is_selecting: true, selected: true })
+    expect(wrapper.find('[data-testid="ui-radio-stub"]').attributes('data-checked')).toBe('true')
+  })
+
+  test('omits the radio when not selecting', () => {
+    const wrapper = mountGridItem({ is_selecting: false })
+    expect(wrapper.find('[data-testid="ui-radio-stub"]').exists()).toBe(false)
+  })
+
+  test('renders the grid-item-menu when not selecting', () => {
+    const wrapper = mountGridItem({ is_selecting: false })
+    expect(wrapper.find('[data-testid="grid-item-menu-stub"]').exists()).toBe(true)
+  })
+
+  test('hides the grid-item-menu while selecting', () => {
+    const wrapper = mountGridItem({ is_selecting: true })
+    expect(wrapper.find('[data-testid="grid-item-menu-stub"]').exists()).toBe(false)
+  })
+
+  test('clicking the radio emits card-selected and does not flip the card', async () => {
+    const wrapper = mountGridItem({ side: 'front', is_selecting: true })
+    await wrapper.find('[data-testid="ui-radio-stub"]').trigger('click')
+
+    expect(wrapper.emitted('card-selected')).toEqual([[]])
+    expect(wrapper.find('[data-testid="card-stub"]').attributes('data-side')).toBe('front')
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- Grid items flip side on click (front ↔ back) with directional transition sfx; flipping is gated off while in selection mode.
- Dark-theme overrides on grid-item-menu buttons and refreshed dark-mode card placeholder colors.
- Drop `md:overflow-hidden` from the card-grid wrapper and forward `$attrs` from the menu trigger.
- New integration suite covers grid-item flip + selection behavior.