### PR TITLE
Virtualize card editor list

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@pinia/colada": "^1.2.0",
     "@stripe/stripe-js": "^9.2.0",
     "@supabase/supabase-js": "^2.103.3",
+    "@tanstack/vue-virtual": "^3.13.24",
     "@types/howler": "^2.2.12",
     "body-scroll-lock": "4.0.0-beta.0",
     "gsap": "^3.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.103.3
         version: 2.103.3
+      '@tanstack/vue-virtual':
+        specifier: ^3.13.24
+        version: 3.13.24(vue@3.5.32(typescript@5.8.3))
       '@types/howler':
         specifier: ^2.2.12
         version: 2.2.12
@@ -1390,6 +1393,14 @@ packages:
     resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/virtual-core@3.14.0':
+    resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
+
+  '@tanstack/vue-virtual@3.13.24':
+    resolution: {integrity: sha512-A0k2qF0zFSUStXSZkGXABouXr2Tw2Ztl/cVIYG9qy84uR8W7UNjAcX3DvzBS3YnDcwvLxab8v7dbmYBZ39itDA==}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.0.0
 
   '@tsconfig/node18@18.2.6':
     resolution: {integrity: sha512-eAWQzAjPj18tKnDzmWstz4OyWewLUNBm9tdoN9LayzoboRktYx3Enk1ZXPmThj55L7c4VWYq/Bzq0A51znZfhw==}
@@ -4655,6 +4666,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
       vite: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+
+  '@tanstack/virtual-core@3.14.0': {}
+
+  '@tanstack/vue-virtual@3.13.24(vue@3.5.32(typescript@5.8.3))':
+    dependencies:
+      '@tanstack/virtual-core': 3.14.0
+      vue: 3.5.32(typescript@5.8.3)
 
   '@tsconfig/node18@18.2.6': {}
 

--- a/src/views/deck/card-editor/list.vue
+++ b/src/views/deck/card-editor/list.vue
@@ -1,37 +1,77 @@
 <script setup lang="ts">
 import ListItem from './list-item.vue'
-import { inject, useTemplateRef } from 'vue'
+import { inject, useTemplateRef, computed, watchEffect } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
 import { type CardListController } from '@/composables/card-editor/card-list-controller'
 
-const { list, hasNextPage, isLoading, observeSentinel } = inject<CardListController>('card-editor')!
+const ROW_PITCH = 407
+const LOAD_MORE_THRESHOLD = 5
+const OVERSCAN = 3
+
+const { list, hasNextPage, isLoading, loadNextPage } = inject<CardListController>('card-editor')!
 const { all_cards } = list
 
-const sentinel = useTemplateRef<HTMLElement>('sentinel')
+const scroll_el = useTemplateRef<HTMLElement>('scroll_el')
 
-observeSentinel(sentinel)
+const virtualizer = useVirtualizer(
+  computed(() => ({
+    count: all_cards.value.length,
+    getScrollElement: () => scroll_el.value,
+    estimateSize: () => ROW_PITCH,
+    overscan: OVERSCAN,
+    getItemKey: (i: number) => all_cards.value[i].client_id
+  }))
+)
+
+watchEffect(() => {
+  const items = virtualizer.value.getVirtualItems()
+  const last_index = items.at(-1)?.index ?? -1
+
+  if (
+    last_index >= all_cards.value.length - LOAD_MORE_THRESHOLD &&
+    hasNextPage.value &&
+    !isLoading.value
+  ) {
+    loadNextPage()
+  }
+})
 </script>
 
 <template>
   <div
+    ref="scroll_el"
     data-testid="card-list"
-    class="w-full md:h-full md:overflow-auto pb-24 pt-5 flex flex-col items-center bg-brown-100 dark:bg-grey-900 scroll-hidden"
+    class="w-full h-full overflow-y-auto pb-24 pt-5 bg-brown-100 dark:bg-grey-900 scroll-hidden"
   >
