### PR TITLE
Restore deck loading + add API contract test suite

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -40,10 +40,16 @@ Run: `vp test`, `vp test --project Unit|Integration|Contract`, `vp test <file>`,
 
 - Drive components via user interactions; assert on rendered output and emitted events
 - Don't read `wrapper.vm.*` or call internal methods
-- Query only by `data-testid` — never tag, class, or generated stub names (`ui-icon-stub`)
+- **Query only by `data-testid`** — applies to every test type (Unit, Integration, **Contract**, **E2E**). Never query by tag (`input[name="email"]`), class, role + visible text (`getByRole('button', { name: /log in/i })`), or generated stub names (`ui-icon-stub`). Visible text breaks under i18n, role queries are noisy, tag/name attributes are implementation details. If a structural element you need to drive or assert against doesn't have a `data-testid`, **add one to the source** (`component-name__section` naming) before writing the test.
 - Don't assert Tailwind utility classes; semantic/BEM names OK when they are the most direct state signal
 - Find child components with `findAllComponents(ImportedRef)` (or `{ name }` if `defineOptions({ name })` is set)
 - Don't assert audio names — assert audio was played
+
+## E2E flows
+
+- Multi-step flows shared across specs (login, sign-up, deck creation, study session) live as helpers in `tests/e2e/_helpers.ts`. Each helper is a single function that drives the flow and asserts the post-condition (e.g. `loginAs(page, user)` lands on the dashboard before returning).
+- Specs call helpers — they don't re-implement the steps inline. Treat the helper as the contract: if a flow changes, update the helper once, every spec follows.
+- ui-kit primitives that wrap their root in a tooltip/wrapper (e.g. `UiInput`) don't forward `data-testid` to the inner `<input>`. Wrap the call site in a `<div data-testid="...">` and target via `.locator('input')` from the wrapper. `UiButton` uses `inheritAttrs: false` and forwards `$attrs` to the root, so `data-testid` passed at the call site lands correctly.
 
 ## Browser mode constraints
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -15,17 +15,19 @@ If there's any chance the test is catching a real bug, **stop**. Name the test, 
 
 ## Test type selection
 
-| Type            | Env                | Use for                                                               |
-| --------------- | ------------------ | --------------------------------------------------------------------- |
-| **Unit**        | jsdom (Node)       | Pure functions, utilities, non-rendering composables, store logic     |
-| **Integration** | Chromium (browser) | Vue components — anything that renders HTML or uses real browser APIs |
+| Type                      | Env                   | Use for                                                                                                                                                                                                       |
+| ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Unit**                  | jsdom (Node)          | Pure functions, utilities, non-rendering composables, store logic                                                                                                                                             |
+| **Integration**           | Chromium (browser)    | Vue components — anything that renders HTML or uses real browser APIs                                                                                                                                         |
+| **Contract**              | Node + local Supabase | `src/api/<domain>/db/*` — anything that talks to PostgREST / GoTrue / Storage. Catches schema-cache drift, broken FK embeds, RLS regressions. Files live under `tests/contract/api/`. Needs `supabase start`. |
+| **Deno (edge functions)** | Deno                  | `supabase/functions/<name>/` — colocated `index.test.ts`. Inject a fake supabase via `_shared/test-utils.ts`; never hit real network. Run via `deno test` from `supabase/functions/`.                         |
 
-- Files mirror source: `src/components/foo/bar.vue` → `tests/integration/components/foo/bar.test.js`
+- Files mirror source: `src/components/foo/bar.vue` → `tests/integration/components/foo/bar.test.js`; `src/api/decks/db/*` → `tests/contract/api/decks.test.js`
 - Default to jsdom unless rendering or real-browser APIs (matchMedia, layout, focus, clipboard, transitions) are needed
 - Prefer `shallowMount` over `mount` unless a child's behaviour is under test
 - Coverage target 100 %, minimum 85 %
 
-Run: `vp test`, `vp test --project Unit|Integration`, or `vp test <file>`.
+Run: `vp test`, `vp test --project Unit|Integration|Contract`, `vp test <file>`, or `deno test` (from `supabase/functions/`) for edge functions.
 
 ## Async updates
 

