### PR TITLE
feat(deploy): auto-tag + release on manual prod deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,12 @@ on:
         description: Skip the E2E smoke gate (emergency hotfix only)
         type: boolean
         default: false
+      bump:
+        description: Semver bump for manual production deploys (required when environment=production)
+        required: false
+        type: choice
+        default: ''
+        options: ['', patch, minor, major]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -279,3 +285,65 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ vars.NETLIFY_SITE_ID }}
+
+  tag-release:
+    name: Tag + release (manual prod)
+    needs: [migrate, functions, config, frontend]
+    if: |
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.environment == 'production' &&
+      needs.migrate.result != 'failure' &&
+      needs.functions.result != 'failure' &&
+      needs.config.result != 'failure' &&
+      needs.frontend.result != 'failure' &&
+      (needs.migrate.result == 'success' || needs.functions.result == 'success' || needs.config.result == 'success' || needs.frontend.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Validate bump input
+        run: |
+          if [ -z "${{ inputs.bump }}" ]; then
+            echo "::error::'bump' input is required for manual production deploys (patch | minor | major)"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute next version
+        id: ver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          LATEST=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
+          if [ -z "$LATEST" ]; then
+            LATEST="v0.0.0"
+          fi
+          STRIPPED="${LATEST#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$STRIPPED"
+          case "$BUMP" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+            *) echo "::error::invalid bump '$BUMP'"; exit 1 ;;
+          esac
+          NEXT="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Bumping $LATEST -> $NEXT ($BUMP)"
+
+      - name: Create tag + release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT: ${{ steps.ver.outputs.next }}
+        run: |
+          set -euo pipefail
+          gh release create "$NEXT" \
+            --target "${{ github.sha }}" \
+            --title "$NEXT" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- New `bump` choice input (`patch|minor|major`) on `deploy.yml` `workflow_dispatch`.
- New `tag-release` job: on manual prod runs only, after deploy jobs succeed, computes next semver from latest GitHub release and runs `gh release create $NEXT --target $SHA --generate-notes`.
- Skipped when no deploy job ran or any failed; tag-triggered prod deploys unaffected.