### PR TITLE
Study session daily caps and shuffle reordering

### DIFF
--- a/src/api/cards/db/index.ts
+++ b/src/api/cards/db/index.ts
@@ -1,5 +1,6 @@
 export * from './fetch'
 export * from './cards-page'
+export * from './study-session-cards'
 export * from './search'
 export * from './update'
 export * from './delete'

--- a/src/api/cards/db/study-session-cards.ts
+++ b/src/api/cards/db/study-session-cards.ts
@@ -1,0 +1,18 @@
+import { supabase } from '@/supabase-client'
+import logger from '@/utils/logger'
+
+export async function fetchStudySessionCards(
+  deck_id: number,
+  study_all: boolean = false
+): Promise<Card[]> {
+  const { data, error } = await supabase
+    .rpc('get_study_session_cards', { p_deck_id: deck_id, p_study_all: study_all })
+    .select('*, review:reviews(*)')
+
+  if (error) {
+    logger.error(error.message)
+    throw new Error(error.message)
+  }
+
+  return data ?? []
+}

--- a/src/api/cards/queries/index.ts
+++ b/src/api/cards/queries/index.ts
@@ -1,4 +1,5 @@
 export * from './cards-in-deck'
 export * from './cards-page'
+export * from './study-session-cards'
 export * from './search-in-deck'
 export * from './member-card-count'

