### PR TITLE
Prevent mobile horizontal overflow on deck view

### DIFF
--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -51,7 +51,7 @@ function onClick(e: MouseEvent) {
   <div
     data-testid="card-list-item"
     :data-id="card.id"
-    class="group/listitem relative grid w-full grid-cols-[1fr_auto_1fr] gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-colors duration-100 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-grey-700"
+    class="group/listitem relative grid w-full grid-cols-1 sm:grid-cols-[1fr_auto_1fr] sm:gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-colors duration-100 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-grey-700"
     :class="{
       'cursor-pointer': is_selecting,
       'focus-within:bg-brown-300 hover:focus-within:bg-brown-300 dark:focus-within:bg-blue-650 dark:hover:focus-within:bg-blue-650':

--- a/src/views/deck/card-grid/index.vue
+++ b/src/views/deck/card-grid/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import GridItem from './grid-item.vue'
 import { type CardListController } from '@/composables/card-editor/card-list-controller'
-import { computed, inject, ref, useTemplateRef, watch } from 'vue'
+import { computed, inject, ref, useTemplateRef, watch, type CSSProperties } from 'vue'
 import { useGridCapacity } from '@/composables/use-grid-capacity'
 import { useMediaQuery } from '@/composables/use-media-query'
 import { slideInFromDirection, slideOutInDirection } from '@/utils/animations/grid-page'
@@ -21,13 +21,25 @@ const isMd = useMediaQuery('md')
 
 observeSentinel(sentinel)
 
-const { gridStyle, capacity } = useGridCapacity({
+const MIN_ITEM_WIDTH = 170
+const MAX_ITEM_WIDTH = 220
+
+const { gridStyle: desktopGridStyle, capacity } = useGridCapacity({
   bounds: grid_wrapper,
   aspect_ratio: 7 / 8,
-  min_width: 170,
-  max_width: 220,
+  min_width: MIN_ITEM_WIDTH,
+  max_width: MAX_ITEM_WIDTH,
   gap: () => (isMd.value ? 12 : 8)
 })
+
+const mobileGridStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: `repeat(auto-fit, minmax(${MIN_ITEM_WIDTH}px, 1fr))`,
+  gap: '8px',
+  justifyContent: 'center'
+}
+
+const gridStyle = computed(() => (isMd.value ? desktopGridStyle.value : mobileGridStyle))
 
 // only push capacity into the controller while the carousel is active —
 // below md the grid scrolls natively and paging state is irrelevant

--- a/src/views/deck/deck-hero.vue
+++ b/src/views/deck/deck-hero.vue
@@ -34,7 +34,7 @@ function onToggleEditCards() {
 <template>
   <div
     data-testid="deck-hero"
-    class="flex w-max flex-col items-center gap-6 md:flex-row md:items-end xl:flex-col xl:items-start"
+    class="flex max-w-full flex-col items-center gap-6 md:flex-row md:items-end xl:w-max xl:flex-col xl:items-start"
   >
     <deck size="lg" class="relative" :deck="deck">
       <template #actions>

--- a/src/views/deck/page-dots.vue
+++ b/src/views/deck/page-dots.vue
@@ -45,7 +45,7 @@ function onClick() {
     data-theme="brown-700"
     data-theme-dark="brown-100"
     :data-engaged="hovered_index !== null || undefined"
-    class="sm:row-start-3 sm:col-start-2 justify-self-center relative cursor-pointer transition-opacity duration-300 before:content-[''] before:absolute before:-inset-x-10 before:-inset-y-3"
+    class="hidden md:block sm:row-start-3 sm:col-start-2 justify-self-center relative cursor-pointer transition-opacity duration-300 before:content-[''] before:absolute before:-inset-x-10 before:-inset-y-3"
     :class="{ 'opacity-0 pointer-events-none overflow-hidden': editor.mode.value !== 'view' }"
     @pointermove="onPointerMove"
     @pointerleave="onPointerLeave"


### PR DESCRIPTION
## Summary

Deck view caused large horizontal scroll on mobile, breaking app layout.

## Changes

- `deck-hero.vue` — replace `w-max` with `max-w-full`; keep `xl:w-max` for sticky sidebar
- `card-editor/list-item.vue` — collapse `[1fr_auto_1fr]` grid + `gap-x-6` to single column on mobile (side cells already hidden via `sm:flex`/`sm:grid`)
- `card-grid/index.vue` — define inline mobile grid style (`auto-fit, minmax(170px, 1fr)`); solver still drives desktop
- `page-dots.vue` — hide `<md`; carousel only runs md+, and `before:-inset-x-10` pseudo was forcing 40px overflow each side