### PR TITLE
Run E2E smoke against prod build instead of dev server

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,12 +38,15 @@ jobs:
             echo "SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o env | grep ^SERVICE_ROLE_KEY | cut -d= -f2- | tr -d '\"')"
           } >> "$GITHUB_ENV"
 
-      - name: Write local .env for vp dev
+      - name: Write local .env for build
         run: |
           {
             echo "VITE_SUPABASE_URL=$SUPABASE_URL"
             echo "VITE_SUPABASE_API_KEY=$SUPABASE_ANON_KEY"
           } > .env
+
+      - name: Build frontend
+        run: pnpm exec vp build
 
       - name: Run Playwright E2E
         run: pnpm exec playwright test

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
   webServer: process.env.E2E_BASE_URL
     ? undefined
     : {
-        command: 'pnpm exec vp dev --host 127.0.0.1 --port 5173',
+        command: process.env.CI
+          ? 'pnpm exec vp preview --host 127.0.0.1 --port 5173 --strictPort'
+          : 'pnpm exec vp dev --host 127.0.0.1 --port 5173',
         url: 'http://127.0.0.1:5173',
         reuseExistingServer: !process.env.CI,
         timeout: 60_000


### PR DESCRIPTION
## Summary

E2E was running against \`vp dev\`, which hides build-time issues (tree-shaking, asset hashing, code-splitting, prod-only optimizations). Switching to \`vp build\` + \`vp preview\` so the smoke exercises the same bundle that ships.

Local DX unchanged — playwright still uses \`vp dev\` outside CI.

## Changes

- \`playwright.config.ts\` — webServer command picks \`vp preview\` when \`process.env.CI\`, falls back to \`vp dev\` locally.
- \`e2e.yml\` — add \`vp build\` step before playwright runs (one build per E2E run; PR CI doesn't currently build, so no duplication).