-    <list-item
-      v-for="(card, index) in all_cards"
-      :key="card.client_id"
-      :index="index"
-      :card="card"
-      :duplicate="card.is_duplicate ?? false"
-    >
-    </list-item>
     <div
-      v-if="hasNextPage"
-      ref="sentinel"
-      data-testid="card-list__sentinel"
+      data-testid="card-list__viewport"
+      class="relative w-full mx-auto"
+      :style="{ height: `${virtualizer.getTotalSize()}px` }"
+    >
+      <div
+        v-for="vrow in virtualizer.getVirtualItems()"
+        :key="vrow.key as number"
+        data-testid="card-list__row"
+        class="absolute top-0 left-0 w-full flex justify-center"
+        :style="{
+          height: `${vrow.size}px`,
+          transform: `translateY(${vrow.start}px)`
+        }"
+      >
+        <list-item
+          :index="vrow.index"
+          :card="all_cards[vrow.index]"
+          :duplicate="all_cards[vrow.index].is_duplicate ?? false"
+        />
+      </div>
+    </div>
+
+    <div
+      v-if="isLoading"
+      data-testid="card-list__loading"
       class="w-full py-6 flex items-center justify-center text-brown-500"
     >
-      <span v-if="isLoading">Loading…</span>
+      <span>Loading…</span>
     </div>
-    <slot></slot>
   </div>
 </template>

--- a/src/views/deck/index.vue
+++ b/src/views/deck/index.vue
@@ -45,7 +45,13 @@ const { prev_page_number, next_page_number } = editor.carousel
 
     <div
       data-testid="deck-view__main"
-      class="md:h-full relative w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] grid-rows-[auto_minmax(0,1fr)_auto] gap-4 pb-4"
+      :data-mode="editor.mode.value"
+      class="md:h-full relative w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] gap-x-4"
+      :class="
+        editor.mode.value === 'view'
+          ? 'grid-rows-[auto_minmax(0,1fr)_auto] gap-y-4 pb-4'
+          : 'grid-rows-[auto_minmax(0,1fr)_0] gap-y-0 pb-0'
+      "
     >
       <mode-toolbar class="sm:col-start-2" />
 

