### PR TITLE
feat(deck-settings): tablet layout polish

### DIFF
--- a/src/components/layout-kit/modal/mobile-sheet.vue
+++ b/src/components/layout-kit/modal/mobile-sheet.vue
@@ -67,7 +67,7 @@ provide(mobileSheetOverlayKey, overlay_root)
           <div
             data-testid="mobile-sheet__header"
             v-bind="header_bindings"
-            class="w-full flex justify-center items-center place-items-center px-8 pt-11.5 pb-14 gap-6 wave-bottom-[50px] bg-(--theme-primary) text-(--theme-on-primary) relative"
+            class="w-full flex justify-center items-center place-items-center px-18 lg:px-8 pt-11.5 pb-14 gap-6 wave-bottom-[50px] bg-(--theme-primary) text-(--theme-on-primary) relative"
           >
             <div v-if="show_close_button" class="absolute top-0 left-0 p-4">
               <ui-button icon-left="close" icon-only inverted @click="emit('close')" />

--- a/src/components/layout-kit/modal/mobile-sheet.vue
+++ b/src/components/layout-kit/modal/mobile-sheet.vue
@@ -44,7 +44,10 @@ provide(mobileSheetOverlayKey, overlay_root)
 </script>
 
 <template>
-  <div data-testid="mobile-sheet-root" class="relative w-full shrink-0 mobile-modal:mt-auto">
+  <div
+    data-testid="mobile-sheet-root"
+    class="relative w-full shrink-0 mobile-modal:mt-auto [--sheet-px:4.5rem] lg:[--sheet-px:2rem]"
+  >
     <div
       ref="overlay_root"
       data-testid="mobile-sheet__overlay"
@@ -67,7 +70,7 @@ provide(mobileSheetOverlayKey, overlay_root)
           <div
             data-testid="mobile-sheet__header"
             v-bind="header_bindings"
-            class="w-full flex justify-center items-center place-items-center px-18 lg:px-8 pt-11.5 pb-14 gap-6 wave-bottom-[50px] bg-(--theme-primary) text-(--theme-on-primary) relative"
+            class="w-full flex justify-center items-center place-items-center px-(--sheet-px) pt-11.5 pb-14 gap-6 wave-bottom-[50px] bg-(--theme-primary) text-(--theme-on-primary) relative"
           >
             <div v-if="show_close_button" class="absolute top-0 left-0 p-4">
               <ui-button icon-left="close" icon-only inverted @click="emit('close')" />

--- a/src/components/layout-kit/modal/tab-sheet.vue
+++ b/src/components/layout-kit/modal/tab-sheet.vue
@@ -3,7 +3,7 @@ import { computed, provide } from 'vue'
 import mobileSheet, { type MobileSheetProps } from './mobile-sheet.vue'
 import { activeTabKey } from './tab-sheet-context'
 import { useShortcuts } from '@/composables/use-shortcuts'
-import { useMobileBreakpoint } from '@/composables/use-media-query'
+import { useIsTablet } from '@/composables/use-media-query'
 import { emitSfx } from '@/sfx/bus'
 import type { NamespacedAudioKey } from '@/sfx/config'
 import uid from '@/utils/uid'
@@ -57,8 +57,8 @@ if (!active.value) active.value = tabs?.[0]?.value ?? ''
 provide(activeTabKey, active)
 
 const has_tabs = computed(() => !!tabs?.length)
-const below_lg = useMobileBreakpoint('lg', 'lg')
-const sheet_close_button = computed(() => (!has_tabs.value || below_lg.value) && show_close_button)
+const is_tablet = useIsTablet()
+const sheet_close_button = computed(() => (!has_tabs.value || is_tablet.value) && show_close_button)
 
 const tab_panel_id = 'tab-sheet__panel'
 const tab_id_prefix = `tab-sheet__tab--${uid()}--`
