### PR TITLE
fix(cover): drop removed bgImage option from pattern-picker

### DIFF
--- a/src/components/deck/cover-designer/pattern-picker.vue
+++ b/src/components/deck/cover-designer/pattern-picker.vue
@@ -18,7 +18,7 @@ const emit = defineEmits<{
 }>()
 
 function swatchBindings(p: DeckCoverPattern) {
-  const base = coverBindings({ pattern: p }, { border: false, bgImage: false })
+  const base = coverBindings({ pattern: p }, { border: false })
 
   return {
     ...base,


### PR DESCRIPTION
## Summary

- `bgImage` was removed from `CoverBindingsOptions` in 9defc9c but `pattern-picker.vue:21` still passed `bgImage: false`, breaking master build.
- Functionally a no-op — pattern-picker only passes `pattern: p`, so the suppressed branch never had a `bg_image` to suppress.