--- a/.claude/skills/increase-coverage/SKILL.md
+++ b/.claude/skills/increase-coverage/SKILL.md
@@ -10,6 +10,8 @@ Steps:
 # Read `vite.config.ts`
 
 - note the `test.projects` include globs (new files must match) and `coverage.exclude` (skip these — they don't count toward metrics).
+- three projects exist: **Unit** (jsdom), **Integration** (Chromium), **Contract** (Node, real local Supabase). Pick the project that matches the source: pure logic → Unit, components → Integration, `src/api/*/db/*` → Contract. See `.claude/rules/testing.md` for the type table.
+- Contract tests need `supabase start` running locally. Edge functions (`supabase/functions/`) use Deno + colocated `index.test.ts`, not Vitest — they don't count toward Vitest coverage.
 
 # Identify coverage gaps
 

--- a/.claude/skills/update-tests/SKILL.md
+++ b/.claude/skills/update-tests/SKILL.md
@@ -53,9 +53,9 @@ For each source file:
 
 ### Step 2b — Backend changes (`supabase/`)
 
-If the changed files include `supabase/migrations/*.sql` or `supabase/functions/**`:
+#### Migrations (`supabase/migrations/*.sql`)
 
-1. Read the migration or function to understand what changed (new tables, RLS policies, triggers, RPC functions, etc.).
+1. Read the migration to understand what changed (new tables, RLS policies, triggers, RPC functions, views).
 2. Check if existing tests in `supabase/tests/` already cover the changed functionality.
 3. Write pgTAP tests in `supabase/tests/` following the conventions in the existing test files:
    - Use `tests.create_user()` and `tests.set_claims()` helpers for setup
@@ -64,8 +64,27 @@ If the changed files include `supabase/migrations/*.sql` or `supabase/functions/
    - Name files with a numeric prefix for ordering (e.g. `00007_new_feature.sql`)
 4. Run with `supabase test db` to validate.
 5. Prioritise testing: RLS policies (security) > RPC functions (business logic) > triggers (data integrity).
+6. **If the migration changes the resource type of an object** (view↔function, table↔view, `RETURNS TABLE` shape change), the FE↔PostgREST contract may break in ways pgTAP cannot see (FK embed resolution lives in PostgREST, not Postgres). Add or update a contract test under `tests/contract/api/<domain>.test.js` that exercises the FE call path against a real local Supabase. See Step 2d.
+
+#### Edge functions (`supabase/functions/<name>/`)
+
+1. Read the function to understand what changed.
+2. Tests are **Deno**, not Vitest. Colocate as `index.test.ts` next to `index.ts`.
+3. Inject a fake supabase via `supabase/functions/_shared/test-utils.ts` (`makeFakeSupabase`). Never hit a real network — the handler must be exported as a pure `handler({ supabase, ... })` and `Deno.serve(...)` gated on `import.meta.main`.
+4. Run from `supabase/functions/`: `deno test --allow-net --allow-env --allow-read`.
+5. See `docs/src/supabase/edge-functions.md` for full conventions.
 
 Skip to Step 8 for these files — Steps 3–7 are frontend-specific.
+
+### Step 2d — API-layer changes (`src/api/<domain>/db/**`)
+
+Files under `src/api/*/db/` talk to PostgREST. Mocked unit tests pin call shapes but cannot detect schema-cache drift, broken FK embeds, missing GRANTs, or RLS regressions — those are HTTP-layer concerns.
+
+For every changed file under `src/api/*/db/`:
+
+1. Add or extend a contract test under `tests/contract/api/<domain>.test.js`. Each function should have at least one happy-path assertion that runs against a real local Supabase via the `signInAsTestUser` helper in `tests/contract/setup.js`.
+2. Assert on **response shape**, not on which arguments were passed to `supabase.from(...).select(...)`. String-shape assertions pin broken behaviour.
+3. Run with `vp test --project Contract` (needs `supabase start`).
 
 ### Step 2c — Capture business-logic decisions from the current session
 
@@ -91,6 +110,7 @@ For each changed unit of code, choose the **lowest-cost test type** that can mea
 | -------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1        | **Unit**        | Pure functions, utilities, composables with no rendering, store logic that can be called directly                                                                                 |
 | 2        | **Integration** | Vue components — anything that renders HTML (runs in Chromium via browser mode)                                                                                                   |
+| 2        | **Contract**    | `src/api/<domain>/db/*` — anything that round-trips through PostgREST / GoTrue / Storage. See Step 2d.                                                                            |
 | 3        | **E2E**         | **Last resort only.** Use only when the behaviour cannot be covered without full navigation or multi-step flow interaction. Always justify why integration is insufficient first. |
 
 **Default to integration tests for components.** Use `shallowMount` for isolated component tests (stub child components) and `mount` only when child component behaviour is directly under test.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         run: pnpm exec playwright install chromium
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm exec vp test run --coverage --project Unit --project Integration
 
       - name: 'Report Coverage'
         if: always()
@@ -129,3 +129,48 @@ jobs:
 
       - name: Run database tests
         run: supabase test db
+
+  test-contract:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.db == 'true'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase
+        run: supabase start -x realtime,imgproxy,inbucket,pgadmin-schema-diff,migra,postgres-meta,studio,edge-runtime,logflare,vector,supavisor
+
+      - name: Export local Supabase keys
+        run: |
+          {
+            echo "SUPABASE_URL=$(supabase status -o env | grep ^API_URL | cut -d= -f2- | tr -d '\"')"
+            echo "SUPABASE_ANON_KEY=$(supabase status -o env | grep ^ANON_KEY | cut -d= -f2- | tr -d '\"')"
+            echo "SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o env | grep ^SERVICE_ROLE_KEY | cut -d= -f2- | tr -d '\"')"
+          } >> "$GITHUB_ENV"
+
+      - name: Run contract tests
+        run: pnpm exec vp test run --project Contract

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,10 +104,76 @@ jobs:
             config:
               - 'supabase/config.toml'
 
+  e2e-smoke:
+    name: E2E smoke
+    needs: [detect-changes]
+    if: |
+      needs.detect-changes.outputs.frontend == 'true' || inputs.force_frontend ||
+      needs.detect-changes.outputs.migrations == 'true' || inputs.force_migrations ||
+      needs.detect-changes.outputs.functions == 'true' || inputs.force_functions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase
+        run: supabase start -x realtime,imgproxy,inbucket,pgadmin-schema-diff,migra,postgres-meta,studio,edge-runtime,logflare,vector,supavisor
+
+      - name: Export local Supabase keys
+        run: |
+          {
+            echo "SUPABASE_URL=$(supabase status -o env | grep ^API_URL | cut -d= -f2- | tr -d '\"')"
+            echo "SUPABASE_ANON_KEY=$(supabase status -o env | grep ^ANON_KEY | cut -d= -f2- | tr -d '\"')"
+            echo "SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o env | grep ^SERVICE_ROLE_KEY | cut -d= -f2- | tr -d '\"')"
+          } >> "$GITHUB_ENV"
+
+      - name: Write local .env for vp dev
+        run: |
+          {
+            echo "VITE_SUPABASE_URL=$SUPABASE_URL"
+            echo "VITE_SUPABASE_API_KEY=$SUPABASE_ANON_KEY"
+          } > .env
+
+      - name: Run Playwright E2E
+        run: pnpm exec playwright test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   build:
     name: Build frontend
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.frontend == 'true' || inputs.force_frontend
+    needs: [detect-changes, e2e-smoke]
+    if: |
+      always() &&
+      (needs.e2e-smoke.result == 'success' || needs.e2e-smoke.result == 'skipped') &&
+      (needs.detect-changes.outputs.frontend == 'true' || inputs.force_frontend)
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
@@ -146,8 +212,11 @@ jobs:
 
   migrate:
     name: DB migrations
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.migrations == 'true' || inputs.force_migrations
+    needs: [detect-changes, e2e-smoke]
+    if: |
+      always() &&
+      (needs.e2e-smoke.result == 'success' || needs.e2e-smoke.result == 'skipped') &&
+      (needs.detect-changes.outputs.migrations == 'true' || inputs.force_migrations)
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
@@ -171,9 +240,10 @@ jobs:
 
   functions:
     name: Deploy edge functions
-    needs: [detect-changes, migrate]
+    needs: [detect-changes, e2e-smoke, migrate]
     if: |
       always() &&
+      (needs.e2e-smoke.result == 'success' || needs.e2e-smoke.result == 'skipped') &&
       (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') &&
       (needs.detect-changes.outputs.functions == 'true' || inputs.force_functions)
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,61 +111,8 @@ jobs:
       needs.detect-changes.outputs.frontend == 'true' || inputs.force_frontend ||
       needs.detect-changes.outputs.migrations == 'true' || inputs.force_migrations ||
       needs.detect-changes.outputs.functions == 'true' || inputs.force_functions
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install chromium --with-deps
-
-      - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
-      - name: Start Supabase
-        run: supabase start -x realtime,imgproxy,inbucket,pgadmin-schema-diff,migra,postgres-meta,studio,edge-runtime,logflare,vector,supavisor
-
-      - name: Export local Supabase keys
-        run: |
-          {
-            echo "SUPABASE_URL=$(supabase status -o env | grep ^API_URL | cut -d= -f2- | tr -d '\"')"
-            echo "SUPABASE_ANON_KEY=$(supabase status -o env | grep ^ANON_KEY | cut -d= -f2- | tr -d '\"')"
-            echo "SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o env | grep ^SERVICE_ROLE_KEY | cut -d= -f2- | tr -d '\"')"
-          } >> "$GITHUB_ENV"
-
-      - name: Write local .env for vp dev
-        run: |
-          {
-            echo "VITE_SUPABASE_URL=$SUPABASE_URL"
-            echo "VITE_SUPABASE_API_KEY=$SUPABASE_ANON_KEY"
-          } > .env
-
-      - name: Run Playwright E2E
-        run: pnpm exec playwright test
-
-      - name: Upload Playwright report
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 7
+    uses: ./.github/workflows/e2e.yml
+    secrets: inherit
 
   build:
     name: Build frontend

--- a/.github/workflows/e2e-on-label.yml
+++ b/.github/workflows/e2e-on-label.yml
@@ -1,0 +1,83 @@
+name: E2E on label
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  start:
+    name: Post status comment
+    if: contains(github.event.pull_request.labels.*.name, 'smoke-tests')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      comment-id: ${{ steps.post.outputs.comment-id }}
+
+    steps:
+      - name: Find or create E2E comment
+        id: post
+        run: |
+          SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          BODY="⏳ E2E run in progress for \`${SHA}\`..."
+
+          COMMENT_ID=$(gh api \
+            repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            --jq '.[] | select(.body | test("E2E run")) | .id' \
+            | tail -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api \
+              repos/${{ github.repository }}/issues/comments/$COMMENT_ID \
+              --method PATCH \
+              -f body="$BODY"
+          else
+            COMMENT_ID=$(gh api \
+              repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              --method POST \
+              --jq '.id' \
+              -f body="$BODY")
+          fi
+
+          echo "comment-id=$COMMENT_ID" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  run:
+    name: Run E2E
+    needs: [start]
+    if: contains(github.event.pull_request.labels.*.name, 'smoke-tests')
+    uses: ./.github/workflows/e2e.yml
+    secrets: inherit
+
+  finish:
+    name: Update status comment
+    if: always() && contains(github.event.pull_request.labels.*.name, 'smoke-tests')
+    runs-on: ubuntu-latest
+    needs: [start, run]
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Update comment
+        if: always()
+        run: |
+          RESULT="${{ needs.run.result }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+
+          if [ "$RESULT" = "success" ]; then
+            BODY="✅ E2E passed for \`${SHA}\`."
+          else
+            BODY="❌ E2E failed for \`${SHA}\` — [view logs](${RUN_URL})."
+          fi
+
+          gh api \
+            repos/${{ github.repository }}/issues/comments/${{ needs.start.outputs.comment-id }} \
+            --method PATCH \
+            -f body="$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,66 @@
+name: E2E
+
+on:
+  workflow_call:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  smoke:
+    name: E2E smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase
+        run: supabase start -x realtime,imgproxy,inbucket,pgadmin-schema-diff,migra,postgres-meta,studio,edge-runtime,logflare,vector,supavisor
+
+      - name: Export local Supabase keys
+        run: |
+          {
+            echo "SUPABASE_URL=$(supabase status -o env | grep ^API_URL | cut -d= -f2- | tr -d '\"')"
+            echo "SUPABASE_ANON_KEY=$(supabase status -o env | grep ^ANON_KEY | cut -d= -f2- | tr -d '\"')"
+            echo "SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o env | grep ^SERVICE_ROLE_KEY | cut -d= -f2- | tr -d '\"')"
+          } >> "$GITHUB_ENV"
+
+      - name: Write local .env for vp dev
+        run: |
+          {
+            echo "VITE_SUPABASE_URL=$SUPABASE_URL"
+            echo "VITE_SUPABASE_API_KEY=$SUPABASE_ANON_KEY"
+          } > .env
+
+      - name: Run Playwright E2E
+        run: pnpm exec playwright test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ coverage
 /cypress/videos/
 /cypress/screenshots/
 
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
 # Editor directories and files
 docs/.vitepress/cache
 docs/.vitepress/dist

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@intlify/eslint-plugin-vue-i18n": "^4.3.0",
     "@intlify/unplugin-vue-i18n": "^6.0.8",
     "@pinia/testing": "^1.0.3",
+    "@playwright/test": "^1.59.1",
     "@rushstack/eslint-patch": "^1.16.1",
     "@tailwindcss/vite": "^4.2.2",
     "@tsconfig/node18": "^18.2.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['list'], ['github']] : 'list',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure'
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: process.env.E2E_BASE_URL
+    ? undefined
+    : {
+        command: 'pnpm exec vp dev --host 127.0.0.1 --port 5173',
+        url: 'http://127.0.0.1:5173',
+        reuseExistingServer: !process.env.CI,
+        timeout: 60_000
+      }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@pinia/testing':
         specifier: ^1.0.3
         version: 1.0.3(pinia@3.0.4(typescript@5.8.3)(vue@3.5.32(typescript@5.8.3)))
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@rushstack/eslint-patch':
         specifier: ^1.16.1
         version: 1.16.1
@@ -1079,6 +1082,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -4423,6 +4431,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
 

--- a/src/api/decks/db/index.ts
+++ b/src/api/decks/db/index.ts
@@ -20,7 +20,7 @@ export async function fetchMemberDecks(): Promise<Deck[]> {
 export async function fetchDeck(id: number): Promise<Deck> {
   const { data, error } = await supabase
     .rpc('decks_with_stats', { p_today_start: localDayStart() })
-    .select('*, member:members(display_name)')
+    .select('*')
     .eq('id', id)
     .single()
 

--- a/src/views/deck/deck-hero.vue
+++ b/src/views/deck/deck-hero.vue
@@ -62,7 +62,7 @@ function onToggleEditCards() {
       <div class="flex items-center gap-2 text-blue-500">
         <ui-icon src="user" />
         <h2>
-          {{ deck.member?.display_name }}
+          {{ deck.member_display_name }}
         </h2>
       </div>
 

--- a/src/views/welcome/login-dialog.vue
+++ b/src/views/welcome/login-dialog.vue
@@ -39,10 +39,12 @@ async function onSubmit(): Promise<void> {
 
 <template>
   <div
+    data-testid="login-dialog"
     class="w-80 bg-brown-300 rounded-l-6 rounded-br-6 rounded-tr-0.5 p-6 shadow-sm overflow-hidden relative"
   >
     <div class="flex flex-col items-center gap-6">
       <ui-button
+        data-testid="login-dialog__google"
         data-theme="brown-100"
         size="lg"
         :fancy-hover="false"
@@ -57,26 +59,31 @@ async function onSubmit(): Promise<void> {
 
       <form class="w-full flex flex-col items-center gap-6" @submit.prevent="onSubmit">
         <div class="flex flex-col gap-4 w-full">
-          <ui-input
-            type="email"
-            name="email"
-            autocomplete="username"
-            size="lg"
-            v-model="email"
-            :placeholder="t('login-dialog.email')"
-          />
+          <div data-testid="login-dialog__email">
+            <ui-input
+              type="email"
+              name="email"
+              autocomplete="username"
+              size="lg"
+              v-model="email"
+              :placeholder="t('login-dialog.email')"
+            />
+          </div>
 
-          <ui-input
-            type="password"
-            name="password"
-            autocomplete="current-password"
-            size="lg"
-            v-model="password"
-            :placeholder="t('login-dialog.password')"
-          />
+          <div data-testid="login-dialog__password">
+            <ui-input
+              type="password"
+              name="password"
+              autocomplete="current-password"
+              size="lg"
+              v-model="password"
+              :placeholder="t('login-dialog.password')"
+            />
+          </div>
         </div>
 
         <ui-button
+          data-testid="login-dialog__submit"
           size="lg"
           data-theme="blue-500"
           :loading="loading"

--- a/src/views/welcome/splash.vue
+++ b/src/views/welcome/splash.vue
@@ -58,6 +58,7 @@ defineExpose({ openSignup })
       >
         <template #trigger>
           <button
+            data-testid="welcome-view__login-trigger"
             class="bg-brown-300 text-brown-700 px-4 py-2.5 rounded-2.5 text-lg cursor-pointer"
             :class="{ 'rounded-b-0.5': login_dropdown_open }"
             @click="triggerLoginDropdown"

--- a/supabase/migrations/20260502000001_decks-with-stats-member-display-name.sql
+++ b/supabase/migrations/20260502000001_decks-with-stats-member-display-name.sql
@@ -1,0 +1,113 @@
+-- =============================================================================
+-- decks_with_stats: add member_display_name column
+--
+-- PostgREST cannot embed FK-related tables on function results (the row type is
+-- an anonymous record, so no FK metadata is exposed). Bake the display name
+-- into the function output so callers don't need an embed or a second query.
+-- =============================================================================
+
+BEGIN;
+
+DROP FUNCTION public.decks_with_stats(timestamptz);
+
+CREATE FUNCTION public.decks_with_stats(p_today_start timestamptz)
+RETURNS TABLE (
+  id                       bigint,
+  created_at               timestamptz,
+  updated_at               timestamptz,
+  description              text,
+  is_public                boolean,
+  title                    text,
+  member_id                uuid,
+  member_display_name      text,
+  tags                     text[],
+  has_image                boolean,
+  study_config             jsonb,
+  cover_config             jsonb,
+  card_attributes          jsonb,
+  card_count               int,
+  reviewed_today_count     int,
+  new_reviewed_today_count int,
+  due_count                int
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+AS $$
+  SELECT
+    d.id,
+    d.created_at,
+    d.updated_at,
+    d.description,
+    d.is_public,
+    d.title,
+    d.member_id,
+    m.display_name AS member_display_name,
+    d.tags,
+    d.has_image,
+    d.study_config,
+    d.cover_config,
+    d.card_attributes,
+
+    (
+      SELECT count(*)::int
+      FROM public.cards c
+      WHERE c.deck_id = d.id
+    ) AS card_count,
+
+    (
+      SELECT count(DISTINCT rl.card_id)::int
+      FROM public.review_logs rl
+      JOIN public.cards c ON c.id = rl.card_id
+      WHERE c.deck_id = d.id
+        AND rl.review >= p_today_start
+    ) AS reviewed_today_count,
+
+    (
+      SELECT count(DISTINCT rl.card_id)::int
+      FROM public.review_logs rl
+      JOIN public.cards c ON c.id = rl.card_id
+      WHERE c.deck_id = d.id
+        AND rl.state = 0
+        AND rl.review >= p_today_start
+    ) AS new_reviewed_today_count,
+
+    GREATEST(
+      0,
+      CASE
+        WHEN (d.study_config->>'max_reviews_per_day') IS NULL THEN
+          (
+            SELECT count(*)::int
+            FROM public.cards c
+            LEFT JOIN public.reviews r ON r.card_id = c.id
+            WHERE c.deck_id = d.id
+              AND (r.due IS NULL OR r.due <= now())
+          )
+        ELSE
+          LEAST(
+            (
+              SELECT count(*)::int
+              FROM public.cards c
+              LEFT JOIN public.reviews r ON r.card_id = c.id
+              WHERE c.deck_id = d.id
+                AND (r.due IS NULL OR r.due <= now())
+            ),
+            (d.study_config->>'max_reviews_per_day')::int
+              - (
+                SELECT count(DISTINCT rl.card_id)::int
+                FROM public.review_logs rl
+                JOIN public.cards c ON c.id = rl.card_id
+                WHERE c.deck_id = d.id
+                  AND rl.review >= p_today_start
+              )
+          )
+      END
+    ) AS due_count
+
+  FROM public.decks d
+  LEFT JOIN public.members m ON m.id = d.member_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.decks_with_stats(timestamptz) TO authenticated;
+
+COMMIT;

--- a/supabase/tests/00009_decks_with_stats.sql
+++ b/supabase/tests/00009_decks_with_stats.sql
@@ -12,7 +12,26 @@
 
 BEGIN;
 
-SELECT plan(8);
+SELECT plan(9);
+
+-- ── Test: function returns the exact columns the FE consumes ─────────────────
+-- Locks the OUT parameter list of decks_with_stats. Renaming or removing a
+-- column without updating the FE will fail here. (Cannot guard PostgREST
+-- embed resolution — that's a contract-test job — but this catches column
+-- drift cheaply.)
+SELECT bag_eq(
+  $$ SELECT parameter_name
+     FROM information_schema.parameters
+     WHERE specific_schema = 'public'
+       AND specific_name LIKE 'decks_with_stats%'
+       AND parameter_mode = 'OUT' $$,
+  $$ VALUES
+      ('id'), ('created_at'), ('updated_at'), ('description'), ('is_public'),
+      ('title'), ('member_id'), ('member_display_name'), ('tags'), ('has_image'),
+      ('study_config'), ('cover_config'), ('card_attributes'), ('card_count'),
+      ('reviewed_today_count'), ('new_reviewed_today_count'), ('due_count') $$,
+  'decks_with_stats exposes the columns the FE consumes'
+);
 
 -- ── Setup ─────────────────────────────────────────────────────────────────────
 

--- a/tests/contract/api/cards.test.js
+++ b/tests/contract/api/cards.test.js
@@ -1,0 +1,221 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vite-plus/test'
+import { signInAsTestUser } from '../setup.js'
+import { createDeck, insertCardDirect } from '../fixtures.js'
+import {
+  insertCardAt,
+  bulkInsertCardsInDeck,
+  fetchCardsPageByDeckId,
+  fetchAllCardsByDeckId,
+  fetchMemberCardCount,
+  searchCardsInDeck,
+  moveCard,
+  deleteCards,
+  deleteCardsInDeck,
+  upsertCard,
+  upsertCards,
+  moveCardsToDeck
+} from '@/api/cards/db'
+
+let session
+let deck
+
+beforeEach(async () => {
+  session = await signInAsTestUser()
+  deck = await createDeck(session.client, session.userId, { title: 'Cards Test Deck' })
+})
+
+afterEach(async () => {
+  await session?.cleanup()
+  session = null
+  deck = null
+})
+
+describe('insertCardAt (contract)', () => {
+  test('inserts a card at the head of an empty deck and returns id+rank', async () => {
+    const result = await insertCardAt({
+      deck_id: deck.id,
+      anchor_id: null,
+      side: null,
+      front_text: 'Front',
+      back_text: 'Back'
+    })
+    expect(result.id).toEqual(expect.any(Number))
+    expect(result.rank).toEqual(expect.any(Number))
+  })
+
+  test('places after the anchor when side="after"', async () => {
+    const first = await insertCardAt({
+      deck_id: deck.id,
+      anchor_id: null,
+      side: null,
+      front_text: 'A',
+      back_text: 'a'
+    })
+    const second = await insertCardAt({
+      deck_id: deck.id,
+      anchor_id: first.id,
+      side: 'after',
+      front_text: 'B',
+      back_text: 'b'
+    })
+    expect(second.rank).toBeGreaterThan(first.rank)
+  })
+})
+
+describe('bulkInsertCardsInDeck (contract)', () => {
+  test('returns the inserted rows in order', async () => {
+    const cards = await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: [
+        { front_text: 'F1', back_text: 'B1' },
+        { front_text: 'F2', back_text: 'B2' }
+      ]
+    })
+    expect(cards).toHaveLength(2)
+    expect(cards.map((c) => c.front_text)).toEqual(['F1', 'F2'])
+    expect(cards[1].rank).toBeGreaterThan(cards[0].rank)
+  })
+})
+
+describe('fetchCardsPageByDeckId (contract)', () => {
+  test('returns the page slice ordered by rank with embedded review', async () => {
+    await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: Array.from({ length: 5 }, (_, i) => ({
+        front_text: `F${i}`,
+        back_text: `B${i}`
+      }))
+    })
+    const page = await fetchCardsPageByDeckId({ deck_id: deck.id, offset: 1, limit: 2 })
+    expect(page).toHaveLength(2)
+    expect(page[0].rank).toBeLessThan(page[1].rank)
+    expect(page[0]).toHaveProperty('review')
+  })
+})
+
+describe('fetchAllCardsByDeckId (contract)', () => {
+  test('returns every card in the deck', async () => {
+    await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: [
+        { front_text: 'one', back_text: '1' },
+        { front_text: 'two', back_text: '2' }
+      ]
+    })
+    const all = await fetchAllCardsByDeckId(deck.id)
+    expect(all).toHaveLength(2)
+  })
+})
+
+describe('fetchMemberCardCount (contract)', () => {
+  test('counts cards owned by the current member', async () => {
+    expect(await fetchMemberCardCount({ only_due_cards: false })).toBe(0)
+    await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: [
+        { front_text: 'a', back_text: 'a' },
+        { front_text: 'b', back_text: 'b' }
+      ]
+    })
+    expect(await fetchMemberCardCount({ only_due_cards: false })).toBe(2)
+  })
+})
+
+describe('searchCardsInDeck (contract)', () => {
+  test('matches case-insensitive ILIKE on front and back text', async () => {
+    await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: [
+        { front_text: 'Hello world', back_text: 'greeting' },
+        { front_text: 'goodbye', back_text: 'farewell' }
+      ]
+    })
+    const hits = await searchCardsInDeck(deck.id, 'WORLD')
+    expect(hits).toHaveLength(1)
+    expect(hits[0].front_text).toBe('Hello world')
+  })
+})
+
+describe('moveCard (contract)', () => {
+  test('updates the rank of the moved card to sit beside the anchor', async () => {
+    const [a, b, c] = await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: [
+        { front_text: 'A', back_text: '' },
+        { front_text: 'B', back_text: '' },
+        { front_text: 'C', back_text: '' }
+      ]
+    })
+    const new_rank = await moveCard({ card_id: c.id, anchor_id: a.id, side: 'before' })
+    expect(new_rank).toBeLessThan(a.rank)
+    expect(new_rank).toEqual(expect.any(Number))
+    void b
+  })
+})
+
+describe('deleteCards (contract)', () => {
+  test('removes cards by id', async () => {
+    const cards = await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: [
+        { front_text: 'x', back_text: '' },
+        { front_text: 'y', back_text: '' }
+      ]
+    })
+    await deleteCards(cards)
+    const remaining = await fetchAllCardsByDeckId(deck.id)
+    expect(remaining).toHaveLength(0)
+  })
+})
+
+describe('deleteCardsInDeck (contract)', () => {
+  test('deletes all cards except the listed ids', async () => {
+    const cards = await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: [
+        { front_text: 'keep', back_text: '' },
+        { front_text: 'drop1', back_text: '' },
+        { front_text: 'drop2', back_text: '' }
+      ]
+    })
+    const [keep] = cards
+    const deleted = await deleteCardsInDeck({ deck_id: deck.id, except_ids: [keep.id] })
+    expect(deleted).toBe(2)
+    const remaining = await fetchAllCardsByDeckId(deck.id)
+    expect(remaining.map((c) => c.id)).toEqual([keep.id])
+  })
+})
+
+describe('upsertCard / upsertCards (contract)', () => {
+  test('upsertCard updates an existing card', async () => {
+    const card = await insertCardDirect(session.client, deck.id, { front_text: 'old' })
+    const updated = await upsertCard({ ...card, front_text: 'new' })
+    expect(updated.front_text).toBe('new')
+  })
+
+  test('upsertCards updates many in one round-trip', async () => {
+    const cards = await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: [
+        { front_text: 'one', back_text: '' },
+        { front_text: 'two', back_text: '' }
+      ]
+    })
+    const result = await upsertCards(cards.map((c) => ({ ...c, front_text: `${c.front_text}!` })))
+    expect(result).toHaveLength(2)
+    expect(result.every((c) => c.front_text.endsWith('!'))).toBe(true)
+  })
+})
+
+describe('moveCardsToDeck (contract)', () => {
+  test('reassigns deck_id on the given cards', async () => {
+    const target = await createDeck(session.client, session.userId, { title: 'Target' })
+    const [card] = await bulkInsertCardsInDeck({
+      deck_id: deck.id,
+      cards: [{ front_text: 'mover', back_text: '' }]
+    })
+    await moveCardsToDeck([card], target.id)
+    const inTarget = await fetchAllCardsByDeckId(target.id)
+    expect(inTarget.map((c) => c.id)).toContain(card.id)
+  })
+})

--- a/tests/contract/api/decks.test.js
+++ b/tests/contract/api/decks.test.js
@@ -1,0 +1,84 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vite-plus/test'
+import { signInAsTestUser } from '../setup.js'
+import { fetchMemberDecks, fetchDeck, fetchMemberDeckCount } from '@/api/decks/db'
+
+let session
+let displayName
+
+beforeEach(async () => {
+  session = await signInAsTestUser()
+  displayName = `Contract Tester ${session.userId.slice(0, 8)}`
+  const { error } = await session.client
+    .from('members')
+    .update({ display_name: displayName })
+    .eq('id', session.userId)
+  if (error) throw error
+})
+
+afterEach(async () => {
+  await session?.cleanup()
+  session = null
+})
+
+async function insertDeck(overrides = {}) {
+  const { data, error } = await session.client
+    .from('decks')
+    .insert({ title: 'Test Deck', member_id: session.userId, ...overrides })
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+describe('fetchMemberDecks (contract)', () => {
+  test('returns an empty array when the member has no decks', async () => {
+    const decks = await fetchMemberDecks()
+    expect(decks).toEqual([])
+  })
+
+  test('returns the member’s decks with member_display_name populated', async () => {
+    const inserted = await insertDeck({ title: 'My Deck' })
+    const decks = await fetchMemberDecks()
+    expect(decks).toHaveLength(1)
+    expect(decks[0]).toMatchObject({
+      id: inserted.id,
+      title: 'My Deck',
+      member_display_name: displayName,
+      member_id: session.userId
+    })
+  })
+
+  test('exposes the stats columns the FE consumes', async () => {
+    await insertDeck()
+    const [deck] = await fetchMemberDecks()
+    expect(deck).toHaveProperty('card_count')
+    expect(deck).toHaveProperty('due_count')
+    expect(deck).toHaveProperty('reviewed_today_count')
+    expect(deck).toHaveProperty('new_reviewed_today_count')
+  })
+})
+
+describe('fetchDeck (contract)', () => {
+  test('returns the deck with member_display_name embedded into the row', async () => {
+    const inserted = await insertDeck({ title: 'Solo Deck' })
+    const deck = await fetchDeck(inserted.id)
+    expect(deck).toMatchObject({
+      id: inserted.id,
+      title: 'Solo Deck',
+      member_display_name: displayName
+    })
+  })
+
+  test('rejects when the id does not match a visible deck', async () => {
+    await expect(fetchDeck(-1)).rejects.toBeTruthy()
+  })
+})
+
+describe('fetchMemberDeckCount (contract)', () => {
+  test('counts only the current member’s decks', async () => {
+    expect(await fetchMemberDeckCount()).toBe(0)
+    await insertDeck()
+    await insertDeck({ title: 'Second' })
+    expect(await fetchMemberDeckCount()).toBe(2)
+  })
+})

--- a/tests/contract/api/media.test.js
+++ b/tests/contract/api/media.test.js
@@ -1,0 +1,67 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vite-plus/test'
+import { signInAsTestUser } from '../setup.js'
+import { createDeck, insertCardDirect, makeImageFile } from '../fixtures.js'
+import { uploadImage, deleteImage, getImageUrl, insertMedia, deleteMedia } from '@/api/media/db'
+
+let session
+let deck
+let card
+
+beforeEach(async () => {
+  session = await signInAsTestUser()
+  deck = await createDeck(session.client, session.userId)
+  card = await insertCardDirect(session.client, deck.id)
+})
+
+afterEach(async () => {
+  await session?.cleanup()
+  session = null
+  deck = null
+  card = null
+})
+
+describe('uploadImage / deleteImage / getImageUrl (contract)', () => {
+  test('uploads a file under the member folder, returns a public URL, then deletes it', async () => {
+    const path = `${session.userId}/${card.id}/front/test.png`
+    const url = await uploadImage('cards', path, makeImageFile())
+    expect(url).toContain(path)
+
+    expect(getImageUrl('cards', path)).toBe(url)
+
+    await deleteImage('cards', path)
+  })
+})
+
+describe('insertMedia / deleteMedia (contract)', () => {
+  test('inserts a media row and soft-deletes via deleteMedia', async () => {
+    const path = `${session.userId}/${card.id}/front/im.png`
+    await uploadImage('cards', path, makeImageFile())
+
+    await insertMedia({ bucket: 'cards', path, card_id: card.id, slot: 'card_front' })
+
+    const { data: rows } = await session.client
+      .from('media')
+      .select('*')
+      .eq('card_id', card.id)
+      .is('deleted_at', null)
+    expect(rows).toHaveLength(1)
+    const inserted = rows[0]
+
+    await deleteMedia(inserted.id)
+
+    const { data: after } = await session.client
+      .from('media')
+      .select('deleted_at')
+      .eq('id', inserted.id)
+      .single()
+    expect(after.deleted_at).not.toBeNull()
+
+    await deleteImage('cards', path)
+  })
+
+  test('rejects when neither card_id nor deck_id is provided', async () => {
+    await expect(
+      insertMedia({ bucket: 'cards', path: 'x/y.png', slot: 'card_front' })
+    ).rejects.toThrow(/card_id or deck_id/)
+  })
+})

--- a/tests/contract/api/members.test.js
+++ b/tests/contract/api/members.test.js
@@ -1,0 +1,37 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vite-plus/test'
+import { signInAsTestUser } from '../setup.js'
+import { setMemberDisplayName } from '../fixtures.js'
+import { fetchMemberById, upsertMember } from '@/api/members/db'
+
+let session
+
+beforeEach(async () => {
+  session = await signInAsTestUser()
+})
+
+afterEach(async () => {
+  await session?.cleanup()
+  session = null
+})
+
+describe('fetchMemberById (contract)', () => {
+  test('returns the member row for the current user', async () => {
+    const display_name = await setMemberDisplayName(session.client, session.userId)
+    const member = await fetchMemberById(session.userId)
+    expect(member).toMatchObject({ id: session.userId, display_name })
+  })
+
+  test('returns null when the member is not visible (RLS)', async () => {
+    const member = await fetchMemberById('00000000-0000-0000-0000-000000000000')
+    expect(member).toBeNull()
+  })
+})
+
+describe('upsertMember (contract)', () => {
+  test('updates fields on the current member', async () => {
+    const display_name = `Renamed ${session.userId.slice(0, 6)}`
+    await upsertMember({ id: session.userId, display_name })
+    const member = await fetchMemberById(session.userId)
+    expect(member?.display_name).toBe(display_name)
+  })
+})

--- a/tests/contract/api/reviews.test.js
+++ b/tests/contract/api/reviews.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vite-plus/test'
+import { signInAsTestUser } from '../setup.js'
+import { createDeck, insertCardDirect } from '../fixtures.js'
+import { saveReview } from '@/api/reviews/db'
+
+let session
+
+beforeEach(async () => {
+  session = await signInAsTestUser()
+})
+
+afterEach(async () => {
+  await session?.cleanup()
+  session = null
+})
+
+describe('saveReview (contract)', () => {
+  test('writes the review row and review_logs entry for the card', async () => {
+    const deck = await createDeck(session.client, session.userId)
+    const card = await insertCardDirect(session.client, deck.id)
+
+    const now = new Date()
+    const card_state = {
+      due: new Date(now.getTime() + 86_400_000).toISOString(),
+      stability: 1.5,
+      difficulty: 5,
+      elapsed_days: 0,
+      scheduled_days: 1,
+      reps: 1,
+      lapses: 0,
+      last_review: now.toISOString(),
+      state: 1
+    }
+    const log = {
+      rating: 3,
+      state: 1,
+      due: card_state.due,
+      stability: card_state.stability,
+      difficulty: card_state.difficulty,
+      scheduled_days: card_state.scheduled_days,
+      review: now.toISOString()
+    }
+
+    await saveReview(card.id, card_state, log)
+
+    const { data: review } = await session.client
+      .from('reviews')
+      .select('*')
+      .eq('card_id', card.id)
+      .single()
+    expect(review).toMatchObject({
+      card_id: card.id,
+      stability: card_state.stability,
+      difficulty: card_state.difficulty,
+      reps: 1
+    })
+
+    const { data: logs } = await session.client
+      .from('review_logs')
+      .select('*')
+      .eq('card_id', card.id)
+    expect(logs).toHaveLength(1)
+    expect(logs[0].rating).toBe(3)
+  })
+})

--- a/tests/contract/api/shop.test.js
+++ b/tests/contract/api/shop.test.js
@@ -1,0 +1,46 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vite-plus/test'
+import { signInAsTestUser } from '../setup.js'
+import { seedShopItem, deleteShopItem } from '../fixtures.js'
+import { fetchShopItems, upsertPurchase, fetchPurchaseItems } from '@/api/shop/db'
+
+let session
+let item
+
+beforeEach(async () => {
+  session = await signInAsTestUser()
+  item = await seedShopItem({ name: `Item ${Date.now()}`, price: 10 })
+})
+
+afterEach(async () => {
+  await session?.cleanup()
+  if (item) await deleteShopItem(item.id)
+  session = null
+  item = null
+})
+
+describe('fetchShopItems (contract)', () => {
+  test('returns the seeded shop items', async () => {
+    const items = await fetchShopItems()
+    expect(items.map((i) => i.id)).toContain(item.id)
+  })
+})
+
+describe('upsertPurchase / fetchPurchaseItems (contract)', () => {
+  test('records the purchase and surfaces it via fetchPurchaseItems', async () => {
+    await upsertPurchase({ member_id: session.userId, item_id: item.id, quantity: 2 })
+
+    const purchases = await fetchPurchaseItems()
+    const mine = purchases.find((p) => p.item_id === item.id)
+    expect(mine).toBeTruthy()
+    expect(mine.quantity).toBe(2)
+  })
+
+  test('upsert with the same item accumulates quantity', async () => {
+    await upsertPurchase({ member_id: session.userId, item_id: item.id, quantity: 1 })
+    await upsertPurchase({ member_id: session.userId, item_id: item.id, quantity: 3 })
+
+    const purchases = await fetchPurchaseItems()
+    const mine = purchases.find((p) => p.item_id === item.id)
+    expect(mine.quantity).toBe(4)
+  })
+})

--- a/tests/contract/fixtures.js
+++ b/tests/contract/fixtures.js
@@ -1,0 +1,60 @@
+import { adminClient } from './setup.js'
+
+export async function createDeck(client, member_id, overrides = {}) {
+  const { data, error } = await client
+    .from('decks')
+    .insert({ title: 'Fixture Deck', member_id, ...overrides })
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+export async function insertCardDirect(client, deck_id, overrides = {}) {
+  const { data, error } = await client
+    .from('cards')
+    .insert({
+      deck_id,
+      front_text: 'Q',
+      back_text: 'A',
+      rank: Math.floor(Math.random() * 1_000_000),
+      ...overrides
+    })
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+export async function setMemberDisplayName(client, member_id, suffix) {
+  const display_name = `Tester ${member_id.slice(0, 4)}${suffix ? `-${suffix}` : ''}`
+  const { error } = await client.from('members').update({ display_name }).eq('id', member_id)
+  if (error) throw error
+  return display_name
+}
+
+export async function seedShopItem(overrides = {}) {
+  const { data, error } = await adminClient
+    .from('shop_items')
+    .insert({ name: 'Fixture Item', price: 100, category: 'power_ups', ...overrides })
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+export async function deleteShopItem(id) {
+  await adminClient.from('shop_items').delete().eq('id', id)
+}
+
+export function makeImageFile(name = 'test.png') {
+  // 1x1 transparent PNG
+  const bytes = Uint8Array.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+    0x42, 0x60, 0x82
+  ])
+  return new File([bytes], name, { type: 'image/png' })
+}

--- a/tests/contract/setup.js
+++ b/tests/contract/setup.js
@@ -1,0 +1,117 @@
+import { execSync } from 'node:child_process'
+import { vi } from 'vite-plus/test'
+import { createClient } from '@supabase/supabase-js'
+
+function loadSupabaseEnv() {
+  if (
+    process.env.SUPABASE_URL &&
+    process.env.SUPABASE_ANON_KEY &&
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  ) {
+    return {
+      url: process.env.SUPABASE_URL,
+      anonKey: process.env.SUPABASE_ANON_KEY,
+      serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY
+    }
+  }
+  let raw
+  try {
+    raw = execSync('supabase status -o env', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+  } catch (e) {
+    throw new Error(
+      'Contract tests need a running local Supabase. Run `supabase start` first, ' +
+        'or set SUPABASE_URL / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY in the env. ' +
+        `Underlying error: ${e.message}`
+    )
+  }
+  const env = Object.fromEntries(
+    raw
+      .split('\n')
+      .map((line) => line.match(/^(\w+)="?([^"]*)"?$/))
+      .filter(Boolean)
+      .map((m) => [m[1], m[2]])
+  )
+  return {
+    url: env.API_URL,
+    anonKey: env.ANON_KEY,
+    serviceRoleKey: env.SERVICE_ROLE_KEY
+  }
+}
+
+const {
+  url: SUPABASE_URL,
+  anonKey: SUPABASE_ANON_KEY,
+  serviceRoleKey: SUPABASE_SERVICE_ROLE_KEY
+} = loadSupabaseEnv()
+
+const adminClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false }
+})
+
+const ctx = (globalThis.__contract ??= { client: null, memberId: null })
+
+const supabaseProxy = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      if (!ctx.client) {
+        throw new Error(
+          'Contract test used `supabase` before `signInAsTestUser()` ran. Call it in `beforeEach`.'
+        )
+      }
+      const value = ctx.client[prop]
+      return typeof value === 'function' ? value.bind(ctx.client) : value
+    }
+  }
+)
+
+vi.mock('@/supabase-client', () => ({ supabase: supabaseProxy }))
+
+vi.mock('@/stores/member', () => ({
+  useMemberStore: () => ({ id: ctx.memberId })
+}))
+
+vi.mock('@/utils/logger', () => ({
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn() }
+}))
+
+export async function signInAsTestUser() {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const email = `contract-${suffix}@taroflash.test`
+  const password = 'contract-test-password-1234'
+
+  const { data: created, error: createErr } = await adminClient.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true
+  })
+  if (createErr) throw createErr
+  const userId = created.user.id
+
+  const userClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  })
+  const { error: signInErr } = await userClient.auth.signInWithPassword({ email, password })
+  if (signInErr) {
+    await adminClient.auth.admin.deleteUser(userId).catch(() => {})
+    throw signInErr
+  }
+
+  ctx.client = userClient
+  ctx.memberId = userId
+
+  return {
+    userId,
+    client: userClient,
+    cleanup: async () => {
+      ctx.client = null
+      ctx.memberId = null
+      await adminClient.auth.admin.deleteUser(userId).catch(() => {})
+    }
+  }
+}
+
+export { adminClient, SUPABASE_URL }

--- a/tests/e2e/_fixtures.ts
+++ b/tests/e2e/_fixtures.ts
@@ -1,0 +1,84 @@
+import { test as base } from '@playwright/test'
+import { execSync } from 'node:child_process'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+function loadEnv() {
+  if (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return {
+      url: process.env.SUPABASE_URL,
+      serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY
+    }
+  }
+  const raw = execSync('supabase status -o env', { encoding: 'utf8' })
+  const env = Object.fromEntries(
+    raw
+      .split('\n')
+      .map((line) => line.match(/^(\w+)="?([^"]*)"?$/))
+      .filter(Boolean)
+      .map((m) => [m![1], m![2]])
+  )
+  return { url: env.API_URL, serviceRoleKey: env.SERVICE_ROLE_KEY }
+}
+
+function loadAnonKey() {
+  if (process.env.SUPABASE_ANON_KEY) return process.env.SUPABASE_ANON_KEY
+  const raw = execSync('supabase status -o env', { encoding: 'utf8' })
+  const match = raw.match(/^ANON_KEY="?([^"\n]+)"?/m)
+  if (!match) throw new Error('ANON_KEY not found in `supabase status -o env`')
+  return match[1]
+}
+
+const { url: SUPABASE_URL, serviceRoleKey: SERVICE_ROLE_KEY } = loadEnv()
+const SUPABASE_ANON_KEY = loadAnonKey()
+
+const admin: SupabaseClient = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false }
+})
+
+export type SeededUser = {
+  id: string
+  email: string
+  password: string
+  client: SupabaseClient
+}
+
+export const test = base.extend<{ user: SeededUser }>({
+  // eslint-disable-next-line no-empty-pattern -- Playwright fixture signature requires destructuring even when no other fixtures are used
+  user: async ({}, use) => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const email = `e2e-${suffix}@taroflash.test`
+    const password = 'e2e-password-12345'
+    const { data, error } = await admin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true
+    })
+    if (error) throw error
+    const id = data.user!.id
+
+    const client = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { persistSession: false, autoRefreshToken: false }
+    })
+    const { error: signInErr } = await client.auth.signInWithPassword({ email, password })
+    if (signInErr) throw signInErr
+
+    await client
+      .from('members')
+      .update({ display_name: `E2E ${id.slice(0, 6)}` })
+      .eq('id', id)
+
+    await use({ id, email, password, client })
+
+    await admin.auth.admin.deleteUser(id).catch(() => {})
+  }
+})
+
+export async function seedDeck(user: SeededUser, title: string) {
+  // BEFORE INSERT trigger `set_member_id` overrides member_id with auth.uid(),
+  // so seeding must happen through the user's signed-in client.
+  const { data, error } = await user.client.from('decks').insert({ title }).select().single()
+  if (error) throw error
+  return data
+}
+
+export { expect } from '@playwright/test'

--- a/tests/e2e/_helpers.ts
+++ b/tests/e2e/_helpers.ts
@@ -1,0 +1,17 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+import type { SeededUser } from './_fixtures'
+
+/**
+ * Drives the welcome → login-dialog → authenticated flow for a seeded user.
+ * Lands on the dashboard. Use as the canonical entry point for any E2E that
+ * needs an authenticated session — never re-implement the steps inline.
+ */
+export async function loginAs(page: Page, user: SeededUser) {
+  await page.goto('/')
+  await page.getByTestId('welcome-view__login-trigger').click()
+  await page.getByTestId('login-dialog__email').locator('input').fill(user.email)
+  await page.getByTestId('login-dialog__password').locator('input').fill(user.password)
+  await page.getByTestId('login-dialog__submit').click()
+  await expect(page.getByTestId('dashboard')).toBeVisible()
+}

--- a/tests/e2e/auth-and-dashboard.spec.ts
+++ b/tests/e2e/auth-and-dashboard.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect, seedDeck } from './_fixtures'
+
+test('authenticated user lands on the dashboard with their decks visible', async ({
+  page,
+  user
+}) => {
+  const deck = await seedDeck(user, 'E2E Smoke Deck')
+
+  await page.goto('/')
+  await page.getByRole('button', { name: /log in/i }).click()
+  await page.locator('input[name="email"]').fill(user.email)
+  await page.locator('input[name="password"]').fill(user.password)
+  await page.getByRole('button', { name: /let'?s go/i }).click()
+
+  const dashboard = page.getByTestId('dashboard')
+  await expect(dashboard).toBeVisible()
+  await expect(dashboard).toContainText(deck.title)
+})

--- a/tests/e2e/auth-and-dashboard.spec.ts
+++ b/tests/e2e/auth-and-dashboard.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, seedDeck } from './_fixtures'
+import { loginAs } from './_helpers'
 
 test('authenticated user lands on the dashboard with their decks visible', async ({
   page,
@@ -6,13 +7,7 @@ test('authenticated user lands on the dashboard with their decks visible', async
 }) => {
   const deck = await seedDeck(user, 'E2E Smoke Deck')
 
-  await page.goto('/')
-  await page.getByRole('button', { name: /log in/i }).click()
-  await page.locator('input[name="email"]').fill(user.email)
-  await page.locator('input[name="password"]').fill(user.password)
-  await page.getByRole('button', { name: /let'?s go/i }).click()
+  await loginAs(page, user)
 
-  const dashboard = page.getByTestId('dashboard')
-  await expect(dashboard).toBeVisible()
-  await expect(dashboard).toContainText(deck.title)
+  await expect(page.getByTestId('dashboard')).toContainText(deck.title)
 })

--- a/tests/integration/views/deck/deck-hero.test.js
+++ b/tests/integration/views/deck/deck-hero.test.js
@@ -61,8 +61,8 @@ describe('DeckHero', () => {
     )
   })
 
-  test('renders the member display name from deck.member', () => {
-    const wrapper = mount({ deck: { member: { display_name: 'Alice' } } })
+  test('renders the member display name from deck.member_display_name', () => {
+    const wrapper = mount({ deck: { member_display_name: 'Alice' } })
     expect(wrapper.text()).toContain('Alice')
   })
 

--- a/tests/unit/api/decks.test.js
+++ b/tests/unit/api/decks.test.js
@@ -70,15 +70,14 @@ describe('fetchMemberDecks', () => {
 })
 
 describe('fetchDeck', () => {
-  test('calls decks_with_stats RPC with the member embed only — cards are paginated separately', async () => {
-    queryMock.single.mockResolvedValueOnce({ data: { id: 5 }, error: null })
-    await fetchDeck(5)
+  test('calls decks_with_stats RPC filtered by id and returns the row', async () => {
+    const row = { id: 5, title: 'X', member_display_name: 'Alice' }
+    queryMock.single.mockResolvedValueOnce({ data: row, error: null })
+    const result = await fetchDeck(5)
     expect(capturedRpcs[0].fn).toBe('decks_with_stats')
     expect(capturedRpcs[0].args.p_today_start).toEqual(expect.any(String))
-    const [selectArg] = queryMock.select.mock.calls[0]
-    expect(selectArg).toContain('member:members(display_name)')
-    expect(selectArg).not.toContain('cards:cards_with_images')
     expect(queryMock.eq).toHaveBeenCalledWith('id', 5)
+    expect(result).toEqual(row)
   })
 
   test('throws when the query errors', async () => {

--- a/types/deck.d.ts
+++ b/types/deck.d.ts
@@ -17,7 +17,7 @@ type Deck = {
   is_public?: boolean
   title?: string
   member_id?: number
-  member?: { display_name: string }
+  member_display_name?: string
   tags?: string[]
   due_count?: number
   reviewed_today_count?: number

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,6 +67,17 @@ export default defineConfig({
             instances: [{ browser: 'chromium' }]
           }
         }
+      },
+      {
+        extends: true,
+        test: {
+          name: { label: 'Contract', color: 'magenta' },
+          include: ['tests/contract/**/*.test.js'],
+          environment: 'node',
+          setupFiles: ['./tests/contract/setup.js'],
+          testTimeout: 15000,
+          hookTimeout: 15000
+        }
       }
     ],
     coverage: {


### PR DESCRIPTION
## Summary

- **Fix:** `decks_with_stats` view→function migration broke the FE embed `member:members(display_name)`; PostgREST cannot resolve FK relationships on function results. Decks failed to load (PGRST200). Drops+recreates the function with `member_display_name` joined inline, updates the caller and `Deck` type, and adds a pgTAP `bag_eq` against `information_schema.parameters` to lock the OUT-param shape.
- **Test infra:** Adds a third Vitest project, `Contract`, that runs each `src/api/*/db/` function against a real local Supabase. Catches the bug class mocks miss: schema-cache drift, broken embeds, missing GRANTs, RLS regressions, column drift. Covers decks, members, cards, reviews, shop, media (29 tests, ~6s).
- **CI:** New `test-contract` job runs in parallel with `lint-and-test`, gated on `frontend OR db` changes. Boots Supabase, sources keys via `supabase status -o env`, runs `vp test --project Contract`. The FE job now scopes its run to `Unit + Integration` so it doesn't try to run Contract without Supabase booted.

Also dropped a unit-test assertion that pinned the broken `member:members(display_name)` select string.