### PR TITLE
feat(deck-settings): spinbox + all toggle for daily limits

### DIFF
--- a/.claude/rules/theming.md
+++ b/.claude/rules/theming.md
@@ -86,4 +86,3 @@ Never hardcode a raw color (hex or palette class) in `bgx-color-*` when the elem
 - Never use `@apply` — write plain CSS with `var(--theme-*)` directly (see `no-apply` rule).
 - Do not use raw hex values or hardcoded Tailwind color classes (e.g. `bg-blue-500`) for themeable colors.
 - When using `bgx-color-*` inside a themed element, always pass a `var(--theme-*)` token, not a raw color.
-- Add a `themeDark?: MemberTheme` prop alongside `theme` and bind `:data-theme-dark="themeDark ?? theme"` on the same root element. The fallback keeps the element correctly styled when no dark override is needed.

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -128,6 +128,7 @@ async function onSave() {
           </ui-toggle>
 
           <tab-study
+            :card_count="deck?.card_count"
             v-model:shuffle="config.shuffle"
             v-model:flip_cards="config.flip_cards"
             v-model:is_spaced="config.is_spaced"

--- a/src/components/modals/deck-settings/tab-study.vue
+++ b/src/components/modals/deck-settings/tab-study.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import UiToggle from '@/components/ui-kit/toggle.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
+import UiSpinbox from '@/components/ui-kit/spinbox.vue'
+
+type TabStudyProps = {
+  card_count?: number
+}
+
+const { card_count } = defineProps<TabStudyProps>()
 
 const { t } = useI18n()
 
@@ -12,21 +20,60 @@ const auto_play = defineModel<boolean | undefined>('auto_play')
 const max_reviews_per_day = defineModel<number | null | undefined>('max_reviews_per_day')
 const max_new_per_day = defineModel<number | null | undefined>('max_new_per_day')
 
-const REVIEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
-  { label: '20', value: 20 },
-  { label: '50', value: 50 },
-  { label: '100', value: 100 },
-  { label: '200', value: 200 },
-  { label: t('study.settings.all'), value: null }
-]
+const STEP = 5
+const MIN = 5
+const REVIEWS_MAX = 200
+const NEW_MAX = 100
+const REVIEWS_DEFAULT = 50
+const NEW_DEFAULT = 20
 
-const NEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
-  { label: '5', value: 5 },
-  { label: '10', value: 10 },
-  { label: '20', value: 20 },
-  { label: '50', value: 50 },
-  { label: t('study.settings.all'), value: null }
-]
+const is_reviews_all = ref(max_reviews_per_day.value === null)
+const reviews_local = ref(max_reviews_per_day.value ?? REVIEWS_DEFAULT)
+
+const is_new_all = ref(max_new_per_day.value === null)
+const new_local = ref(max_new_per_day.value ?? NEW_DEFAULT)
+
+watch(max_reviews_per_day, (v) => {
+  is_reviews_all.value = v === null
+  if (v != null) reviews_local.value = v
+})
+
+watch(max_new_per_day, (v) => {
+  is_new_all.value = v === null
+  if (v != null) new_local.value = v
+})
+
+function onReviewsChange(n: number) {
+  reviews_local.value = n
+  const all = n >= REVIEWS_MAX
+  is_reviews_all.value = all
+  max_reviews_per_day.value = all ? null : n
+}
+
+function onNewChange(n: number) {
+  new_local.value = n
+  const all = n >= NEW_MAX
+  is_new_all.value = all
+  max_new_per_day.value = all ? null : n
+}
+
+const reviews_all = computed({
+  get: () => is_reviews_all.value,
+  set: (on: boolean) => {
+    if (on && card_count != null) reviews_local.value = card_count
+    is_reviews_all.value = on
+    max_reviews_per_day.value = on ? null : reviews_local.value
+  }
+})
+
+const new_all = computed({
+  get: () => is_new_all.value,
+  set: (on: boolean) => {
+    if (on && card_count != null) new_local.value = card_count
+    is_new_all.value = on
+    max_new_per_day.value = on ? null : new_local.value
+  }
+})
 </script>
 
 <template>
@@ -63,22 +110,18 @@ const NEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
       <span class="text-sm font-medium text-brown-700">
         {{ t('deck.settings-modal.study.max-reviews-per-day') }}
       </span>
