### PR TITLE
Add ui-kit spinbox component

### DIFF
--- a/src/components/ui-kit/spinbox.vue
+++ b/src/components/ui-kit/spinbox.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
+
+type SpinboxSize = 'sm' | 'base' | 'lg'
+
+type SpinboxProps = {
+  min?: number
+  max?: number
+  step?: number
+  size?: SpinboxSize
+  label?: string
+  suffix?: string
+}
+
+const {
+  min = -Infinity,
+  max = Infinity,
+  step = 1,
+  size = 'base',
+  label,
+  suffix
+} = defineProps<SpinboxProps>()
+
+const value = defineModel<number>('value', { required: true })
+
+const can_decrement = computed(() => value.value > min)
+const can_increment = computed(() => value.value < max)
+
+const size_classes = computed(() => {
+  const map: Record<SpinboxSize, { row: string; btn: string; icon: string; val: string }> = {
+    sm: {
+      row: 'rounded-3_5 p-0.5 gap-0.5',
+      btn: 'h-6 rounded-2_5',
+      icon: 'w-4 h-4',
+      val: 'text-sm px-1.5'
+    },
+    base: {
+      row: 'rounded-4 p-1 gap-0.5',
+      btn: 'h-8 rounded-3',
+      icon: 'w-5 h-5',
+      val: 'text-base px-2'
+    },
+    lg: {
+      row: 'rounded-5_5 p-1.5 gap-1',
+      btn: 'h-10 rounded-4',
+      icon: 'w-6 h-6',
+      val: 'text-lg px-3'
+    }
+  }
+  return map[size]
+})
+
+function clamp(n: number) {
+  return Math.min(max, Math.max(min, n))
+}
+
+function decrement() {
+  if (!can_decrement.value) return
+  value.value = clamp(value.value - step)
+}
+
+function increment() {
+  if (!can_increment.value) return
+  value.value = clamp(value.value + step)
+}
+</script>
+
+<template>
+  <label data-testid="ui-kit-spinbox-container" class="flex flex-col gap-1.5 w-max">
+    <span v-if="label" data-testid="ui-kit-spinbox__label" class="text-brown-700">
+      {{ label }}
+    </span>
+    <div
+      data-testid="ui-kit-spinbox"
+      class="inline-flex items-center bg-brown-100"
+      :class="size_classes.row"
+    >
+      <button
+        type="button"
+        data-testid="ui-kit-spinbox__decrement"
+        class="inline-flex items-center justify-center aspect-square text-brown-700 cursor-pointer transition-[background-color,color,transform] duration-100 hover:bg-(--theme-primary) hover:text-(--theme-on-primary) active:scale-95 disabled:opacity-[0.35] disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-brown-700"
+        :class="size_classes.btn"
+        :disabled="!can_decrement"
+        v-sfx="{ hover: 'ui.click_07', click: 'ui.select' }"
+        @click="decrement"
+      >
+        <ui-icon src="horizontal-rule" :class="size_classes.icon" />
+      </button>
+
+      <div
+        data-testid="ui-kit-spinbox__value"
+        class="min-w-[3ch] text-center tabular-nums text-brown-700 select-none"
+        :class="size_classes.val"
+      >
+        {{ value }}<span v-if="suffix" class="ml-0.5 text-brown-500">{{ suffix }}</span>
+      </div>
+
+      <button
+        type="button"
+        data-testid="ui-kit-spinbox__increment"
+        class="inline-flex items-center justify-center aspect-square text-brown-700 cursor-pointer transition-[background-color,color,transform] duration-100 hover:bg-(--theme-primary) hover:text-(--theme-on-primary) active:scale-95 disabled:opacity-[0.35] disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-brown-700"
+        :class="size_classes.btn"
+        :disabled="!can_increment"
+        v-sfx="{ hover: 'ui.click_07', click: 'ui.select' }"
+        @click="increment"
+      >
+        <ui-icon src="add" :class="size_classes.icon" />
+      </button>
+    </div>
+  </label>
+</template>

