### PR TITLE
Clickable deck thumbnail and deck-settings perf

### DIFF
--- a/.claude/rules/vue-script-order.md
+++ b/.claude/rules/vue-script-order.md
@@ -1,0 +1,65 @@
+# Vue `<script setup>` ordering
+
+Declarations live in fixed top-to-bottom order. No mid-file `ref` / `computed` / `function` definitions sprinkled near their first use.
+
+```
+1. imports
+2. types          — type aliases / interfaces (always at top)
+3. defines        — defineProps / defineEmits / defineSlots / defineExpose / defineOptions
+4. composables    — useI18n(), useStore(), useFoo(), inject(), provide()
+                    + local state refs (ref(), reactive(), shallowRef())
+5. computed       — every computed() / writable computed
+6. lifecycle      — onMounted / onBeforeUnmount / etc.
+7. functions      — handlers, helpers, async actions
+8. watchers       — watch() / watchEffect() at the very bottom
+```
+
+## Rules
+
+- Group each bucket together. Don't interleave (e.g. don't put a `function` between two `computed`s).
+- All `type` / `interface` declarations sit at the top, above defines — even when only used by one bucket.
+- State refs (`ref`, `reactive`) belong with composables — they're the file's "setup" surface.
+- `provide()` calls go right after the composable that produced the value.
+- Lifecycle goes after computed because hooks usually orchestrate state declared above and don't depend on local functions.
+- Watchers go last — they react to everything else and frequently call the functions declared above them.
+
+## Good
+
+```ts
+// imports
+import { computed, onMounted, provide, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+// types
+type ActiveTab = 'general' | 'design' | 'study'
+export type DeckSettingsResponse = boolean
+
+// defines
+const { deck, close } = defineProps<{ ... }>()
+
+// composables + state
+const { t } = useI18n()
+const editor = useDeckEditor(deck)
+provide(deckEditorKey, editor)
+
+const active_tab = ref<ActiveTab | null>(null)
+const preview_mounted = ref(false)
+
+// computed
+const displayed_tab = computed(() => active_tab.value ?? 'general')
+const tab_component = computed(() => TAB_COMPONENTS[displayed_tab.value])
+
+// lifecycle
+onMounted(() => {
+  requestAnimationFrame(() => (preview_mounted.value = true))
+})
+
+// functions
+function onSave() { ... }
+function onTabEnter(...) { ... }
+
+// watchers
+watch(is_tablet, (below) => {
+  if (below && active_tab.value === 'danger-zone') active_tab.value = null
+})
+```

