### PR TITLE
docs(rules): revise theming, condense code-style, add css rule

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,46 +1,30 @@
 ---
-lastUpdated: 2026-04-25T00:00:00Z
-paths:
-  - 'src/**/*.{ts,vue}'
-  - 'tests/**/*.{ts,js}'
-  - 'supabase/**/*.{ts,sql}'
+lastUpdated: 2026-05-06T00:00:00Z
 ---
 
 # Code Style
 
-## Blank lines between logical blocks inside functions
+## Group function bodies into visual phases
 
-Group statements that work together, then separate distinct phases with a single blank line. A function body that runs setup → core work → cleanup should read as three visual chunks, not one wall of text.
+A function should read as setup → core work → wrap-up, not a wall of text. Put a single blank line between phases; keep tight clusters tight.
+
+**Insert a blank line:**
+
+- Between declarations and their first use.
+- Around early returns / guard clauses.
+- Between distinct phases (validate → resolve → mutate → emit).
+- Before a new conceptual unit, even a one-liner (emit, side-effect).
+
+**Don't insert one:**
+
+- Inside a tight cluster of related declarations.
+- Between consecutive assignments on the same object.
+- Inside a 2–3 line `if` / `for` body.
+- Between every line.
+
+Rule of thumb: if you can name a chunk in one phrase, it's a group — separate the next phrase. If you can't name it, the chunk is too small or the function is doing too much.
 
 ```ts
-// Bad — every step blends into the next
-function addCard(left_card_id?: number, right_card_id?: number) {
-  let anchor_id: number | null = null
-  let side: 'before' | 'after' | null = null
-  if (left_card_id !== undefined) {
-    anchor_id = left_card_id
-    side = 'after'
-  } else if (right_card_id !== undefined) {
-    anchor_id = right_card_id
-    side = 'before'
-  }
-  const new_card: Card = {
-    id: tempPlaceholderId(),
-    rank: 0,
-    deck_id: deck_id.value,
-    front_text: '',
-    back_text: ''
-  }
-  temp_entries.value.push({
-    client_id: uid(),
-    card: new_card,
-    anchor_id,
-    side,
-    real_id: null
-  })
-}
-
-// Good — three phases, visually separated
 function addCard(left_card_id?: number, right_card_id?: number) {
   let anchor_id: number | null = null
   let side: 'before' | 'after' | null = null
@@ -61,62 +45,15 @@ function addCard(left_card_id?: number, right_card_id?: number) {
     back_text: ''
   }
 
-  temp_entries.value.push({
-    client_id: uid(),
-    card: new_card,
-    anchor_id,
-    side,
-    real_id: null
-  })
+  temp_entries.value.push({ client_id: uid(), card: new_card, anchor_id, side, real_id: null })
 }
 ```
 
-## Where blank lines belong
+## At most one level of nesting
 
