### PR TITLE
Deck page dots

### DIFF
--- a/src/composables/card-editor/card-carousel.ts
+++ b/src/composables/card-editor/card-carousel.ts
@@ -76,6 +76,22 @@ export function useCardCarousel({ list, cards_query, card_count }: Args) {
     emitSfx('ui.slide_up')
   }
 
+  /**
+   * Jump directly to a 0-based page index. No-op when paging is disabled
+   * or the target equals the current page; clamps out-of-range values.
+   */
+  function goToPage(n: number) {
+    if (!can_paginate.value) return
+
+    const target = Math.max(0, Math.min(total_pages.value - 1, n))
+    if (target === page.value) return
+
+    page_direction.value = target > page.value ? 'forward' : 'backward'
+    page.value = target
+
+    emitSfx('ui.slide_up')
+  }
+
   watch(total_pages, (n) => {
     if (page.value > n - 1) page.value = Math.max(0, n - 1)
   })
@@ -108,6 +124,7 @@ export function useCardCarousel({ list, cards_query, card_count }: Args) {
     next_page_number,
     setVisibleCapacity,
     prevPage,
-    nextPage
+    nextPage,
+    goToPage
   }
 }

--- a/src/composables/use-grid-capacity.ts
+++ b/src/composables/use-grid-capacity.ts
@@ -93,7 +93,10 @@ export function useGridCapacity({
     if (!el) return
 
     gridWidth.value = el.clientWidth
-    boundsHeight.value = (bounds?.value ?? el).clientHeight
+
+    const style = getComputedStyle(el)
+    const grid_pad_y = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom)
+    boundsHeight.value = (bounds?.value ?? el).clientHeight - grid_pad_y
 
     const first = el.firstElementChild as HTMLElement | null
     if (first) {

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -242,6 +242,7 @@
   "deck-view.actions.cancel": "Stop Editing",
   "deck-view.actions.prev-page": "Page {page}",
   "deck-view.actions.next-page": "Page {page}",
+  "deck-view.page-dots.tooltip": "Page {page}",
   "deck-view.add-card": "Add Card",
   "deck-view.no-cards": "No Cards",
   "deck-view.tabs.card-view": "View",

--- a/src/views/deck/index.vue
+++ b/src/views/deck/index.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import DeckHero from '@/views/deck/deck-hero.vue'
 import ModeToolbar from './mode-toolbar/index.vue'
 import ModeStack from './mode-stack.vue'
+import PageDots from './page-dots.vue'
 import PageNavButton from './page-nav-button.vue'
 import { useDeckQuery } from '@/api/decks'
 import { useCardListController } from '@/composables/card-editor/card-list-controller'
@@ -44,7 +45,7 @@ const { prev_page_number, next_page_number } = editor.carousel
 
     <div
       data-testid="deck-view__main"
-      class="md:h-full relative w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] grid-rows-[auto_1fr] gap-4 pb-4"
+      class="md:h-full relative w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] grid-rows-[auto_minmax(0,1fr)_auto] gap-4 pb-4"
     >
       <mode-toolbar class="sm:col-start-2" />
 
@@ -58,6 +59,8 @@ const { prev_page_number, next_page_number } = editor.carousel
       <page-nav-button direction="next">
         {{ t('deck-view.actions.next-page', { page: next_page_number }) }}
       </page-nav-button>
+
+      <page-dots />
     </div>
   </section>
 </template>

--- a/src/views/deck/page-dots.vue
+++ b/src/views/deck/page-dots.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { inject, ref, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+import UiTooltip from '@/components/ui-kit/tooltip.vue'
+import { emitSfx } from '@/sfx/bus'
+import type { CardListController } from '@/composables/card-editor/card-list-controller'
+
+const editor = inject<CardListController>('card-editor')!
+const { t } = useI18n()
+
+const { total_pages, page, can_paginate, goToPage } = editor.carousel
+
+const row_ref = useTemplateRef<HTMLElement>('row')
+const hovered_index = ref<number | null>(null)
+
+function onPointerMove(e: PointerEvent) {
+  const row = row_ref.value
+  if (!row) return
+
+  const rect = row.getBoundingClientRect()
+  const t = (e.clientX - rect.left) / rect.width
+  const i = Math.floor(t * total_pages.value)
+
+  const next = Math.max(0, Math.min(total_pages.value - 1, i))
+
+  if (next !== hovered_index.value) {
+    hovered_index.value = next
+    emitSfx('ui.click_07', { debounce: 10 })
+  }
+}
+
+function onPointerLeave() {
+  hovered_index.value = null
+}
+
+function onClick() {
+  if (hovered_index.value !== null) goToPage(hovered_index.value)
+}
+</script>
+
+<template>
+  <div
+    v-if="can_paginate"
+    data-testid="deck-view__page-dots"
+    data-theme="brown-300"
+    data-theme-dark="brown-300"
+    :data-engaged="hovered_index !== null || undefined"
+    class="sm:row-start-3 sm:col-start-2 justify-self-center relative cursor-pointer transition-opacity duration-300 before:content-[''] before:absolute before:-inset-x-10 before:-inset-y-6"
+    :class="{ 'opacity-0 pointer-events-none': editor.mode.value !== 'view' }"
+    @pointermove="onPointerMove"
+    @pointerleave="onPointerLeave"
+    @click="onClick"
+  >
+    <div ref="row" data-testid="deck-view__page-dots__row" class="flex items-center gap-2">
+      <ui-tooltip
+        v-for="n in total_pages"
+        :key="n"
+        element="span"
+        :text="t('deck-view.page-dots.tooltip', { page: n })"
+        :visible="hovered_index === n - 1"
+        position="top"
+        :gap="6"
+        :data-testid="`deck-view__page-dots__dot-${n}`"
+        :data-active="hovered_index === n - 1 || page === n - 1 || undefined"
+        class="size-2 rounded-full bg-(--theme-on-neutral) opacity-50 scale-75 data-active:opacity-100 data-active:scale-125 transition-[opacity,scale] duration-200 ease-out pointer-events-none"
+      />
+    </div>
+  </div>
+</template>

--- a/tests/integration/views/deck/page-dots.test.js
+++ b/tests/integration/views/deck/page-dots.test.js
@@ -1,0 +1,241 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h, ref, computed } from 'vue'
+
+const { emitSfxMock } = vi.hoisted(() => ({ emitSfxMock: vi.fn() }))
+vi.mock('@/sfx/bus', () => ({ emitSfx: emitSfxMock }))
+
+import PageDots from '@/views/deck/page-dots.vue'
+
+const UiTooltipStub = defineComponent({
+  name: 'UiTooltip',
+  inheritAttrs: false,
+  props: ['text', 'visible', 'element', 'position', 'gap'],
+  setup(props, { attrs }) {
+    return () =>
+      h(props.element ?? 'span', {
+        ...attrs,
+        'data-tooltip-text': props.text,
+        'data-tooltip-visible': props.visible || undefined
+      })
+  }
+})
+
+function makeEditor({
+  mode = 'view',
+  total_pages = 3,
+  page = 0,
+  can_paginate = true,
+  goToPage = vi.fn()
+} = {}) {
+  return {
+    mode: ref(mode),
+    carousel: {
+      total_pages: computed(() => total_pages),
+      page: ref(page),
+      can_paginate: computed(() => can_paginate),
+      goToPage
+    }
+  }
+}
+
+function mount(editor = makeEditor()) {
+  return shallowMount(PageDots, {
+    global: {
+      provide: { 'card-editor': editor },
+      stubs: { UiTooltip: UiTooltipStub }
+    }
+  })
+}
+
+async function firePointerMove(wrapper, clientX) {
+  const el = wrapper.find('[data-testid="deck-view__page-dots"]').element
+  const event = new PointerEvent('pointermove', {
+    clientX,
+    bubbles: true,
+    cancelable: true
+  })
+  el.dispatchEvent(event)
+  await wrapper.vm.$nextTick()
+}
+
+// rect helper: row spans 0–300px, so 5 dots map to 60px slices.
+function stubRowRect(wrapper, { left = 0, width = 300 } = {}) {
+  const row = wrapper.find('[data-testid="deck-view__page-dots__row"]').element
+  row.getBoundingClientRect = () => ({
+    left,
+    width,
+    right: left + width,
+    top: 0,
+    bottom: 0,
+    height: 0,
+    x: left,
+    y: 0,
+    toJSON: () => ({})
+  })
+}
+
+describe('PageDots', () => {
+  let editor
+
+  beforeEach(() => {
+    editor = makeEditor()
+    emitSfxMock.mockReset()
+  })
+
+  test('does not render when can_paginate is false', () => {
+    editor = makeEditor({ can_paginate: false })
+    const wrapper = mount(editor)
+    expect(wrapper.find('[data-testid="deck-view__page-dots"]').exists()).toBe(false)
+  })
+
+  test('renders one dot per page', () => {
+    editor = makeEditor({ total_pages: 4 })
+    const wrapper = mount(editor)
+    expect(wrapper.find('[data-testid="deck-view__page-dots__dot-1"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="deck-view__page-dots__dot-4"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="deck-view__page-dots__dot-5"]').exists()).toBe(false)
+  })
+
+  test('marks the current page dot active at rest', () => {
+    editor = makeEditor({ total_pages: 3, page: 1 })
+    const wrapper = mount(editor)
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-2"]').attributes('data-active')
+    ).toBe('true')
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-1"]').attributes('data-active')
+    ).toBeUndefined()
+  })
+
+  test('pointermove keeps the current page dot active and adds the hovered dot', async () => {
+    editor = makeEditor({ total_pages: 5, page: 4 })
+    const wrapper = mount(editor)
+    stubRowRect(wrapper, { left: 0, width: 300 })
+
+    // x=150 → t=0.5 → floor(0.5*5)=2 → dot-3 hovered
+    await firePointerMove(wrapper, 150)
+
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-3"]').attributes('data-active')
+    ).toBe('true')
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-5"]').attributes('data-active')
+    ).toBe('true')
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-1"]').attributes('data-active')
+    ).toBeUndefined()
+  })
+
+  test('pointermove past the right edge clamps to the last dot', async () => {
+    editor = makeEditor({ total_pages: 4 })
+    const wrapper = mount(editor)
+    stubRowRect(wrapper, { left: 0, width: 200 })
+
+    await firePointerMove(wrapper, 9999)
+
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-4"]').attributes('data-active')
+    ).toBe('true')
+  })
+
+  test('pointermove sets data-engaged on the container', async () => {
+    editor = makeEditor()
+    const wrapper = mount(editor)
+    stubRowRect(wrapper)
+
+    const container = wrapper.find('[data-testid="deck-view__page-dots"]')
+    expect(container.attributes('data-engaged')).toBeUndefined()
+
+    await firePointerMove(wrapper, 50)
+    expect(container.attributes('data-engaged')).toBe('true')
+  })
+
+  test('pointerleave clears engagement and falls back to the current page', async () => {
+    editor = makeEditor({ total_pages: 5, page: 0 })
+    const wrapper = mount(editor)
+    stubRowRect(wrapper, { left: 0, width: 300 })
+
+    const container = wrapper.find('[data-testid="deck-view__page-dots"]')
+    await firePointerMove(wrapper, 150)
+    await container.trigger('pointerleave')
+
+    expect(container.attributes('data-engaged')).toBeUndefined()
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-1"]').attributes('data-active')
+    ).toBe('true')
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-3"]').attributes('data-active')
+    ).toBeUndefined()
+  })
+
+  test('tooltip becomes visible only on the hovered dot', async () => {
+    editor = makeEditor({ total_pages: 3 })
+    const wrapper = mount(editor)
+    stubRowRect(wrapper, { left: 0, width: 300 })
+
+    await firePointerMove(wrapper, 150)
+
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-2"]').attributes('data-tooltip-visible')
+    ).toBe('true')
+    expect(
+      wrapper.find('[data-testid="deck-view__page-dots__dot-1"]').attributes('data-tooltip-visible')
+    ).toBeUndefined()
+  })
+
+  test('click invokes goToPage with the hovered index', async () => {
+    const goToPage = vi.fn()
+    editor = makeEditor({ total_pages: 5, goToPage })
+    const wrapper = mount(editor)
+    stubRowRect(wrapper, { left: 0, width: 500 })
+
+    const container = wrapper.find('[data-testid="deck-view__page-dots"]')
+    await firePointerMove(wrapper, 350) // t=0.7 → idx=3
+    await container.trigger('click')
+
+    expect(goToPage).toHaveBeenCalledOnce()
+    expect(goToPage).toHaveBeenCalledWith(3)
+  })
+
+  test('emits a tick sfx only when the hovered dot index changes', async () => {
+    editor = makeEditor({ total_pages: 5 })
+    const wrapper = mount(editor)
+    stubRowRect(wrapper, { left: 0, width: 500 })
+
+    await firePointerMove(wrapper, 50) // idx 0
+    await firePointerMove(wrapper, 60) // still idx 0
+    await firePointerMove(wrapper, 150) // idx 1
+    await firePointerMove(wrapper, 250) // idx 2
+
+    expect(emitSfxMock).toHaveBeenCalledTimes(3)
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.click_07', { debounce: 10 })
+  })
+
+  test('click without a prior pointermove is a no-op', async () => {
+    const goToPage = vi.fn()
+    editor = makeEditor({ goToPage })
+    const wrapper = mount(editor)
+
+    await wrapper.find('[data-testid="deck-view__page-dots"]').trigger('click')
+    expect(goToPage).not.toHaveBeenCalled()
+  })
+
+  // The container is hidden via opacity classes when mode !== 'view'. Class
+  // assertion is unavoidable here — there is no other state signal exposed
+  // on the rendered DOM (mirrors page-nav-button's note).
+  test('applies hidden classes when editor.mode is not view', () => {
+    editor = makeEditor({ mode: 'edit' })
+    const wrapper = mount(editor)
+    const cls = wrapper.find('[data-testid="deck-view__page-dots"]').classes()
+    expect(cls).toContain('opacity-0')
+    expect(cls).toContain('pointer-events-none')
+  })
+
+  test('does not apply hidden classes in view mode', () => {
+    editor = makeEditor({ mode: 'view' })
+    const wrapper = mount(editor)
+    const cls = wrapper.find('[data-testid="deck-view__page-dots"]').classes()
+    expect(cls).not.toContain('opacity-0')
+  })
+})

