### PR TITLE
Fix daily-cap counts when reviewing past UTC midnight

### DIFF
--- a/src/api/cards/db/study-session-cards.ts
+++ b/src/api/cards/db/study-session-cards.ts
@@ -1,12 +1,17 @@
 import { supabase } from '@/supabase-client'
 import logger from '@/utils/logger'
+import { localDayStart } from '@/utils/date'
 
 export async function fetchStudySessionCards(
   deck_id: number,
   study_all: boolean = false
 ): Promise<Card[]> {
   const { data, error } = await supabase
-    .rpc('get_study_session_cards', { p_deck_id: deck_id, p_study_all: study_all })
+    .rpc('get_study_session_cards', {
+      p_deck_id: deck_id,
+      p_today_start: localDayStart(),
+      p_study_all: study_all
+    })
     .select('*, review:reviews(*)')
 
   if (error) {

--- a/src/api/decks/db/index.ts
+++ b/src/api/decks/db/index.ts
@@ -1,11 +1,11 @@
 import { supabase } from '@/supabase-client'
 import { useMemberStore } from '@/stores/member'
 import logger from '@/utils/logger'
-import { isoNow } from '@/utils/date'
+import { isoNow, localDayStart } from '@/utils/date'
 
 export async function fetchMemberDecks(): Promise<Deck[]> {
   const { data, error } = await supabase
-    .from('decks_with_stats')
+    .rpc('decks_with_stats', { p_today_start: localDayStart() })
     .select('*')
     .eq('member_id', useMemberStore().id)
 
@@ -19,7 +19,7 @@ export async function fetchMemberDecks(): Promise<Deck[]> {
 
 export async function fetchDeck(id: number): Promise<Deck> {
   const { data, error } = await supabase
-    .from('decks_with_stats')
+    .rpc('decks_with_stats', { p_today_start: localDayStart() })
     .select('*, member:members(display_name)')
     .eq('id', id)
     .single()
@@ -29,7 +29,7 @@ export async function fetchDeck(id: number): Promise<Deck> {
     throw error
   }
 
-  return data
+  return data as Deck
 }
 
 export async function fetchMemberDeckCount(): Promise<number> {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -2,6 +2,17 @@ export function isoNow(): string {
   return new Date().toISOString()
 }
 
+/**
+ * ISO timestamp of the start of the caller's local day (00:00 in their
+ * current timezone). Used to scope "today's" daily-cap counts on the
+ * backend without baking a timezone assumption into SQL.
+ */
+export function localDayStart(): string {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  return start.toISOString()
+}
+
 type DateInput = string | number | Date
 
 function toDate(input: DateInput): Date {

--- a/supabase/migrations/20260502000000_decks-with-stats-fn-and-day-start.sql
+++ b/supabase/migrations/20260502000000_decks-with-stats-fn-and-day-start.sql
@@ -1,0 +1,208 @@
+-- =============================================================================
+-- decks_with_stats: replace view with a parameterized function
+-- get_study_session_cards: accept p_today_start
+--
+-- Both endpoints now take the caller's local day start as a timestamptz so
+-- daily caps stay correct regardless of the user's timezone (and survive
+-- travel between zones). The FE computes 00:00 local, serialises as ISO,
+-- and passes it in. BE just compares.
+-- =============================================================================
+
+BEGIN;
+
+DROP VIEW public.decks_with_stats;
+
+CREATE OR REPLACE FUNCTION public.decks_with_stats(p_today_start timestamptz)
+RETURNS TABLE (
+  id              bigint,
+  created_at      timestamptz,
+  updated_at      timestamptz,
+  description     text,
+  is_public       boolean,
+  title           text,
+  member_id       uuid,
+  tags            text[],
+  has_image       boolean,
+  study_config    jsonb,
+  cover_config    jsonb,
+  card_attributes jsonb,
+  card_count                int,
+  reviewed_today_count      int,
+  new_reviewed_today_count  int,
+  due_count                 int
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+AS $$
+  SELECT
+    d.id,
+    d.created_at,
+    d.updated_at,
+    d.description,
+    d.is_public,
+    d.title,
+    d.member_id,
+    d.tags,
+    d.has_image,
+    d.study_config,
+    d.cover_config,
+    d.card_attributes,
+
+    (
+      SELECT count(*)::int
+      FROM public.cards c
+      WHERE c.deck_id = d.id
+    ) AS card_count,
+
+    (
+      SELECT count(DISTINCT rl.card_id)::int
+      FROM public.review_logs rl
+      JOIN public.cards c ON c.id = rl.card_id
+      WHERE c.deck_id = d.id
+        AND rl.review >= p_today_start
+    ) AS reviewed_today_count,
+
+    (
+      SELECT count(DISTINCT rl.card_id)::int
+      FROM public.review_logs rl
+      JOIN public.cards c ON c.id = rl.card_id
+      WHERE c.deck_id = d.id
+        AND rl.state = 0
+        AND rl.review >= p_today_start
+    ) AS new_reviewed_today_count,
+
+    GREATEST(
+      0,
+      CASE
+        WHEN (d.study_config->>'max_reviews_per_day') IS NULL THEN
+          (
+            SELECT count(*)::int
+            FROM public.cards c
+            LEFT JOIN public.reviews r ON r.card_id = c.id
+            WHERE c.deck_id = d.id
+              AND (r.due IS NULL OR r.due <= now())
+          )
+        ELSE
+          LEAST(
+            (
+              SELECT count(*)::int
+              FROM public.cards c
+              LEFT JOIN public.reviews r ON r.card_id = c.id
+              WHERE c.deck_id = d.id
+                AND (r.due IS NULL OR r.due <= now())
+            ),
+            (d.study_config->>'max_reviews_per_day')::int
+              - (
+                SELECT count(DISTINCT rl.card_id)::int
+                FROM public.review_logs rl
+                JOIN public.cards c ON c.id = rl.card_id
+                WHERE c.deck_id = d.id
+                  AND rl.review >= p_today_start
+              )
+          )
+      END
+    ) AS due_count
+
+  FROM public.decks d;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.decks_with_stats(timestamptz) TO authenticated;
+
+
+-- ── get_study_session_cards: accept p_today_start ────────────────────────────
+DROP FUNCTION IF EXISTS public.get_study_session_cards(bigint, boolean);
+
+CREATE OR REPLACE FUNCTION public.get_study_session_cards(
+  p_deck_id      bigint,
+  p_today_start  timestamptz,
+  p_study_all    boolean DEFAULT false
+)
+RETURNS SETOF public.cards_with_images
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+AS $$
+DECLARE
+  v_max_total       int;
+  v_max_new         int;
+  v_used_total      int;
+  v_used_new        int;
+  v_remaining_total int;
+  v_remaining_new   int;
+  v_new_available   int;
+  v_new_take        int;
+  v_review_take     int;
+BEGIN
+  IF p_study_all THEN
+    RETURN QUERY
+    SELECT cwi.*
+    FROM public.cards_with_images cwi
+    WHERE cwi.deck_id = p_deck_id
+    ORDER BY cwi.rank;
+    RETURN;
+  END IF;
+
+  SELECT
+    (study_config->>'max_reviews_per_day')::int,
+    (study_config->>'max_new_per_day')::int
+  INTO v_max_total, v_max_new
+  FROM public.decks
+  WHERE id = p_deck_id;
+
+  SELECT
+    count(DISTINCT rl.card_id)::int,
+    count(DISTINCT rl.card_id) FILTER (WHERE rl.state = 0)::int
+  INTO v_used_total, v_used_new
+  FROM public.review_logs rl
+  JOIN public.cards c ON c.id = rl.card_id
+  WHERE c.deck_id = p_deck_id
+    AND rl.review >= p_today_start;
+
+  v_remaining_total := GREATEST(0, COALESCE(v_max_total - v_used_total, 2147483647));
+  v_remaining_new   := GREATEST(0, COALESCE(v_max_new   - v_used_new,   2147483647));
+
+  SELECT count(*)::int
+  INTO v_new_available
+  FROM public.cards c
+  LEFT JOIN public.reviews r ON r.card_id = c.id
+  WHERE c.deck_id = p_deck_id
+    AND r.id IS NULL;
+
+  v_new_take    := LEAST(v_new_available, v_remaining_new, v_remaining_total);
+  v_review_take := GREATEST(0, v_remaining_total - v_new_take);
+
+  RETURN QUERY
+  WITH new_queue AS (
+    SELECT c.id, 1 AS bucket, c.rank
+    FROM public.cards c
+    LEFT JOIN public.reviews r ON r.card_id = c.id
+    WHERE c.deck_id = p_deck_id
+      AND r.id IS NULL
+    ORDER BY c.rank
+    LIMIT v_new_take
+  ),
+  review_queue AS (
+    SELECT c.id, 2 AS bucket, c.rank
+    FROM public.cards c
+    JOIN public.reviews r ON r.card_id = c.id
+    WHERE c.deck_id = p_deck_id
+      AND r.due <= now()
+    ORDER BY c.rank
+    LIMIT v_review_take
+  ),
+  queue AS (
+    SELECT id, bucket, rank FROM new_queue
+    UNION ALL
+    SELECT id, bucket, rank FROM review_queue
+  )
+  SELECT cwi.*
+  FROM public.cards_with_images cwi
+  JOIN queue q ON q.id = cwi.id
+  ORDER BY q.bucket, q.rank;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_study_session_cards(bigint, timestamptz, boolean) TO authenticated;
+
+COMMIT;

--- a/supabase/tests/00007_card_attributes.sql
+++ b/supabase/tests/00007_card_attributes.sql
@@ -46,7 +46,7 @@ SET LOCAL role = 'authenticated';
 SELECT results_eq(
   $$
     SELECT card_attributes
-    FROM public.decks_with_stats
+    FROM public.decks_with_stats(date_trunc('day', now()))
     WHERE id = 900
   $$,
   $$
@@ -72,7 +72,7 @@ SET LOCAL role = 'authenticated';
 SELECT results_eq(
   $$
     SELECT card_attributes IS NULL
-    FROM public.decks_with_stats
+    FROM public.decks_with_stats(date_trunc('day', now()))
     WHERE id = 901
   $$,
   $$ VALUES (true) $$,

--- a/supabase/tests/00009_decks_with_stats.sql
+++ b/supabase/tests/00009_decks_with_stats.sql
@@ -47,13 +47,13 @@ SET LOCAL role = 'authenticated';
 
 -- Test 1: Alice can read her own decks through the view.
 SELECT lives_ok(
-  $$ SELECT * FROM public.decks_with_stats WHERE id IN (100, 101) $$,
+  $$ SELECT * FROM public.decks_with_stats(date_trunc('day', now())) WHERE id IN (100, 101) $$,
   'Alice can read her own decks via decks_with_stats'
 );
 
 -- Test 2: card_count is accurate on Alice's private deck (2 cards).
 SELECT is(
-  (SELECT card_count FROM public.decks_with_stats WHERE id = 100),
+  (SELECT card_count FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 100),
   2,
   'card_count on deck 100 equals 2'
 );
@@ -61,14 +61,14 @@ SELECT is(
 -- Test 3: due_count on deck 100 is 1 — card 1000 is due (no review),
 -- card 1001 is not (review.due is in the future).
 SELECT is(
-  (SELECT due_count FROM public.decks_with_stats WHERE id = 100),
+  (SELECT due_count FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 100),
   1,
   'due_count on deck 100 equals 1 (only card 1000 is currently due)'
 );
 
 -- Test 4: due_count on Alice's public deck 101 is 1 — card 1100 has no review.
 SELECT is(
-  (SELECT due_count FROM public.decks_with_stats WHERE id = 101),
+  (SELECT due_count FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 101),
   1,
   'due_count on deck 101 equals 1 (card 1100 has no review, so it is due)'
 );
@@ -77,7 +77,7 @@ SELECT is(
 -- If security_invoker were not set, the view would run as postgres and
 -- return Bob's row — this assertion would fail.
 SELECT is(
-  (SELECT count(*) FROM public.decks_with_stats WHERE id = 200)::int,
+  (SELECT count(*) FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 200)::int,
   0,
   'security_invoker: Alice cannot read Bob''s private deck via decks_with_stats'
 );
@@ -86,7 +86,7 @@ SELECT is(
 -- Catches accidental join-style duplication where a deck with N cards
 -- would return N rows.
 SELECT is(
-  (SELECT count(*) FROM public.decks_with_stats WHERE member_id = '11111111-1111-1111-1111-111111111111')::int,
+  (SELECT count(*) FROM public.decks_with_stats(date_trunc('day', now())) WHERE member_id = '11111111-1111-1111-1111-111111111111')::int,
   2,
   'view row count equals member deck count (no join duplication)'
 );

--- a/supabase/tests/00012_study_session_cards.sql
+++ b/supabase/tests/00012_study_session_cards.sql
@@ -13,7 +13,7 @@
 
 BEGIN;
 
-SELECT plan(11);
+SELECT plan(13);
 
 -- ── Setup ─────────────────────────────────────────────────────────────────────
 SELECT tests.create_user('11111111-1111-1111-1111-111111111111'::uuid, 'alice_caps');
@@ -59,21 +59,21 @@ SET LOCAL role = 'authenticated';
 -- Test 1: with no review_logs yet, due_count is clamped to max_reviews_per_day.
 -- Raw due = 4 (1000, 1001, 1002, 1003), cap = 3, used = 0 → 3.
 SELECT is(
-  (SELECT due_count FROM public.decks_with_stats WHERE id = 100),
+  (SELECT due_count FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 100),
   3,
   'due_count clamped by max_reviews_per_day when no reviews logged today'
 );
 
 -- Test 2: reviewed_today_count is 0 before any logs.
 SELECT is(
-  (SELECT reviewed_today_count FROM public.decks_with_stats WHERE id = 100),
+  (SELECT reviewed_today_count FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 100),
   0,
   'reviewed_today_count is 0 before any review_logs'
 );
 
 -- Test 3: NULL caps mean unlimited — due_count = raw due (2 new = both due).
 SELECT is(
-  (SELECT due_count FROM public.decks_with_stats WHERE id = 101),
+  (SELECT due_count FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 101),
   2,
   'due_count is uncapped when max_reviews_per_day is null'
 );
@@ -82,7 +82,7 @@ SELECT is(
 -- with due review cards up to max_reviews_per_day = 3. Expected order:
 -- [1 new card by rank, 2 due review cards by rank] = [1000, 1002, 1003].
 SELECT results_eq(
-  $$ SELECT id FROM public.get_study_session_cards(100) $$,
+  $$ SELECT id FROM public.get_study_session_cards(100, date_trunc('day', now())) $$,
   $$ VALUES (1000::bigint), (1002::bigint), (1003::bigint) $$,
   'queue: 1 new card + due reviews up to total cap, ordered by rank'
 );
@@ -98,14 +98,14 @@ SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
 
 -- Test 5: reviewed_today_count = 1 after the log.
 SELECT is(
-  (SELECT reviewed_today_count FROM public.decks_with_stats WHERE id = 100),
+  (SELECT reviewed_today_count FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 100),
   1,
   'reviewed_today_count counts logged reviews from today'
 );
 
 -- Test 6: new_reviewed_today_count = 1 (the state=0 log).
 SELECT is(
-  (SELECT new_reviewed_today_count FROM public.decks_with_stats WHERE id = 100),
+  (SELECT new_reviewed_today_count FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 100),
   1,
   'new_reviewed_today_count counts state=0 logs only'
 );
@@ -113,7 +113,7 @@ SELECT is(
 -- Test 7: due_count clamped by remaining budget. Raw due now = 3 (1001, 1002,
 -- 1003 — 1000 has a future review). Cap budget = 3 - 1 = 2. So due_count = 2.
 SELECT is(
-  (SELECT due_count FROM public.decks_with_stats WHERE id = 100),
+  (SELECT due_count FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 100),
   2,
   'due_count subtracts reviewed_today from max_reviews_per_day'
 );
@@ -122,7 +122,7 @@ SELECT is(
 -- skips 1001 (new budget exhausted: 1 used, max 1). Returns 2 due reviews:
 -- [1002, 1003] up to remaining total budget = 2.
 SELECT results_eq(
-  $$ SELECT id FROM public.get_study_session_cards(100) $$,
+  $$ SELECT id FROM public.get_study_session_cards(100, date_trunc('day', now())) $$,
   $$ VALUES (1002::bigint), (1003::bigint) $$,
   'queue respects exhausted new-card budget and remaining total budget'
 );
@@ -130,9 +130,25 @@ SELECT results_eq(
 -- Test 9: p_study_all = true returns every card in deck regardless of caps,
 -- in rank order.
 SELECT results_eq(
-  $$ SELECT id FROM public.get_study_session_cards(100, true) $$,
+  $$ SELECT id FROM public.get_study_session_cards(100, date_trunc('day', now()), true) $$,
   $$ VALUES (1000::bigint), (1001::bigint), (1002::bigint), (1003::bigint), (1004::bigint) $$,
   'p_study_all bypasses caps and returns all cards in rank order'
+);
+
+-- Test 9a: p_today_start in the future ignores all logs → reviewed_today = 0
+-- (proves the parameter actually scopes the count).
+SELECT is(
+  (SELECT reviewed_today_count FROM public.decks_with_stats(now() + interval '1 day') WHERE id = 100),
+  0,
+  'p_today_start in the future yields reviewed_today_count = 0'
+);
+
+-- Test 9b: with reviewed_today = 0, due_count uses the full cap. Raw due now
+-- is 3 (1001, 1002, 1003 — 1000 has future review). Cap = 3. due_count = 3.
+SELECT is(
+  (SELECT due_count FROM public.decks_with_stats(now() + interval '1 day') WHERE id = 100),
+  3,
+  'p_today_start in the future restores due_count to the unclamped cap'
 );
 
 
@@ -143,7 +159,7 @@ SET LOCAL role = 'authenticated';
 
 -- Test 10: Bob cannot read Alice's deck stats.
 SELECT is(
-  (SELECT count(*) FROM public.decks_with_stats WHERE id = 100)::int,
+  (SELECT count(*) FROM public.decks_with_stats(date_trunc('day', now())) WHERE id = 100)::int,
   0,
   'security_invoker: Bob cannot see Alice''s deck via decks_with_stats'
 );
@@ -151,7 +167,7 @@ SELECT is(
 -- Test 11: Bob's RPC call against Alice's deck returns no rows (his own
 -- claims scope cards/reviews — the function runs as invoker so RLS applies).
 SELECT is(
-  (SELECT count(*) FROM public.get_study_session_cards(100))::int,
+  (SELECT count(*) FROM public.get_study_session_cards(100, date_trunc('day', now())))::int,
   0,
   'security_invoker: Bob''s call to get_study_session_cards on Alice''s deck returns 0 rows'
 );

--- a/tests/unit/api/decks.test.js
+++ b/tests/unit/api/decks.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 
-const { queryMock, capturedTables } = vi.hoisted(() => {
+const { queryMock, capturedTables, capturedRpcs } = vi.hoisted(() => {
   const queryMock = {
     select: vi.fn(),
     eq: vi.fn(),
@@ -9,13 +9,17 @@ const { queryMock, capturedTables } = vi.hoisted(() => {
     upsert: vi.fn(),
     delete: vi.fn()
   }
-  return { queryMock, capturedTables: [] }
+  return { queryMock, capturedTables: [], capturedRpcs: [] }
 })
 
 vi.mock('@/supabase-client', () => ({
   supabase: {
     from: vi.fn((table) => {
       capturedTables.push(table)
+      return queryMock
+    }),
+    rpc: vi.fn((fn, args) => {
+      capturedRpcs.push({ fn, args })
       return queryMock
     })
   }
@@ -43,14 +47,17 @@ beforeEach(() => {
   queryMock.order.mockReturnValue(queryMock)
   queryMock.delete.mockReturnValue(queryMock)
   capturedTables.length = 0
+  capturedRpcs.length = 0
   supabase.from.mockClear()
+  supabase.rpc.mockClear()
 })
 
 describe('fetchMemberDecks', () => {
-  test('reads from decks_with_stats filtered by current member', async () => {
+  test('calls decks_with_stats RPC filtered by current member', async () => {
     queryMock.eq.mockResolvedValueOnce({ data: [{ id: 1 }], error: null })
     const result = await fetchMemberDecks()
-    expect(capturedTables[0]).toBe('decks_with_stats')
+    expect(capturedRpcs[0].fn).toBe('decks_with_stats')
+    expect(capturedRpcs[0].args.p_today_start).toEqual(expect.any(String))
     expect(queryMock.eq).toHaveBeenCalledWith('member_id', 'member-uuid-1')
     expect(result).toEqual([{ id: 1 }])
   })
@@ -63,10 +70,11 @@ describe('fetchMemberDecks', () => {
 })
 
 describe('fetchDeck', () => {
-  test('reads from decks_with_stats with the member embed only — cards are paginated separately', async () => {
+  test('calls decks_with_stats RPC with the member embed only — cards are paginated separately', async () => {
     queryMock.single.mockResolvedValueOnce({ data: { id: 5 }, error: null })
     await fetchDeck(5)
-    expect(capturedTables[0]).toBe('decks_with_stats')
+    expect(capturedRpcs[0].fn).toBe('decks_with_stats')
+    expect(capturedRpcs[0].args.p_today_start).toEqual(expect.any(String))
     const [selectArg] = queryMock.select.mock.calls[0]
     expect(selectArg).toContain('member:members(display_name)')
     expect(selectArg).not.toContain('cards:cards_with_images')

--- a/tests/unit/utils/date.test.js
+++ b/tests/unit/utils/date.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
-import { isoNow, formatShortDate, toRelative } from '@/utils/date'
+import { isoNow, localDayStart, formatShortDate, toRelative } from '@/utils/date'
 
 describe('isoNow', () => {
   afterEach(() => {
@@ -17,6 +17,32 @@ describe('isoNow', () => {
     // would still parse correctly but is a silent drift from the old Luxon
     // behavior and harder to reason about in logs.
     expect(isoNow().endsWith('Z')).toBe(true)
+  })
+})
+
+describe('localDayStart', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('returns midnight of the local day as a UTC ISO string', () => {
+    vi.useFakeTimers()
+    // 2026-03-15 14:30 in the host's local timezone — pick a Date constructor
+    // form that fixes local fields rather than UTC fields.
+    vi.setSystemTime(new Date(2026, 2, 15, 14, 30, 0))
+    const expected = new Date(2026, 2, 15).toISOString()
+    expect(localDayStart()).toBe(expected)
+  })
+
+  test('rolls back to start of day even moments before midnight', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 2, 15, 23, 59, 59))
+    const expected = new Date(2026, 2, 15).toISOString()
+    expect(localDayStart()).toBe(expected)
+  })
+
+  test('returns an ISO string ending in Z (Postgres timestamptz friendly)', () => {
+    expect(localDayStart().endsWith('Z')).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

Daily review caps misbehaved for users in zones west of UTC: \`date_trunc('day', now())\` rolled over to the next day before the user's local day did, so reviews from earlier in their day were excluded from \`reviewed_today_count\` and \`due_count\` reverted to the unclamped cap.

## Changes

- Convert \`decks_with_stats\` from a view to a function and add a \`p_today_start timestamptz\` parameter; same param added to \`get_study_session_cards\`.
- New FE helper \`localDayStart()\` returns ISO of 00:00 in the caller's local timezone; \`fetchMemberDecks\`, \`fetchDeck\`, and \`fetchStudySessionCards\` all pass it through. Travel between zones now reflows naturally.
- Existing pgTAP call sites updated for the new function signatures; new cases (test 9a/9b) prove \`p_today_start\` actually scopes the count.
- Unit tests for \`localDayStart\`.