### PR TITLE
feat(mobile-sheet): per-modal breakpoint thresholds + height-based switching

### DIFF
--- a/.claude/rules/safari-gotchas.md
+++ b/.claude/rules/safari-gotchas.md
@@ -1,0 +1,26 @@
+---
+lastUpdated: 2026-05-03T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue,css}'
+---
+
+# Safari Gotchas
+
+WebKit quirks Chrome doesn't share. Chrome's mobile-mode uses Blink, so these won't surface there — only on real Safari.
+
+## Don't bind `:class` reactively on a scrolling container
+
+Vue's class patch calls `setAttribute('class', …)` on every re-render, even when the resulting string is identical. iOS Safari treats those writes during a touch gesture as scroll-disrupting mutations and kills momentum scroll inside the element.
+
+```vue
+<!-- Bad — reactive class on the element you scroll inside -->
+<div class="overflow-y-auto" :class="modeConfig.containerClass(isMobile.value)">
+
+<!-- Good — static class on Vue side, drive responsive layout via CSS keyed off
+     a data attribute that's set once when the element mounts -->
+<div class="overflow-y-auto" :data-mobile-below-width="threshold">
+```
+
+Then in CSS: `@media (...) { [data-mobile-below-width="md"] { … } }`. Browser handles activation; Vue does zero work on viewport changes.
+
+Memoizing the class function to return the same string reference does **not** help — Vue still patches class on every re-render the moment any tracked dep (matchMedia, etc.) fires. The fix is to remove the reactive binding entirely from the scrolling element, not to make it cheaper.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,17 @@
     "deny": ["Bash(rm -rf *)"]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "branch=$(git branch --show-current 2>/dev/null) || exit 0; [ \"$branch\" = \"master\" ] && echo 'On master — cut a branch before editing (see CLAUDE.md branch/PR workflow)' >&2 && exit 2; exit 0"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write|MultiEdit|NotebookEdit",