--- a/src/api/cards/queries/study-session-cards.ts
+++ b/src/api/cards/queries/study-session-cards.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@pinia/colada'
+import { toValue, type MaybeRefOrGetter } from 'vue'
+import { fetchStudySessionCards } from '../db'
+
+/**
+ * Server-built study queue for a deck. Applies daily caps + new/review
+ * partition on the backend; FE just consumes the ordered result.
+ */
+export function useStudySessionCardsQuery(
+  deck_id: MaybeRefOrGetter<number>,
+  study_all: MaybeRefOrGetter<boolean> = false
+) {
+  return useQuery({
+    key: () => ['cards', toValue(deck_id), 'study-session', toValue(study_all)],
+    query: () => fetchStudySessionCards(toValue(deck_id), toValue(study_all))
+  })
+}

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -125,7 +125,8 @@ async function onSave() {
             v-model:flip_cards="config.flip_cards"
             v-model:is_spaced="config.is_spaced"
             v-model:auto_play="config.auto_play"
-            v-model:card_limit="config.card_limit"
+            v-model:max_reviews_per_day="config.max_reviews_per_day"
+            v-model:max_new_per_day="config.max_new_per_day"
           />
         </div>
       </div>

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import CoverDesignerToolbar from './cover-designer/index.vue'
 import CardDesignerToolbar from './card-designer-toolbar.vue'
 import TabBar from './tab-bar.vue'
+import TabStudy from './tab-study.vue'
 import Card from '@/components/card/index.vue'
 import { useDeckEditor } from '@/composables/deck-editor'
 import UiButton from '@/components/ui-kit/button.vue'
@@ -23,7 +24,7 @@ const { deck, close } = defineProps<{
 }>()
 
 const { t } = useI18n()
-const { saveDeck, settings, cover, card_attributes } = useDeckEditor(deck)
+const { saveDeck, settings, config, cover, card_attributes } = useDeckEditor(deck)
 
 const active_tab = ref<DesignerTab>('cover')
 
@@ -118,6 +119,14 @@ async function onSave() {
               {{ t('deck.settings-modal.is-public') }}
             </div>
           </ui-toggle>
+
+          <tab-study
+            v-model:shuffle="config.shuffle"
+            v-model:flip_cards="config.flip_cards"
+            v-model:is_spaced="config.is_spaced"
+            v-model:auto_play="config.auto_play"
+            v-model:card_limit="config.card_limit"
+          />
         </div>
       </div>
     </template>

--- a/src/components/modals/deck-settings/tab-study.vue
+++ b/src/components/modals/deck-settings/tab-study.vue
@@ -59,7 +59,7 @@ const NEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
       </div>
     </ui-toggle>
 
-    <div class="flex flex-col gap-2">
+    <div data-testid="tab-study__max-reviews" class="flex flex-col gap-2">
       <span class="text-sm font-medium text-brown-700">
         {{ t('deck.settings-modal.study.max-reviews-per-day') }}
       </span>
@@ -67,6 +67,8 @@ const NEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
         <button
           v-for="preset in REVIEW_LIMIT_PRESETS"
           :key="String(preset.value)"
+          data-testid="tab-study__max-reviews-preset"
+          :data-active="max_reviews_per_day === preset.value"
           class="h-9 min-w-12 cursor-pointer rounded-4 px-3 text-sm font-medium transition-all duration-75"
           :class="
             max_reviews_per_day === preset.value
@@ -80,7 +82,7 @@ const NEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
       </div>
     </div>
 
-    <div class="flex flex-col gap-2">
+    <div data-testid="tab-study__max-new" class="flex flex-col gap-2">
       <span class="text-sm font-medium text-brown-700">
         {{ t('deck.settings-modal.study.max-new-per-day') }}
       </span>
@@ -88,6 +90,8 @@ const NEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
         <button
           v-for="preset in NEW_LIMIT_PRESETS"
           :key="String(preset.value)"
+          data-testid="tab-study__max-new-preset"
+          :data-active="max_new_per_day === preset.value"
           class="h-9 min-w-12 cursor-pointer rounded-4 px-3 text-sm font-medium transition-all duration-75"
           :class="
             max_new_per_day === preset.value

--- a/src/components/modals/deck-settings/tab-study.vue
+++ b/src/components/modals/deck-settings/tab-study.vue
@@ -9,9 +9,18 @@ const shuffle = defineModel<boolean | undefined>('shuffle')
 const flip_cards = defineModel<boolean | undefined>('flip_cards')
 const is_spaced = defineModel<boolean | undefined>('is_spaced')
 const auto_play = defineModel<boolean | undefined>('auto_play')
-const card_limit = defineModel<number | null | undefined>('card_limit')
+const max_reviews_per_day = defineModel<number | null | undefined>('max_reviews_per_day')
+const max_new_per_day = defineModel<number | null | undefined>('max_new_per_day')
 
-const CARD_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
+const REVIEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
+  { label: '20', value: 20 },
+  { label: '50', value: 50 },
+  { label: '100', value: 100 },
+  { label: '200', value: 200 },
+  { label: t('study.settings.all'), value: null }
+]
+
+const NEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
   { label: '5', value: 5 },
   { label: '10', value: 10 },
   { label: '20', value: 20 },
@@ -52,19 +61,40 @@ const CARD_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
 
     <div class="flex flex-col gap-2">
       <span class="text-sm font-medium text-brown-700">
-        {{ t('deck.settings-modal.study.card-limit') }}
+        {{ t('deck.settings-modal.study.max-reviews-per-day') }}
       </span>
       <div class="flex gap-2">
         <button
-          v-for="preset in CARD_LIMIT_PRESETS"
+          v-for="preset in REVIEW_LIMIT_PRESETS"
           :key="String(preset.value)"
           class="h-9 min-w-12 cursor-pointer rounded-4 px-3 text-sm font-medium transition-all duration-75"
           :class="
-            card_limit === preset.value
+            max_reviews_per_day === preset.value
               ? 'bg-blue-500 text-brown-100'
               : 'bg-brown-100 text-brown-700 hover:bg-brown-200'
           "
-          @click="card_limit = preset.value"
+          @click="max_reviews_per_day = preset.value"
+        >
+          {{ preset.label }}
+        </button>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <span class="text-sm font-medium text-brown-700">
+        {{ t('deck.settings-modal.study.max-new-per-day') }}
+      </span>
+      <div class="flex gap-2">
+        <button
+          v-for="preset in NEW_LIMIT_PRESETS"
+          :key="String(preset.value)"
+          class="h-9 min-w-12 cursor-pointer rounded-4 px-3 text-sm font-medium transition-all duration-75"
+          :class="
+            max_new_per_day === preset.value
+              ? 'bg-blue-500 text-brown-100'
+              : 'bg-brown-100 text-brown-700 hover:bg-brown-200'
+          "
+          @click="max_new_per_day = preset.value"
         >
           {{ preset.label }}
         </button>

--- a/src/components/modals/study-session/session-flashcard.vue
+++ b/src/components/modals/study-session/session-flashcard.vue
@@ -14,7 +14,7 @@ import { useModalRequestClose } from '@/composables/modal'
 import { type Grade } from 'ts-fsrs'
 import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 import Card from '@/components/card/index.vue'
-import { useCardsInDeckQuery } from '@/api/cards'
+import { useStudySessionCardsQuery } from '@/api/cards'
 import { useFlushDeckReviews } from '@/api/reviews'
 import { emitSfx } from '@/sfx/bus'
 
@@ -76,7 +76,10 @@ const card_view = computed<'skeleton' | 'edit' | 'read'>(() => {
   return 'read'
 })
 
-const cards_query = useCardsInDeckQuery(() => deck.id!)
+const cards_query = useStudySessionCardsQuery(
+  () => deck.id!,
+  () => !!config.study_all_cards
+)
 const flushDeckReviews = useFlushDeckReviews()
 
 onMounted(() => {

--- a/src/composables/study-session/study-session-core.ts
+++ b/src/composables/study-session/study-session-core.ts
@@ -33,7 +33,8 @@ export function useStudySessionCore(_config?: Partial<DeckConfig>) {
     study_mode: _config?.study_mode ?? 'flashcard',
     study_all_cards: _config?.study_all_cards ?? false,
     shuffle: _config?.shuffle ?? false,
-    card_limit: _config?.card_limit ?? null,
+    max_reviews_per_day: _config?.max_reviews_per_day ?? null,
+    max_new_per_day: _config?.max_new_per_day ?? null,
     flip_cards: _config?.flip_cards ?? false,
     is_spaced: _config?.is_spaced ?? true,
     auto_play: _config?.auto_play ?? false
@@ -75,7 +76,8 @@ export function useStudySessionCore(_config?: Partial<DeckConfig>) {
     config.study_mode = updates.study_mode ?? config.study_mode
     config.study_all_cards = updates.study_all_cards ?? config.study_all_cards
     config.shuffle = updates.shuffle ?? config.shuffle
-    config.card_limit = updates.card_limit ?? config.card_limit
+    config.max_reviews_per_day = updates.max_reviews_per_day ?? config.max_reviews_per_day
+    config.max_new_per_day = updates.max_new_per_day ?? config.max_new_per_day
     config.flip_cards = updates.flip_cards ?? config.flip_cards
 
     if (_raw_cards.value.length) _processCards()
@@ -93,10 +95,6 @@ export function useStudySessionCore(_config?: Partial<DeckConfig>) {
       const review_cards = filtered.filter((c) => c.review)
       review_cards.sort(() => Math.random() - 0.5)
       filtered = [...new_cards, ...review_cards]
-    }
-
-    if (config.card_limit) {
-      filtered = filtered.slice(0, config.card_limit)
     }
 
     _cards_in_deck.value = filtered.map(_setupCard)

--- a/src/composables/study-session/study-session-core.ts
+++ b/src/composables/study-session/study-session-core.ts
@@ -89,7 +89,10 @@ export function useStudySessionCore(_config?: Partial<DeckConfig>) {
     }
 
     if (config.shuffle) {
-      filtered = filtered.sort(() => Math.random() - 0.5)
+      const new_cards = filtered.filter((c) => !c.review)
+      const review_cards = filtered.filter((c) => c.review)
+      review_cards.sort(() => Math.random() - 0.5)
+      filtered = [...new_cards, ...review_cards]
     }
 
     if (config.card_limit) {

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -233,7 +233,8 @@
   "deck.settings-modal.study.flip-cards": "Start on Back",
   "deck.settings-modal.study.shuffle": "Shuffle Cards",
   "deck.settings-modal.study.retry-failed": "Retry Failed Cards",
-  "deck.settings-modal.study.card-limit": "Cards Per Session",
+  "deck.settings-modal.study.max-reviews-per-day": "Max Reviews Per Day",
+  "deck.settings-modal.study.max-new-per-day": "Max New Cards Per Day",
   "deck.settings-modal.study.is-spaced": "Spaced Repetition",
   "deck.settings-modal.study.auto-play": "Auto-Play Audio",
 

--- a/supabase/migrations/20260501000000_decks-with-stats-daily-cap.sql
+++ b/supabase/migrations/20260501000000_decks-with-stats-daily-cap.sql
@@ -1,0 +1,103 @@
+-- =============================================================================
+-- decks_with_stats: clamp due_count by daily caps
+-- =============================================================================
+--
+-- The deck `study_config` jsonb may now contain:
+--   max_reviews_per_day  - hard cap on total cards (new + due) surfaced today
+--   max_new_per_day      - sub-cap on how many of those may be brand-new cards
+--
+-- This migration:
+--   1. Adds `reviewed_today_count`     - distinct cards from this deck this
+--                                        member already reviewed today.
+--   2. Adds `new_reviewed_today_count` - of those, how many were brand-new
+--                                        (FSRS state = 0 at review time).
+--   3. Clamps `due_count`              - LEAST(raw_due, max_per_day - already).
+--
+-- "Today" = UTC day boundary (date_trunc('day', now())). Member-local
+-- timezones are deferred until members.timezone exists.
+-- =============================================================================
+
+BEGIN;
+
+DROP VIEW public.decks_with_stats;
+
+CREATE VIEW public.decks_with_stats
+WITH (security_invoker = true) AS
+SELECT
+  d.id,
+  d.created_at,
+  d.updated_at,
+  d.description,
+  d.is_public,
+  d.title,
+  d.member_id,
+  d.tags,
+  d.has_image,
+  d.study_config,
+  d.cover_config,
+  d.card_attributes,
+
+  (
+    SELECT count(*)::int
+    FROM public.cards c
+    WHERE c.deck_id = d.id
+  ) AS card_count,
+
+  -- Distinct cards from this deck reviewed today (any state).
+  -- review_logs RLS scopes this to auth.uid() automatically (security_invoker).
+  (
+    SELECT count(DISTINCT rl.card_id)::int
+    FROM public.review_logs rl
+    JOIN public.cards c ON c.id = rl.card_id
+    WHERE c.deck_id = d.id
+      AND rl.review >= date_trunc('day', now())
+  ) AS reviewed_today_count,
+
+  -- Subset of the above where the card was brand-new at review time.
+  -- FSRS state 0 = New; only the very first review of a card has state = 0.
+  (
+    SELECT count(DISTINCT rl.card_id)::int
+    FROM public.review_logs rl
+    JOIN public.cards c ON c.id = rl.card_id
+    WHERE c.deck_id = d.id
+      AND rl.state = 0
+      AND rl.review >= date_trunc('day', now())
+  ) AS new_reviewed_today_count,
+
+  -- Clamped due_count: if max_reviews_per_day is set, subtract today's
+  -- reviewed count from it and clamp to >= 0; otherwise unbounded.
+  GREATEST(
+    0,
+    CASE
+      WHEN (d.study_config->>'max_reviews_per_day') IS NULL THEN
+        (
+          SELECT count(*)::int
+          FROM public.cards c
+          LEFT JOIN public.reviews r ON r.card_id = c.id
+          WHERE c.deck_id = d.id
+            AND (r.due IS NULL OR r.due <= now())
+        )
+      ELSE
+        LEAST(
+          (
+            SELECT count(*)::int
+            FROM public.cards c
+            LEFT JOIN public.reviews r ON r.card_id = c.id
+            WHERE c.deck_id = d.id
+              AND (r.due IS NULL OR r.due <= now())
+          ),
+          (d.study_config->>'max_reviews_per_day')::int
+            - (
+              SELECT count(DISTINCT rl.card_id)::int
+              FROM public.review_logs rl
+              JOIN public.cards c ON c.id = rl.card_id
+              WHERE c.deck_id = d.id
+                AND rl.review >= date_trunc('day', now())
+            )
+        )
+    END
+  ) AS due_count
+
+FROM public.decks d;
+
+COMMIT;

--- a/supabase/migrations/20260501000001_get-study-session-cards.sql
+++ b/supabase/migrations/20260501000001_get-study-session-cards.sql
@@ -1,0 +1,118 @@
+-- =============================================================================
+-- get_study_session_cards: server-side study queue
+-- =============================================================================
+--
+-- Returns the ordered cards-with-images rows to study right now for a deck:
+--   1. New cards (no row in `reviews`) up to remaining `max_new_per_day`.
+--   2. Due review cards filling the rest of `max_reviews_per_day`.
+--
+-- "Today's usage" reads from `review_logs` (UTC day boundary). Caps live in
+-- the deck's `study_config` jsonb. NULL/missing cap = unlimited.
+--
+-- Returns SETOF public.cards_with_images so PostgREST can embed reviews via
+-- the existing FK chain: callers do
+--     supabase.rpc('get_study_session_cards', { p_deck_id })
+--             .select('*, review:reviews(*)')
+-- and get exactly the same row shape as the existing cards-page query.
+-- =============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_study_session_cards(
+  p_deck_id    bigint,
+  p_study_all  boolean DEFAULT false
+)
+RETURNS SETOF public.cards_with_images
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+AS $$
+DECLARE
+  v_max_total       int;
+  v_max_new         int;
+  v_used_total      int;
+  v_used_new        int;
+  v_remaining_total int;
+  v_remaining_new   int;
+  v_new_available   int;
+  v_new_take        int;
+  v_review_take     int;
+BEGIN
+  -- study_all bypasses caps + due filter — return every card in rank order.
+  IF p_study_all THEN
+    RETURN QUERY
+    SELECT cwi.*
+    FROM public.cards_with_images cwi
+    WHERE cwi.deck_id = p_deck_id
+    ORDER BY cwi.rank;
+    RETURN;
+  END IF;
+
+  -- Read caps. NULL = unlimited.
+  SELECT
+    (study_config->>'max_reviews_per_day')::int,
+    (study_config->>'max_new_per_day')::int
+  INTO v_max_total, v_max_new
+  FROM public.decks
+  WHERE id = p_deck_id;
+
+  -- Today's usage: distinct cards from this deck reviewed since UTC midnight.
+  SELECT
+    count(DISTINCT rl.card_id)::int,
+    count(DISTINCT rl.card_id) FILTER (WHERE rl.state = 0)::int
+  INTO v_used_total, v_used_new
+  FROM public.review_logs rl
+  JOIN public.cards c ON c.id = rl.card_id
+  WHERE c.deck_id = p_deck_id
+    AND rl.review >= date_trunc('day', now());
+
+  -- Remaining budget. NULL cap → sentinel large int meaning unlimited.
+  v_remaining_total := GREATEST(0, COALESCE(v_max_total - v_used_total, 2147483647));
+  v_remaining_new   := GREATEST(0, COALESCE(v_max_new   - v_used_new,   2147483647));
+
+  -- How many new cards exist in this deck (no review row yet).
+  SELECT count(*)::int
+  INTO v_new_available
+  FROM public.cards c
+  LEFT JOIN public.reviews r ON r.card_id = c.id
+  WHERE c.deck_id = p_deck_id
+    AND r.id IS NULL;
+
+  -- New cards drawn first; review cards fill the rest.
+  v_new_take    := LEAST(v_new_available, v_remaining_new, v_remaining_total);
+  v_review_take := GREATEST(0, v_remaining_total - v_new_take);
+
+  RETURN QUERY
+  WITH new_queue AS (
+    SELECT c.id, 1 AS bucket, c.rank
+    FROM public.cards c
+    LEFT JOIN public.reviews r ON r.card_id = c.id
+    WHERE c.deck_id = p_deck_id
+      AND r.id IS NULL
+    ORDER BY c.rank
+    LIMIT v_new_take
+  ),
+  review_queue AS (
+    SELECT c.id, 2 AS bucket, c.rank
+    FROM public.cards c
+    JOIN public.reviews r ON r.card_id = c.id
+    WHERE c.deck_id = p_deck_id
+      AND r.due <= now()
+    ORDER BY c.rank
+    LIMIT v_review_take
+  ),
+  queue AS (
+    SELECT id, bucket, rank FROM new_queue
+    UNION ALL
+    SELECT id, bucket, rank FROM review_queue
+  )
+  SELECT cwi.*
+  FROM public.cards_with_images cwi
+  JOIN queue q ON q.id = cwi.id
+  ORDER BY q.bucket, q.rank;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_study_session_cards(bigint, boolean) TO authenticated;
+
+COMMIT;

--- a/supabase/tests/00012_study_session_cards.sql
+++ b/supabase/tests/00012_study_session_cards.sql
@@ -1,0 +1,161 @@
+-- =============================================================================
+-- decks_with_stats daily-cap clamping + get_study_session_cards RPC
+--
+-- Covers:
+--   1. decks_with_stats exposes reviewed_today_count + new_reviewed_today_count
+--      and clamps due_count by max_reviews_per_day - reviewed_today.
+--   2. get_study_session_cards returns ordered (new-first, then review)
+--      respecting both max_new_per_day and max_reviews_per_day.
+--   3. p_study_all = true bypasses caps.
+--   4. NULL caps mean unlimited.
+--   5. RLS scopes both view + RPC to the calling member.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(11);
+
+-- ── Setup ─────────────────────────────────────────────────────────────────────
+SELECT tests.create_user('11111111-1111-1111-1111-111111111111'::uuid, 'alice_caps');
+SELECT tests.create_user('22222222-2222-2222-2222-222222222222'::uuid, 'bob_caps');
+
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+
+-- Deck 100: max_reviews_per_day = 3, max_new_per_day = 1
+-- 5 cards: 1000, 1001 are NEW (no review row); 1002, 1003 are due reviews; 1004 is not due.
+INSERT INTO public.decks (id, title, is_public, study_config) VALUES
+  (100, 'Caps Deck', false, '{"max_reviews_per_day": 3, "max_new_per_day": 1}'::jsonb);
+
+INSERT INTO public.cards (id, deck_id, front_text, back_text, rank) VALUES
+  (1000, 100, 'New A', '', 1000),
+  (1001, 100, 'New B', '', 2000),
+  (1002, 100, 'Due A', '', 3000),
+  (1003, 100, 'Due B', '', 4000),
+  (1004, 100, 'Future', '', 5000);
+
+INSERT INTO public.reviews (id, card_id, due, stability, difficulty) VALUES
+  (300, 1002, now() - interval '1 day', 1.0, 5.0),
+  (301, 1003, now() - interval '1 hour', 1.0, 5.0),
+  (302, 1004, now() + interval '7 days', 1.0, 5.0);
+
+-- Deck 101: no caps (NULL) — unlimited.
+INSERT INTO public.decks (id, title, is_public, study_config) VALUES
+  (101, 'Unlimited Deck', false, '{}'::jsonb);
+INSERT INTO public.cards (id, deck_id, front_text, back_text, rank) VALUES
+  (1100, 101, 'A', '', 1000),
+  (1101, 101, 'B', '', 2000);
+
+-- Bob has his own deck — used to confirm RLS isolation.
+SELECT tests.set_claims('22222222-2222-2222-2222-222222222222'::uuid);
+INSERT INTO public.decks (id, title, is_public) VALUES (200, 'Bob Deck', false);
+INSERT INTO public.cards (id, deck_id, front_text, back_text, rank) VALUES
+  (2000, 200, 'Bob', '', 1000);
+
+
+-- ── Act as Alice ──────────────────────────────────────────────────────────────
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 1: with no review_logs yet, due_count is clamped to max_reviews_per_day.
+-- Raw due = 4 (1000, 1001, 1002, 1003), cap = 3, used = 0 → 3.
+SELECT is(
+  (SELECT due_count FROM public.decks_with_stats WHERE id = 100),
+  3,
+  'due_count clamped by max_reviews_per_day when no reviews logged today'
+);
+
+-- Test 2: reviewed_today_count is 0 before any logs.
+SELECT is(
+  (SELECT reviewed_today_count FROM public.decks_with_stats WHERE id = 100),
+  0,
+  'reviewed_today_count is 0 before any review_logs'
+);
+
+-- Test 3: NULL caps mean unlimited — due_count = raw due (2 new = both due).
+SELECT is(
+  (SELECT due_count FROM public.decks_with_stats WHERE id = 101),
+  2,
+  'due_count is uncapped when max_reviews_per_day is null'
+);
+
+-- Test 4: get_study_session_cards respects max_new_per_day = 1, then fills
+-- with due review cards up to max_reviews_per_day = 3. Expected order:
+-- [1 new card by rank, 2 due review cards by rank] = [1000, 1002, 1003].
+SELECT results_eq(
+  $$ SELECT id FROM public.get_study_session_cards(100) $$,
+  $$ VALUES (1000::bigint), (1002::bigint), (1003::bigint) $$,
+  'queue: 1 new card + due reviews up to total cap, ordered by rank'
+);
+
+-- Log one review event for a NEW card today (state = 0).
+SET LOCAL role = 'postgres';
+INSERT INTO public.review_logs (card_id, member_id, rating, state, due, review)
+VALUES (1000, '11111111-1111-1111-1111-111111111111', 3, 0, now(), now());
+INSERT INTO public.reviews (id, card_id, due, stability, difficulty)
+VALUES (303, 1000, now() + interval '1 day', 1.0, 5.0);
+SET LOCAL role = 'authenticated';
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+
+-- Test 5: reviewed_today_count = 1 after the log.
+SELECT is(
+  (SELECT reviewed_today_count FROM public.decks_with_stats WHERE id = 100),
+  1,
+  'reviewed_today_count counts logged reviews from today'
+);
+
+-- Test 6: new_reviewed_today_count = 1 (the state=0 log).
+SELECT is(
+  (SELECT new_reviewed_today_count FROM public.decks_with_stats WHERE id = 100),
+  1,
+  'new_reviewed_today_count counts state=0 logs only'
+);
+
+-- Test 7: due_count clamped by remaining budget. Raw due now = 3 (1001, 1002,
+-- 1003 — 1000 has a future review). Cap budget = 3 - 1 = 2. So due_count = 2.
+SELECT is(
+  (SELECT due_count FROM public.decks_with_stats WHERE id = 100),
+  2,
+  'due_count subtracts reviewed_today from max_reviews_per_day'
+);
+
+-- Test 8: queue now skips 1000 (already reviewed today, no longer due) and
+-- skips 1001 (new budget exhausted: 1 used, max 1). Returns 2 due reviews:
+-- [1002, 1003] up to remaining total budget = 2.
+SELECT results_eq(
+  $$ SELECT id FROM public.get_study_session_cards(100) $$,
+  $$ VALUES (1002::bigint), (1003::bigint) $$,
+  'queue respects exhausted new-card budget and remaining total budget'
+);
+
+-- Test 9: p_study_all = true returns every card in deck regardless of caps,
+-- in rank order.
+SELECT results_eq(
+  $$ SELECT id FROM public.get_study_session_cards(100, true) $$,
+  $$ VALUES (1000::bigint), (1001::bigint), (1002::bigint), (1003::bigint), (1004::bigint) $$,
+  'p_study_all bypasses caps and returns all cards in rank order'
+);
+
+
+-- ── Act as Bob — RLS scoping ──────────────────────────────────────────────────
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims('22222222-2222-2222-2222-222222222222'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 10: Bob cannot read Alice's deck stats.
+SELECT is(
+  (SELECT count(*) FROM public.decks_with_stats WHERE id = 100)::int,
+  0,
+  'security_invoker: Bob cannot see Alice''s deck via decks_with_stats'
+);
+
+-- Test 11: Bob's RPC call against Alice's deck returns no rows (his own
+-- claims scope cards/reviews — the function runs as invoker so RLS applies).
+SELECT is(
+  (SELECT count(*) FROM public.get_study_session_cards(100))::int,
+  0,
+  'security_invoker: Bob''s call to get_study_session_cards on Alice''s deck returns 0 rows'
+);
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/integration/components/modals/deck-settings/index.test.js
+++ b/tests/integration/components/modals/deck-settings/index.test.js
@@ -20,6 +20,7 @@ vi.mock('@/composables/deck-editor', async () => {
         description: deck?.description ?? '',
         is_public: deck?.is_public ?? true
       }),
+      config: reactive({ study_all_cards: false }),
       cover: reactive({}),
       card_attributes: reactive({ front: {}, back: {} })
     })

--- a/tests/integration/components/modals/deck-settings/tab-study.test.js
+++ b/tests/integration/components/modals/deck-settings/tab-study.test.js
@@ -1,0 +1,135 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, useAttrs } from 'vue'
+import TabStudy from '@/components/modals/deck-settings/tab-study.vue'
+
+// Render-function stubs (no template strings — Chromium browser mode is
+// runtime-only Vue).
+const ToggleStub = defineComponent({
+  name: 'UiToggle',
+  props: { checked: { type: Boolean, default: false } },
+  emits: ['update:checked'],
+  inheritAttrs: false,
+  setup(props, { slots, emit }) {
+    const attrs = useAttrs()
+    return () =>
+      h(
+        'label',
+        { ...attrs, 'data-testid': 'ui-kit-toggle', 'data-checked': String(!!props.checked) },
+        [
+          h('span', { 'data-testid': 'ui-kit-toggle__label' }, slots.default?.()),
+          h('input', {
+            type: 'checkbox',
+            checked: !!props.checked,
+            'data-testid': 'ui-kit-toggle__input',
+            onChange: (e) => emit('update:checked', e.target.checked)
+          })
+        ]
+      )
+  }
+})
+
+const IconStub = defineComponent({
+  name: 'UiIcon',
+  props: ['src'],
+  setup(p) {
+    return () => h('span', { 'data-testid': 'ui-icon', 'data-src': p.src })
+  }
+})
+
+function makeTabStudy(props = {}) {
+  return mount(TabStudy, {
+    props,
+    global: {
+      stubs: { UiToggle: ToggleStub, UiIcon: IconStub },
+      mocks: { $t: (k) => k }
+    }
+  })
+}
+
+describe('TabStudy', () => {
+  test('renders all four toggles', () => {
+    const wrapper = makeTabStudy()
+    expect(wrapper.findAll('[data-testid="ui-kit-toggle"]')).toHaveLength(4)
+  })
+
+  test('renders 5 review-limit + 5 new-limit preset buttons', () => {
+    const wrapper = makeTabStudy()
+    const buttons = wrapper.findAll('button')
+    // 5 + 5 = 10
+    expect(buttons).toHaveLength(10)
+  })
+
+  test('emits update:shuffle when shuffle toggle changes', async () => {
+    const wrapper = makeTabStudy({ shuffle: false })
+    const toggles = wrapper.findAllComponents(ToggleStub)
+    // Order: is_spaced, shuffle, flip_cards, auto_play
+    await toggles[1].vm.$emit('update:checked', true)
+    expect(wrapper.emitted('update:shuffle')).toEqual([[true]])
+  })
+
+  test('emits update:flip_cards from the flip-cards toggle', async () => {
+    const wrapper = makeTabStudy({ flip_cards: false })
+    const toggles = wrapper.findAllComponents(ToggleStub)
+    await toggles[2].vm.$emit('update:checked', true)
+    expect(wrapper.emitted('update:flip_cards')).toEqual([[true]])
+  })
+
+  test('emits update:is_spaced from the spaced-repetition toggle', async () => {
+    const wrapper = makeTabStudy({ is_spaced: true })
+    const toggles = wrapper.findAllComponents(ToggleStub)
+    await toggles[0].vm.$emit('update:checked', false)
+    expect(wrapper.emitted('update:is_spaced')).toEqual([[false]])
+  })
+
+  test('emits update:auto_play from the auto-play toggle', async () => {
+    const wrapper = makeTabStudy({ auto_play: false })
+    const toggles = wrapper.findAllComponents(ToggleStub)
+    await toggles[3].vm.$emit('update:checked', true)
+    expect(wrapper.emitted('update:auto_play')).toEqual([[true]])
+  })
+
+  test('clicking a review-limit preset emits update:max_reviews_per_day with that value', async () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 20 })
+    const buttons = wrapper.findAll('button')
+    // First 5 buttons = review-limit presets [20, 50, 100, 200, null]
+    await buttons[2].trigger('click')
+    expect(wrapper.emitted('update:max_reviews_per_day')).toEqual([[100]])
+  })
+
+  test('clicking the "all" review-limit preset emits null', async () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 50 })
+    const buttons = wrapper.findAll('button')
+    await buttons[4].trigger('click')
+    expect(wrapper.emitted('update:max_reviews_per_day')).toEqual([[null]])
+  })
+
+  test('clicking a new-limit preset emits update:max_new_per_day with that value', async () => {
+    const wrapper = makeTabStudy({ max_new_per_day: 5 })
+    const buttons = wrapper.findAll('button')
+    // Buttons 5–9 = new-limit presets [5, 10, 20, 50, null]
+    await buttons[6].trigger('click')
+    expect(wrapper.emitted('update:max_new_per_day')).toEqual([[10]])
+  })
+
+  test('clicking the "all" new-limit preset emits null', async () => {
+    const wrapper = makeTabStudy({ max_new_per_day: 10 })
+    const buttons = wrapper.findAll('button')
+    await buttons[9].trigger('click')
+    expect(wrapper.emitted('update:max_new_per_day')).toEqual([[null]])
+  })
+
+  test('marks the active review-limit preset via data-active', () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 100 })
+    const presets = wrapper.findAll('[data-testid="tab-study__max-reviews-preset"]')
+    expect(presets[2].attributes('data-active')).toBe('true')
+    expect(presets[0].attributes('data-active')).toBe('false')
+  })
+
+  test('marks the active new-limit preset via data-active', () => {
+    const wrapper = makeTabStudy({ max_new_per_day: 20 })
+    const presets = wrapper.findAll('[data-testid="tab-study__max-new-preset"]')
+    expect(presets[2].attributes('data-active')).toBe('true')
+    expect(presets[0].attributes('data-active')).toBe('false')
+  })
+})