--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -11,7 +11,10 @@ const { deck, size = 'base' } = defineProps<{
 </script>
 
 <template>
-  <div data-testid="deck-thumbnail" class="relative cursor-pointer h-min">
+  <div
+    data-testid="deck-thumbnail"
+    class="deck-thumbnail--outline pointer-fine:hover:scale-101 relative cursor-pointer h-min transition-all duration-75"
+  >
     <card side="cover" :size="size" :cover_config="deck?.cover_config" />
 
     <div
@@ -23,3 +26,24 @@ const { deck, size = 'base' } = defineProps<{
     </div>
   </div>
 </template>
+
+<style scoped>
+@media (pointer: fine) {
+  .deck-thumbnail--outline:hover {
+    --outline-color: var(--color-white);
+    --outline-size: 2px;
+    --outline-size--inset: calc(var(--outline-size) * -1);
+    --outline-diag: calc(var(--outline-size) * 0.7071);
+    --outline-diag--inset: calc(var(--outline-diag) * -1);
+
+    filter: drop-shadow(var(--outline-size) 0 0 var(--outline-color))
+      drop-shadow(var(--outline-size--inset) 0 0 var(--outline-color))
+      drop-shadow(0 var(--outline-size) 0 var(--outline-color))
+      drop-shadow(0 var(--outline-size--inset) 0 var(--outline-color))
+      drop-shadow(var(--outline-diag) var(--outline-diag) 0 var(--outline-color))
+      drop-shadow(var(--outline-diag--inset) var(--outline-diag) 0 var(--outline-color))
+      drop-shadow(var(--outline-diag) var(--outline-diag--inset) 0 var(--outline-color))
+      drop-shadow(var(--outline-diag--inset) var(--outline-diag--inset) 0 var(--outline-color));
+  }
+}
+</style>

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -1,12 +1,6 @@
 <script setup lang="ts">
-import { computed, provide, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, onMounted, provide, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import TabDesign from './tab-design/index.vue'
-import TabGeneral from './tab-general/index.vue'
-import TabStudy from './tab-study/index.vue'
-import TabDangerZone from './tab-danger-zone/index.vue'
-import TabIndex from './tab-index/index.vue'
-import DeckDesignPreview from '@/components/deck/deck-design-preview.vue'
 import DeckAside from './deck-aside.vue'
 import { emitSfx } from '@/sfx/bus'
 import { slideFadeRightEnter, slideFadeRightLeave } from '@/utils/animations/slide-fade-right'
@@ -25,11 +19,29 @@ import Card from '@/components/card/index.vue'
 import TabSheet from '@/components/layout-kit/modal/tab-sheet.vue'
 
 export type DeckSettingsResponse = boolean
+type ActiveTab = 'general' | 'design' | 'study' | 'danger-zone'
 
 const { deck, close } = defineProps<{
   deck: Deck
   close: (response?: DeckSettingsResponse) => void
 }>()
+
+const TabDesign = defineAsyncComponent(() => import('./tab-design/index.vue'))
+const TabGeneral = defineAsyncComponent(() => import('./tab-general/index.vue'))
+const TabStudy = defineAsyncComponent(() => import('./tab-study/index.vue'))
+const TabDangerZone = defineAsyncComponent(() => import('./tab-danger-zone/index.vue'))
+const TabIndex = defineAsyncComponent(() => import('./tab-index/index.vue'))
+const DeckDesignPreview = defineAsyncComponent(
+  () => import('@/components/deck/deck-design-preview.vue')
+)
+
+const TAB_COMPONENTS = {
+  index: TabIndex,
+  design: TabDesign,
+  general: TabGeneral,
+  study: TabStudy,
+  'danger-zone': TabDangerZone
+}
 
 const { t } = useI18n()
 
@@ -39,22 +51,18 @@ provide(deckEditorKey, editor)
 const danger = useDeckDangerActions(editor, deck, close)
 provide(deckDangerActionsKey, danger)
 
+const is_tablet = useIsTablet()
+const is_mobile = useMobileBreakpoint('md')
+
+const active_tab = useSessionRef<ActiveTab | null>('deck-settings.active-tab', null)
+const tab_outlet = ref<HTMLElement>()
+
 const tabs = computed(() => [
   { value: 'general', icon: 'label', label: t('deck.settings-modal.tab.general') },
   { value: 'design', icon: 'design-services', label: t('deck.settings-modal.tab.design') },
   { value: 'study', icon: 'school-cap', label: t('deck.settings-modal.tab.study') },
   { value: 'danger-zone', icon: 'delete', label: t('deck.settings-modal.tab.danger-zone') }
 ])
-
-type ActiveTab = 'general' | 'design' | 'study' | 'danger-zone'
-const active_tab = useSessionRef<ActiveTab | null>('deck-settings.active-tab', null)
-
-const is_tablet = useIsTablet()
-const is_mobile = useMobileBreakpoint('md')
-
-watch(is_tablet, (is_below) => {
-  if (is_below && active_tab.value === 'danger-zone') active_tab.value = null
-})
 
 const displayed_tab = computed(() => active_tab.value ?? (is_tablet.value ? 'index' : 'general'))
 
@@ -72,6 +80,19 @@ const visible_side = computed(() =>
   displayed_tab.value === 'design' ? editor.active_side.value : 'cover'
 )
 
+const tab_component = computed(() => TAB_COMPONENTS[displayed_tab.value])
+
+onMounted(() => {
+  const idle = window.requestIdleCallback ?? ((cb: IdleRequestCallback) => setTimeout(cb, 200))
+  idle(() => {
+    import('./tab-design/index.vue')
+    import('./tab-general/index.vue')
+    import('./tab-study/index.vue')
+    import('./tab-danger-zone/index.vue')
+    import('./tab-index/index.vue')
+  })
+})
+
 function onPreviewSide(side: CardSide) {
   if (displayed_tab.value !== 'design') return
   editor.setActiveSide(side)
@@ -86,18 +107,6 @@ function onBack() {
   emitSfx('ui.select')
   active_tab.value = null
 }
-
-const tab_outlet = ref<HTMLElement>()
-
-const TAB_COMPONENTS = {
-  index: TabIndex,
-  design: TabDesign,
-  general: TabGeneral,
-  study: TabStudy,
-  'danger-zone': TabDangerZone
-}
-
-const tab_component = computed(() => TAB_COMPONENTS[displayed_tab.value])
 
 function onTabLeave(el: Element, done: () => void) {
   if (!is_mobile.value || !tab_outlet.value) {
@@ -114,6 +123,10 @@ function onTabEnter(el: Element, done: () => void) {
   }
   tabHeightEnter(tab_outlet.value)(el, done)
 }
+
+watch(is_tablet, (is_below) => {
+  if (is_below && active_tab.value === 'danger-zone') active_tab.value = null
+})
 </script>
 
 <template>

--- a/src/views/deck/deck-hero.vue
+++ b/src/views/deck/deck-hero.vue
@@ -36,7 +36,7 @@ function onToggleEditCards() {
     data-testid="deck-hero"
     class="flex max-w-full flex-col items-center gap-6 md:flex-row md:items-end xl:w-max xl:flex-col xl:items-start"
   >
-    <deck-thumbnail size="lg" class="relative" :deck="deck">
+    <deck-thumbnail size="lg" class="relative" :deck="deck" @click="onSettingsClicked">
       <template #actions>
         <ui-button
           data-testid="deck-hero__settings-button"
@@ -45,7 +45,6 @@ function onToggleEditCards() {
           icon-left="build"
           class="absolute! -top-2.5 -left-2.5"
           icon-only
-          @click="onSettingsClicked"
           >{{ t('deck.settings-modal.title') }}</ui-button
         >
       </template>

--- a/tests/integration/components/deck/deck-thumbnail.test.js
+++ b/tests/integration/components/deck/deck-thumbnail.test.js
@@ -79,4 +79,21 @@ describe('Deck', () => {
     const wrapper = shallowMount(Deck, { props: {} })
     expect(wrapper.text()).toBe('')
   })
+
+  // ── actions slot ──────────────────────────────────────────────────────────────
+
+  test('renders the actions slot above the title', () => {
+    const wrapper = shallowMount(Deck, {
+      props: { deck: { title: 'My Deck' } },
+      slots: { actions: '<button data-testid="thumbnail-action">act</button>' }
+    })
+    expect(wrapper.find('[data-testid="thumbnail-action"]').exists()).toBe(true)
+  })
+
+  test('emits click when the root wrapper is clicked', async () => {
+    const wrapper = makeDeck()
+    await wrapper.find('[data-testid="deck-thumbnail"]').trigger('click')
+    expect(wrapper.emitted('click')).toBeTruthy()
+    expect(wrapper.emitted('click')).toHaveLength(1)
+  })
 })

--- a/tests/integration/components/modals/deck-settings/index.test.js
+++ b/tests/integration/components/modals/deck-settings/index.test.js
@@ -484,4 +484,33 @@ describe('DeckSettings — overlay actions', () => {
 
     expect(close).toHaveBeenCalledWith(false)
   })
+
+  test('mounts under requestIdleCallback fallback (setTimeout) without throwing', async () => {
+    const originalIdle = window.requestIdleCallback
+    // @ts-ignore — drop rIC to force the setTimeout fallback path in onMounted
+    window.requestIdleCallback = undefined
+
+    expect(() => makeWrapper()).not.toThrow()
+    await flushPromises()
+
+    window.requestIdleCallback = originalIdle
+  })
+
+  test('mounts and fires the idle prefetch callback', async () => {
+    const idleSpy = vi.fn((cb) => {
+      cb({ didTimeout: false, timeRemaining: () => 50 })
+      return 0
+    })
+    const originalIdle = window.requestIdleCallback
+    // @ts-ignore — intercept the rIC call so the prefetch runs synchronously
+    window.requestIdleCallback = idleSpy
+
+    makeWrapper()
+    await flushPromises()
+
+    expect(idleSpy).toHaveBeenCalledTimes(1)
+    expect(idleSpy.mock.calls[0][0]).toBeTypeOf('function')
+
+    window.requestIdleCallback = originalIdle
+  })
 })

--- a/tests/integration/views/deck/deck-hero.test.js
+++ b/tests/integration/views/deck/deck-hero.test.js
@@ -1,12 +1,17 @@
-import { describe, test, expect, vi } from 'vite-plus/test'
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
 import { defineComponent, h, ref, useAttrs } from 'vue'
 
+const { mockOpenSettings, mockStartStudy } = vi.hoisted(() => ({
+  mockOpenSettings: vi.fn(() => ({ response: Promise.resolve(false) })),
+  mockStartStudy: vi.fn()
+}))
+
 vi.mock('@/composables/modals/use-deck-settings-modal', () => ({
-  useDeckSettingsModal: () => ({ open: vi.fn(() => ({ response: Promise.resolve(false) })) })
+  useDeckSettingsModal: () => ({ open: mockOpenSettings })
 }))
 vi.mock('@/composables/modals/use-study-modal', () => ({
-  useStudyModal: () => ({ start: vi.fn() })
+  useStudyModal: () => ({ start: mockStartStudy })
 }))
 
 import DeckHero from '@/views/deck/deck-hero.vue'
@@ -21,13 +26,27 @@ const UiButtonStub = defineComponent({
   }
 })
 
+const DeckThumbnailStub = defineComponent({
+  name: 'DeckThumbnail',
+  inheritAttrs: false,
+  setup(_props, { slots, emit }) {
+    const attrs = useAttrs()
+    return () =>
+      h(
+        'div',
+        { ...attrs, 'data-testid': 'deck-thumbnail', onClick: () => emit('click') },
+        slots.actions?.()
+      )
+  }
+})
+
 function mount({ deck = {}, editor } = {}) {
   return shallowMount(DeckHero, {
     props: {
       deck: { id: 1, title: 'd', card_count: 10, ...deck }
     },
     global: {
-      stubs: { UiButton: UiButtonStub },
+      stubs: { UiButton: UiButtonStub, DeckThumbnail: DeckThumbnailStub },
       provide: editor === undefined ? {} : { 'card-editor': editor }
     }
   })
@@ -42,6 +61,11 @@ function modeButton(wrapper) {
 }
 
 describe('DeckHero', () => {
+  beforeEach(() => {
+    mockOpenSettings.mockClear()
+    mockStartStudy.mockClear()
+  })
+
   // ── Display ────────────────────────────────────────────────────────────────
 
   test('renders the card_count in the cards-in-deck label', () => {
@@ -98,6 +122,30 @@ describe('DeckHero', () => {
       await modeButton(wrapper).trigger('click')
       // No throw + button still renders the default label
       expect(modeButton(wrapper).exists()).toBe(true)
+    })
+  })
+
+  // ── Settings modal ────────────────────────────────────────────────────────
+
+  describe('settings modal', () => {
+    test('clicking the deck thumbnail opens the settings modal with the deck', async () => {
+      const deck = { id: 42, title: 'd', card_count: 0 }
+      const wrapper = mount({ deck })
+
+      await wrapper.find('[data-testid="deck-thumbnail"]').trigger('click')
+
+      expect(mockOpenSettings).toHaveBeenCalledTimes(1)
+      expect(mockOpenSettings).toHaveBeenCalledWith(expect.objectContaining({ id: 42 }))
+    })
+
+    test('clicking the study button starts the study session', async () => {
+      const deck = { id: 7, title: 'd', card_count: 0 }
+      const wrapper = mount({ deck })
+
+      await wrapper.find('[data-testid="overview-panel__study-button"]').trigger('click')
+
+      expect(mockStartStudy).toHaveBeenCalledTimes(1)
+      expect(mockStartStudy).toHaveBeenCalledWith(expect.objectContaining({ id: 7 }))
     })
   })
 })


### PR DESCRIPTION
## Summary

- Deck thumbnail now opens settings on click anywhere in the card, with a white hover outline + slight scale on pointer-fine devices.
- Deck-settings modal mounts faster: all 5 tab components and the floating preview are `defineAsyncComponent`-loaded, then idle-prefetched after mount so first tab swap is still instant.
- Added `.claude/rules/vue-script-order.md` documenting the script-setup declaration order (imports → types → defines → composables → computed → lifecycle → functions → watchers). Applied to `deck-settings/index.vue`.