### PR TITLE
docs(rules): add i18n rule

### DIFF
--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -1,0 +1,36 @@
+---
+lastUpdated: 2026-05-06T00:00:00Z
+paths:
+  - 'src/**/*.{vue,ts}'
+  - 'src/locales/*.json'
+---
+
+# i18n
+
+All user-facing strings go through `useI18n()` / `$t()`. Never hardcode display text in templates, prop values (`title`, `placeholder`, `label`, `alt`, etc.), or strings passed to `toast.*` / `alert.*` / modal `title`/`message`. Strings live in `src/locales/en-us.json`.
+
+## Key naming
+
+Each key encodes **where** the string lives and **what role** it plays. A translator should know from the key alone whether it's a button, heading, placeholder, label, error, or list item — without opening the source.
+
+```
+<feature>.<component-or-section>.<role>
+```
+
+- Suffix the role: `-button`, `-label`, `-placeholder`, `-heading`, `-fallback`, `-error`, `-confirm`, `-cta`.
+- Pair sibling keys: `alert.delete-card.title` + `alert.delete-card.message` + `alert.delete-card.confirm`.
+- Group score-tier / state-driven copy under the state, not the value: `reward-stack.tier-100.heading`, not `reward-stack.perfect-score`.
+
+## No shared keys across unrelated callsites
+
+Every callsite gets its own key. If the same English value shows up in two places, give each its own key — the value can stay identical today, but the keys let translators (and future copy changes) diverge cleanly.
+
+Reuse is OK only when it's structurally the same string: a `v-for` loop, a single component rendered twice, or the same fallback used by a dynamic key (`t(\`x.\${state}\`)`).
+
+**No `common.*` namespace.** Reaching for `common.cancel` / `common.save` strips the surrounding context. Use `move-cards-modal.cancel`, `deck.settings-modal.submit-edit`, etc.
+
+## Adding a string
+
+1. Add the key to `src/locales/en-us.json` next to its sibling keys (alphabetical-ish within the namespace).
+2. Reference via `t('...')` (script) or `{{ t('...') }}` / `:placeholder="t('...')"` (template).
+3. Don't introduce new top-level namespaces casually — fit the string into an existing feature namespace when possible.


### PR DESCRIPTION
## Summary
Adds \`.claude/rules/i18n.md\` capturing the conventions enforced by the four-PR translation audit (#180–#183):
- All user-facing strings go through \`t()\` / \`\$t()\`
- Key naming encodes location + role (\`-button\`, \`-label\`, \`-placeholder\`, …)
- No shared keys across unrelated callsites; no \`common.*\` namespace
- Add new keys next to sibling keys in \`src/locales/en-us.json\`