--- a/tests/integration/components/modals/study-session/session-flashcard.test.js
+++ b/tests/integration/components/modals/study-session/session-flashcard.test.js
@@ -42,7 +42,7 @@ vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
 vi.mock('@/api/cards', () => {
   const passthrough = () => ({ mutate: vi.fn(), mutateAsync: vi.fn().mockResolvedValue(undefined) })
   return {
-    useCardsInDeckQuery: () => ({
+    useStudySessionCardsQuery: () => ({
       data: cardsDataRef,
       refetch: vi.fn(),
       refresh: vi.fn()

--- a/tests/unit/composables/study-session/flashcard-session.test.js
+++ b/tests/unit/composables/study-session/flashcard-session.test.js
@@ -408,31 +408,10 @@ describe('useFlashcardSession', () => {
     expect(session.cards.value).toHaveLength(0)
   })
 
-  // ── card_limit ─────────────────────────────────────────────────────────────
-
-  test('card_limit slices the deck to the given count', () => {
-    const cards = Array.from({ length: 5 }, () => makeDueCard({ review: null }))
-    const session = useFlashcardSession({
-      study_all_cards: true,
-      retry_failed_cards: false,
-      card_limit: 3
-    })
-    session.setCards(cards)
-
-    expect(session.cards.value).toHaveLength(3)
-  })
-
-  test('card_limit of null uses all cards', () => {
-    const cards = Array.from({ length: 5 }, () => makeDueCard({ review: null }))
-    const session = useFlashcardSession({
-      study_all_cards: true,
-      retry_failed_cards: false,
-      card_limit: null
-    })
-    session.setCards(cards)
-
-    expect(session.cards.value).toHaveLength(5)
-  })
+  // ── daily caps ─────────────────────────────────────────────────────────────
+  // Daily caps are now applied server-side in get_study_session_cards. The FE
+  // composable just consumes the pre-sliced result, so no FE-side test for
+  // max_reviews_per_day / max_new_per_day belongs here.
 
   // ── shuffle ────────────────────────────────────────────────────────────────
 

--- a/types/deck.d.ts
+++ b/types/deck.d.ts
@@ -20,6 +20,8 @@ type Deck = {
   member?: { display_name: string }
   tags?: string[]
   due_count?: number
+  reviewed_today_count?: number
+  new_reviewed_today_count?: number
   study_config?: DeckConfig
   cover_config?: DeckCover
   card_attributes?: DeckCardAttributes
@@ -35,7 +37,8 @@ type DeckConfig = {
   study_mode?: DeckStudyMode
   study_all_cards: boolean
   shuffle?: boolean
-  card_limit?: number | null
+  max_reviews_per_day?: number | null
+  max_new_per_day?: number | null
   flip_cards?: boolean
   is_spaced?: boolean
   auto_play?: boolean


### PR DESCRIPTION
## Summary

Adds per-deck daily caps for review sessions (max reviews/day, max new cards/day) with a server-built study queue, and changes shuffle to randomize only review cards while keeping new/learning cards in their original order.

## Changes

- **Shuffle** partitions the queue: new cards (no prior review) keep raw rank order at the front; review cards are shuffled after. Avoids contextual priming between related cards while preserving learning order.
- **Daily caps** replace the single \`card_limit\` setting with two new \`DeckConfig\` fields: \`max_reviews_per_day\` (total cap, includes new) and \`max_new_per_day\` (subcap on brand-new cards).
- **\`decks_with_stats\` view** exposes \`reviewed_today_count\` and \`new_reviewed_today_count\`, and clamps \`due_count\` by remaining day budget. Uses \`review_logs\` with UTC day boundary.
- **New RPC \`get_study_session_cards(p_deck_id, p_study_all)\`** returns \`SETOF cards_with_images\` with the queue already partitioned (new first, then due reviews) and capped server-side. PostgREST embeds reviews via the existing FK chain — single roundtrip.
- **Settings modal** wires \`tab-study\` into the deck-settings right column with two preset pickers (review limit, new limit). \`data-active\` exposed on preset buttons for testability.
- **pgTAP** (00012): 11 assertions covering clamping, queue ordering, \`p_study_all\` bypass, and RLS scoping.
- **FE tests**: new \`tab-study.test.js\` (12 cases); existing \`session-flashcard.test.js\` updated for the new query hook.