### PR TITLE
CI lint step, configurable deploys, drop tests from prod release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
-name: Tests
+name: CI
 
 on:
   pull_request:
 
 jobs:
-  test:
+  verify:
     runs-on: ubuntu-latest
 
     permissions:
@@ -28,6 +28,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Run lint
+        run: pnpm exec vp lint
 
       - name: Install Playwright Chromium
         run: pnpm exec playwright install chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  verify:
+  lint-and-test:
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,57 +8,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  test:
-    name: Run tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install chromium
-
-      - name: Run tests
-        run: pnpm test
-
-  test-db:
-    name: Run database tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
-      - name: Start Supabase
-        run: supabase start -x realtime,storage-api,imgproxy,inbucket,postgrest-api,pgadmin-schema-diff,migra,postgres-meta,studio,edge-runtime,logflare,vector,supavisor
-
-      - name: Run database tests
-        run: supabase test db
-
   deploy:
     name: Deploy
-    needs: [test, test-db]
     uses: ./.github/workflows/deploy.yml
     with:
       environment: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: boolean
         default: false
+      force_config:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       environment:
@@ -38,6 +42,10 @@ on:
         description: Force edge functions deploy
         type: boolean
         default: false
+      force_config:
+        description: Force Supabase config push
+        type: boolean
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -52,6 +60,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       migrations: ${{ steps.filter.outputs.migrations }}
       functions: ${{ steps.filter.outputs.functions }}
+      config: ${{ steps.filter.outputs.config }}
 
     steps:
       - name: Checkout
@@ -92,6 +101,8 @@ jobs:
               - 'supabase/migrations/**'
             functions:
               - 'supabase/functions/**'
+            config:
+              - 'supabase/config.toml'
 
   build:
     name: Build frontend
@@ -195,6 +206,34 @@ jobs:
 
       - name: Deploy functions
         run: supabase functions deploy --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+  config:
+    name: Push Supabase config
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.config == 'true' || inputs.force_config
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project
+        run: supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }} --password "${{ secrets.SUPABASE_DB_PASSWORD }}"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Push config
+        run: supabase config push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,13 +7,96 @@ on:
         description: GitHub environment to deploy to (staging or production)
         required: true
         type: string
+      force_frontend:
+        required: false
+        type: boolean
+        default: false
+      force_migrations:
+        required: false
+        type: boolean
+        default: false
+      force_functions:
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment to deploy to
+        required: true
+        type: choice
+        options: [staging, production]
+      force_frontend:
+        description: Force frontend deploy
+        type: boolean
+        default: false
+      force_migrations:
+        description: Force DB migrations
+        type: boolean
+        default: false
+      force_functions:
+        description: Force edge functions deploy
+        type: boolean
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      migrations: ${{ steps.filter.outputs.migrations }}
+      functions: ${{ steps.filter.outputs.functions }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve diff base
+        id: base
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # PR-triggered staging deploy → leave empty so paths-filter uses PR base.
+        # Release / manual deploy     → previous release tag (or empty for first deploy).
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "ref=" >> $GITHUB_OUTPUT
+          else
+            PREV=$(gh release list --limit 2 --json tagName --jq '.[1].tagName // ""')
+            echo "ref=$PREV" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          base: ${{ steps.base.outputs.ref }}
+          filters: |
+            frontend:
+              - 'src/**'
+              - 'public/**'
+              - 'index.html'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'vite.config.*'
+              - 'tsconfig*.json'
+              - 'netlify.toml'
+            migrations:
+              - 'supabase/migrations/**'
+            functions:
+              - 'supabase/functions/**'
+
   build:
     name: Build frontend
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.frontend == 'true' || inputs.force_frontend
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
@@ -52,7 +135,8 @@ jobs:
 
   migrate:
     name: DB migrations
-    needs: [build]
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.migrations == 'true' || inputs.force_migrations
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
@@ -76,7 +160,11 @@ jobs:
 
   functions:
     name: Deploy edge functions
-    needs: [migrate]
+    needs: [detect-changes, migrate]
+    if: |
+      always() &&
+      (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') &&
+      (needs.detect-changes.outputs.functions == 'true' || inputs.force_functions)
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
@@ -112,7 +200,12 @@ jobs:
 
   frontend:
     name: Deploy frontend
-    needs: [migrate, functions]
+    needs: [build, migrate, functions]
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      needs.migrate.result != 'failure' &&
+      needs.functions.result != 'failure'
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:


### PR DESCRIPTION
## Summary

Three CI/CD changes:

1. **Lint runs on every PR** — combined into a single \`verify\` job alongside tests so \`pnpm install\` runs once.
2. **Prod release deploys skip the test re-run** — anything reaching \`master\` already passed CI.
3. **Deploy jobs are now selective** — frontend, migrations, and edge functions each run only when their files changed since the previous release (or PR base for staging). Manual override available via \`force_*\` inputs.

## Changes

- Workflow renamed: \`Tests\` → \`CI\` (\`tests.yml\` → \`ci.yml\`). Single \`verify\` job for lint + tests.
- \`deploy-production.yml\` calls \`deploy.yml\` directly, no test gate.
- \`deploy.yml\` adds a \`detect-changes\` job using \`dorny/paths-filter\`. Diff base is the previous release tag for prod / manual, the PR base for staging.
- \`deploy.yml\` exposes \`force_frontend / force_migrations / force_functions\` inputs (workflow_call + workflow_dispatch) for manual override.
- \`frontend\` deploy job uses \`always() && build success && others != failure\` so skipped backend jobs don't block FE.

## Follow-up

- ⚠️ Branch protection: required check \`test\` no longer exists. Update to \`verify\` post-merge.
- First deploy after this lands has no "previous release" diff target on first run; \`paths-filter\` falls back to no base, which means everything detects as changed → full deploy. Subsequent deploys will be selective.