### PR TITLE
fix(ci): use list closure instead of nonlocal in strip script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,14 +242,14 @@ jobs:
           def is_strip(key: str) -> bool:
               return '/src/' in key and '/src/api/' not in key
 
-          stripped = 0
+          counter = [0]
+
           def visit(node):
-              nonlocal stripped
               if isinstance(node, dict):
                   for k in list(node.keys()):
                       if isinstance(k, str) and is_strip(k):
                           del node[k]
-                          stripped += 1
+                          counter[0] += 1
                       else:
                           visit(node[k])
               elif isinstance(node, list):
@@ -258,7 +258,7 @@ jobs:
 
           visit(blob)
           path.write_text(json.dumps(blob))
-          print(f'stripped {stripped} non-api file entries from stale contract blob')
+          print(f'stripped {counter[0]} non-api file entries from stale contract blob')
           PY
 
       - name: Merge coverage


### PR DESCRIPTION
## Summary

`nonlocal` requires the binding to exist in an enclosing function scope. In the previous patch the counter lived at module level (heredoc-driven `python3 -`), so Python rejected it with `SyntaxError: no binding for nonlocal 'stripped' found` and the coverage-report job failed.

Replace with a one-element list closure (`counter = [0]`) which works under module scope.

Validated locally on master's stale contract blob: stripped 220 non-api entries, sfx coverage restored as before.