--- a/tests/unit/composables/card-editor/card-carousel.test.js
+++ b/tests/unit/composables/card-editor/card-carousel.test.js
@@ -124,6 +124,70 @@ describe('useCardCarousel', () => {
     })
   })
 
+  // ── goToPage ─────────────────────────────────────────────────────────────
+
+  describe('goToPage', () => {
+    test('jumps to the target page and emits sfx', () => {
+      const { carousel } = makeCarousel({ card_count: 30 })
+      carousel.setVisibleCapacity(10) // total_pages = 3
+      carousel.goToPage(2)
+      expect(carousel.page.value).toBe(2)
+      expect(emitSfxMock).toHaveBeenCalledWith('ui.slide_up')
+    })
+
+    test('sets direction=forward when target > current', () => {
+      const { carousel } = makeCarousel({ card_count: 30 })
+      carousel.setVisibleCapacity(10)
+      carousel.goToPage(2)
+      expect(carousel.page_direction.value).toBe('forward')
+    })
+
+    test('sets direction=backward when target < current', () => {
+      const { carousel } = makeCarousel({ card_count: 30 })
+      carousel.setVisibleCapacity(10)
+      carousel.nextPage()
+      carousel.nextPage() // page = 2
+      emitSfxMock.mockReset()
+      carousel.goToPage(0)
+      expect(carousel.page.value).toBe(0)
+      expect(carousel.page_direction.value).toBe('backward')
+      expect(emitSfxMock).toHaveBeenCalledWith('ui.slide_up')
+    })
+
+    test('clamps an out-of-range target to the last page', () => {
+      const { carousel } = makeCarousel({ card_count: 30 })
+      carousel.setVisibleCapacity(10)
+      carousel.goToPage(99)
+      expect(carousel.page.value).toBe(2)
+    })
+
+    test('clamps a negative target to 0', () => {
+      const { carousel } = makeCarousel({ card_count: 30 })
+      carousel.setVisibleCapacity(10)
+      carousel.nextPage() // page = 1
+      emitSfxMock.mockReset()
+      carousel.goToPage(-5)
+      expect(carousel.page.value).toBe(0)
+    })
+
+    test('is a no-op when target equals current page (no sfx)', () => {
+      const { carousel } = makeCarousel({ card_count: 30 })
+      carousel.setVisibleCapacity(10)
+      emitSfxMock.mockReset()
+      carousel.goToPage(0)
+      expect(carousel.page.value).toBe(0)
+      expect(emitSfxMock).not.toHaveBeenCalled()
+    })
+
+    test('is a no-op when paging is disabled', () => {
+      const { carousel } = makeCarousel({ card_count: 4 })
+      carousel.setVisibleCapacity(10) // total_pages = 1
+      carousel.goToPage(2)
+      expect(carousel.page.value).toBe(0)
+      expect(emitSfxMock).not.toHaveBeenCalled()
+    })
+  })
+
   // ── page clamping when total_pages shrinks ───────────────────────────────
 
   describe('page clamping', () => {


### PR DESCRIPTION
## Summary

Adds clickable page-dots indicator below the card grid. Dots track pointer position across a wider hit-area, scale up when active (current page or hovered), and emit a click sfx on hover transitions. Includes a small grid-capacity fix so cards stop overflowing into the row gap.

## Changes

- `feat(deck)` — new `page-dots.vue` floating in row 3 of the deck grid; `goToPage(n)` added to the carousel; tooltip per dot showing page number; pointer-x normalised to nearest dot, both current and hovered dots stay active
- `fix(deck)` — `useGridCapacity` now subtracts the grid element's own vertical padding from bounds height before row math
- Integration tests for `page-dots`, unit tests for `goToPage`

## Test plan

- [ ] Hover across dots — active state hands off cleanly with no gaps
- [ ] Current page dot stays scaled while hovering another
- [ ] Click a dot → grid pages to that index
- [ ] Card grid no longer overflows into the dots row at varying viewport heights
- [ ] Dots hidden in edit / import-export modes