### PR TITLE
Add lint to CI and drop tests from prod deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
-name: Tests
+name: CI
 
 on:
   pull_request:
 
 jobs:
-  test:
+  verify:
     runs-on: ubuntu-latest
 
     permissions:
@@ -28,6 +28,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Run lint
+        run: pnpm exec vp lint
 
       - name: Install Playwright Chromium
         run: pnpm exec playwright install chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  verify:
+  lint-and-test:
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,57 +8,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  test:
-    name: Run tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install chromium
-
-      - name: Run tests
-        run: pnpm test
-
-  test-db:
-    name: Run database tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
-      - name: Start Supabase
-        run: supabase start -x realtime,storage-api,imgproxy,inbucket,postgrest-api,pgadmin-schema-diff,migra,postgres-meta,studio,edge-runtime,logflare,vector,supavisor
-
-      - name: Run database tests
-        run: supabase test db
-
   deploy:
     name: Deploy
-    needs: [test, test-db]
     uses: ./.github/workflows/deploy.yml
     with:
       environment: production


### PR DESCRIPTION
## Summary

Adds a lint step to PR checks and stops re-running tests on the production deploy pipeline, since anything that reaches \`master\` has already passed CI.

## Changes

- Combine the previously parallel \`lint\` and \`test\` jobs into a single \`verify\` job so \`pnpm install\` runs once. Lint runs first; if it fails, tests don't waste time.
- Rename workflow from **Tests** → **CI** (file: \`tests.yml\` → \`ci.yml\`) — it now covers lint too.
- \`deploy-production.yml\` no longer runs \`test\` or \`test-db\` — release-triggered deploys just deploy.

## Follow-up

- ⚠️ Branch protection rules likely reference the old \`test\` job name. Update required checks to \`verify\` after merge or the rule will block PRs waiting on a job that no longer exists.