-      <div class="flex gap-2">
-        <button
-          v-for="preset in REVIEW_LIMIT_PRESETS"
-          :key="String(preset.value)"
-          data-testid="tab-study__max-reviews-preset"
-          :data-active="max_reviews_per_day === preset.value"
-          class="h-9 min-w-12 cursor-pointer rounded-4 px-3 text-sm font-medium transition-all duration-75"
-          :class="
-            max_reviews_per_day === preset.value
-              ? 'bg-blue-500 text-brown-100'
-              : 'bg-brown-100 text-brown-700 hover:bg-brown-200'
-          "
-          @click="max_reviews_per_day = preset.value"
-        >
-          {{ preset.label }}
-        </button>
+      <div data-testid="tab-study__max-reviews-row" class="flex items-center gap-4">
+        <ui-spinbox
+          :value="reviews_local"
+          :min="MIN"
+          :max="REVIEWS_MAX"
+          :step="STEP"
+          wrap
+          @update:value="onReviewsChange"
+        />
+        <ui-toggle data-testid="tab-study__max-reviews-all" v-model:checked="reviews_all">
+          {{ t('study.settings.all') }}
+        </ui-toggle>
       </div>
     </div>
 
@@ -86,22 +129,18 @@ const NEW_LIMIT_PRESETS: Array<{ label: string; value: number | null }> = [
       <span class="text-sm font-medium text-brown-700">
         {{ t('deck.settings-modal.study.max-new-per-day') }}
       </span>
-      <div class="flex gap-2">
-        <button
-          v-for="preset in NEW_LIMIT_PRESETS"
-          :key="String(preset.value)"
-          data-testid="tab-study__max-new-preset"
-          :data-active="max_new_per_day === preset.value"
-          class="h-9 min-w-12 cursor-pointer rounded-4 px-3 text-sm font-medium transition-all duration-75"
-          :class="
-            max_new_per_day === preset.value
-              ? 'bg-blue-500 text-brown-100'
-              : 'bg-brown-100 text-brown-700 hover:bg-brown-200'
-          "
-          @click="max_new_per_day = preset.value"
-        >
-          {{ preset.label }}
-        </button>
+      <div data-testid="tab-study__max-new-row" class="flex items-center gap-4">
+        <ui-spinbox
+          :value="new_local"
+          :min="MIN"
+          :max="NEW_MAX"
+          :step="STEP"
+          wrap
+          @update:value="onNewChange"
+        />
+        <ui-toggle data-testid="tab-study__max-new-all" v-model:checked="new_all">
+          {{ t('study.settings.all') }}
+        </ui-toggle>
       </div>
     </div>
   </div>

--- a/src/components/ui-kit/spinbox.vue
+++ b/src/components/ui-kit/spinbox.vue
@@ -11,6 +11,7 @@ type SpinboxProps = {
   size?: SpinboxSize
   label?: string
   suffix?: string
+  wrap?: boolean
 }
 
 const {
@@ -19,13 +20,14 @@ const {
   step = 1,
   size = 'base',
   label,
-  suffix
+  suffix,
+  wrap = false
 } = defineProps<SpinboxProps>()
 
 const value = defineModel<number>('value', { required: true })
 
-const can_decrement = computed(() => value.value > min)
-const can_increment = computed(() => value.value < max)
+const can_decrement = computed(() => value.value > min || (wrap && Number.isFinite(max)))
+const can_increment = computed(() => value.value < max || (wrap && Number.isFinite(min)))
 
 const size_classes = computed(() => {
   const map: Record<SpinboxSize, { row: string; btn: string; icon: string; val: string }> = {
@@ -33,19 +35,19 @@ const size_classes = computed(() => {
       row: 'rounded-3_5 p-0.5 gap-0.5',
       btn: 'h-6 rounded-2_5',
       icon: 'w-4 h-4',
-      val: 'text-sm px-1.5'
+      val: 'text-base px-1.5 w-10'
     },
     base: {
       row: 'rounded-4 p-1 gap-0.5',
       btn: 'h-8 rounded-3',
       icon: 'w-5 h-5',
-      val: 'text-base px-2'
+      val: 'text-base px-2 w-12'
     },
     lg: {
       row: 'rounded-5_5 p-1.5 gap-1',
       btn: 'h-10 rounded-4',
       icon: 'w-6 h-6',
-      val: 'text-lg px-3'
+      val: 'text-base px-3 w-14'
     }
   }
   return map[size]
@@ -56,21 +58,62 @@ function clamp(n: number) {
 }
 
 function decrement() {
-  if (!can_decrement.value) return
+  if (value.value <= min) {
+    if (wrap && Number.isFinite(max)) value.value = max
+    return
+  }
   value.value = clamp(value.value - step)
 }
 
 function increment() {
-  if (!can_increment.value) return
+  if (value.value >= max) {
+    if (wrap && Number.isFinite(min)) value.value = min
+    return
+  }
   value.value = clamp(value.value + step)
+}
+
+function onInput(e: Event) {
+  const raw = (e.target as HTMLInputElement).value
+  if (raw === '') return
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return
+  value.value = clamp(n)
+}
+
+function onBeforeInput(e: InputEvent) {
+  if (e.data == null) return
+  const allow_minus = min < 0
+  for (const ch of e.data) {
+    if (ch >= '0' && ch <= '9') continue
+    if (ch === '-' && allow_minus) continue
+    e.preventDefault()
+    return
+  }
+}
+
+function onFocus(e: FocusEvent) {
+  ;(e.target as HTMLInputElement).select()
+}
+
+function onBlur(e: Event) {
+  const el = e.target as HTMLInputElement
+  const n = Number(el.value)
+  if (!Number.isFinite(n) || el.value === '') {
+    el.value = String(value.value)
+    return
+  }
+  const clamped = clamp(n)
+  value.value = clamped
+  el.value = String(clamped)
 }
 </script>
 
 <template>
-  <label data-testid="ui-kit-spinbox-container" class="flex flex-col gap-1.5 w-max">
-    <span v-if="label" data-testid="ui-kit-spinbox__label" class="text-brown-700">
+  <div data-testid="ui-kit-spinbox-container" class="flex flex-col gap-1.5 w-max">
+    <label v-if="label" data-testid="ui-kit-spinbox__label" class="text-brown-700">
       {{ label }}
-    </span>
+    </label>
     <div
       data-testid="ui-kit-spinbox"
       class="inline-flex items-center bg-brown-100"
@@ -82,18 +125,29 @@ function increment() {
         class="inline-flex items-center justify-center aspect-square text-brown-700 cursor-pointer transition-[background-color,color,transform] duration-100 hover:bg-(--theme-primary) hover:text-(--theme-on-primary) active:scale-95 disabled:opacity-[0.35] disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-brown-700"
         :class="size_classes.btn"
         :disabled="!can_decrement"
-        v-sfx="{ hover: 'ui.click_07' }"
+        v-sfx="{ hover: 'ui.click_07', click: 'ui.select' }"
         @click="decrement"
       >
         <ui-icon src="horizontal-rule" :class="size_classes.icon" />
       </button>
 
-      <div
-        data-testid="ui-kit-spinbox__value"
-        class="min-w-[3ch] text-center tabular-nums text-brown-700 select-none"
-        :class="size_classes.val"
-      >
-        {{ value }}<span v-if="suffix" class="ml-0.5 text-brown-500">{{ suffix }}</span>
+      <div data-testid="ui-kit-spinbox__value" class="inline-flex items-baseline justify-center">
+        <input
+          type="text"
+          inputmode="numeric"
+          data-testid="ui-kit-spinbox__input"
+          class="text-center tabular-nums text-brown-700 bg-transparent outline-none"
+          :class="size_classes.val"
+          :value="value"
+          :step="step"
+          @beforeinput="onBeforeInput"
+          @focus="onFocus"
+          @input="onInput"
+          @blur="onBlur"
+        />
+        <span v-if="suffix" data-testid="ui-kit-spinbox__suffix" class="ml-0.5 text-brown-500">
+          {{ suffix }}
+        </span>
       </div>
 
       <button
@@ -102,11 +156,11 @@ function increment() {
         class="inline-flex items-center justify-center aspect-square text-brown-700 cursor-pointer transition-[background-color,color,transform] duration-100 hover:bg-(--theme-primary) hover:text-(--theme-on-primary) active:scale-95 disabled:opacity-[0.35] disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-brown-700"
         :class="size_classes.btn"
         :disabled="!can_increment"
-        v-sfx="{ hover: 'ui.click_07' }"
+        v-sfx="{ hover: 'ui.click_07', click: 'ui.select' }"
         @click="increment"
       >
         <ui-icon src="add" :class="size_classes.icon" />
       </button>
     </div>
-  </label>
+  </div>
 </template>

--- a/tests/integration/components/modals/deck-settings/tab-study.test.js
+++ b/tests/integration/components/modals/deck-settings/tab-study.test.js
@@ -199,6 +199,73 @@ describe('TabStudy', () => {
     expect(emitted[0][0]).toBeGreaterThan(0)
   })
 
+  test('toggling reviews "all" on pre-fills the spinbox with card_count', async () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 50, card_count: 137 })
+    const allToggle = wrapper.find('[data-testid="tab-study__max-reviews-all"]')
+    await allToggle.find('input').setValue(true)
+    const spinbox = wrapper.find(
+      '[data-testid="tab-study__max-reviews-row"] [data-testid="ui-kit-spinbox"]'
+    )
+    expect(spinbox.attributes('data-value')).toBe('137')
+  })
+
+  test('toggling new "all" on pre-fills the spinbox with card_count', async () => {
+    const wrapper = makeTabStudy({ max_new_per_day: 10, card_count: 42 })
+    const allToggle = wrapper.find('[data-testid="tab-study__max-new-all"]')
+    await allToggle.find('input').setValue(true)
+    const spinbox = wrapper.find(
+      '[data-testid="tab-study__max-new-row"] [data-testid="ui-kit-spinbox"]'
+    )
+    expect(spinbox.attributes('data-value')).toBe('42')
+  })
+
+  test('toggling "all" on without card_count leaves spinbox value unchanged', async () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 50 })
+    const allToggle = wrapper.find('[data-testid="tab-study__max-reviews-all"]')
+    await allToggle.find('input').setValue(true)
+    const spinbox = wrapper.find(
+      '[data-testid="tab-study__max-reviews-row"] [data-testid="ui-kit-spinbox"]'
+    )
+    expect(spinbox.attributes('data-value')).toBe('50')
+  })
+
+  test('toggling reviews "all" off emits the last numeric local value', async () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 75 })
+    const allToggle = wrapper.find('[data-testid="tab-study__max-reviews-all"]')
+    await allToggle.find('input').setValue(true)
+    await allToggle.find('input').setValue(false)
+    const emitted = wrapper.emitted('update:max_reviews_per_day')
+    expect(emitted[emitted.length - 1]).toEqual([75])
+  })
+
+  test('decrementing from null state turns "all" off and emits a numeric value', async () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: null })
+    const dec = wrapper.find(
+      '[data-testid="tab-study__max-reviews-row"] [data-testid="ui-kit-spinbox__decrement"]'
+    )
+    await dec.trigger('click')
+    const emitted = wrapper.emitted('update:max_reviews_per_day')
+    const last = emitted[emitted.length - 1][0]
+    expect(typeof last).toBe('number')
+    expect(last).toBeLessThan(200)
+  })
+
+  test('external prop change to null updates the "all" toggle state', async () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 50 })
+    await wrapper.setProps({ max_reviews_per_day: null })
+    const allToggle = wrapper.find('[data-testid="tab-study__max-reviews-all"]')
+    expect(allToggle.attributes('data-checked')).toBe('true')
+  })
+
+  test('external prop change to a number updates the spinbox value', async () => {
+    const wrapper = makeTabStudy({ max_new_per_day: 10 })
+    await wrapper.setProps({ max_new_per_day: 80 })
+    const spinbox = wrapper.find(
+      '[data-testid="tab-study__max-new-row"] [data-testid="ui-kit-spinbox"]'
+    )
+    expect(spinbox.attributes('data-value')).toBe('80')
+  })
+
   test('the "all" toggles reflect null state via data-checked', () => {
     const wrapper = makeTabStudy({ max_reviews_per_day: null, max_new_per_day: 20 })
     const reviewsAll = wrapper.find('[data-testid="tab-study__max-reviews-all"]')

--- a/tests/integration/components/modals/deck-settings/tab-study.test.js
+++ b/tests/integration/components/modals/deck-settings/tab-study.test.js
@@ -3,8 +3,6 @@ import { mount } from '@vue/test-utils'
 import { defineComponent, h, useAttrs } from 'vue'
 import TabStudy from '@/components/modals/deck-settings/tab-study.vue'
 
-// Render-function stubs (no template strings — Chromium browser mode is
-// runtime-only Vue).
 const ToggleStub = defineComponent({
   name: 'UiToggle',
   props: { checked: { type: Boolean, default: false } },
@@ -15,7 +13,11 @@ const ToggleStub = defineComponent({
     return () =>
       h(
         'label',
-        { ...attrs, 'data-testid': 'ui-kit-toggle', 'data-checked': String(!!props.checked) },
+        {
+          'data-testid': 'ui-kit-toggle',
+          'data-checked': String(!!props.checked),
+          ...attrs
+        },
         [
           h('span', { 'data-testid': 'ui-kit-toggle__label' }, slots.default?.()),
           h('input', {
@@ -37,33 +39,77 @@ const IconStub = defineComponent({
   }
 })
 
+const SpinboxStub = defineComponent({
+  name: 'UiSpinbox',
+  props: {
+    value: { type: Number, required: true },
+    min: { type: Number, default: -Infinity },
+    max: { type: Number, default: Infinity },
+    step: { type: Number, default: 1 }
+  },
+  emits: ['update:value'],
+  inheritAttrs: false,
+  setup(props, { emit }) {
+    const attrs = useAttrs()
+    return () =>
+      h(
+        'div',
+        {
+          ...attrs,
+          'data-testid': 'ui-kit-spinbox',
+          'data-value': String(props.value),
+          'data-min': String(props.min),
+          'data-max': String(props.max),
+          'data-step': String(props.step)
+        },
+        [
+          h(
+            'button',
+            {
+              type: 'button',
+              'data-testid': 'ui-kit-spinbox__decrement',
+              onClick: () => emit('update:value', Math.max(props.min, props.value - props.step))
+            },
+            '-'
+          ),
+          h(
+            'button',
+            {
+              type: 'button',
+              'data-testid': 'ui-kit-spinbox__increment',
+              onClick: () => emit('update:value', Math.min(props.max, props.value + props.step))
+            },
+            '+'
+          )
+        ]
+      )
+  }
+})
+
 function makeTabStudy(props = {}) {
   return mount(TabStudy, {
     props,
     global: {
-      stubs: { UiToggle: ToggleStub, UiIcon: IconStub },
+      stubs: { UiToggle: ToggleStub, UiIcon: IconStub, UiSpinbox: SpinboxStub },
       mocks: { $t: (k) => k }
     }
   })
 }
 
 describe('TabStudy', () => {
-  test('renders all four toggles', () => {
+  test('renders four behavior toggles plus two "all" toggles', () => {
     const wrapper = makeTabStudy()
-    expect(wrapper.findAll('[data-testid="ui-kit-toggle"]')).toHaveLength(4)
+    expect(wrapper.findAllComponents(ToggleStub)).toHaveLength(6)
   })
 
-  test('renders 5 review-limit + 5 new-limit preset buttons', () => {
+  test('renders a spinbox for each daily limit', () => {
     const wrapper = makeTabStudy()
-    const buttons = wrapper.findAll('button')
-    // 5 + 5 = 10
-    expect(buttons).toHaveLength(10)
+    expect(wrapper.findAll('[data-testid="ui-kit-spinbox"]')).toHaveLength(2)
   })
 
   test('emits update:shuffle when shuffle toggle changes', async () => {
     const wrapper = makeTabStudy({ shuffle: false })
     const toggles = wrapper.findAllComponents(ToggleStub)
-    // Order: is_spaced, shuffle, flip_cards, auto_play
     await toggles[1].vm.$emit('update:checked', true)
     expect(wrapper.emitted('update:shuffle')).toEqual([[true]])
   })
@@ -89,47 +135,75 @@ describe('TabStudy', () => {
     expect(wrapper.emitted('update:auto_play')).toEqual([[true]])
   })
 
-  test('clicking a review-limit preset emits update:max_reviews_per_day with that value', async () => {
-    const wrapper = makeTabStudy({ max_reviews_per_day: 20 })
-    const buttons = wrapper.findAll('button')
-    // First 5 buttons = review-limit presets [20, 50, 100, 200, null]
-    await buttons[2].trigger('click')
-    expect(wrapper.emitted('update:max_reviews_per_day')).toEqual([[100]])
+  test('reviews spinbox is configured: step 5, min 5, max 200', () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 50 })
+    const spinbox = wrapper.find(
+      '[data-testid="tab-study__max-reviews-row"] [data-testid="ui-kit-spinbox"]'
+    )
+    expect(spinbox.attributes('data-step')).toBe('5')
+    expect(spinbox.attributes('data-min')).toBe('5')
+    expect(spinbox.attributes('data-max')).toBe('200')
+    expect(spinbox.attributes('data-value')).toBe('50')
   })
 
-  test('clicking the "all" review-limit preset emits null', async () => {
+  test('new spinbox is configured: step 5, min 5, max 100', () => {
+    const wrapper = makeTabStudy({ max_new_per_day: 10 })
+    const spinbox = wrapper.find(
+      '[data-testid="tab-study__max-new-row"] [data-testid="ui-kit-spinbox"]'
+    )
+    expect(spinbox.attributes('data-step')).toBe('5')
+    expect(spinbox.attributes('data-min')).toBe('5')
+    expect(spinbox.attributes('data-max')).toBe('100')
+    expect(spinbox.attributes('data-value')).toBe('10')
+  })
+
+  test('incrementing reviews spinbox emits update:max_reviews_per_day with stepped value', async () => {
     const wrapper = makeTabStudy({ max_reviews_per_day: 50 })
-    const buttons = wrapper.findAll('button')
-    await buttons[4].trigger('click')
+    await wrapper
+      .find('[data-testid="tab-study__max-reviews-row"] [data-testid="ui-kit-spinbox__increment"]')
+      .trigger('click')
+    expect(wrapper.emitted('update:max_reviews_per_day')).toEqual([[55]])
+  })
+
+  test('reaching reviews max emits null (switches to all)', async () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 195 })
+    await wrapper
+      .find('[data-testid="tab-study__max-reviews-row"] [data-testid="ui-kit-spinbox__increment"]')
+      .trigger('click')
+    const emitted = wrapper.emitted('update:max_reviews_per_day')
+    expect(emitted[emitted.length - 1]).toEqual([null])
+  })
+
+  test('reaching new-per-day max emits null (switches to all)', async () => {
+    const wrapper = makeTabStudy({ max_new_per_day: 95 })
+    await wrapper
+      .find('[data-testid="tab-study__max-new-row"] [data-testid="ui-kit-spinbox__increment"]')
+      .trigger('click')
+    const emitted = wrapper.emitted('update:max_new_per_day')
+    expect(emitted[emitted.length - 1]).toEqual([null])
+  })
+
+  test('toggling the reviews "all" toggle on emits null', async () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: 50 })
+    const allToggle = wrapper.find('[data-testid="tab-study__max-reviews-all"]')
+    await allToggle.find('input').setValue(true)
     expect(wrapper.emitted('update:max_reviews_per_day')).toEqual([[null]])
   })
 
-  test('clicking a new-limit preset emits update:max_new_per_day with that value', async () => {
-    const wrapper = makeTabStudy({ max_new_per_day: 5 })
-    const buttons = wrapper.findAll('button')
-    // Buttons 5–9 = new-limit presets [5, 10, 20, 50, null]
-    await buttons[6].trigger('click')
-    expect(wrapper.emitted('update:max_new_per_day')).toEqual([[10]])
+  test('toggling the new "all" toggle off restores a numeric value', async () => {
+    const wrapper = makeTabStudy({ max_new_per_day: null })
+    const allToggle = wrapper.find('[data-testid="tab-study__max-new-all"]')
+    await allToggle.find('input').setValue(false)
+    const emitted = wrapper.emitted('update:max_new_per_day')
+    expect(typeof emitted[0][0]).toBe('number')
+    expect(emitted[0][0]).toBeGreaterThan(0)
   })
 
-  test('clicking the "all" new-limit preset emits null', async () => {
-    const wrapper = makeTabStudy({ max_new_per_day: 10 })
-    const buttons = wrapper.findAll('button')
-    await buttons[9].trigger('click')
-    expect(wrapper.emitted('update:max_new_per_day')).toEqual([[null]])
-  })
-
-  test('marks the active review-limit preset via data-active', () => {
-    const wrapper = makeTabStudy({ max_reviews_per_day: 100 })
-    const presets = wrapper.findAll('[data-testid="tab-study__max-reviews-preset"]')
-    expect(presets[2].attributes('data-active')).toBe('true')
-    expect(presets[0].attributes('data-active')).toBe('false')
-  })
-
-  test('marks the active new-limit preset via data-active', () => {
-    const wrapper = makeTabStudy({ max_new_per_day: 20 })
-    const presets = wrapper.findAll('[data-testid="tab-study__max-new-preset"]')
-    expect(presets[2].attributes('data-active')).toBe('true')
-    expect(presets[0].attributes('data-active')).toBe('false')
+  test('the "all" toggles reflect null state via data-checked', () => {
+    const wrapper = makeTabStudy({ max_reviews_per_day: null, max_new_per_day: 20 })
+    const reviewsAll = wrapper.find('[data-testid="tab-study__max-reviews-all"]')
+    const newAll = wrapper.find('[data-testid="tab-study__max-new-all"]')
+    expect(reviewsAll.attributes('data-checked')).toBe('true')
+    expect(newAll.attributes('data-checked')).toBe('false')
   })
 })

--- a/tests/integration/components/ui-kit/spinbox.test.js
+++ b/tests/integration/components/ui-kit/spinbox.test.js
@@ -146,6 +146,135 @@ describe('UiSpinbox', () => {
     expect(findIncrement(wrapper).attributes('disabled')).toBeUndefined()
   })
 
+  // ── Typing ─────────────────────────────────────────────────────────────────
+
+  test('typing a number updates value via input event', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    input.element.value = '42'
+    await input.trigger('input')
+    expect(wrapper.emitted('update:value')).toEqual([[42]])
+  })
+
+  test('typing a value above max clamps via input event', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    input.element.value = '999'
+    await input.trigger('input')
+    expect(wrapper.emitted('update:value')).toEqual([[100]])
+  })
+
+  test('clearing the input does not emit update:value', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    input.element.value = ''
+    await input.trigger('input')
+    expect(wrapper.emitted('update:value')).toBeUndefined()
+  })
+
+  test('blur on empty input restores the current value', async () => {
+    const wrapper = mountSpinbox({ value: 7, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    input.element.value = ''
+    await input.trigger('blur')
+    expect(input.element.value).toBe('7')
+    expect(wrapper.emitted('update:value')).toBeUndefined()
+  })
+
+  test('blur clamps a typed below-min value to min', async () => {
+    const wrapper = mountSpinbox({ value: 50, min: 5, max: 100 })
+    const input = findInput(wrapper)
+    input.element.value = '1'
+    await input.trigger('input')
+    await input.trigger('blur')
+    const emitted = wrapper.emitted('update:value')
+    expect(emitted[emitted.length - 1]).toEqual([5])
+    expect(input.element.value).toBe('5')
+  })
+
+  test('focus selects all text in the input', async () => {
+    const wrapper = mountSpinbox({ value: 42 })
+    const input = findInput(wrapper)
+    input.element.focus()
+    await input.trigger('focus')
+    expect(input.element.selectionStart).toBe(0)
+    expect(input.element.selectionEnd).toBe(String(input.element.value).length)
+  })
+
+  // ── Input mask (beforeinput) ───────────────────────────────────────────────
+
+  test('blocks "." via beforeinput', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    const event = new InputEvent('beforeinput', { data: '.', cancelable: true })
+    input.element.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('blocks "e" via beforeinput', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    const event = new InputEvent('beforeinput', { data: 'e', cancelable: true })
+    input.element.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('blocks "+" via beforeinput', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    const event = new InputEvent('beforeinput', { data: '+', cancelable: true })
+    input.element.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('blocks "-" when min is non-negative', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 0, max: 100 })
+    const input = findInput(wrapper)
+    const event = new InputEvent('beforeinput', { data: '-', cancelable: true })
+    input.element.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('allows "-" when min is negative', async () => {
+    const wrapper = mountSpinbox({ value: 0, min: -10, max: 10 })
+    const input = findInput(wrapper)
+    const event = new InputEvent('beforeinput', { data: '-', cancelable: true })
+    input.element.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  test('allows digits via beforeinput', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    const event = new InputEvent('beforeinput', { data: '7', cancelable: true })
+    input.element.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  test('blocks pasted strings containing non-digits', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    const event = new InputEvent('beforeinput', { data: '12.5', cancelable: true })
+    input.element.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('beforeinput with null data (e.g. backspace) is allowed', async () => {
+    const wrapper = mountSpinbox({ value: 5, min: 1, max: 100 })
+    const input = findInput(wrapper)
+    const event = new InputEvent('beforeinput', { data: null, cancelable: true })
+    input.element.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  // ── Container is not a label (regression) ──────────────────────────────────
+
+  test('container is a div, not a label, so clicks do not bubble to decrement', () => {
+    const wrapper = mountSpinbox({ value: 5 })
+    const container = wrapper.find('[data-testid="ui-kit-spinbox-container"]')
+    expect(container.element.tagName).toBe('DIV')
+  })
+
   // ── Defaults ──────────────────────────────────────────────────────────────
 
   test('with no min/max, both buttons are enabled by default', () => {

--- a/tests/integration/components/ui-kit/spinbox.test.js
+++ b/tests/integration/components/ui-kit/spinbox.test.js
@@ -10,6 +10,14 @@ function findValue(wrapper) {
   return wrapper.find('[data-testid="ui-kit-spinbox__value"]')
 }
 
+function findInput(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-spinbox__input"]')
+}
+
+function findSuffix(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-spinbox__suffix"]')
+}
+
 function findDecrement(wrapper) {
   return wrapper.find('[data-testid="ui-kit-spinbox__decrement"]')
 }
@@ -46,20 +54,20 @@ describe('UiSpinbox', () => {
 
   // ── Value display ──────────────────────────────────────────────────────────
 
-  test('shows the current value', () => {
+  test('shows the current value in the input', () => {
     const wrapper = mountSpinbox({ value: 7 })
-    expect(findValue(wrapper).text()).toContain('7')
+    expect(findInput(wrapper).element.value).toBe('7')
   })
 
   test('appends suffix when suffix prop is set', () => {
     const wrapper = mountSpinbox({ value: 30, suffix: 'px' })
-    expect(findValue(wrapper).text()).toContain('30')
-    expect(findValue(wrapper).text()).toContain('px')
+    expect(findInput(wrapper).element.value).toBe('30')
+    expect(findSuffix(wrapper).text()).toBe('px')
   })
 
   test('does not render suffix span when suffix is omitted', () => {
     const wrapper = mountSpinbox({ value: 30 })
-    expect(findValue(wrapper).text().trim()).toBe('30')
+    expect(findSuffix(wrapper).exists()).toBe(false)
   })
 
   // ── Increment / decrement (v-model) ────────────────────────────────────────
@@ -116,6 +124,26 @@ describe('UiSpinbox', () => {
     const wrapper = mountSpinbox({ value: 8, max: 10, step: 10 })
     await findIncrement(wrapper).trigger('click')
     expect(wrapper.emitted('update:value')).toEqual([[10]])
+  })
+
+  // ── Wrap ───────────────────────────────────────────────────────────────────
+
+  test('decrement at min wraps to max when wrap is enabled', async () => {
+    const wrapper = mountSpinbox({ value: 1, min: 1, max: 10, wrap: true })
+    await findDecrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[10]])
+  })
+
+  test('increment at max wraps to min when wrap is enabled', async () => {
+    const wrapper = mountSpinbox({ value: 10, min: 1, max: 10, wrap: true })
+    await findIncrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[1]])
+  })
+
+  test('wrap keeps both buttons enabled at the bounds', () => {
+    const wrapper = mountSpinbox({ value: 1, min: 1, max: 10, wrap: true })
+    expect(findDecrement(wrapper).attributes('disabled')).toBeUndefined()
+    expect(findIncrement(wrapper).attributes('disabled')).toBeUndefined()
   })
 
   // ── Defaults ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace 5-button daily-limit presets in deck settings with `ui-kit/spinbox` (step 5, min 5, max 200 reviews / 100 new) plus a `ui-kit/toggle` for "all". Reaching the spinbox max flips the parent model to `null`; toggling "all" on pre-fills the spinbox with the deck's `card_count`.
- Spinbox upgrades: editable text input (masked to digits, "-" only when `min<0`); focus selects all; blur clamps invalid; click sfx; `wrap` prop cycles at min/max with bounds-stay-enabled. Outer `<label>` → `<div>` to fix click-bubbling that fired the decrement button when clicking the value area.
- Drop a redundant `themeDark` bullet from `theming.md`.