-- Between **declaration block** and **first use** of those declarations.
-- Around an **early return / guard clause** when the rest of the function is doing different work.
-- Between **distinct phases**: validation → resolution → mutation → emit.
-- Before a **new conceptual unit** even if it's only one line (e.g. an emit or a side-effect that wraps up the function).
-
-## Where they don't
-
-- Inside a tight cluster of variable declarations that name parts of the same thing.
-- Between consecutive assignments on a single object being built up.
-- Inside an `if` / `for` body that only has 2–3 lines.
-- Between every line — that's noise, not grouping.
-
-## Rule of thumb
-
-If you can summarise a chunk of lines with a single phrase ("resolve the anchor", "build the temp card", "stage it"), it's a group. Put a blank line before the next phrase. If you can't summarise it, the chunk is too small or the function is doing too much — fix that, not the whitespace.
-
-## Keep nesting at most one level deep
-
-Function bodies should not nest more than one level of `if` / `for` / `try`. When the path forks, **invert the condition and return early** instead of pushing the main path inside an `if`. Every extra indent makes the happy path harder to see.
+Don't nest more than one `if` / `for` / `try`. When a path forks, invert the condition and return early instead of pushing the main path inside an `if`.
 
 ```ts
-// Bad — happy path is buried two levels deep
-async function save(id: number, values: Partial<Card>) {
-  const entry = list.findEntryByCardId(id)
-  if (entry && entry.real_id === null) {
-    saving.value = true
-    try {
-      const inserted = await insertCard({ ... })
-      list.promoteTemp(id, inserted.id, inserted.rank, values)
-    } finally {
-      saving.value = false
-    }
-    return
-  }
-  const card = entry?.card ?? list.findCard(id)
-  if (!card) return
-  saving.value = true
-  try {
-    await saveCard(card, values)
-  } finally {
-    saving.value = false
-  }
-}
-
 // Good — orchestrator routes; each branch is its own one-job function
 async function save(id: number, values: Partial<Card>) {
   const entry = list.findEntryByCardId(id)
@@ -132,9 +69,9 @@ async function save(id: number, values: Partial<Card>) {
 
 ## One responsibility per function
 
-Each function either **orchestrates other functions** or **performs one concrete piece of work** — not both. Mixing the two is what produces the deep-nested wall above.
+A function either orchestrates other functions or performs one concrete piece of work — never both.
 
-- Orchestrator: routes, sequences, handles errors. Body is mostly other function calls.
-- Worker: does the thing (network call, DOM mutation, payload build). Body has the actual logic.
+- **Orchestrator**: routes, sequences, handles errors. Body is mostly calls.
+- **Worker**: does the thing (network, DOM, payload). Body has the logic.
 
-Signal you've crossed the line: a function that calls a helper _and_ contains a `try/finally` _and_ builds an object literal inline. Pull each chunk into its own function and let the parent orchestrate.
+Signal you've crossed the line: a function that calls a helper _and_ wraps a `try/finally` _and_ builds an object literal inline. Split it.

--- a/.claude/rules/css.md
+++ b/.claude/rules/css.md
@@ -1,0 +1,20 @@
+---
+lastUpdated: 2026-05-06T00:00:00Z
+paths:
+  - 'src/**/*.vue'
+---
+
+# CSS in Vue files
+
+**Default to Tailwind utility classes in the template.** Don't open a `<style>` block unless one of these conditions clearly applies:
+
+- **Extremely large class blocks** — the inline list is so long it hurts readability and structure.
+- **Duplicated classes across multiple elements** — the same set repeats on siblings or across the file.
+- **Complex state management** — selectors like `:hover`/`:focus`/`:disabled` chains, sibling/descendant selectors, pseudo-elements, or animations that don't map cleanly to utility variants.
+
+When you do reach for a `<style>` block:
+
+- Write plain CSS with `var(--theme-*)` / `var(--color-*)` tokens — never `@apply` (see `no-apply` rule).
+- Keep the rule scoped to the component; don't leak global selectors.
+
+If none of the conditions apply, keep it inline — even when the class list looks long, utilities beat a one-off style block.

--- a/.claude/rules/theming.md
+++ b/.claude/rules/theming.md
@@ -1,5 +1,5 @@
 ---
-lastUpdated: 2026-04-17T01:31:17Z
+lastUpdated: 2026-05-06T00:00:00Z
 paths:
   - 'src/**/*.{vue,css}'
 ---
@@ -10,38 +10,44 @@ Colors are applied via the `data-theme` attribute, which scopes a set of semanti
 
 ## How it works
 
-1. A `theme` prop accepts a `MemberTheme` value (e.g. `'blue-500'`, `'green-400'`).
-2. That value is bound to `data-theme` on the root element of the component.
-3. `palettes.css` maps each theme value to a set of `--theme-*` variables using a comma selector that covers two activation conditions:
+1. Parents apply theming by setting `data-theme` (and optionally `data-theme-dark`) directly on the element or component — the value is a `MemberTheme` (e.g. `'blue-500'`, `'green-400'`).
+2. On a component, those attributes flow through to its root element via Vue's normal attribute inheritance. Components do **not** declare a `theme` / `themeDark` prop; they just let the attrs forward.
+3. `palettes.css` maps each theme value to a set of `--theme-*` variables using a comma selector covering two activation conditions:
    - `[data-theme='X']` — `(0,1,0)` always active (light or dark mode)
    - `[data-theme='dark'] [data-theme-dark='X']` — `(0,2,0)` active when the root is dark
-     Because each selector in a comma list carries its own specificity (unlike `:is()`, which elevates all arms to the highest), the descendant form genuinely beats the plain form in dark mode.
+     Each selector in a comma list keeps its own specificity (unlike `:is()`, which elevates all arms to the highest), so the descendant form genuinely beats the plain form in dark mode.
 4. Available tokens: `--theme-primary` / `--theme-on-primary`, `--theme-secondary` / `--theme-on-secondary`, `--theme-accent` / `--theme-on-accent`, `--theme-neutral` / `--theme-on-neutral`.
 5. Child elements reference those variables via Tailwind's arbitrary-property syntax or plain CSS.
 
 > **Dark mode root**: `use-theme` always writes an explicit `'light'` or `'dark'` to `data-theme` on `document.documentElement` — even when the user's preference is `'system'`. CSS never needs a `prefers-color-scheme` media-query fallback.
 
-## In a component
+## At a call site
+
+Pass `data-theme` (and `data-theme-dark` if needed) directly on the child element or component:
 
 ```vue
