### PR TITLE
UI picker polish and blocking sfx option

### DIFF
--- a/src/components/modals/deck-settings/tab-index/index.vue
+++ b/src/components/modals/deck-settings/tab-index/index.vue
@@ -36,7 +36,7 @@ const emit = defineEmits<{
 }>()
 
 function onNavigate(value: TabIndexNavValue) {
-  emitSfx('ui.select')
+  emitSfx('ui.select', { blocking: true })
   emit('navigate', value)
 }
 </script>

--- a/src/components/ui-kit/pattern-picker.vue
+++ b/src/components/ui-kit/pattern-picker.vue
@@ -53,12 +53,12 @@ function onPatternSelect(p: DeckCoverPattern | undefined) {
         :data-selected="pattern === selected_pattern || undefined"
         v-sfx.hover="'ui.click_07'"
         v-bind="swatchBindings(pattern)"
-        class="w-14.5 aspect-square rounded-6 rounded-tr-3 rounded-bl-3 cursor-pointer bg-(--theme-primary) data-selected:ring-4 ring-brown-100 relative"
+        class="w-14.5 aspect-square rounded-6 rounded-tr-3 rounded-bl-3 cursor-pointer bg-(--theme-primary) hover:ring-4 data-selected:ring-4 ring-white relative"
         @click="onPatternSelect(pattern)"
       >
         <div
           v-if="pattern === selected_pattern"
-          class="absolute -top-2 -right-2 bg-brown-100 p-0.5 rounded-full flex items-center justify-center"
+          class="absolute -top-2 -right-2 bg-white p-0.5 rounded-full flex items-center justify-center"
         >
           <ui-icon src="check" class="text-(--theme-primary)" />
         </div>

--- a/src/components/ui-kit/theme-picker.vue
+++ b/src/components/ui-kit/theme-picker.vue
@@ -37,7 +37,7 @@ function onThemeSelect(option: DeckTheme) {
     <h3 data-testid="theme-picker__label" class="text-brown-700 dark:text-brown-100">
       {{ label }}
     </h3>
-    <div data-testid="theme-picker" class="w-full flex gap-3">
+    <div data-testid="theme-picker" class="w-full flex flex-wrap gap-3">
       <button
         v-for="option in supported_themes"
         :key="`${option.light}:${option.dark ?? option.light}`"
@@ -45,7 +45,7 @@ function onThemeSelect(option: DeckTheme) {
         :data-theme="option.light"
         :data-theme-dark="option.dark"
         v-sfx.hover="'ui.click_07'"
-        class="w-9 aspect-square bg-(--theme-primary) rounded-8 rounded-tr-3 cursor-pointer relative! hover:outline-5 outline-white"
+        class="w-9 shrink-0 aspect-square bg-(--theme-primary) rounded-8 rounded-tr-3 cursor-pointer relative! hover:outline-5 outline-white"
         :class="{ 'outline-5 outline-white': isSelected(option) }"
         @click="onThemeSelect(option)"
       >

--- a/src/phone/apps/settings/component/tab-index/index.vue
+++ b/src/phone/apps/settings/component/tab-index/index.vue
@@ -35,7 +35,7 @@ const emit = defineEmits<{
 }>()
 
 function onNavigate(value: TabIndexNavValue) {
-  emitSfx('ui.select')
+  emitSfx('ui.select', { blocking: true })
   emit('navigate', value)
 }
 </script>

--- a/src/sfx/directive.ts
+++ b/src/sfx/directive.ts
@@ -9,6 +9,7 @@ export type SfxOptions = {
   focus?: NamespacedAudioKey
   blur?: NamespacedAudioKey
   debounce?: number
+  click_blocking?: boolean
 }
 
 type SfxBindingValue = NamespacedAudioKey | SfxOptions
@@ -61,7 +62,10 @@ function _attach(el: HTMLElement, binding: DirectiveBinding<SfxBindingValue>) {
       if (!state.cfg.click) return
       if (state.mods.prevent) e.preventDefault()
       if (state.mods.stop) e.stopPropagation()
-      emitSfx(state.cfg.click, { debounce: state.cfg.debounce })
+      emitSfx(state.cfg.click, {
+        debounce: state.cfg.debounce,
+        blocking: state.cfg.click_blocking
+      })
     })
   )
 

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -12,6 +12,7 @@ import {
 export type PlayOptions = {
   volume?: number
   debounce?: number
+  blocking?: boolean
 }
 
 // Audio files ship as separate hashed assets; Howler fetches them when
@@ -26,7 +27,7 @@ const AUDIO_FILES = import.meta.glob('@/assets/audio/**/*.{wav,mp3,ogg}', {
 
 const DEFAULT_VOLUME = 0.5
 const DEFAULT_CATEGORY_VOLUME = 1
-const DEBOUNCE_DELAY = 50
+const DEBOUNCE_DELAY = 10
 const QUEUE_TIMEOUT = 10
 
 class AudioPlayer {
@@ -35,6 +36,7 @@ class AudioPlayer {
   unlock_registered = false
   unlocked = false
   queued_sound: { key: NamespacedAudioKey; options: PlayOptions } | undefined
+  blocking = false
 
   setup = () => {
     if (this.initialized) return Promise.resolve()
@@ -50,6 +52,8 @@ class AudioPlayer {
   }
 
   play = async (key: NamespacedAudioKey, options: PlayOptions = {}): Promise<void> => {
+    if (options.blocking) this.blocking = true
+
     return debounce(() => this._play(key, options), {
       delay: options.debounce ?? DEBOUNCE_DELAY,
       key
@@ -67,6 +71,8 @@ class AudioPlayer {
   }
 
   private _play = async (key: NamespacedAudioKey, options: PlayOptions = {}): Promise<void> => {
+    if (this.blocking && !options.blocking) return
+
     if (!this.unlocked) {
       this._enqueue(key, options)
       return
@@ -81,6 +87,7 @@ class AudioPlayer {
     await this._ensureContextRunning()
 
     if (Howler.ctx && Howler.ctx.state !== 'running') {
+      if (options.blocking) this.blocking = false
       return
     }
 
@@ -106,6 +113,7 @@ class AudioPlayer {
         sound.off('end', settle)
         sound.off('playerror', settle)
         clearTimeout(timer)
+        if (options.blocking) this.blocking = false
         resolve()
       }
       const fallbackMs = Math.ceil((sound.duration() || 1) * 1000) + 500

--- a/tests/integration/components/modals/deck-settings/tab-index.test.js
+++ b/tests/integration/components/modals/deck-settings/tab-index.test.js
@@ -78,10 +78,10 @@ describe('TabIndex', () => {
     expect(wrapper.emitted('navigate')).toEqual([['design']])
   })
 
-  test('plays the select sfx on nav click', async () => {
+  test('plays the select sfx as a blocking sound on nav click', async () => {
     const { wrapper } = makeTab()
     await wrapper.find('[data-testid="tab-index__nav-card"][data-value="general"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select', { blocking: true })
   })
 
   test('renders inlined danger reset + delete buttons', () => {

--- a/tests/integration/phone/apps/settings/component/tab-index.test.js
+++ b/tests/integration/phone/apps/settings/component/tab-index.test.js
@@ -77,10 +77,10 @@ describe('TabIndex', () => {
     expect(wrapper.emitted('navigate')).toEqual([['subscription']])
   })
 
-  test('plays the select sfx on nav click', async () => {
+  test('plays the select sfx as a blocking sound on nav click', async () => {
     const { wrapper } = makeTab()
     await wrapper.find('[data-testid="tab-index__nav-card"][data-value="profile"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select', { blocking: true })
   })
 
   test('renders the inlined delete-account button', () => {

--- a/tests/unit/sfx/directive.test.js
+++ b/tests/unit/sfx/directive.test.js
@@ -90,7 +90,22 @@ describe('vSfx directive', () => {
 
       el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
 
-      expect(emitSfx).toHaveBeenCalledWith('ui.click_07', { debounce: undefined })
+      expect(emitSfx).toHaveBeenCalledWith('ui.click_07', {
+        debounce: undefined,
+        blocking: undefined
+      })
+      unmount(el)
+    })
+
+    test('forwards click_blocking option as PlayOptions.blocking', () => {
+      const el = mountDirective({ click: 'ui.select', click_blocking: true })
+
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+      expect(emitSfx).toHaveBeenCalledWith('ui.select', {
+        debounce: undefined,
+        blocking: true
+      })
       unmount(el)
     })
   })

--- a/tests/unit/sfx/player.test.js
+++ b/tests/unit/sfx/player.test.js
@@ -49,6 +49,7 @@ describe('audio_player._play', () => {
     audio_player.loaded_sounds.clear()
     audio_player.unlocked = true
     audio_player.queued_sound = undefined
+    audio_player.blocking = false
     vi.useRealTimers()
   })
 
@@ -140,6 +141,72 @@ describe('audio_player._play', () => {
 
   test('throws when sound not loaded', async () => {
     await expect(audio_player.play('ui.missing')).rejects.toThrow('Sound "ui.missing" not loaded.')
+  })
+
+  test('sets blocking flag synchronously when play() called with blocking option', () => {
+    const sound = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.select', sound)
+
+    audio_player.play('ui.select', { blocking: true })
+
+    expect(audio_player.blocking).toBe(true)
+  })
+
+  test('drops non-blocking sound while blocking flag is set', async () => {
+    const blocker = makeFakeSound()
+    const other = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.select', blocker)
+    audio_player.loaded_sounds.set('ui.click_07', other)
+
+    const blocking_promise = audio_player.play('ui.select', { blocking: true })
+    await audio_player.play('ui.click_07')
+
+    expect(other.play).not.toHaveBeenCalled()
+
+    blocker._fire('end')
+    await blocking_promise
+  })
+
+  test('clears blocking flag once the blocking sound ends', async () => {
+    const sound = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.select', sound)
+
+    const promise = audio_player.play('ui.select', { blocking: true })
+    expect(audio_player.blocking).toBe(true)
+
+    await Promise.resolve()
+    sound._fire('end')
+    await promise
+
+    expect(audio_player.blocking).toBe(false)
+  })
+
+  test('allows another blocking sound to play even while flag is set (self-bypass)', async () => {
+    const a = makeFakeSound()
+    const b = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.select', a)
+    audio_player.loaded_sounds.set('ui.click_07', b)
+
+    const p1 = audio_player.play('ui.select', { blocking: true })
+    const p2 = audio_player.play('ui.click_07', { blocking: true })
+
+    await Promise.resolve()
+    expect(b.play).toHaveBeenCalled()
+
+    a._fire('end')
+    b._fire('end')
+    await Promise.all([p1, p2])
+  })
+
+  test('clears blocking flag when context fails to resume', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockRejectedValue(new Error('needs gesture'))
+    const sound = makeFakeSound()
+    audio_player.loaded_sounds.set('ui.select', sound)
+
+    await audio_player.play('ui.select', { blocking: true })
+
+    expect(audio_player.blocking).toBe(false)
   })
 
   test('applies volume option before playing', async () => {


### PR DESCRIPTION
## Summary

Adds a `blocking` option to the sfx system that halts other sounds while a blocking sound plays, wires it into deck/app settings nav-card clicks, and polishes the ui-kit pickers.

## Changes

- `feat(sfx)`: `PlayOptions.blocking` + `SfxOptions.click_blocking` — sets a player flag that drops other sounds until end / playerror / timeout
- `feat(settings)`: deck-settings + app-settings nav-cards emit `ui.select` with `blocking: true` so subsequent hover sfx from the destination tab don't overlap the click sound
- `feat(ui-kit)`: pattern-picker gains a hover ring; selection ring + check badge switched to white
- `feat(ui-kit)`: theme-picker swatches now wrap and use `shrink-0` so they no longer compress under tight widths