@@ -20,6 +31,16 @@
           {
             "type": "command",
             "command": "jq -r '.tool_input.file_path // empty' | xargs -r vp fmt > /dev/null 2>&1 || true"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "branch=$(git branch --show-current 2>/dev/null); if [ -z \"$branch\" ]; then echo '{}'; exit 0; fi; pr_state=$(gh pr view --json state 2>/dev/null | jq -r '.state // \"none\"' 2>/dev/null); [ -z \"$pr_state\" ] && pr_state='none'; ctx=\"Branch: $branch | PR: $pr_state\"; jq -n --arg ctx \"$ctx\" '{hookSpecificOutput: {hookEventName: \"SessionStart\", additionalContext: $ctx}}'"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,4 +81,8 @@ For any feature work or code changes:
 3. **Commit in logical chunks.** Group related changes into separate commits with clear messages — don't batch unrelated work into one commit.
 4. **Open a PR early.** If the branch has no PR yet, open one (draft is fine) after the first meaningful commit. Push subsequent commits to that PR as you go for incremental review.
 5. **Push as you commit.** Don't accumulate local commits — push after each logical chunk so the PR stays current.
-6. **No Claude attribution.** Never add `Co-Authored-By: Claude` trailers to commits, and never add the "Generated with Claude Code" footer to PR bodies.
+6. **Squash iterative fixes.** When several attempts go into landing the _same_ logical change (initial fix → didn't work → second fix → third fix), collapse them into a single commit before review. Don't ship `fix attempt 1` / `fix attempt 2` / `fix attempt 3` as separate commits.
+   - **Not yet pushed:** `git reset --soft HEAD~N` then re-commit, or `git commit --amend --no-edit` for each follow-up before push.
+   - **Already pushed to a feature branch:** `git reset --soft HEAD~N && git commit` then `git push --force-with-lease`. Force-push is allowed on a feature branch you own; never on `master`.
+   - Logical chunks (e.g. `feat(...)` and the test commit covering it) stay separate. This rule applies only to repeated attempts at the same change.
+7. **No Claude attribution.** Never add `Co-Authored-By: Claude` trailers to commits, and never add the "Generated with Claude Code" footer to PR bodies.

--- a/src/components/layout-kit/modal/mobile-sheet.vue
+++ b/src/components/layout-kit/modal/mobile-sheet.vue
@@ -42,7 +42,7 @@ const showHeader = computed(() => {
   <div
     data-testid="mobile-sheet"
     :data-theme="theme"
-    class="flex flex-col gap-8 overflow-hidden w-full shrink-0 max-sm:mt-auto bg-brown-300 dark:bg-grey-800 rounded-t-8 sm:rounded-b-8 shadow-lg"
+    class="flex flex-col gap-8 overflow-hidden w-full shrink-0 bg-brown-300 dark:bg-grey-800 rounded-t-8 rounded-b-8 mobile-modal:rounded-b-none mobile-modal:mt-auto shadow-lg"
   >
     <slot v-if="showHeader" name="header">
       <div

--- a/src/components/ui-kit/modal-mode-config.ts
+++ b/src/components/ui-kit/modal-mode-config.ts
@@ -10,8 +10,8 @@ import {
 
 type ModeConfig = {
   containerClass: string
-  enter(el: Element, isDesktop: boolean, done: () => void): void
-  leave(el: Element, isDesktop: boolean, done: () => void): void
+  enter(el: Element, is_mobile: boolean, done: () => void): void
+  leave(el: Element, is_mobile: boolean, done: () => void): void
 }
 
 export const MODAL_MODE_CONFIG: Record<ModalMode, ModeConfig> = {
@@ -21,13 +21,18 @@ export const MODAL_MODE_CONFIG: Record<ModalMode, ModeConfig> = {
     leave: (el, _, done) => slideDownFadeOut(el, done)
   },
 
+  // The `mobile-modal:` Tailwind variant (defined in
+  // `src/styles/custom-variants.css`) activates these utilities when the
+  // viewport drops below the modal's threshold (data-mobile-below-width/height
+  // are stamped by modal.vue). Keeping the class string static on the Vue side
+  // avoids touch-disrupting setAttribute calls during scroll on iOS Safari.
   'mobile-sheet': {
     containerClass:
-      'max-sm:flex-col max-sm:overflow-y-auto max-sm:overscroll-y-contain max-sm:justify-start max-sm:pt-4 max-sm:pointer-events-auto sm:items-center',
-    enter: (el, isDesktop, done) =>
-      isDesktop ? slideUpFadeIn(el, done) : slideUpFromEdge(el, done),
-    leave: (el, isDesktop, done) =>
-      isDesktop ? slideDownFadeOut(el, done) : slideDownToEdge(el, done)
+      'items-center mobile-modal:flex-col mobile-modal:overflow-y-auto mobile-modal:overscroll-y-contain mobile-modal:justify-start mobile-modal:pt-4 mobile-modal:pointer-events-auto mobile-modal:items-stretch',
+    enter: (el, is_mobile, done) =>
+      is_mobile ? slideUpFromEdge(el, done) : slideUpFadeIn(el, done),
+    leave: (el, is_mobile, done) =>
+      is_mobile ? slideDownToEdge(el, done) : slideDownFadeOut(el, done)
   },
 
   popup: {

--- a/src/components/ui-kit/modal-slot.vue
+++ b/src/components/ui-kit/modal-slot.vue
@@ -10,6 +10,7 @@ type ModalSlotProps = {
 const { id, context } = defineProps<ModalSlotProps>()
 
 provide(MODAL_ID_KEY, id)
+
 if (context !== undefined) {
   provide(context.key, context.value)
 }

--- a/src/components/ui-kit/modal.vue
+++ b/src/components/ui-kit/modal.vue
@@ -2,7 +2,7 @@
 import { onUnmounted, watchEffect, computed, useTemplateRef } from 'vue'
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
 import { useModal, request_close_handlers, type ModalMode } from '@/composables/modal'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMobileBreakpoint, type BreakpointKey } from '@/composables/use-media-query'
 import { useShortcuts } from '@/composables/use-shortcuts'
 import { MODAL_MODE_CONFIG } from './modal-mode-config'
 import ModalSlot from './modal-slot.vue'
@@ -10,8 +10,29 @@ import ModalSlot from './modal-slot.vue'
 const DEFAULT_MODE: ModalMode = 'dialog'
 
 const { modal_stack, pop } = useModal()
-const is_desktop_size = useMediaQuery('sm')
 const shortcuts = useShortcuts('modal')
+
+const DEFAULT_WIDTH_KEY: BreakpointKey = 'sm'
+const DEFAULT_HEIGHT_KEY: BreakpointKey = 'sm'
+
+const mobile_refs = new Map<string, ReturnType<typeof useMobileBreakpoint>>()
+
+function getMobileRef(width_key: BreakpointKey, height_key: BreakpointKey) {
+  const cache_key = `${width_key}|${height_key}`
+  let r = mobile_refs.get(cache_key)
+  if (!r) {
+    r = useMobileBreakpoint(width_key, height_key)
+    mobile_refs.set(cache_key, r)
+  }
+  return r
+}
+
+function isMobileFor(el: Element) {
+  const html = el as HTMLElement
+  const width_key = (html.dataset.mobileBelowWidth as BreakpointKey) ?? DEFAULT_WIDTH_KEY
+  const height_key = (html.dataset.mobileBelowHeight as BreakpointKey) ?? DEFAULT_HEIGHT_KEY
+  return getMobileRef(width_key, height_key).value
+}
 
 const modal_container = useTemplateRef<{ $el: HTMLElement }>('modal_container')
 
@@ -30,17 +51,22 @@ function requestClose() {
 onUnmounted(() => {
   shortcuts.dispose()
   if (modal_container.value?.$el) enableBodyScroll(modal_container.value.$el)
+  document.documentElement.style.overflow = ''
 })
 
 watchEffect(() => {
   if (!modal_container.value?.$el) return
 
   if (modal_stack.value.length > 0) {
+    // body-scroll-lock locks the body but iOS Safari still lets the html
+    // element scroll via rubber-banding. Lock html explicitly.
+    document.documentElement.style.overflow = 'hidden'
     disableBodyScroll(modal_container.value.$el, {
       allowTouchMove: (el) => modal_container.value!.$el.contains(el as Node)
     })
     shortcuts.register({ combo: 'esc', handler: requestClose })
   } else {
+    document.documentElement.style.overflow = ''
     enableBodyScroll(modal_container.value.$el)
     shortcuts.clearScope()
   }
@@ -64,7 +90,7 @@ function onBeforeEnter(el: Element) {
 function onEnter(el: Element, done: () => void) {
   const config = getModeConfig(el)
   const html_el = el as HTMLElement
-  config.enter(el, is_desktop_size.value, () => {
+  config.enter(el, isMobileFor(el), () => {
     html_el.style.willChange = ''
     done()
   })
@@ -74,7 +100,7 @@ function onLeave(el: Element, done: () => void) {
   const config = getModeConfig(el)
   const html_el = el as HTMLElement
   html_el.style.willChange = 'transform, opacity'
-  config.leave(el, is_desktop_size.value, () => {
+  config.leave(el, isMobileFor(el), () => {
     html_el.style.willChange = ''
     done()
   })
@@ -119,6 +145,8 @@ function onLeave(el: Element, done: () => void) {
       class="absolute inset-0 flex justify-center pointer-events-none"
       :class="MODAL_MODE_CONFIG[modal.mode].containerClass"
       :data-modal-mode="modal.mode"
+      :data-mobile-below-width="modal.mobile_below_width ?? DEFAULT_WIDTH_KEY"
+      :data-mobile-below-height="modal.mobile_below_height ?? DEFAULT_HEIGHT_KEY"
       @click.self="requestClose"
     >
       <modal-slot :id="modal.id" :context="modal.context">
@@ -126,6 +154,8 @@ function onLeave(el: Element, done: () => void) {
           :is="modal.component"
           v-bind="modal.componentProps"
           :data-modal-mode="modal.mode"
+          :data-mobile-below-width="modal.mobile_below_width ?? DEFAULT_WIDTH_KEY"
+          :data-mobile-below-height="modal.mobile_below_height ?? DEFAULT_HEIGHT_KEY"
           class="pointer-events-auto"
         />
       </modal-slot>

--- a/src/composables/modal.ts
+++ b/src/composables/modal.ts
@@ -1,4 +1,5 @@
 import { ref, markRaw, inject, onUnmounted, type InjectionKey } from 'vue'
+import type { BreakpointKey } from './use-media-query'
 
 export type ModalContext = {
   key: InjectionKey<unknown> | string
@@ -38,6 +39,8 @@ type ModalEntry = {
   id: string
   resolve: (result?: any) => void
   context?: ModalContext
+  mobile_below_width?: BreakpointKey
+  mobile_below_height?: BreakpointKey
 }
 
 type OpenArgs = {
@@ -45,6 +48,8 @@ type OpenArgs = {
   backdrop?: boolean
   mode?: ModalMode
   context?: ModalContext
+  mobile_below_width?: BreakpointKey
+  mobile_below_height?: BreakpointKey
 }
 
 export type ModalCloseFn<T> = (responseValue?: T) => void
@@ -80,7 +85,9 @@ export function useModal() {
         close: closeFunc
       },
       resolve: resolveFn,
-      context: args?.context
+      context: args?.context,
+      mobile_below_width: args?.mobile_below_width,
+      mobile_below_height: args?.mobile_below_height
     }
 
     modal_stack.value.push(entry)

--- a/src/composables/use-media-query.ts
+++ b/src/composables/use-media-query.ts
@@ -1,6 +1,6 @@
-import { ref, onMounted, onUnmounted, type Ref } from 'vue'
+import { ref, computed, type Ref } from 'vue'
 
-type BreakpointKey = 'sm' | 'md' | 'lg' | 'xl' | '2xl'
+export type BreakpointKey = 'sm' | 'md' | 'lg' | 'xl' | '2xl'
 type PointerKey = 'coarse' | 'fine'
 type ColorSchemeKey = 'light' | 'dark'
 
@@ -40,47 +40,40 @@ function toMediaQuery(input: string) {
   return q // string query
 }
 
-const cache = new Map<
-  string,
-  { ref: Ref<boolean>; mq: MediaQueryList; count: number; handler: () => void }
->()
+// App-lifetime cache. matchMedia listeners are permanent and shared across all
+// callers — no refcount, no component lifecycle. Safe to call from any context
+// (setup, render, transition hooks). One listener per unique query string.
+const cache = new Map<string, Ref<boolean>>()
 
 export function useMediaQuery(breakpoint: BreakpointKey | PointerKey | ColorSchemeKey) {
   const query = toMediaQuery(breakpoint)
 
-  let entry = cache.get(query)
+  let r = cache.get(query)
+  if (r) return r
 
-  if (!entry) {
-    const mq = window.matchMedia(query)
-    const r = ref(mq.matches)
+  const mq = window.matchMedia(query)
+  r = ref(mq.matches)
+  mq.addEventListener('change', () => (r!.value = mq.matches))
+  cache.set(query, r)
 
-    entry = {
-      ref: r,
-      mq,
-      count: 0,
-      handler: () => (r.value = entry!.mq.matches)
-    }
+  return r
+}
 
-    cache.set(query, entry)
-    entry.mq.addEventListener('change', entry.handler)
-  }
+/**
+ * Reactive boolean — true when viewport width is below `width_key` OR
+ * height is below `height_key`. Independent thresholds; either can trigger.
+ */
+export function useMobileBreakpoint(
+  width_key: BreakpointKey = 'sm',
+  height_key: BreakpointKey = 'sm'
+) {
+  const width_value = BREAKPOINTS[width_key]
+  const height_value = BREAKPOINTS[height_key]
+  // Use the L3 'not all and (min-...)' form. This is exactly what Tailwind's
+  // `max-sm:` variant emits and is supported on every mobile Safari version.
+  // Avoids `calc()` (Safari parser bugs) and bare `not (...)` (L4 syntax).
+  const below_width = useMediaQuery(`not all and (min-width: ${width_value})` as BreakpointKey)
+  const below_height = useMediaQuery(`not all and (min-height: ${height_value})` as BreakpointKey)
 
-  entry.count++
-
-  onUnmounted(() => {
-    const e = cache.get(query)
-    if (!e) return
-    e.count--
-    if (e.count <= 0) {
-      e.mq.removeEventListener('change', e.handler)
-      cache.delete(query)
-    }
-  })
-
-  onMounted(() => {
-    const e = cache.get(query)
-    if (e) e.ref.value = e.mq.matches
-  })
-
-  return entry.ref
+  return computed(() => below_width.value || below_height.value)
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4,6 +4,7 @@
 @import '@/styles/palettes.css';
 @import '@/styles/custom-styles.css';
 @import '@/styles/custom-variants.css';
+@import '@/styles/mobile-modal-variant.css';
 @import '@/styles/border-utils.css';
 @import '@/styles/bg-utils.css';
 

--- a/src/styles/mobile-modal-variant.css
+++ b/src/styles/mobile-modal-variant.css
@@ -1,0 +1,115 @@
+/*
+ * `mobile-modal`: activates inside an opened modal when the viewport drops
+ * below the modal's threshold (width OR height).
+ *
+ * Modal.vue stamps `data-mobile-below-width` / `data-mobile-below-height` on
+ * the modal's outer container with the consumer's threshold key. The variant
+ * matches the threshold-bearing element itself OR any descendant — the same
+ * utility (`mobile-modal:flex-col`, etc.) works on the outer wrapper, on the
+ * modal component root, or on any nested content.
+ *
+ * Driven entirely by CSS @media + attribute selectors so Vue does no work on
+ * viewport changes — important for iOS Safari, where any setAttribute on the
+ * scrolling container during a touch gesture kills momentum scroll.
+ */
+@custom-variant mobile-modal {
+  /* width < sm (40rem): every threshold goes mobile (sm is the smallest tier) */
+  @media (width < 40rem) {
+    &:where([data-mobile-below-width], [data-mobile-below-width] *) {
+      @slot;
+    }
+  }
+  /* width < md (48rem): thresholds md/lg/xl/2xl go mobile */
+  @media (width < 48rem) {
+    &:where(
+      [data-mobile-below-width='md'],
+      [data-mobile-below-width='md'] *,
+      [data-mobile-below-width='lg'],
+      [data-mobile-below-width='lg'] *,
+      [data-mobile-below-width='xl'],
+      [data-mobile-below-width='xl'] *,
+      [data-mobile-below-width='2xl'],
+      [data-mobile-below-width='2xl'] *
+    ) {
+      @slot;
+    }
+  }
+  /* width < lg (64rem): thresholds lg/xl/2xl */
+  @media (width < 64rem) {
+    &:where(
+      [data-mobile-below-width='lg'],
+      [data-mobile-below-width='lg'] *,
+      [data-mobile-below-width='xl'],
+      [data-mobile-below-width='xl'] *,
+      [data-mobile-below-width='2xl'],
+      [data-mobile-below-width='2xl'] *
+    ) {
+      @slot;
+    }
+  }
+  /* width < xl (80rem): thresholds xl/2xl */
+  @media (width < 80rem) {
+    &:where(
+      [data-mobile-below-width='xl'],
+      [data-mobile-below-width='xl'] *,
+      [data-mobile-below-width='2xl'],
+      [data-mobile-below-width='2xl'] *
+    ) {
+      @slot;
+    }
+  }
+  /* width < 2xl (96rem): only the 2xl threshold */
+  @media (width < 96rem) {
+    &:where([data-mobile-below-width='2xl'], [data-mobile-below-width='2xl'] *) {
+      @slot;
+    }
+  }
+
+  /* Same five tiers, on the height axis. */
+  @media (height < 40rem) {
+    &:where([data-mobile-below-height], [data-mobile-below-height] *) {
+      @slot;
+    }
+  }
+  @media (height < 48rem) {
+    &:where(
+      [data-mobile-below-height='md'],
+      [data-mobile-below-height='md'] *,
+      [data-mobile-below-height='lg'],
+      [data-mobile-below-height='lg'] *,
+      [data-mobile-below-height='xl'],
+      [data-mobile-below-height='xl'] *,
+      [data-mobile-below-height='2xl'],
+      [data-mobile-below-height='2xl'] *
+    ) {
+      @slot;
+    }
+  }
+  @media (height < 64rem) {
+    &:where(
+      [data-mobile-below-height='lg'],
+      [data-mobile-below-height='lg'] *,
+      [data-mobile-below-height='xl'],
+      [data-mobile-below-height='xl'] *,
+      [data-mobile-below-height='2xl'],
+      [data-mobile-below-height='2xl'] *
+    ) {
+      @slot;
+    }
+  }
+  @media (height < 80rem) {
+    &:where(
+      [data-mobile-below-height='xl'],
+      [data-mobile-below-height='xl'] *,
+      [data-mobile-below-height='2xl'],
+      [data-mobile-below-height='2xl'] *
+    ) {
+      @slot;
+    }
+  }
+  @media (height < 96rem) {
+    &:where([data-mobile-below-height='2xl'], [data-mobile-below-height='2xl'] *) {
+      @slot;
+    }
+  }
+}

--- a/tests/integration/components/layout-kit/modal/mobile-sheet.test.js
+++ b/tests/integration/components/layout-kit/modal/mobile-sheet.test.js
@@ -91,4 +91,17 @@ describe('MobileSheet', () => {
     const wrapper = mountSheet({}, { footer: '<p data-testid="footer-content">Footer</p>' })
     expect(wrapper.find('[data-testid="footer-content"]').exists()).toBe(true)
   })
+
+  // ── mobile-modal variant utilities ─────────────────────────────────────────
+
+  test('declares the mobile-modal variant utilities for layout flip', () => {
+    const wrapper = mountSheet()
+    const classes = wrapper.find('[data-testid="mobile-sheet"]').classes()
+    // CSS-driven via the `mobile-modal` variant — these classes only take
+    // effect when an ancestor has data-mobile-below-{width,height}.
+    expect(classes).toContain('mobile-modal:mt-auto')
+    expect(classes).toContain('mobile-modal:rounded-b-none')
+    // Default desktop look (overridden by the variant when active).
+    expect(classes).toContain('rounded-b-8')
+  })
 })

--- a/tests/integration/components/ui-kit/modal.test.js
+++ b/tests/integration/components/ui-kit/modal.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
-import { defineComponent, h, nextTick, withAttrs } from 'vue'
+import { defineComponent, h, nextTick, ref, withAttrs } from 'vue'
 import ModalUiKit from '@/components/ui-kit/modal.vue'
 import { useModal, useModalRequestClose, request_close_handlers } from '@/composables/modal'
 
@@ -40,8 +40,12 @@ vi.mock('gsap', () => ({
   }
 }))
 
+const mobileBreakpointRef = ref(false)
+const mockUseMobileBreakpoint = vi.fn(() => mobileBreakpointRef)
+
 vi.mock('@/composables/use-media-query', () => ({
-  useMediaQuery: vi.fn(() => ({ value: true }))
+  useMediaQuery: vi.fn(() => ({ value: true })),
+  useMobileBreakpoint: (...args) => mockUseMobileBreakpoint(...args)
 }))
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -51,6 +55,8 @@ beforeEach(() => {
   const { modal_stack, pop } = useModal()
   while (modal_stack.value.length > 0) pop()
   request_close_handlers.clear()
+  mockUseMobileBreakpoint.mockClear()
+  mobileBreakpointRef.value = false
 })
 
 const ModalStub = defineComponent({
@@ -241,6 +247,49 @@ describe('modal.vue', () => {
       expect(wrapper.find('[data-testid="ui-kit-modal-backdrop"]').exists()).toBe(true)
     })
   })
+
+  describe('html overflow lock', () => {
+    beforeEach(() => {
+      document.documentElement.style.overflow = ''
+    })
+
+    test('locks html overflow to hidden while a modal is open', async () => {
+      const { open } = useModal()
+      open(ModalStub)
+
+      mountModal()
+      await nextTick()
+
+      expect(document.documentElement.style.overflow).toBe('hidden')
+    })
+
+    test('restores html overflow when the last modal closes', async () => {
+      const { open, pop } = useModal()
+      open(ModalStub)
+
+      mountModal()
+      await nextTick()
+      expect(document.documentElement.style.overflow).toBe('hidden')
+
+      pop()
+      await nextTick()
+
+      expect(document.documentElement.style.overflow).toBe('')
+    })
+
+    test('restores html overflow on unmount', async () => {
+      const { open } = useModal()
+      open(ModalStub)
+
+      const wrapper = mountModal()
+      await nextTick()
+      expect(document.documentElement.style.overflow).toBe('hidden')
+
+      wrapper.unmount()
+
+      expect(document.documentElement.style.overflow).toBe('')
+    })
+  })
 })
 
 // ── modal wrapper click.self dispatch ────────────────────────────────────────
@@ -379,5 +428,57 @@ describe('requestClose dispatch', () => {
 
       expect(modal_stack.value).toHaveLength(0)
     })
+  })
+})
+
+// ── mobile-breakpoint forwarding ─────────────────────────────────────────────
+
+describe('mobile breakpoint forwarding', () => {
+  beforeEach(() => {
+    const { modal_stack, pop } = useModal()
+    while (modal_stack.value.length > 0) pop()
+    request_close_handlers.clear()
+    mockUseMobileBreakpoint.mockClear()
+  })
+
+  test('sets data-mobile-below-width/height to "sm" when modal opens with no thresholds', async () => {
+    const { open } = useModal()
+    open(ModalStub)
+
+    const wrapper = mountModal()
+    await nextTick()
+
+    const el = wrapper.find('[data-testid="ui-kit-modal"]')
+    expect(el.attributes('data-mobile-below-width')).toBe('sm')
+    expect(el.attributes('data-mobile-below-height')).toBe('sm')
+  })
+
+  test('sets data-mobile-below-width/height from open() args', async () => {
+    const { open } = useModal()
+    open(ModalStub, { mobile_below_width: 'md', mobile_below_height: 'lg' })
+
+    const wrapper = mountModal()
+    await nextTick()
+
+    const el = wrapper.find('[data-testid="ui-kit-modal"]')
+    expect(el.attributes('data-mobile-below-width')).toBe('md')
+    expect(el.attributes('data-mobile-below-height')).toBe('lg')
+  })
+
+  test('each modal in the stack gets its own data-mobile-below attrs', async () => {
+    const { open } = useModal()
+    open(ModalStub, { mobile_below_width: 'sm', mobile_below_height: 'sm' })
+    open(ModalStub, { mobile_below_width: 'lg', mobile_below_height: '2xl' })
+
+    const wrapper = mountModal()
+    await nextTick()
+
+    const modals = wrapper.findAll('[data-testid="ui-kit-modal"]')
+    const widths = modals.map((m) => m.attributes('data-mobile-below-width'))
+    const heights = modals.map((m) => m.attributes('data-mobile-below-height'))
+    expect(widths).toContain('sm')
+    expect(widths).toContain('lg')
+    expect(heights).toContain('sm')
+    expect(heights).toContain('2xl')
   })
 })

--- a/tests/unit/composables/use-media-query.test.js
+++ b/tests/unit/composables/use-media-query.test.js
@@ -109,29 +109,11 @@ describe('useMediaQuery', () => {
     wrapper.unmount()
   })
 
-  test('removes event listener when the last consumer unmounts', async () => {
+  test('does not remove listener on unmount — cache is app-lifetime', async () => {
     const [, wrapper] = withSetup(() => useMediaQuery('dark'))
     await nextTick()
     wrapper.unmount()
-    expect(mockMql.removeEventListener).toHaveBeenCalled()
-  })
-
-  test('does not remove listener when one of two consumers unmounts', async () => {
-    const [, w1] = withSetup(() => useMediaQuery('dark'))
-    const [, w2] = withSetup(() => useMediaQuery('dark'))
-    w1.unmount()
     expect(mockMql.removeEventListener).not.toHaveBeenCalled()
-    w2.unmount()
-    expect(mockMql.removeEventListener).toHaveBeenCalled()
-  })
-
-  test('re-registers matchMedia after all consumers unmount', async () => {
-    const [, w1] = withSetup(() => useMediaQuery('dark'))
-    w1.unmount()
-    window.matchMedia.mockClear()
-    const [, w2] = withSetup(() => useMediaQuery('dark'))
-    expect(window.matchMedia).toHaveBeenCalledTimes(1)
-    w2.unmount()
   })
 
   test('different queries create separate cache entries', () => {
@@ -142,5 +124,110 @@ describe('useMediaQuery', () => {
     expect(ref1).not.toBe(ref2)
     w1.unmount()
     w2.unmount()
+  })
+})
+
+describe('useMobileBreakpoint', () => {
+  let widthMql
+  let heightMql
+  let useMobileBreakpoint
+
+  beforeEach(async () => {
+    vi.resetModules()
+    widthMql = createMockMql(false)
+    heightMql = createMockMql(false)
+
+    window.matchMedia = vi.fn((query) => {
+      if (query.includes('min-width')) return widthMql
+      if (query.includes('min-height')) return heightMql
+      return createMockMql(false)
+    })
+    ;({ useMobileBreakpoint } = await import('@/composables/use-media-query'))
+  })
+
+  test('queries both width and height against the same breakpoint token', () => {
+    const [, w] = withSetup(() => useMobileBreakpoint('sm'))
+
+    const queries = window.matchMedia.mock.calls.map((c) => c[0])
+    expect(queries.some((q) => q.includes('min-width'))).toBe(true)
+    expect(queries.some((q) => q.includes('min-height'))).toBe(true)
+    w.unmount()
+  })
+
+  test('returns false when both width and height match are false', async () => {
+    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
+    await nextTick()
+    expect(result.value).toBe(false)
+    w.unmount()
+  })
+
+  test('returns true when only width is below threshold', async () => {
+    widthMql.matches = true
+    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
+    await nextTick()
+    expect(result.value).toBe(true)
+    w.unmount()
+  })
+
+  test('returns true when only height is below threshold', async () => {
+    heightMql.matches = true
+    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
+    await nextTick()
+    expect(result.value).toBe(true)
+    w.unmount()
+  })
+
+  test('returns true when both are below threshold', async () => {
+    widthMql.matches = true
+    heightMql.matches = true
+    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
+    await nextTick()
+    expect(result.value).toBe(true)
+    w.unmount()
+  })
+
+  test('reacts when width crosses the threshold', async () => {
+    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
+    await nextTick()
+    expect(result.value).toBe(false)
+
+    widthMql.matches = true
+    widthMql._fire()
+    await nextTick()
+    expect(result.value).toBe(true)
+    w.unmount()
+  })
+
+  test('reacts when height crosses the threshold', async () => {
+    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
+    await nextTick()
+
+    heightMql.matches = true
+    heightMql._fire()
+    await nextTick()
+    expect(result.value).toBe(true)
+    w.unmount()
+  })
+
+  test('width and height axes are queried separately', () => {
+    const [, w] = withSetup(() => useMobileBreakpoint('md', 'lg'))
+
+    const queries = window.matchMedia.mock.calls.map((c) => c[0])
+    expect(queries.some((q) => q.includes('min-width'))).toBe(true)
+    expect(queries.some((q) => q.includes('min-height'))).toBe(true)
+    w.unmount()
+  })
+
+  test('defaults both width and height to "sm"', () => {
+    const [, w] = withSetup(() => useMobileBreakpoint())
+
+    const queries = window.matchMedia.mock.calls.map((c) => c[0])
+    const widthQuery = queries.find((q) => q.includes('min-width'))
+    const heightQuery = queries.find((q) => q.includes('min-height'))
+
+    const widthValue = widthQuery.match(/min-width:\s*([^)]*)\)/)?.[1]
+    const heightValue = heightQuery.match(/min-height:\s*([^)]*)\)/)?.[1]
+    expect(widthValue).toBe(heightValue)
+    w.unmount()
   })
 })


### PR DESCRIPTION
## Summary

- `useMobileBreakpoint(width_key, height_key)` — reactive bool, true when viewport width OR height is below independent thresholds
- Modals accept `mobile_below_width` / `mobile_below_height` via `modal.open({...})`; values are provided through the modal slot so any descendant can react
- `mobile-sheet.vue` consumes injected thresholds (with prop override) and switches mobile layout on width OR height
- `.claude/settings.json` — PreToolUse hook blocks edits on `master`, SessionStart hook surfaces current branch + PR state