@@ -117,7 +117,7 @@ shortcuts.register([
       <div
         data-testid="tab-sheet__sidebar"
         :class="[
-          'hidden lg:flex flex-col gap-10 bg-brown-200 dark:bg-grey-900 p-4.5 shrink-0',
+          'hidden lg:pointer-fine:flex flex-col gap-10 bg-brown-200 dark:bg-grey-900 p-4.5 shrink-0',
           parts?.sidebar
         ]"
       >
@@ -164,7 +164,7 @@ shortcuts.register([
       :id="tab_panel_id"
       data-testid="tab-sheet__content"
       role="tabpanel"
-      :class="['p-8 pt-0', parts?.content]"
+      :class="['px-18 lg:px-8 pb-8 pt-0', parts?.content]"
     >
       <slot></slot>
     </div>

--- a/src/components/layout-kit/modal/tab-sheet.vue
+++ b/src/components/layout-kit/modal/tab-sheet.vue
@@ -105,7 +105,12 @@ shortcuts.register([
 </script>
 
 <template>
-  <mobile-sheet :title="title" :cover_config="cover_config" :show_close_button="sheet_close_button">
+  <mobile-sheet
+    :title="title"
+    :cover_config="cover_config"
+    :show_close_button="sheet_close_button"
+    @close="emit('close')"
+  >
     <template v-if="$slots.overlay" #overlay><slot name="overlay"></slot></template>
     <template v-if="$slots.header" #header><slot name="header"></slot></template>
     <template v-if="$slots['header-content']" #header-content>
@@ -164,7 +169,7 @@ shortcuts.register([
       :id="tab_panel_id"
       data-testid="tab-sheet__content"
       role="tabpanel"
-      :class="['px-18 lg:px-8 pb-8 pt-0', parts?.content]"
+      :class="['px-(--sheet-px) pb-8 pt-0', parts?.content]"
     >
       <slot></slot>
     </div>

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -91,10 +91,10 @@ function onBack() {
     data-testid="deck-settings-container"
     data-theme="green-500"
     data-theme-dark="green-800"
-    class="w-auto! lg:pointer-fine:w-245! md:h-167"
+    class="w-full! max-w-205.5 lg:pointer-fine:max-w-none lg:pointer-fine:w-245! h-167"
     :tabs="tabs"
     :cover_config="{ pattern: 'endless-clouds' }"
-    :parts="{ content: 'flex gap-6 h-full items-start' }"
+    :parts="{ content: 'flex gap-14 h-full items-start' }"
     hover_sfx="ui.click_07"
     v-model:active="sidebar_active"
     @close="close(false)"
@@ -112,7 +112,7 @@ function onBack() {
 
     <div
       data-testid="deck-settings__main"
-      class="relative flex flex-1 flex-col gap-4 md:w-85 lg:pointer-fine:w-auto min-w-0"
+      class="relative flex flex-1 flex-col gap-4 w-full min-w-0"
     >
       <tab-index v-if="displayed_tab === 'index'" @navigate="active_tab = $event" />
       <tab-design v-else-if="displayed_tab === 'design'" />
@@ -139,7 +139,7 @@ function onBack() {
           :aria-label="t('deck.settings-modal.back-button')"
           data-theme="yellow-500"
           data-theme-dark="yellow-700"
-          class="pointer-events-auto absolute! left-4 top-29 drop-shadow-xs"
+          class="pointer-events-auto absolute! left-(--sheet-px) top-29 drop-shadow-xs"
           @click="onBack"
         >
           <ui-icon src="arrow-back" class="w-4 h-4" />
@@ -147,7 +147,7 @@ function onBack() {
         </ui-tag-button>
       </transition>
 
-      <div class="pointer-events-auto absolute right-6 top-6">
+      <div class="pointer-events-auto absolute right-(--sheet-px) top-6">
         <div class="relative">
           <card
             size="xl"

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -16,7 +16,7 @@ import {
   deckDangerActionsKey
 } from '@/composables/deck/use-deck-danger-actions'
 import { useSessionRef } from '@/composables/use-session-ref'
-import { useMobileBreakpoint } from '@/composables/use-media-query'
+import { useIsTablet } from '@/composables/use-media-query'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import UiTagButton from '@/components/ui-kit/tag-button.vue'
@@ -48,13 +48,13 @@ const tabs = computed(() => [
 type ActiveTab = 'general' | 'design' | 'study' | 'danger-zone'
 const active_tab = useSessionRef<ActiveTab | null>('deck-settings.active-tab', null)
 
-const below_lg = useMobileBreakpoint('lg', 'lg')
+const is_tablet = useIsTablet()
 
-watch(below_lg, (is_below) => {
+watch(is_tablet, (is_below) => {
   if (is_below && active_tab.value === 'danger-zone') active_tab.value = null
 })
 
-const displayed_tab = computed(() => active_tab.value ?? (below_lg.value ? 'index' : 'general'))
+const displayed_tab = computed(() => active_tab.value ?? (is_tablet.value ? 'index' : 'general'))
 
 const sidebar_active = computed({
   get: () => active_tab.value ?? 'general',
@@ -91,7 +91,7 @@ function onBack() {
     data-testid="deck-settings-container"
     data-theme="green-500"
     data-theme-dark="green-800"
-    class="w-auto! lg:w-245! md:h-167"
+    class="w-auto! lg:pointer-fine:w-245! md:h-167"
     :tabs="tabs"
     :cover_config="{ pattern: 'endless-clouds' }"
     :parts="{ content: 'flex gap-6 h-full items-start' }"
@@ -112,7 +112,7 @@ function onBack() {
 
     <div
       data-testid="deck-settings__main"
-      class="relative flex flex-1 flex-col gap-4 md:w-85 lg:w-auto min-w-0"
+      class="relative flex flex-1 flex-col gap-4 md:w-85 lg:pointer-fine:w-auto min-w-0"
     >
       <tab-index v-if="displayed_tab === 'index'" @navigate="active_tab = $event" />
       <tab-design v-else-if="displayed_tab === 'design'" />
@@ -134,7 +134,7 @@ function onBack() {
         @leave="(el, done) => slideFadeRightLeave(el, done)"
       >
         <ui-tag-button
-          v-if="below_lg && active_tab !== null"
+          v-if="is_tablet && active_tab !== null"
           data-testid="deck-settings__back-button"
           :aria-label="t('deck.settings-modal.back-button')"
           data-theme="yellow-500"

--- a/src/composables/modals/use-deck-settings-modal.ts
+++ b/src/composables/modals/use-deck-settings-modal.ts
@@ -15,6 +15,8 @@ export function useDeckSettingsModal() {
     const result = modal.open<DeckSettingsResponse>(DeckSettings, {
       backdrop: true,
       mode: 'mobile-sheet',
+      mobile_below_width: 'md',
+      mobile_below_height: 'lg',
       props: { deck }
     })
     result.response.then(() => emitSfx('ui.pop_up_close'))

--- a/src/composables/use-media-query.ts
+++ b/src/composables/use-media-query.ts
@@ -77,3 +77,15 @@ export function useMobileBreakpoint(
 
   return computed(() => below_width.value || below_height.value)
 }
+
+/**
+ * Reactive boolean — true when the viewport sits below the `lg` breakpoint
+ * (width or height) OR the primary pointer is coarse (touch). The pointer
+ * check lets a large touch screen (e.g. an iPad in landscape) opt into the
+ * tablet layout even when its viewport would otherwise read as desktop.
+ */
+export function useIsTablet() {
+  const below_lg = useMobileBreakpoint('lg', 'lg')
+  const coarse = useMediaQuery('coarse')
+  return computed(() => below_lg.value || coarse.value)
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -157,7 +157,7 @@
 
   /* Breakpoints */
   --breakpoint-sm: 40rem;
-  --breakpoint-md: 48rem;
+  --breakpoint-md: 52rem;
   --breakpoint-lg: 64rem;
   --breakpoint-xl: 80rem;
   --breakpoint-2xl: 96rem;

--- a/src/styles/mobile-modal-variant.css
+++ b/src/styles/mobile-modal-variant.css
@@ -19,8 +19,8 @@
       @slot;
     }
   }
-  /* width < md (48rem): thresholds md/lg/xl/2xl go mobile */
-  @media (width < 48rem) {
+  /* width < md (52rem): thresholds md/lg/xl/2xl go mobile */
+  @media (width < 52rem) {
     &:where(
       [data-mobile-below-width='md'],
       [data-mobile-below-width='md'] *,
@@ -71,7 +71,7 @@
       @slot;
     }
   }
-  @media (height < 48rem) {
+  @media (height < 52rem) {
     &:where(
       [data-mobile-below-height='md'],
       [data-mobile-below-height='md'] *,

--- a/tests/integration/components/layout-kit/modal/tab-sheet.test.js
+++ b/tests/integration/components/layout-kit/modal/tab-sheet.test.js
@@ -210,6 +210,13 @@ describe('TabSheet', () => {
     expect(wrapper.emitted('close')).toBeTruthy()
   })
 
+  test('re-emits close when the underlying mobile-sheet emits close', async () => {
+    const wrapper = mountSheet()
+    const sheet = wrapper.findComponent({ name: 'MobileSheet' })
+    sheet.vm.$emit('close')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
   // ── mobile-sheet close-button fallback (below lg) ─────────────────────────
 
   test('does not surface the mobile-sheet close button on desktop when tabs are present', () => {

--- a/tests/integration/components/layout-kit/modal/tab-sheet.test.js
+++ b/tests/integration/components/layout-kit/modal/tab-sheet.test.js
@@ -4,16 +4,17 @@ import { defineComponent, h } from 'vue'
 import { setActivePinia, createPinia } from 'pinia'
 
 vi.mock('@/composables/use-media-query', () => ({
-  useMobileBreakpoint: () => ({
+  useMobileBreakpoint: () => ({ value: false }),
+  useMediaQuery: () => ({ value: false }),
+  useIsTablet: () => ({
     get value() {
-      return globalThis.__belowLg ?? false
+      return globalThis.__isTablet ?? false
     }
-  }),
-  useMediaQuery: () => ({ value: false })
+  })
 }))
 
 function setBelowLg(v) {
-  globalThis.__belowLg = v
+  globalThis.__isTablet = v
 }
 
 import TabSheet from '@/components/layout-kit/modal/tab-sheet.vue'

--- a/tests/integration/components/modals/deck-settings/index.test.js
+++ b/tests/integration/components/modals/deck-settings/index.test.js
@@ -35,16 +35,17 @@ vi.mock('vue-router', () => ({
 
 vi.mock('@/composables/use-media-query', async () => {
   const vue = await import('vue')
-  const belowLg = vue.ref(false)
-  globalThis.__deckSettingsBelowLg = belowLg
+  const isTablet = vue.ref(false)
+  globalThis.__deckSettingsIsTablet = isTablet
   return {
-    useMobileBreakpoint: () => belowLg,
-    useMediaQuery: () => vue.ref(false)
+    useMobileBreakpoint: () => vue.ref(false),
+    useMediaQuery: () => vue.ref(false),
+    useIsTablet: () => isTablet
   }
 })
 
 function setBelowLg(v) {
-  if (globalThis.__deckSettingsBelowLg) globalThis.__deckSettingsBelowLg.value = v
+  if (globalThis.__deckSettingsIsTablet) globalThis.__deckSettingsIsTablet.value = v
 }
 
 vi.mock('@/composables/deck-editor', async () => {

--- a/tests/unit/composables/use-deck-settings-modal.test.js
+++ b/tests/unit/composables/use-deck-settings-modal.test.js
@@ -34,7 +34,7 @@ describe('useDeckSettingsModal', () => {
     expect(mockEmitSfx).toHaveBeenCalled()
   })
 
-  test('opens modal with backdrop, mobile-sheet mode, and the deck prop', () => {
+  test('opens modal with backdrop, mobile-sheet mode, mobile thresholds, and the deck prop', () => {
     const deck = { id: 42, title: 'A' }
     mockOpen.mockReturnValueOnce(makeModalResult(undefined))
 
@@ -44,6 +44,8 @@ describe('useDeckSettingsModal', () => {
     expect(mockOpen).toHaveBeenCalledWith(asyncComponentMatcher, {
       backdrop: true,
       mode: 'mobile-sheet',
+      mobile_below_width: 'md',
+      mobile_below_height: 'lg',
       props: { deck }
     })
   })

--- a/tests/unit/composables/use-media-query.test.js
+++ b/tests/unit/composables/use-media-query.test.js
@@ -231,3 +231,68 @@ describe('useMobileBreakpoint', () => {
     w.unmount()
   })
 })
+
+describe('useIsTablet', () => {
+  let widthMql
+  let heightMql
+  let coarseMql
+  let useIsTablet
+
+  beforeEach(async () => {
+    vi.resetModules()
+    widthMql = createMockMql(false)
+    heightMql = createMockMql(false)
+    coarseMql = createMockMql(false)
+
+    window.matchMedia = vi.fn((query) => {
+      if (query.includes('min-width')) return widthMql
+      if (query.includes('min-height')) return heightMql
+      if (query.includes('pointer: coarse')) return coarseMql
+      return createMockMql(false)
+    })
+    ;({ useIsTablet } = await import('@/composables/use-media-query'))
+  })
+
+  test('returns false on a wide fine-pointer viewport', async () => {
+    const [result, w] = withSetup(() => useIsTablet())
+    await nextTick()
+    expect(result.value).toBe(false)
+    w.unmount()
+  })
+
+  test('returns true when below the lg width breakpoint', async () => {
+    widthMql.matches = true
+    const [result, w] = withSetup(() => useIsTablet())
+    await nextTick()
+    expect(result.value).toBe(true)
+    w.unmount()
+  })
+
+  test('returns true when below the lg height breakpoint', async () => {
+    heightMql.matches = true
+    const [result, w] = withSetup(() => useIsTablet())
+    await nextTick()
+    expect(result.value).toBe(true)
+    w.unmount()
+  })
+
+  test('returns true on a wide viewport when the pointer is coarse', async () => {
+    coarseMql.matches = true
+    const [result, w] = withSetup(() => useIsTablet())
+    await nextTick()
+    expect(result.value).toBe(true)
+    w.unmount()
+  })
+
+  test('reacts when the pointer becomes coarse mid-session', async () => {
+    const [result, w] = withSetup(() => useIsTablet())
+    await nextTick()
+    expect(result.value).toBe(false)
+
+    coarseMql.matches = true
+    coarseMql._fire()
+    await nextTick()
+    expect(result.value).toBe(true)
+    w.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

- Widen the `md` breakpoint to 52rem so tablet/coarse-pointer viewports get the tablet layout for longer.
- Fix the deck-settings header close button in tablet variant by forwarding `mobile-sheet`'s close emit through `tab-sheet`.
- Introduce `--sheet-px` on `mobile-sheet` and consume it from the header, body content, and the deck-settings overlay (back button + deck preview) so all edges track the same padding across breakpoints.
- Cap the deck-settings modal at `max-w-205.5` in the tablet variant and let the body fill the width.
- Drop the modal's mobile width/height thresholds so it switches into mobile-sheet on smaller viewports.