### PR TITLE
Scroll-bar in deck edit mode + stone palette refresh

### DIFF
--- a/src/components/card/index.vue
+++ b/src/components/card/index.vue
@@ -196,8 +196,8 @@ function onLeave(el: Element, done: () => void) {
 }
 
 [data-theme='dark'] .card-container {
-  --card-bg-color: var(--color-brown-500);
-  --card-text-color: var(--color-brown-800);
+  --card-bg-color: var(--color-stone-700);
+  --card-text-color: var(--color-brown-100);
   --card-text-color--placeholder: var(--color-brown-500);
 }
 </style>

--- a/src/components/deck.vue
+++ b/src/components/deck.vue
@@ -16,7 +16,7 @@ const { deck, size = 'base' } = defineProps<{
 
     <div
       v-if="!hide_title"
-      class="absolute w-full -bottom-2.5 bg-brown-300 dark:bg-grey-750 p-4 rounded-5.5"
+      class="absolute w-full -bottom-2.5 bg-brown-300 dark:bg-stone-700 p-4 rounded-5.5"
     >
       <slot name="actions"></slot>
       <h2 class="text-xl text-center text-brown-700 dark:text-brown-100">{{ deck?.title }}</h2>

--- a/src/components/ui-kit/scroll-bar.vue
+++ b/src/components/ui-kit/scroll-bar.vue
@@ -204,10 +204,6 @@ function isPageTarget(el: HTMLElement) {
   --transition-dur: 0.05s;
   --transition: background-color 0.05s ease-in-out, outline 0.05s ease-in-out;
 
-  position: fixed;
-  top: 100px;
-  bottom: 32px;
-  right: 24px;
   width: 4px;
 
   user-select: none;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13,30 +13,40 @@
 
   --color-white: #ffffff;
   --color-black: #000000;
+
   --color-blue-900: #1b2a3a;
   --color-blue-800: #2d455e;
   --color-blue-650: #0a7588;
   --color-blue-500: #11b7d4;
   --color-blue-400: #6cbfd5;
+
+  --color-stone-900: #292c2e;
+  --color-stone-700: #393e40;
+
   --color-green-800: #467d60;
   --color-green-600: #6f9b80;
   --color-green-400: #a4c6ae;
   --color-green-300: #e4edd9;
   --color-green-200: #e8f6e7;
+
   --color-purple-700: #675694;
   --color-purple-500: #ad89d8;
   --color-purple-400: #bea0df;
   --color-purple-200: #c6c4db;
+
   --color-pink-500: #f388a5;
   --color-pink-400: #f599b3;
+
   --color-red-600: #d44c4c;
   --color-red-500: #e66061;
   --color-red-400: #f97b7b;
   --color-red-300: #ffa399;
+
   --color-yellow-700: #d69224;
   --color-yellow-600: #fc946f;
   --color-yellow-500: #fbc56f;
   --color-yellow-400: #f7d279;
+
   --color-brown-800: #4a3b30;
   --color-brown-700: #744e2a;
   --color-brown-500: #b8b1a9;
@@ -44,11 +54,9 @@
   --color-brown-200: #ede9df;
   --color-brown-100: #f3f1ea;
   --color-brown-50: #f9f8f5;
+
   --color-grey-900: #1c1c1c;
   --color-grey-800: #292929;
-
-  --color-grey-750: #292c2e; /* dark mode card bg - has some blue in it - WORKING ON IT */
-
   --color-grey-700: #4f4f4f;
   --color-grey-500: #959595;
   --color-grey-400: #b2b2b2;

--- a/src/styles/palettes.css
+++ b/src/styles/palettes.css
@@ -55,6 +55,18 @@
   --theme-on-primary: var(--color-brown-100);
 }
 
+[data-theme='stone-700'],
+[data-theme='dark'] [data-theme-dark='stone-700'] {
+  --theme-primary: var(--color-stone-700);
+  --theme-on-primary: var(--color-brown-100);
+}
+
+[data-theme='stone-900'],
+[data-theme='dark'] [data-theme-dark='stone-900'] {
+  --theme-primary: var(--color-stone-900);
+  --theme-on-primary: var(--color-brown-100);
+}
+
 [data-theme='grey-400'],
 [data-theme='dark'] [data-theme-dark='grey-400'] {
   --theme-primary: var(--color-grey-400);
@@ -70,6 +82,18 @@
 [data-theme='grey-900'],
 [data-theme='dark'] [data-theme-dark='grey-900'] {
   --theme-primary: var(--color-grey-900);
+}
+
+[data-theme='brown-700'],
+[data-theme='dark'] [data-theme-dark='brown-700'] {
+  --theme-primary: var(--color-brown-700);
+  --theme-on-primary: var(--color-brown-100);
+}
+
+[data-theme='brown-500'],
+[data-theme='dark'] [data-theme-dark='brown-500'] {
+  --theme-primary: var(--color-brown-500);
+  --theme-on-primary: var(--color-brown-100);
 }
 
 [data-theme='brown-300'],
@@ -197,12 +221,6 @@
 [data-theme='grey-800'],
 [data-theme='dark'] [data-theme-dark='grey-800'] {
   --theme-primary: var(--color-grey-800);
-  --theme-on-primary: var(--color-brown-100);
-}
-
-[data-theme='grey-750'],
-[data-theme='dark'] [data-theme-dark='grey-750'] {
-  --theme-primary: var(--color-grey-750);
   --theme-on-primary: var(--color-brown-100);
 }
 

--- a/src/utils/animations/fade.ts
+++ b/src/utils/animations/fade.ts
@@ -1,0 +1,11 @@
+import { gsap } from 'gsap'
+
+const DURATION = 0.3
+
+export function fadeEnter(el: Element, done: () => void) {
+  gsap.fromTo(el, { opacity: 0 }, { opacity: 1, duration: DURATION, onComplete: done })
+}
+
+export function fadeLeave(el: Element, done: () => void) {
+  gsap.to(el, { opacity: 0, duration: DURATION, onComplete: done })
+}

--- a/src/views/deck/card-grid/grid-item-menu.vue
+++ b/src/views/deck/card-grid/grid-item-menu.vue
@@ -19,7 +19,7 @@ defineOptions({ inheritAttrs: false })
     <template #trigger="{ toggle, is_open }">
       <ui-button
         data-theme="brown-300"
-        data-theme-dark="grey-800"
+        data-theme-dark="stone-900"
         icon-only
         icon-right="more"
         data-testid="grid-item__menu-trigger"
@@ -34,7 +34,7 @@ defineOptions({ inheritAttrs: false })
 
     <ui-button
       data-theme="brown-300"
-      data-theme-dark="grey-800"
+      data-theme-dark="stone-900"
       size="sm"
       icon-right="edit"
       class="shadow-xs"
@@ -43,7 +43,7 @@ defineOptions({ inheritAttrs: false })
     </ui-button>
     <ui-button
       data-theme="brown-300"
-      data-theme-dark="grey-800"
+      data-theme-dark="stone-900"
       size="sm"
       icon-right="move-item"
       class="shadow-xs"
@@ -52,14 +52,14 @@ defineOptions({ inheritAttrs: false })
     </ui-button>
     <ui-button
       data-theme="brown-300"
-      data-theme-dark="grey-800"
+      data-theme-dark="stone-900"
       size="sm"
       icon-right="reorder"
       class="shadow-xs"
     >
       {{ t('deck-view.item-options.reorder') }}
     </ui-button>
-    <ui-button data-theme="brown-300" data-theme-dark="grey-800" size="sm" class="shadow-xs">
+    <ui-button data-theme="brown-300" data-theme-dark="stone-900" size="sm" class="shadow-xs">
       {{ t('deck-view.item-options.select') }}
     </ui-button>
     <ui-button

--- a/src/views/deck/deck-hero.vue
+++ b/src/views/deck/deck-hero.vue
@@ -96,7 +96,7 @@ function onToggleEditCards() {
         data-testid="overview-panel__settings-button"
         :icon-left="mode === 'edit' ? 'stop' : 'edit'"
         :data-theme="mode === 'edit' ? 'yellow-500' : 'brown-300'"
-        :data-theme-dark="mode === 'edit' ? 'yellow-700' : 'grey-800'"
+        :data-theme-dark="mode === 'edit' ? 'yellow-700' : 'stone-700'"
         full-width
         size="xl"
         @click="onToggleEditCards"

--- a/src/views/deck/index.vue
+++ b/src/views/deck/index.vue
@@ -6,6 +6,8 @@ import ModeToolbar from './mode-toolbar/index.vue'
 import ModeStack from './mode-stack.vue'
 import PageDots from './page-dots.vue'
 import PageNavButton from './page-nav-button.vue'
+import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
+import { fadeEnter, fadeLeave } from '@/utils/animations/fade'
 import { useDeckQuery } from '@/api/decks'
 import { useCardListController } from '@/composables/card-editor/card-list-controller'
 
@@ -46,12 +48,7 @@ const { prev_page_number, next_page_number } = editor.carousel
     <div
       data-testid="deck-view__main"
       :data-mode="editor.mode.value"
-      class="md:h-full relative w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] gap-x-4"
-      :class="
-        editor.mode.value === 'view'
-          ? 'grid-rows-[auto_minmax(0,1fr)_auto] gap-y-4 pb-4'
-          : 'grid-rows-[auto_minmax(0,1fr)_0] gap-y-0 pb-0'
-      "
+      class="md:h-full relative w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] grid-rows-[auto_minmax(0,1fr)_auto] gap-x-4 gap-y-4 pb-4"
     >
       <mode-toolbar class="sm:col-start-2" />
 
@@ -65,6 +62,14 @@ const { prev_page_number, next_page_number } = editor.carousel
       <page-nav-button direction="next">
         {{ t('deck-view.actions.next-page', { page: next_page_number }) }}
       </page-nav-button>
+
+      <Transition :css="false" @enter="fadeEnter" @leave="fadeLeave">
+        <scroll-bar
+          v-if="editor.mode.value === 'edit'"
+          class="sm:row-start-2 sm:col-start-3 absolute inset-y-10 left-1/2 -translate-x-1/2"
+          target="[data-testid='card-list']"
+        />
+      </Transition>
 
       <page-dots />
     </div>

--- a/src/views/deck/mode-stack.vue
+++ b/src/views/deck/mode-stack.vue
@@ -12,11 +12,8 @@ import type { CardListController } from '@/composables/card-editor/card-list-con
 
 const editor = inject<CardListController>('card-editor')!
 
-const overlay_component = computed(() => {
-  if (editor.mode.value === 'edit') return CardEditor
-  if (editor.mode.value === 'import-export') return CardImporter
-  return null
-})
+const is_editing = computed(() => editor.mode.value === 'edit')
+const is_importing = computed(() => editor.mode.value === 'import-export')
 </script>
 
 <template>
@@ -31,16 +28,22 @@ const overlay_component = computed(() => {
     >
       <Transition
         :css="false"
-        mode="out-in"
         @before-enter="primeOverlayBelow"
         @enter="slideOverlayUp"
         @leave="slideOverlayDown"
       >
-        <component
-          :is="overlay_component"
-          v-if="overlay_component"
-          class="size-full pointer-events-auto"
-        />
+        <div v-show="is_editing" class="size-full pointer-events-auto">
+          <card-editor class="size-full" />
+        </div>
+      </Transition>
+
+      <Transition
+        :css="false"
+        @before-enter="primeOverlayBelow"
+        @enter="slideOverlayUp"
+        @leave="slideOverlayDown"
+      >
+        <card-importer v-if="is_importing" class="size-full pointer-events-auto" />
       </Transition>
     </div>
   </div>

--- a/src/views/deck/mode-toolbar/mode-view.vue
+++ b/src/views/deck/mode-toolbar/mode-view.vue
@@ -20,7 +20,7 @@ const { page, total_pages, prev_page_number, next_page_number, prevPage, nextPag
       <ui-button
         data-testid="mode-view__search-button"
         data-theme="brown-300"
-        data-theme-dark="grey-800"
+        data-theme-dark="stone-700"
         size="sm"
         icon-left="search"
         icon-only
@@ -54,7 +54,7 @@ const { page, total_pages, prev_page_number, next_page_number, prevPage, nextPag
         <ui-button
           data-testid="mode-view__previous-page-button"
           data-theme="brown-300"
-          data-theme-dark="grey-800"
+          data-theme-dark="stone-700"
           icon-only
           size="sm"
           icon-left="arrow-left"
@@ -67,7 +67,7 @@ const { page, total_pages, prev_page_number, next_page_number, prevPage, nextPag
         <ui-button
           data-testid="mode-view__next-page-button"
           data-theme="brown-300"
-          data-theme-dark="grey-800"
+          data-theme-dark="stone-700"
           icon-only
           size="sm"
           icon-left="arrow-right"

--- a/src/views/deck/page-dots.vue
+++ b/src/views/deck/page-dots.vue
@@ -42,8 +42,8 @@ function onClick() {
   <div
     v-if="can_paginate"
     data-testid="deck-view__page-dots"
-    data-theme="brown-300"
-    data-theme-dark="brown-300"
+    data-theme="brown-700"
+    data-theme-dark="brown-100"
     :data-engaged="hovered_index !== null || undefined"
     class="sm:row-start-3 sm:col-start-2 justify-self-center relative cursor-pointer transition-opacity duration-300 before:content-[''] before:absolute before:-inset-x-10 before:-inset-y-3"
     :class="{ 'opacity-0 pointer-events-none overflow-hidden': editor.mode.value !== 'view' }"
@@ -62,7 +62,7 @@ function onClick() {
         :gap="6"
         :data-testid="`deck-view__page-dots__dot-${n}`"
         :data-active="hovered_index === n - 1 || page === n - 1 || undefined"
-        class="size-2 rounded-full bg-(--theme-on-neutral) opacity-50 scale-75 data-active:opacity-100 data-active:scale-125 transition-[opacity,scale] duration-200 ease-out pointer-events-none"
+        class="size-2 rounded-full bg-(--theme-primary) opacity-50 scale-75 data-active:opacity-100 data-active:scale-125 transition-[opacity,scale] duration-200 ease-out pointer-events-none"
       />
     </div>
   </div>

--- a/src/views/deck/page-nav-button.vue
+++ b/src/views/deck/page-nav-button.vue
@@ -26,6 +26,7 @@ function onClick() {
   <ui-button
     :data-testid="testid"
     data-theme="brown-300"
+    data-theme-dark="stone-700"
     class="sm:row-start-2 self-center max-sm:hidden! transition duration-300"
     :class="[column, { 'opacity-0 pointer-events-none': editor.mode.value !== 'view' }]"
     icon-only

--- a/tests/integration/views/deck/index.test.js
+++ b/tests/integration/views/deck/index.test.js
@@ -38,6 +38,12 @@ const PageNavButtonStub = defineComponent({
     () =>
       h('div', { 'data-testid': `page-nav-${props.direction}` }, slots.default?.())
 })
+const ScrollBarStub = defineComponent({
+  name: 'ScrollBar',
+  props: ['target'],
+  setup: (props) => () =>
+    h('div', { 'data-testid': 'scroll-bar-stub', 'data-target': props.target })
+})
 
 function makeEditor({ mode = 'view', cards = [], isLoading = false } = {}) {
   return {
@@ -66,7 +72,8 @@ function mount({ deck = { id: 1, name: 'Test' }, editorOpts = {} } = {}) {
         ModeToolbar: ModeToolbarStub,
         ModeStack: ModeStackStub,
         PageDots: PageDotsStub,
-        PageNavButton: PageNavButtonStub
+        PageNavButton: PageNavButtonStub,
+        ScrollBar: ScrollBarStub
       }
     }
   })
@@ -134,5 +141,30 @@ describe('DeckView (views/deck/index.vue)', () => {
     const wrapper = mount()
     expect(wrapper.find('[data-testid="page-nav-prev"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="page-nav-next"]').exists()).toBe(true)
+  })
+
+  test('does not render the scroll-bar in view mode', () => {
+    const wrapper = mount({ editorOpts: { mode: 'view' } })
+    expect(wrapper.find('[data-testid="scroll-bar-stub"]').exists()).toBe(false)
+  })
+
+  test('does not render the scroll-bar in import-export mode', () => {
+    const wrapper = mount({ editorOpts: { mode: 'import-export' } })
+    expect(wrapper.find('[data-testid="scroll-bar-stub"]').exists()).toBe(false)
+  })
+
+  test('renders the scroll-bar when mode is edit and targets the card-list', () => {
+    const wrapper = mount({ editorOpts: { mode: 'edit' } })
+    const bar = wrapper.find('[data-testid="scroll-bar-stub"]')
+    expect(bar.exists()).toBe(true)
+    expect(bar.attributes('data-target')).toBe("[data-testid='card-list']")
+  })
+
+  test('keeps the main grid layout stable across modes (no row-height swap)', () => {
+    const view = mount({ editorOpts: { mode: 'view' } })
+    const edit = mount({ editorOpts: { mode: 'edit' } })
+    const viewClasses = view.find('[data-testid="deck-view__main"]').classes()
+    const editClasses = edit.find('[data-testid="deck-view__main"]').classes()
+    expect(viewClasses).toEqual(editClasses)
   })
 })

--- a/tests/integration/views/deck/mode-stack.test.js
+++ b/tests/integration/views/deck/mode-stack.test.js
@@ -49,6 +49,18 @@ function mount(editor = makeEditor()) {
   })
 }
 
+function transitions(wrapper) {
+  return wrapper.findAll('[data-testid="deck-view__mode-stack__overlay-clip"] transition-stub')
+}
+
+function editorTransition(wrapper) {
+  return transitions(wrapper)[0]
+}
+
+function importerTransition(wrapper) {
+  return transitions(wrapper)[1]
+}
+
 describe('ModeStack', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -87,61 +99,83 @@ describe('ModeStack', () => {
     expect(cls).toContain('scale-95')
   })
 
-  // shallowMount wraps overlay content in <transition-stub>. The dynamic
-  // `<component :is>` resolves to either nothing (view mode) or an SFC stub
-  // (`<index-stub>` for both card-editor/index.vue and card-importer.vue).
-  function hasOverlayChild(wrapper) {
-    return wrapper.find('[data-testid="deck-view__mode-stack__overlay-clip"] transition-stub')
-      .element.children.length
-  }
-
-  test('renders no overlay component in view mode', () => {
+  test('renders the card-editor at all times for stable scroll target', () => {
     const wrapper = mount(makeEditor('view'))
-    expect(hasOverlayChild(wrapper)).toBe(0)
+    expect(wrapper.findComponent({ name: 'CardEditor' }).exists()).toBe(true)
   })
 
-  test('renders an overlay component when mode is edit', async () => {
+  test('hides the card-editor wrapper via display:none in view mode', () => {
+    const wrapper = mount(makeEditor('view'))
+    const editorWrapper = editorTransition(wrapper).element.firstElementChild
+    expect(editorWrapper.style.display).toBe('none')
+  })
+
+  test('shows the card-editor wrapper when mode is edit', () => {
+    const wrapper = mount(makeEditor('edit'))
+    const editorWrapper = editorTransition(wrapper).element.firstElementChild
+    expect(editorWrapper.style.display).toBe('')
+  })
+
+  test('toggles card-editor visibility when mode flips between view and edit', async () => {
     const editor = makeEditor('view')
     const wrapper = mount(editor)
-    expect(hasOverlayChild(wrapper)).toBe(0)
+    let editorWrapper = editorTransition(wrapper).element.firstElementChild
+    expect(editorWrapper.style.display).toBe('none')
 
     editor.mode.value = 'edit'
     await nextTick()
     await nextTick()
+    editorWrapper = editorTransition(wrapper).element.firstElementChild
+    expect(editorWrapper.style.display).toBe('')
 
-    expect(hasOverlayChild(wrapper)).toBe(1)
+    editor.mode.value = 'view'
+    await nextTick()
+    await nextTick()
+    editorWrapper = editorTransition(wrapper).element.firstElementChild
+    expect(editorWrapper.style.display).toBe('none')
   })
 
-  test('renders an overlay component when mode is import-export', async () => {
+  test('does not render the card-importer in view mode', () => {
+    const wrapper = mount(makeEditor('view'))
+    expect(importerTransition(wrapper).element.children.length).toBe(0)
+    expect(wrapper.findComponent({ name: 'CardImporter' }).exists()).toBe(false)
+  })
+
+  test('renders the card-importer when mode is import-export', async () => {
     const editor = makeEditor('view')
     const wrapper = mount(editor)
+    expect(wrapper.findComponent({ name: 'CardImporter' }).exists()).toBe(false)
 
     editor.mode.value = 'import-export'
     await nextTick()
     await nextTick()
 
-    expect(hasOverlayChild(wrapper)).toBe(1)
+    expect(wrapper.findComponent({ name: 'CardImporter' }).exists()).toBe(true)
   })
 
-  test('removes the overlay when returning to view mode', async () => {
-    const editor = makeEditor('edit')
+  test('removes the card-importer when leaving import-export mode', async () => {
+    const editor = makeEditor('import-export')
     const wrapper = mount(editor)
-    expect(hasOverlayChild(wrapper)).toBe(1)
+    expect(wrapper.findComponent({ name: 'CardImporter' }).exists()).toBe(true)
 
     editor.mode.value = 'view'
     await nextTick()
     await nextTick()
 
-    expect(hasOverlayChild(wrapper)).toBe(0)
+    expect(wrapper.findComponent({ name: 'CardImporter' }).exists()).toBe(false)
   })
 
-  test('forwards size-full and pointer-events-auto to the overlay element', () => {
+  test('forwards size-full and pointer-events-auto to the editor wrapper', () => {
     const wrapper = mount(makeEditor('edit'))
-    const overlay = wrapper.find(
-      '[data-testid="deck-view__mode-stack__overlay-clip"] transition-stub'
-    ).element.firstElementChild
-    expect(overlay).not.toBeNull()
-    expect(overlay.classList.contains('size-full')).toBe(true)
-    expect(overlay.classList.contains('pointer-events-auto')).toBe(true)
+    const editorWrapper = editorTransition(wrapper).element.firstElementChild
+    expect(editorWrapper.classList.contains('size-full')).toBe(true)
+    expect(editorWrapper.classList.contains('pointer-events-auto')).toBe(true)
+  })
+
+  test('forwards size-full and pointer-events-auto to the importer', () => {
+    const wrapper = mount(makeEditor('import-export'))
+    const importerEl = importerTransition(wrapper).element.firstElementChild
+    expect(importerEl.classList.contains('size-full')).toBe(true)
+    expect(importerEl.classList.contains('pointer-events-auto')).toBe(true)
   })
 })

--- a/tests/unit/utils/animations/fade.test.js
+++ b/tests/unit/utils/animations/fade.test.js
@@ -1,0 +1,86 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+
+const { mockFromTo, mockTo } = vi.hoisted(() => ({
+  mockFromTo: vi.fn(),
+  mockTo: vi.fn()
+}))
+
+vi.mock('gsap', () => ({ gsap: { fromTo: mockFromTo, to: mockTo } }))
+
+import { fadeEnter, fadeLeave } from '@/utils/animations/fade'
+
+const el = document.createElement('div')
+const done = vi.fn()
+
+describe('fade animations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('fadeEnter', () => {
+    test('tweens opacity from 0 to 1', () => {
+      fadeEnter(el, done)
+
+      expect(mockFromTo).toHaveBeenCalledWith(
+        el,
+        { opacity: 0 },
+        expect.objectContaining({ opacity: 1 })
+      )
+    })
+
+    test('uses a positive duration', () => {
+      fadeEnter(el, done)
+
+      const opts = mockFromTo.mock.calls[0][2]
+      expect(opts.duration).toBeGreaterThan(0)
+    })
+
+    test('calls done via onComplete', () => {
+      fadeEnter(el, done)
+
+      const opts = mockFromTo.mock.calls[0][2]
+      expect(opts.onComplete).toBe(done)
+    })
+
+    test('does not call gsap.to', () => {
+      fadeEnter(el, done)
+
+      expect(mockTo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('fadeLeave', () => {
+    test('tweens opacity to 0', () => {
+      fadeLeave(el, done)
+
+      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ opacity: 0 }))
+    })
+
+    test('uses a positive duration', () => {
+      fadeLeave(el, done)
+
+      const opts = mockTo.mock.calls[0][1]
+      expect(opts.duration).toBeGreaterThan(0)
+    })
+
+    test('calls done via onComplete', () => {
+      fadeLeave(el, done)
+
+      const opts = mockTo.mock.calls[0][1]
+      expect(opts.onComplete).toBe(done)
+    })
+
+    test('does not call gsap.fromTo', () => {
+      fadeLeave(el, done)
+
+      expect(mockFromTo).not.toHaveBeenCalled()
+    })
+  })
+
+  test('fadeEnter and fadeLeave share the same duration', () => {
+    fadeEnter(el, done)
+    fadeLeave(el, done)
+
+    expect(mockFromTo.mock.calls[0][2].duration).toBe(mockTo.mock.calls[0][1].duration)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `ui-kit/scroll-bar` to the deck view's card editor in edit mode, anchored to the next-page-button grid cell. Card editor now stays mounted across mode switches (v-show) so the scroll target is stable. Bundled drive-by: replaces `grey-750/800` dark-mode tokens with new `stone-700/900` palette.

## Changes

- **feat(deck-view):** scroll-bar mounts in edit mode only, fades in/out via Vue Transition + new `fadeEnter` / `fadeLeave` GSAP utilities
- **feat(deck-view):** card editor always rendered inside `mode-stack` (v-show) so card-list DOM persists; card-importer still v-if
- **feat(deck-view):** main grid no longer collapses last row when mode flips — eliminates layout jump
- **fix(scroll-bar):** drop `position: fixed` styling so consumers can place it in flow
- **refactor(theme):** add `stone-700`/`stone-900` color tokens + theme entries; retire `grey-750`; swap call-sites from `grey-800` to `stone-*`
- **test:** new unit tests for `fade.ts`; updated `mode-stack` and deck `index` tests for v-show + scroll-bar gating