### PR TITLE
ci(deploy): add skip_smoke input for emergency hotfixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_smoke:
+        description: Skip the E2E smoke gate (use only for emergency hotfixes)
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       environment:
@@ -44,6 +49,10 @@ on:
         default: false
       force_config:
         description: Force Supabase config push
+        type: boolean
+        default: false
+      skip_smoke:
+        description: Skip the E2E smoke gate (emergency hotfix only)
         type: boolean
         default: false
 
@@ -108,9 +117,11 @@ jobs:
     name: E2E smoke
     needs: [detect-changes]
     if: |
-      needs.detect-changes.outputs.frontend == 'true' || inputs.force_frontend ||
-      needs.detect-changes.outputs.migrations == 'true' || inputs.force_migrations ||
-      needs.detect-changes.outputs.functions == 'true' || inputs.force_functions
+      !inputs.skip_smoke && (
+        needs.detect-changes.outputs.frontend == 'true' || inputs.force_frontend ||
+        needs.detect-changes.outputs.migrations == 'true' || inputs.force_migrations ||
+        needs.detect-changes.outputs.functions == 'true' || inputs.force_functions
+      )
     uses: ./.github/workflows/e2e.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary

Adds an opt-in `skip_smoke` input to the deploy workflow so an urgent hotfix can ship without waiting on the ~3 min E2E smoke gate.

- Defaults to `false` — normal deploys still run smoke.
- Plumbed through both `workflow_call` and `workflow_dispatch`, so it shows up in the manual "Run workflow" UI and is forwardable from `deploy-staging.yml` / `deploy-production.yml` if needed.
- When `true`, the `e2e-smoke` job's `if` evaluates false → job skips. Existing `build` / `migrate` / `functions` gates already accept `result == 'skipped'`, so they proceed unchanged.