-<script setup lang="ts">
-type MyComponentProps = {
-  theme?: MemberTheme
-  themeDark?: MemberTheme
-}
-
-const { theme = 'blue-500', themeDark } = defineProps<MyComponentProps>()
-</script>
-
 <template>
-  <div :data-theme="theme" :data-theme-dark="themeDark ?? theme">
-    <!-- consume the scoped tokens anywhere inside -->
+  <ui-button data-theme="blue-500" data-theme-dark="blue-300">Save</ui-button>
+
+  <div data-theme="green-400">
     <div class="bg-(--theme-primary) text-(--theme-on-primary)">...</div>
   </div>
 </template>
 ```
 
-When `themeDark` is omitted it falls back to `theme`, so the element remains correctly styled in dark mode even without an explicit override. Only bind `data-theme-dark` on elements that already bind `data-theme`.
+If `data-theme-dark` is omitted, the same `data-theme` value applies in dark mode.
+
+## Inside a themed component
+
+Don't declare `theme` / `themeDark` props. With default `inheritAttrs`, `data-theme` and `data-theme-dark` from the call site flow onto the component's root automatically. Consume the scoped tokens anywhere inside:
+
+```vue
+<template>
+  <div class="bg-(--theme-primary) text-(--theme-on-primary)">...</div>
+</template>
+```
+
+If the component uses `defineOptions({ inheritAttrs: false })`, forward the attrs explicitly onto the root that should carry the theme.
 
 ## In CSS / `<style>`
 
@@ -76,12 +82,11 @@ To make the texture color follow the active theme token, pass the token through 
 <div class="bgx-diagonal-stripes bgx-color-[var(--theme-on-neutral)]" />
 ```
 
-Never hardcode a raw color (hex or palette class) in `bgx-color-*` when the element lives inside a themed scope — always use `var(--theme-*)`.
-
 ## Rules
 
-- **Always** type theme props as `MemberTheme` (defined in `types/member.d.ts`), not `string`.
-- Bind `data-theme` on the outermost element that needs theming so descendents inherit it.
+- **Always** write styles using tailwind classes, only opting for a style block when styling becomes complex or oversized for inline classes.
+- Set `data-theme` (and `data-theme-dark` when needed) on the outermost element or component that should carry the theme — descendants inherit the tokens.
+- Don't add `theme` / `themeDark` props to components — let `data-theme` / `data-theme-dark` forward via `inheritAttrs`.
 - Use `--theme-*` tokens for any color that should vary with the theme; use `--color-*` tokens only for colors that are fixed regardless of theme.
 - Never use `@apply` — write plain CSS with `var(--theme-*)` directly (see `no-apply` rule).
 - Do not use raw hex values or hardcoded Tailwind color classes (e.g. `bg-blue-500`) for themeable colors.


### PR DESCRIPTION
## Summary

- **theming.md**: drop the deprecated \`theme\` / \`themeDark\` prop pattern. Components now rely on \`data-theme\` / \`data-theme-dark\` set at the call site flowing through via \`inheritAttrs\`. Updates How-it-works, examples, and the rules list.
- **code-style.md**: trim ~45% without dropping guidance. Kept always-on (no \`paths\`) intentionally — the rule was getting missed when scoped narrowly.
- **css.md** (new): default to Tailwind utilities in the template; open a \`<style>\` block only for extremely large class lists, duplication across multiple elements, or complex state that doesn't map to utility variants. Plain CSS with theme tokens when justified — no \`@apply\`.