--- a/src/views/deck/page-dots.vue
+++ b/src/views/deck/page-dots.vue
@@ -46,7 +46,7 @@ function onClick() {
     data-theme-dark="brown-300"
     :data-engaged="hovered_index !== null || undefined"
     class="sm:row-start-3 sm:col-start-2 justify-self-center relative cursor-pointer transition-opacity duration-300 before:content-[''] before:absolute before:-inset-x-10 before:-inset-y-3"
-    :class="{ 'opacity-0 pointer-events-none': editor.mode.value !== 'view' }"
+    :class="{ 'opacity-0 pointer-events-none overflow-hidden': editor.mode.value !== 'view' }"
     @pointermove="onPointerMove"
     @pointerleave="onPointerLeave"
     @click="onClick"

--- a/tests/integration/views/deck/card-editor/list.test.js
+++ b/tests/integration/views/deck/card-editor/list.test.js
@@ -1,14 +1,28 @@
-import { describe, test, expect, vi } from 'vite-plus/test'
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
-import { ref, computed } from 'vue'
+import { ref, computed, shallowRef } from 'vue'
+
+const { useVirtualizerMock } = vi.hoisted(() => ({ useVirtualizerMock: vi.fn() }))
+vi.mock('@tanstack/vue-virtual', () => ({ useVirtualizer: useVirtualizerMock }))
 
 import List from '@/views/deck/card-editor/list.vue'
+
+const ROW_PITCH = 407
+
+function makeVirtualItems(indexes) {
+  return indexes.map((i) => ({
+    key: `cid-${i}`,
+    index: i,
+    start: i * ROW_PITCH,
+    size: ROW_PITCH
+  }))
+}
 
 function makeEditor({
   cards = [],
   hasNextPage = ref(false),
   isLoading = ref(false),
-  observeSentinel = vi.fn()
+  loadNextPage = vi.fn()
 } = {}) {
   return {
     list: {
@@ -16,8 +30,17 @@ function makeEditor({
     },
     hasNextPage,
     isLoading,
-    observeSentinel
+    loadNextPage
   }
+}
+
+function setupVirtualizer({ items, totalSize }) {
+  const virtualizer = shallowRef({
+    getVirtualItems: () => items,
+    getTotalSize: () => totalSize
+  })
+  useVirtualizerMock.mockReturnValue(virtualizer)
+  return virtualizer
 }
 
 function mount(options = {}) {
@@ -32,53 +55,56 @@ function mount(options = {}) {
 }
 
 describe('CardList (list.vue)', () => {
-  // ── Sentinel rendering — gated by hasNextPage ─────────────────────────────
-
-  test('omits the sentinel when there is no next page (every row is loaded)', () => {
-    const wrapper = mount({ hasNextPage: ref(false) })
-    expect(wrapper.find('[data-testid="card-list__sentinel"]').exists()).toBe(false)
+  beforeEach(() => {
+    useVirtualizerMock.mockReset()
   })
 
-  test('renders the sentinel when hasNextPage is true', () => {
-    const wrapper = mount({ hasNextPage: ref(true) })
-    expect(wrapper.find('[data-testid="card-list__sentinel"]').exists()).toBe(true)
+  test('renders one row per virtual item from the virtualizer', () => {
+    const cards = [{ id: 1 }, { id: 2 }, { id: 3 }]
+    setupVirtualizer({ items: makeVirtualItems([0, 1, 2]), totalSize: 3 * ROW_PITCH })
+
+    const wrapper = mount({ editor: makeEditor({ cards }) })
+
+    expect(wrapper.findAll('[data-testid="card-list__row"]')).toHaveLength(3)
   })
 
-  test('shows a loading indicator inside the sentinel while fetching the next page', () => {
-    const wrapper = mount({ hasNextPage: ref(true), isLoading: ref(true) })
-    expect(wrapper.find('[data-testid="card-list__sentinel"]').text()).toContain('Loading')
+  test('renders only virtual items returned by the virtualizer (windowed)', () => {
+    const cards = Array.from({ length: 100 }, (_, i) => ({ id: i }))
+    setupVirtualizer({ items: makeVirtualItems([10, 11, 12, 13, 14]), totalSize: 100 * ROW_PITCH })
+
+    const wrapper = mount({ editor: makeEditor({ cards }) })
+
+    const rows = wrapper.findAll('[data-testid="card-list__row"]')
+    expect(rows).toHaveLength(5)
   })
 
-  test('hides the loading indicator when not actively fetching', () => {
-    const wrapper = mount({ hasNextPage: ref(true), isLoading: ref(false) })
-    expect(wrapper.find('[data-testid="card-list__sentinel"]').text()).not.toContain('Loading')
-  })
-
-  // ── observeSentinel wiring ────────────────────────────────────────────────
-
-  test('hands the sentinel ref to observeSentinel on mount', () => {
-    const observeSentinel = vi.fn()
-    mount({ observeSentinel })
-    expect(observeSentinel).toHaveBeenCalledOnce()
-  })
-
-  // ── List item rendering — client_id + duplicate prop ─────────────────────
-
-  test('renders one list-item per card from all_cards', () => {
+  test('forwards card and index to each list-item by virtual index', () => {
     const cards = [
       { id: 1, front_text: 'a' },
-      { id: 2, front_text: 'b' }
+      { id: 2, front_text: 'b' },
+      { id: 3, front_text: 'c' }
     ]
+    setupVirtualizer({ items: makeVirtualItems([1, 2]), totalSize: 3 * ROW_PITCH })
+
     const wrapper = mount({ editor: makeEditor({ cards }) })
-    expect(wrapper.findAllComponents({ name: 'ListItem' })).toHaveLength(2)
+
+    const items = wrapper.findAllComponents({ name: 'ListItem' })
+    expect(items).toHaveLength(2)
+    expect(items[0].props('index')).toBe(1)
+    expect(items[0].props('card').front_text).toBe('b')
+    expect(items[1].props('index')).toBe(2)
+    expect(items[1].props('card').front_text).toBe('c')
   })
 
-  test('forwards card.is_duplicate as the duplicate prop on each list-item', () => {
+  test('forwards card.is_duplicate as the duplicate prop', () => {
     const cards = [
       { id: 1, is_duplicate: true },
       { id: 2, is_duplicate: false }
     ]
+    setupVirtualizer({ items: makeVirtualItems([0, 1]), totalSize: 2 * ROW_PITCH })
+
     const wrapper = mount({ editor: makeEditor({ cards }) })
+
     const items = wrapper.findAllComponents({ name: 'ListItem' })
     expect(items[0].props('duplicate')).toBe(true)
     expect(items[1].props('duplicate')).toBe(false)
@@ -86,7 +112,99 @@ describe('CardList (list.vue)', () => {
 
   test('defaults duplicate to false when card.is_duplicate is missing', () => {
     const cards = [{ id: 1 }]
+    setupVirtualizer({ items: makeVirtualItems([0]), totalSize: ROW_PITCH })
+
     const wrapper = mount({ editor: makeEditor({ cards }) })
+
     expect(wrapper.findAllComponents({ name: 'ListItem' })[0].props('duplicate')).toBe(false)
+  })
+
+  test('sets viewport height from virtualizer.getTotalSize', () => {
+    const cards = Array.from({ length: 5 }, (_, i) => ({ id: i }))
+    setupVirtualizer({ items: makeVirtualItems([0]), totalSize: 5 * ROW_PITCH })
+
+    const wrapper = mount({ editor: makeEditor({ cards }) })
+
+    const viewport = wrapper.find('[data-testid="card-list__viewport"]')
+    expect(viewport.attributes('style')).toContain(`height: ${5 * ROW_PITCH}px`)
+  })
+
+  test('positions each row at translateY(virtualItem.start)', () => {
+    const cards = [{ id: 1 }, { id: 2 }]
+    setupVirtualizer({ items: makeVirtualItems([0, 1]), totalSize: 2 * ROW_PITCH })
+
+    const wrapper = mount({ editor: makeEditor({ cards }) })
+
+    const rows = wrapper.findAll('[data-testid="card-list__row"]')
+    expect(rows[0].attributes('style')).toContain('translateY(0px)')
+    expect(rows[1].attributes('style')).toContain(`translateY(${ROW_PITCH}px)`)
+  })
+
+  test('shows the loading indicator while fetching', () => {
+    const cards = [{ id: 1 }]
+    setupVirtualizer({ items: makeVirtualItems([0]), totalSize: ROW_PITCH })
+
+    const wrapper = mount({ editor: makeEditor({ cards, isLoading: ref(true) }) })
+
+    expect(wrapper.find('[data-testid="card-list__loading"]').exists()).toBe(true)
+  })
+
+  test('hides the loading indicator when not fetching', () => {
+    const cards = [{ id: 1 }]
+    setupVirtualizer({ items: makeVirtualItems([0]), totalSize: ROW_PITCH })
+
+    const wrapper = mount({ editor: makeEditor({ cards, isLoading: ref(false) }) })
+
+    expect(wrapper.find('[data-testid="card-list__loading"]').exists()).toBe(false)
+  })
+
+  // ── Pagination via virtualizer range ──────────────────────────────────────
+
+  test('calls loadNextPage when the last visible row is within 5 of the end and hasNextPage', () => {
+    const cards = Array.from({ length: 10 }, (_, i) => ({ id: i }))
+    // last visible index = 5; cards.length - 5 = 5 → triggers load
+    setupVirtualizer({ items: makeVirtualItems([3, 4, 5]), totalSize: 10 * ROW_PITCH })
+
+    const loadNextPage = vi.fn()
+    mount({ editor: makeEditor({ cards, hasNextPage: ref(true), loadNextPage }) })
+
+    expect(loadNextPage).toHaveBeenCalledOnce()
+  })
+
+  test('does not call loadNextPage when last visible row is far from the end', () => {
+    const cards = Array.from({ length: 100 }, (_, i) => ({ id: i }))
+    setupVirtualizer({ items: makeVirtualItems([0, 1, 2]), totalSize: 100 * ROW_PITCH })
+
+    const loadNextPage = vi.fn()
+    mount({ editor: makeEditor({ cards, hasNextPage: ref(true), loadNextPage }) })
+
+    expect(loadNextPage).not.toHaveBeenCalled()
+  })
+
+  test('does not call loadNextPage when hasNextPage is false', () => {
+    const cards = Array.from({ length: 6 }, (_, i) => ({ id: i }))
+    setupVirtualizer({ items: makeVirtualItems([3, 4, 5]), totalSize: 6 * ROW_PITCH })
+
+    const loadNextPage = vi.fn()
+    mount({ editor: makeEditor({ cards, hasNextPage: ref(false), loadNextPage }) })
+
+    expect(loadNextPage).not.toHaveBeenCalled()
+  })
+
+  test('does not call loadNextPage when already loading', () => {
+    const cards = Array.from({ length: 6 }, (_, i) => ({ id: i }))
+    setupVirtualizer({ items: makeVirtualItems([3, 4, 5]), totalSize: 6 * ROW_PITCH })
+
+    const loadNextPage = vi.fn()
+    mount({
+      editor: makeEditor({
+        cards,
+        hasNextPage: ref(true),
+        isLoading: ref(true),
+        loadNextPage
+      })
+    })
+
+    expect(loadNextPage).not.toHaveBeenCalled()
   })
 })

--- a/tests/integration/views/deck/index.test.js
+++ b/tests/integration/views/deck/index.test.js
@@ -1,0 +1,138 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h, ref, computed } from 'vue'
+
+const { useDeckQueryMock, useCardListControllerMock } = vi.hoisted(() => ({
+  useDeckQueryMock: vi.fn(),
+  useCardListControllerMock: vi.fn()
+}))
+
+vi.mock('@/api/decks', () => ({ useDeckQuery: useDeckQueryMock }))
+vi.mock('@/composables/card-editor/card-list-controller', () => ({
+  useCardListController: useCardListControllerMock
+}))
+
+import DeckView from '@/views/deck/index.vue'
+
+const DeckHeroStub = defineComponent({
+  name: 'DeckHero',
+  setup: () => () => h('div', { 'data-testid': 'deck-hero-stub' })
+})
+const ModeToolbarStub = defineComponent({
+  name: 'ModeToolbar',
+  setup: () => () => h('div', { 'data-testid': 'mode-toolbar-stub' })
+})
+const ModeStackStub = defineComponent({
+  name: 'ModeStack',
+  setup: () => () => h('div', { 'data-testid': 'mode-stack-stub' })
+})
+const PageDotsStub = defineComponent({
+  name: 'PageDots',
+  setup: () => () => h('div', { 'data-testid': 'page-dots-stub' })
+})
+const PageNavButtonStub = defineComponent({
+  name: 'PageNavButton',
+  props: ['direction'],
+  setup:
+    (props, { slots }) =>
+    () =>
+      h('div', { 'data-testid': `page-nav-${props.direction}` }, slots.default?.())
+})
+
+function makeEditor({ mode = 'view', cards = [], isLoading = false } = {}) {
+  return {
+    mode: ref(mode),
+    list: { all_cards: computed(() => cards) },
+    isLoading: ref(isLoading),
+    carousel: {
+      prev_page_number: computed(() => 1),
+      next_page_number: computed(() => 2)
+    }
+  }
+}
+
+function makeDeckQuery(deck) {
+  return { data: ref(deck) }
+}
+
+function mount({ deck = { id: 1, name: 'Test' }, editorOpts = {} } = {}) {
+  useDeckQueryMock.mockReturnValue(makeDeckQuery(deck))
+  useCardListControllerMock.mockReturnValue(makeEditor(editorOpts))
+  return shallowMount(DeckView, {
+    props: { id: '1' },
+    global: {
+      stubs: {
+        DeckHero: DeckHeroStub,
+        ModeToolbar: ModeToolbarStub,
+        ModeStack: ModeStackStub,
+        PageDots: PageDotsStub,
+        PageNavButton: PageNavButtonStub
+      }
+    }
+  })
+}
+
+describe('DeckView (views/deck/index.vue)', () => {
+  beforeEach(() => {
+    useDeckQueryMock.mockReset()
+    useCardListControllerMock.mockReset()
+  })
+
+  test('renders the deck-hero when the deck query has data', () => {
+    const wrapper = mount({ deck: { id: 1, name: 'Test' } })
+    expect(wrapper.find('[data-testid="deck-hero-stub"]').exists()).toBe(true)
+  })
+
+  test('omits the deck-hero when the deck query has no data yet', () => {
+    const wrapper = mount({ deck: null })
+    expect(wrapper.find('[data-testid="deck-hero-stub"]').exists()).toBe(false)
+  })
+
+  test('renders the empty placeholder when not loading and no cards', () => {
+    const wrapper = mount({ editorOpts: { cards: [], isLoading: false } })
+    expect(wrapper.find('[data-testid="deck-view__empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="mode-stack-stub"]').exists()).toBe(false)
+  })
+
+  test('renders the mode-stack while loading even with no cards yet', () => {
+    const wrapper = mount({ editorOpts: { cards: [], isLoading: true } })
+    expect(wrapper.find('[data-testid="deck-view__empty"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="mode-stack-stub"]').exists()).toBe(true)
+  })
+
+  test('renders the mode-stack when cards are loaded', () => {
+    const wrapper = mount({ editorOpts: { cards: [{ id: 1 }] } })
+    expect(wrapper.find('[data-testid="mode-stack-stub"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="deck-view__empty"]').exists()).toBe(false)
+  })
+
+  test('reflects editor.mode in data-mode on the main grid', () => {
+    const view = mount({ editorOpts: { mode: 'view' } })
+    expect(view.find('[data-testid="deck-view__main"]').attributes('data-mode')).toBe('view')
+
+    const edit = mount({ editorOpts: { mode: 'edit' } })
+    expect(edit.find('[data-testid="deck-view__main"]').attributes('data-mode')).toBe('edit')
+
+    const importExport = mount({ editorOpts: { mode: 'import-export' } })
+    expect(importExport.find('[data-testid="deck-view__main"]').attributes('data-mode')).toBe(
+      'import-export'
+    )
+  })
+
+  test('passes the parsed numeric deck id to useDeckQuery', () => {
+    mount()
+    const idArg = useDeckQueryMock.mock.calls[0][0]
+    expect(idArg.value).toBe(1)
+  })
+
+  test('passes the parsed numeric deck id to useCardListController', () => {
+    mount()
+    expect(useCardListControllerMock).toHaveBeenCalledWith({ deck_id: 1 })
+  })
+
+  test('renders both page-nav buttons with their direction', () => {
+    const wrapper = mount()
+    expect(wrapper.find('[data-testid="page-nav-prev"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="page-nav-next"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

The card editor mounted every list-item upfront, causing a visible delay on first slide-in and unbounded growth as decks scale past a few hundred cards. List now virtualizes via `@tanstack/vue-virtual` at a fixed 407px row pitch with a 5-row near-end load-more watcher, and the editor stretches to the viewport bottom when active so the scroll surface is full-height.

## Changes

- Virtualize `card-editor/list.vue`; drop `observeSentinel` in favor of virtualizer-range pagination
- Add `@tanstack/vue-virtual` dep
- Collapse `page-dots` row + bottom padding when `editor.mode !== 'view'`; add `data-mode` on `deck-view__main` for test signal
- Add `overflow-hidden` to `page-dots` so collapsed row clips its content
- Rewrite `list.test.js` for virtualizer; new `views/deck/index.test.js`