--- a/tests/integration/components/ui-kit/spinbox.test.js
+++ b/tests/integration/components/ui-kit/spinbox.test.js
@@ -1,0 +1,134 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import UiSpinbox from '@/components/ui-kit/spinbox.vue'
+
+function mountSpinbox(props = {}) {
+  return shallowMount(UiSpinbox, { props: { value: 0, ...props } })
+}
+
+function findValue(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-spinbox__value"]')
+}
+
+function findDecrement(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-spinbox__decrement"]')
+}
+
+function findIncrement(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-spinbox__increment"]')
+}
+
+describe('UiSpinbox', () => {
+  // ── Structure ──────────────────────────────────────────────────────────────
+
+  test('renders the spinbox container', () => {
+    const wrapper = mountSpinbox()
+    expect(wrapper.find('[data-testid="ui-kit-spinbox"]').exists()).toBe(true)
+  })
+
+  test('renders increment and decrement buttons', () => {
+    const wrapper = mountSpinbox()
+    expect(findIncrement(wrapper).exists()).toBe(true)
+    expect(findDecrement(wrapper).exists()).toBe(true)
+  })
+
+  test('does not render label span when label prop is omitted', () => {
+    const wrapper = mountSpinbox()
+    expect(wrapper.find('[data-testid="ui-kit-spinbox__label"]').exists()).toBe(false)
+  })
+
+  test('renders the label span when label prop is provided', () => {
+    const wrapper = mountSpinbox({ label: 'Font size' })
+    const label = wrapper.find('[data-testid="ui-kit-spinbox__label"]')
+    expect(label.exists()).toBe(true)
+    expect(label.text()).toBe('Font size')
+  })
+
+  // ── Value display ──────────────────────────────────────────────────────────
+
+  test('shows the current value', () => {
+    const wrapper = mountSpinbox({ value: 7 })
+    expect(findValue(wrapper).text()).toContain('7')
+  })
+
+  test('appends suffix when suffix prop is set', () => {
+    const wrapper = mountSpinbox({ value: 30, suffix: 'px' })
+    expect(findValue(wrapper).text()).toContain('30')
+    expect(findValue(wrapper).text()).toContain('px')
+  })
+
+  test('does not render suffix span when suffix is omitted', () => {
+    const wrapper = mountSpinbox({ value: 30 })
+    expect(findValue(wrapper).text().trim()).toBe('30')
+  })
+
+  // ── Increment / decrement (v-model) ────────────────────────────────────────
+
+  test('clicking increment emits update:value with value + step', async () => {
+    const wrapper = mountSpinbox({ value: 5, step: 1 })
+    await findIncrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[6]])
+  })
+
+  test('clicking decrement emits update:value with value - step', async () => {
+    const wrapper = mountSpinbox({ value: 5, step: 1 })
+    await findDecrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[4]])
+  })
+
+  test('honors a custom step value', async () => {
+    const wrapper = mountSpinbox({ value: 30, step: 10 })
+    await findIncrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[40]])
+  })
+
+  // ── Bounds ─────────────────────────────────────────────────────────────────
+
+  test('decrement button is disabled at min', () => {
+    const wrapper = mountSpinbox({ value: 1, min: 1 })
+    expect(findDecrement(wrapper).attributes('disabled')).toBeDefined()
+  })
+
+  test('increment button is disabled at max', () => {
+    const wrapper = mountSpinbox({ value: 10, max: 10 })
+    expect(findIncrement(wrapper).attributes('disabled')).toBeDefined()
+  })
+
+  test('decrement at min does not emit update:value', async () => {
+    const wrapper = mountSpinbox({ value: 1, min: 1 })
+    await findDecrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toBeUndefined()
+  })
+
+  test('increment at max does not emit update:value', async () => {
+    const wrapper = mountSpinbox({ value: 10, max: 10 })
+    await findIncrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toBeUndefined()
+  })
+
+  test('decrement clamps to min when step would overshoot', async () => {
+    const wrapper = mountSpinbox({ value: 3, min: 1, step: 10 })
+    await findDecrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[1]])
+  })
+
+  test('increment clamps to max when step would overshoot', async () => {
+    const wrapper = mountSpinbox({ value: 8, max: 10, step: 10 })
+    await findIncrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[10]])
+  })
+
+  // ── Defaults ──────────────────────────────────────────────────────────────
+
+  test('with no min/max, both buttons are enabled by default', () => {
+    const wrapper = mountSpinbox({ value: 0 })
+    expect(findDecrement(wrapper).attributes('disabled')).toBeUndefined()
+    expect(findIncrement(wrapper).attributes('disabled')).toBeUndefined()
+  })
+
+  test('default step is 1', async () => {
+    const wrapper = mountSpinbox({ value: 5 })
+    await findIncrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[6]])
+  })
+})


### PR DESCRIPTION
## Summary

Introduces a numeric stepper primitive `<ui-spinbox>` to ui-kit. Matches the existing `<ui-input>` design language (brown-100 surface, themed primary on hover). Supports `min`, `max`, `step`, `size` (`sm`/`base`/`lg`), `label`, `suffix`, and v-model on `value`.

## Changes

- New `src/components/ui-kit/spinbox.vue` — Tailwind-only styling, no `<style>` block.
- Hover sfx `ui.click_07`; click sfx is the consumer's responsibility (matches `ui-button` pattern).
- Tests covering structure, label/suffix rendering, increment/decrement, custom step, min/max disabled state, and overshoot clamping.

## Test plan

- [ ] `vp test --no-coverage tests/integration/components/ui-kit/spinbox.test.js`
- [ ] Visual check in any consuming component once landed