### PR TITLE
UI play-on-tap interaction for buttons and deck thumbnails

### DIFF
--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -1,20 +1,48 @@
 <script setup lang="ts">
+import { useAttrs } from 'vue'
 import Card from '@/components/card/index.vue'
+import { usePlayOnTap } from '@/composables/use-play-on-tap'
+import { emitSfx } from '@/sfx/bus'
+import type { NamespacedAudioKey } from '@/sfx/config'
 
 type CardSize = InstanceType<typeof Card>['$props']['size']
 
-const { deck, size = 'base' } = defineProps<{
+const {
+  deck,
+  size = 'base',
+  click_sfx
+} = defineProps<{
   deck?: Deck
   size?: CardSize
   hide_title?: boolean
+  click_sfx?: NamespacedAudioKey
 }>()
+
+const attrs = useAttrs()
+
+const { playing, interceptClick } = usePlayOnTap({
+  animate: false,
+  beforePlay: () => {
+    if (click_sfx) emitSfx(click_sfx)
+  }
+})
+
+function onCaptureClick(e: MouseEvent) {
+  const handler = attrs.onClick as ((ev: MouseEvent) => void) | undefined
+
+  if (!handler) return
+
+  interceptClick(e, handler)
+}
 </script>
 
 <template>
   <div
     data-testid="deck-thumbnail"
-    class="deck-thumbnail--outline pointer-fine:hover:scale-101 relative cursor-pointer h-min transition-all duration-75"
+    class="deck-thumbnail--outline pointer-fine:hover:scale-101 data-[playing=true]:scale-101 pointer-coarse:data-[playing=true]:scale-105 pointer-fine:transition-transform duration-75 relative cursor-pointer h-min touch-manipulation"
+    :data-playing="playing || null"
     v-sfx.hover="'ui.click_07'"
+    @click.capture="onCaptureClick"
   >
     <card side="cover" :size="size" :cover_config="deck?.cover_config" />
 
@@ -29,22 +57,30 @@ const { deck, size = 'base' } = defineProps<{
 </template>
 
 <style scoped>
+.deck-thumbnail--outline {
+  will-change: filter, transform;
+  --outline-color: var(--color-white);
+  --outline-size: 2px;
+  --outline-size--inset: calc(var(--outline-size) * -1);
+  --outline-diag: calc(var(--outline-size) * 0.7071);
+  --outline-diag--inset: calc(var(--outline-diag) * -1);
+  --outline-filter: drop-shadow(var(--outline-size) 0 0 var(--outline-color))
+    drop-shadow(var(--outline-size--inset) 0 0 var(--outline-color))
+    drop-shadow(0 var(--outline-size) 0 var(--outline-color))
+    drop-shadow(0 var(--outline-size--inset) 0 var(--outline-color))
+    drop-shadow(var(--outline-diag) var(--outline-diag) 0 var(--outline-color))
+    drop-shadow(var(--outline-diag--inset) var(--outline-diag) 0 var(--outline-color))
+    drop-shadow(var(--outline-diag) var(--outline-diag--inset) 0 var(--outline-color))
+    drop-shadow(var(--outline-diag--inset) var(--outline-diag--inset) 0 var(--outline-color));
+}
+
 @media (pointer: fine) {
   .deck-thumbnail--outline:hover {
-    --outline-color: var(--color-white);
-    --outline-size: 2px;
-    --outline-size--inset: calc(var(--outline-size) * -1);
-    --outline-diag: calc(var(--outline-size) * 0.7071);
-    --outline-diag--inset: calc(var(--outline-diag) * -1);
-
-    filter: drop-shadow(var(--outline-size) 0 0 var(--outline-color))
-      drop-shadow(var(--outline-size--inset) 0 0 var(--outline-color))
-      drop-shadow(0 var(--outline-size) 0 var(--outline-color))
-      drop-shadow(0 var(--outline-size--inset) 0 var(--outline-color))
-      drop-shadow(var(--outline-diag) var(--outline-diag) 0 var(--outline-color))
-      drop-shadow(var(--outline-diag--inset) var(--outline-diag) 0 var(--outline-color))
-      drop-shadow(var(--outline-diag) var(--outline-diag--inset) 0 var(--outline-color))
-      drop-shadow(var(--outline-diag--inset) var(--outline-diag--inset) 0 var(--outline-color));
+    filter: var(--outline-filter);
   }
+}
+
+.deck-thumbnail--outline[data-playing='true'] {
+  filter: var(--outline-filter);
 }
 </style>

--- a/src/components/layout-kit/modal/mobile-sheet.vue
+++ b/src/components/layout-kit/modal/mobile-sheet.vue
@@ -101,7 +101,14 @@ provide(mobileSheetOverlayKey, overlay_root)
             ]"
           >
             <div v-if="show_close_button" class="absolute top-0 left-0 p-4">
-              <ui-button icon-left="close" icon-only inverted @click="emit('close')" />
+              <ui-button
+                icon-left="close"
+                icon-only
+                inverted
+                @click="emit('close')"
+                play-on-tap
+                :sfx="{ click: 'ui.select' }"
+              />
             </div>
 
             <slot name="header-content">

--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { computed, useSlots } from 'vue'
+import { computed, useAttrs, useSlots } from 'vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
+import { usePlayOnTap } from '@/composables/use-play-on-tap'
+import { emitSfx } from '@/sfx/bus'
 import type { SfxOptions } from '@/sfx/directive'
 
 defineOptions({ inheritAttrs: false })
@@ -19,6 +21,7 @@ export type ButtonProps = {
   sfx?: SfxOptions
   fullWidth?: boolean
   mobileTooltip?: boolean
+  playOnTap?: boolean
 }
 
 const {
@@ -30,10 +33,24 @@ const {
   fancyHover = true,
   sfx = {},
   fullWidth = false,
-  mobileTooltip = false
+  mobileTooltip = false,
+  playOnTap = false
 } = defineProps<ButtonProps>()
 
 const slots = useSlots()
+const attrs = useAttrs()
+
+const { playing, interceptClick } = usePlayOnTap({
+  reset: false,
+  beforePlay: () => {
+    const click_sfx = merged_sfx.value.click
+    if (!click_sfx) return
+    emitSfx(click_sfx, {
+      debounce: merged_sfx.value.debounce,
+      blocking: merged_sfx.value.click_blocking
+    })
+  }
+})
 
 const merged_sfx = computed(() => {
   return {
@@ -43,6 +60,13 @@ const merged_sfx = computed(() => {
 })
 
 const tooltip_active = computed(() => iconOnly && !!slots.default)
+
+function onCaptureClick(e: MouseEvent) {
+  if (!playOnTap) return
+  const handler = attrs.onClick as ((ev: MouseEvent) => void) | undefined
+  if (!handler) return
+  interceptClick(e, handler)
+}
 </script>
 
 <template>
@@ -56,6 +80,8 @@ const tooltip_active = computed(() => iconOnly && !!slots.default)
     class="ui-kit-btn group/btn"
     v-sfx="merged_sfx"
     v-bind="$attrs"
+    :data-playing="playing || null"
+    @click.capture="onCaptureClick"
     :class="[
       `ui-kit-btn--${size}`,
       `ui-kit-btn--${variant}`,
@@ -78,7 +104,7 @@ const tooltip_active = computed(() => iconOnly && !!slots.default)
       :class="{
         'bg-(--theme-primary) flex items-center justify-center': loading,
         hidden: !loading,
-        'group-hover/btn:block': !loading && fancyHover,
+        'group-hover/btn:block group-data-[playing=true]/btn:block': !loading && fancyHover,
         'bgx-color-[var(--theme-neutral)]': variant === 'solid',
         'bgx-color-[var(--theme-on-neutral)]': inverted
       }"
@@ -229,5 +255,15 @@ const tooltip_active = computed(() => iconOnly && !!slots.default)
   .ui-kit-btn:hover .btn-icon.btn-icon--right {
     transform: scale(1.3) rotate(5deg);
   }
+}
+
+.ui-kit-btn[data-playing] {
+  --btn-outline-width: 2px;
+}
+.ui-kit-btn[data-playing] .btn-icon.btn-icon--left {
+  transform: scale(1.3) rotate(-5deg);
+}
+.ui-kit-btn[data-playing] .btn-icon.btn-icon--right {
+  transform: scale(1.3) rotate(5deg);
 }
 </style>

--- a/src/composables/use-play-on-tap.ts
+++ b/src/composables/use-play-on-tap.ts
@@ -1,0 +1,55 @@
+import { ref } from 'vue'
+import { useMediaQuery } from '@/composables/use-media-query'
+import { BUTTON_TAP_DURATION, playButtonTap } from '@/utils/animations/button-tap'
+
+type Options = {
+  /** Run GSAP scale/rotate tween on the element. When false, just hold `playing` for the same duration so consumers can drive their own CSS via `[data-playing]`. Defaults to true. */
+  animate?: boolean
+  /** Flip `playing` back to false after `onAfter` runs. Defaults to true. Set false to hold the active state (e.g. when a GSAP transform should remain applied until unmount). */
+  reset?: boolean
+  /** How long (in seconds) the tap state holds — also the duration handed to GSAP when `animate` is true. Defaults to `BUTTON_TAP_DURATION`. */
+  duration?: number
+  /** Pointer environments where the intercept is active. Defaults to 'coarse-only' so desktop clicks pass straight through; 'always' forces the tap on every pointer type. */
+  activeOn?: 'coarse-only' | 'always'
+  /** Hook fired at the start of the intercept (after stop/preventDefault, before the tween). Use for sfx or other side-effects. */
+  beforePlay?: (e: MouseEvent) => void
+}
+
+/**
+ * Intercepts a click, plays (or waits out) the button-tap animation, then invokes the original handler.
+ * The MouseEvent is preserved end-to-end so downstream handlers still see `isTrusted=true` within the
+ * browser's user-activation window.
+ */
+export function usePlayOnTap(options: Options = {}) {
+  const playing = ref(false)
+  const animate = options.animate ?? true
+  const reset = options.reset ?? true
+  const duration = options.duration ?? BUTTON_TAP_DURATION
+  const active_on = options.activeOn ?? 'coarse-only'
+  const is_coarse = useMediaQuery('coarse')
+
+  /** Stop the click, run the tap (or its delay), then invoke `onAfter` with the original event. No-op while already playing. */
+  async function interceptClick(e: MouseEvent, onAfter: (e: MouseEvent) => void) {
+    if (playing.value) return
+
+    if (active_on === 'coarse-only' && !is_coarse.value) return
+
+    e.stopImmediatePropagation()
+    e.preventDefault()
+
+    options.beforePlay?.(e)
+
+    playing.value = true
+    if (animate) {
+      await playButtonTap(e.currentTarget as HTMLElement, duration)
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, duration * 1000))
+    }
+
+    onAfter(e)
+
+    if (reset) playing.value = false
+  }
+
+  return { playing, interceptClick }
+}

--- a/src/utils/animations/button-tap.ts
+++ b/src/utils/animations/button-tap.ts
@@ -1,0 +1,15 @@
+import { gsap } from 'gsap'
+
+export const BUTTON_TAP_DURATION = 0.1
+
+export function playButtonTap(el: Element, duration: number = BUTTON_TAP_DURATION) {
+  return new Promise<void>((resolve) => {
+    gsap.to(el, {
+      scale: 1.2,
+      rotate: 3,
+      duration,
+      ease: 'power2.out',
+      onComplete: resolve
+    })
+  })
+}

--- a/src/views/deck/deck-hero.vue
+++ b/src/views/deck/deck-hero.vue
@@ -36,7 +36,13 @@ function onToggleEditCards() {
     data-testid="deck-hero"
     class="flex max-w-full flex-col items-center gap-6 md:flex-row md:items-end xl:w-max xl:flex-col xl:items-start"
   >
-    <deck-thumbnail size="lg" class="relative" :deck="deck" @click="onSettingsClicked">
+    <deck-thumbnail
+      size="lg"
+      class="relative"
+      :deck="deck"
+      :click_sfx="'ui.select'"
+      @click="onSettingsClicked"
+    >
       <template #actions>
         <ui-button
           data-testid="deck-hero__settings-button"

--- a/tests/integration/components/deck/deck-thumbnail.test.js
+++ b/tests/integration/components/deck/deck-thumbnail.test.js
@@ -1,9 +1,24 @@
-import { describe, test, expect, vi } from 'vite-plus/test'
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
-import Deck from '@/components/deck/deck-thumbnail.vue'
+
+const { coarseRef, mockEmitSfx } = vi.hoisted(() => ({
+  coarseRef: { value: true },
+  mockEmitSfx: vi.fn()
+}))
+
+vi.mock('@/composables/use-media-query', () => ({
+  useMediaQuery: () => coarseRef
+}))
+
+vi.mock('@/sfx/bus', () => ({
+  emitSfx: mockEmitSfx,
+  emitHoverSfx: vi.fn()
+}))
 
 // Stub GSAP — pulled in transitively via Card
 vi.mock('gsap', () => ({ gsap: { fromTo: vi.fn(), to: vi.fn() } }))
+
+import Deck from '@/components/deck/deck-thumbnail.vue'
 
 function makeDeck(deck = {}, extraProps = {}) {
   return shallowMount(Deck, {
@@ -95,5 +110,91 @@ describe('Deck', () => {
     await wrapper.find('[data-testid="deck-thumbnail"]').trigger('click')
     expect(wrapper.emitted('click')).toBeTruthy()
     expect(wrapper.emitted('click')).toHaveLength(1)
+  })
+
+  // ── play-on-tap ────────────────────────────────────────────────────────────
+
+  describe('play-on-tap', () => {
+    beforeEach(() => {
+      coarseRef.value = true
+      mockEmitSfx.mockClear()
+    })
+
+    test('invokes the parent click handler after the hold completes on coarse pointers', async () => {
+      vi.useFakeTimers()
+      const onClick = vi.fn()
+      const wrapper = shallowMount(Deck, {
+        props: { deck: { title: 'X' } },
+        attrs: { onClick }
+      })
+
+      const click = wrapper.find('[data-testid="deck-thumbnail"]').trigger('click')
+
+      // Hold matches usePlayOnTap default — non-animate path uses setTimeout.
+      vi.advanceTimersByTime(500)
+      await click
+      vi.useRealTimers()
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    test('data-playing flips on while the hold is in flight', async () => {
+      vi.useFakeTimers()
+      const wrapper = shallowMount(Deck, {
+        props: { deck: { title: 'X' } },
+        attrs: { onClick: vi.fn() }
+      })
+
+      wrapper.find('[data-testid="deck-thumbnail"]').trigger('click')
+      await Promise.resolve() // let intercept run up to the await
+
+      expect(wrapper.find('[data-testid="deck-thumbnail"]').attributes('data-playing')).toBe('true')
+      vi.advanceTimersByTime(500)
+      vi.useRealTimers()
+    })
+
+    test('emits click_sfx via beforePlay when provided', async () => {
+      vi.useFakeTimers()
+      const wrapper = shallowMount(Deck, {
+        props: { deck: { title: 'X' }, click_sfx: 'ui.select' },
+        attrs: { onClick: vi.fn() }
+      })
+
+      wrapper.find('[data-testid="deck-thumbnail"]').trigger('click')
+      await Promise.resolve()
+
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
+      vi.advanceTimersByTime(500)
+      vi.useRealTimers()
+    })
+
+    test('does not emit click_sfx when prop is absent', async () => {
+      vi.useFakeTimers()
+      const wrapper = shallowMount(Deck, {
+        props: { deck: { title: 'X' } },
+        attrs: { onClick: vi.fn() }
+      })
+
+      wrapper.find('[data-testid="deck-thumbnail"]').trigger('click')
+      await Promise.resolve()
+
+      expect(mockEmitSfx).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(500)
+      vi.useRealTimers()
+    })
+
+    test('does not intercept on pointer:fine — click goes through immediately', async () => {
+      coarseRef.value = false
+      const onClick = vi.fn()
+      const wrapper = shallowMount(Deck, {
+        props: { deck: { title: 'X' } },
+        attrs: { onClick }
+      })
+
+      await wrapper.find('[data-testid="deck-thumbnail"]').trigger('click')
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+      expect(mockEmitSfx).not.toHaveBeenCalled()
+    })
   })
 })

--- a/tests/integration/components/layout-kit/modal/mobile-sheet.test.js
+++ b/tests/integration/components/layout-kit/modal/mobile-sheet.test.js
@@ -91,6 +91,13 @@ describe('MobileSheet', () => {
     expect(wrapper.findComponent({ name: 'UiButton' }).exists()).toBe(false)
   })
 
+  test('close button opts into play-on-tap with ui.select sfx', () => {
+    const wrapper = mountSheet({ title: 'My Sheet' })
+    const closeBtn = wrapper.findComponent({ name: 'UiButton' })
+    expect(closeBtn.props('playOnTap')).toBe(true)
+    expect(closeBtn.props('sfx')).toEqual({ click: 'ui.select' })
+  })
+
   // ── default + footer slots ─────────────────────────────────────────────────
 
   test('renders default slot content into body', () => {

--- a/tests/integration/components/ui-kit/button.test.js
+++ b/tests/integration/components/ui-kit/button.test.js
@@ -1,5 +1,24 @@
-import { describe, test, expect } from 'vite-plus/test'
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
+
+const { coarseRef, mockEmitSfx } = vi.hoisted(() => ({
+  coarseRef: { value: true },
+  mockEmitSfx: vi.fn()
+}))
+
+vi.mock('@/composables/use-media-query', () => ({
+  useMediaQuery: () => coarseRef
+}))
+
+vi.mock('gsap', () => ({
+  gsap: { to: vi.fn((_el, opts) => opts?.onComplete?.()) }
+}))
+
+vi.mock('@/sfx/bus', () => ({
+  emitSfx: mockEmitSfx,
+  emitHoverSfx: vi.fn()
+}))
+
 import UiButton from '@/components/ui-kit/button.vue'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
 
@@ -67,5 +86,102 @@ describe('UiButton', () => {
     expect(wrapper.find('[data-testid="ui-kit-button"]').attributes('data-theme-dark')).toBe(
       'grey-900'
     )
+  })
+
+  // ── playOnTap ──────────────────────────────────────────────────────────────
+
+  describe('playOnTap', () => {
+    beforeEach(() => {
+      coarseRef.value = true
+      mockEmitSfx.mockClear()
+    })
+
+    test('defers the click handler until after the tap animation on coarse pointers', async () => {
+      const onClick = vi.fn()
+      const wrapper = shallowMount(UiButton, {
+        props: { playOnTap: true },
+        attrs: { onClick }
+      })
+
+      await wrapper.find('[data-testid="ui-kit-button"]').trigger('click')
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    test('toggles data-playing while the tap is in flight', async () => {
+      let resolveTween
+      const { gsap } = await import('gsap')
+      gsap.to.mockImplementationOnce(
+        (_el, opts) =>
+          new Promise((resolve) => {
+            resolveTween = () => {
+              opts.onComplete()
+              resolve()
+            }
+          })
+      )
+
+      const onClick = vi.fn()
+      const wrapper = shallowMount(UiButton, {
+        props: { playOnTap: true },
+        attrs: { onClick }
+      })
+
+      await wrapper.find('[data-testid="ui-kit-button"]').trigger('click')
+
+      expect(wrapper.find('[data-testid="ui-kit-button"]').attributes('data-playing')).toBe('true')
+
+      resolveTween()
+    })
+
+    test('does not intercept on pointer:fine — handler fires natively', async () => {
+      coarseRef.value = false
+      const onClick = vi.fn()
+      const wrapper = shallowMount(UiButton, {
+        props: { playOnTap: true },
+        attrs: { onClick }
+      })
+
+      await wrapper.find('[data-testid="ui-kit-button"]').trigger('click')
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not intercept when playOnTap is false', async () => {
+      const onClick = vi.fn()
+      const wrapper = shallowMount(UiButton, {
+        props: { playOnTap: false },
+        attrs: { onClick }
+      })
+
+      const { gsap } = await import('gsap')
+      gsap.to.mockClear()
+      await wrapper.find('[data-testid="ui-kit-button"]').trigger('click')
+
+      expect(gsap.to).not.toHaveBeenCalled()
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    test('emits click sfx at the start of the tap when sfx.click is set', async () => {
+      const wrapper = shallowMount(UiButton, {
+        props: { playOnTap: true, sfx: { click: 'ui.select' } },
+        attrs: { onClick: vi.fn() }
+      })
+
+      await wrapper.find('[data-testid="ui-kit-button"]').trigger('click')
+
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.select', expect.any(Object))
+    })
+
+    test('omits sfx when sfx.click is not set', async () => {
+      const wrapper = shallowMount(UiButton, {
+        props: { playOnTap: true },
+        attrs: { onClick: vi.fn() }
+      })
+
+      await wrapper.find('[data-testid="ui-kit-button"]').trigger('click')
+
+      expect(mockEmitSfx).not.toHaveBeenCalled()
+    })
   })
 })

--- a/tests/unit/composables/use-play-on-tap.test.js
+++ b/tests/unit/composables/use-play-on-tap.test.js
@@ -1,0 +1,198 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+const { coarseRef, mockUseMediaQuery, mockPlayButtonTap } = vi.hoisted(() => {
+  const coarseRef = { value: true }
+  return {
+    coarseRef,
+    mockUseMediaQuery: vi.fn(() => coarseRef),
+    mockPlayButtonTap: vi.fn(() => Promise.resolve())
+  }
+})
+
+vi.mock('@/composables/use-media-query', () => ({
+  useMediaQuery: mockUseMediaQuery
+}))
+
+vi.mock('@/utils/animations/button-tap', () => ({
+  BUTTON_TAP_DURATION: 0.1,
+  playButtonTap: mockPlayButtonTap
+}))
+
+import { usePlayOnTap } from '@/composables/use-play-on-tap'
+
+function makeEvent(target = document.createElement('div')) {
+  const e = new MouseEvent('click', { bubbles: true, cancelable: true })
+  Object.defineProperty(e, 'currentTarget', { value: target, configurable: true })
+  vi.spyOn(e, 'stopImmediatePropagation')
+  vi.spyOn(e, 'preventDefault')
+  return e
+}
+
+describe('usePlayOnTap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    coarseRef.value = true
+    mockPlayButtonTap.mockImplementation(() => Promise.resolve())
+  })
+
+  describe('coarse-only gating (default)', () => {
+    test('returns playing ref initialized to false', () => {
+      const { playing } = usePlayOnTap()
+      expect(playing.value).toBe(false)
+    })
+
+    test('runs animation when pointer is coarse', async () => {
+      const { interceptClick, playing } = usePlayOnTap()
+      const onAfter = vi.fn()
+      const e = makeEvent()
+
+      await interceptClick(e, onAfter)
+
+      expect(mockPlayButtonTap).toHaveBeenCalled()
+      expect(onAfter).toHaveBeenCalledWith(e)
+      expect(playing.value).toBe(false) // reset defaults true
+    })
+
+    test('skips intercept on pointer:fine and does not call onAfter', async () => {
+      coarseRef.value = false
+      const { interceptClick, playing } = usePlayOnTap()
+      const onAfter = vi.fn()
+      const e = makeEvent()
+
+      await interceptClick(e, onAfter)
+
+      expect(e.stopImmediatePropagation).not.toHaveBeenCalled()
+      expect(e.preventDefault).not.toHaveBeenCalled()
+      expect(mockPlayButtonTap).not.toHaveBeenCalled()
+      expect(onAfter).not.toHaveBeenCalled()
+      expect(playing.value).toBe(false)
+    })
+  })
+
+  describe('activeOn: "always"', () => {
+    test('runs on pointer:fine when activeOn=always', async () => {
+      coarseRef.value = false
+      const { interceptClick } = usePlayOnTap({ activeOn: 'always' })
+      const onAfter = vi.fn()
+      const e = makeEvent()
+
+      await interceptClick(e, onAfter)
+
+      expect(mockPlayButtonTap).toHaveBeenCalled()
+      expect(onAfter).toHaveBeenCalled()
+    })
+  })
+
+  describe('event handling', () => {
+    test('stops propagation and prevents default before animation', async () => {
+      const { interceptClick } = usePlayOnTap()
+      const e = makeEvent()
+      await interceptClick(e, vi.fn())
+
+      expect(e.stopImmediatePropagation).toHaveBeenCalled()
+      expect(e.preventDefault).toHaveBeenCalled()
+    })
+
+    test('sets playing=true during animation, before onAfter runs', async () => {
+      let playingDuringTween
+      mockPlayButtonTap.mockImplementation(() => {
+        playingDuringTween = playing.value
+        return Promise.resolve()
+      })
+      const { interceptClick, playing } = usePlayOnTap()
+      await interceptClick(makeEvent(), vi.fn())
+      expect(playingDuringTween).toBe(true)
+    })
+  })
+
+  describe('re-entrancy', () => {
+    test('is a no-op while already playing', async () => {
+      let resolveTween
+      mockPlayButtonTap.mockImplementation(() => new Promise((r) => (resolveTween = r)))
+      const { interceptClick, playing } = usePlayOnTap()
+      const onAfter = vi.fn()
+
+      const first = interceptClick(makeEvent(), onAfter)
+      await nextTick()
+      expect(playing.value).toBe(true)
+
+      await interceptClick(makeEvent(), onAfter)
+      expect(mockPlayButtonTap).toHaveBeenCalledTimes(1)
+
+      resolveTween()
+      await first
+      await flushPromises()
+    })
+  })
+
+  describe('beforePlay hook', () => {
+    test('fires before the animation, after stop/preventDefault', async () => {
+      const beforePlay = vi.fn()
+      mockPlayButtonTap.mockImplementation(() => {
+        expect(beforePlay).toHaveBeenCalledTimes(1)
+        return Promise.resolve()
+      })
+      const { interceptClick } = usePlayOnTap({ beforePlay })
+      const e = makeEvent()
+      await interceptClick(e, vi.fn())
+      expect(beforePlay).toHaveBeenCalledWith(e)
+    })
+
+    test('is not called when intercept is skipped', async () => {
+      coarseRef.value = false
+      const beforePlay = vi.fn()
+      const { interceptClick } = usePlayOnTap({ beforePlay })
+      await interceptClick(makeEvent(), vi.fn())
+      expect(beforePlay).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('reset', () => {
+    test('resets playing to false after onAfter when reset=true (default)', async () => {
+      const { interceptClick, playing } = usePlayOnTap()
+      await interceptClick(makeEvent(), vi.fn())
+      expect(playing.value).toBe(false)
+    })
+
+    test('holds playing=true after onAfter when reset=false', async () => {
+      const { interceptClick, playing } = usePlayOnTap({ reset: false })
+      await interceptClick(makeEvent(), vi.fn())
+      expect(playing.value).toBe(true)
+    })
+  })
+
+  describe('animate option', () => {
+    test('uses GSAP when animate is true (default)', async () => {
+      const { interceptClick } = usePlayOnTap()
+      await interceptClick(makeEvent(), vi.fn())
+      expect(mockPlayButtonTap).toHaveBeenCalled()
+    })
+
+    test('uses setTimeout-based hold when animate=false', async () => {
+      vi.useFakeTimers()
+      const { interceptClick, playing } = usePlayOnTap({ animate: false, duration: 0.25 })
+      const onAfter = vi.fn()
+
+      const p = interceptClick(makeEvent(), onAfter)
+      await nextTick()
+      expect(playing.value).toBe(true)
+      expect(mockPlayButtonTap).not.toHaveBeenCalled()
+      expect(onAfter).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(250)
+      await p
+      expect(onAfter).toHaveBeenCalled()
+      vi.useRealTimers()
+    })
+  })
+
+  describe('duration option', () => {
+    test('forwards duration to playButtonTap', async () => {
+      const { interceptClick } = usePlayOnTap({ duration: 0.4 })
+      await interceptClick(makeEvent(), vi.fn())
+      expect(mockPlayButtonTap).toHaveBeenCalledWith(expect.any(HTMLElement), 0.4)
+    })
+  })
+})

--- a/tests/unit/utils/animations/button-tap.test.js
+++ b/tests/unit/utils/animations/button-tap.test.js
@@ -1,0 +1,45 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+
+const { mockTo } = vi.hoisted(() => ({
+  mockTo: vi.fn((_el, opts) => opts?.onComplete?.())
+}))
+
+vi.mock('gsap', () => ({ gsap: { to: mockTo } }))
+
+import { BUTTON_TAP_DURATION, playButtonTap } from '@/utils/animations/button-tap'
+
+const el = document.createElement('div')
+
+describe('playButtonTap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('tweens scale and rotate on the element', () => {
+    playButtonTap(el)
+    expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ scale: 1.2, rotate: 3 }))
+  })
+
+  test('defaults duration to BUTTON_TAP_DURATION', () => {
+    playButtonTap(el)
+    expect(mockTo.mock.calls[0][1].duration).toBe(BUTTON_TAP_DURATION)
+  })
+
+  test('forwards the duration argument', () => {
+    playButtonTap(el, 0.5)
+    expect(mockTo.mock.calls[0][1].duration).toBe(0.5)
+  })
+
+  test('resolves the returned promise via onComplete', async () => {
+    await expect(playButtonTap(el)).resolves.toBeUndefined()
+  })
+
+  test('uses power2.out easing', () => {
+    playButtonTap(el)
+    expect(mockTo.mock.calls[0][1].ease).toBe('power2.out')
+  })
+
+  test('BUTTON_TAP_DURATION is a positive number', () => {
+    expect(BUTTON_TAP_DURATION).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `usePlayOnTap` composable and a `playOnTap` option on `ui-button` that defers a click handler until after a quick tap animation, firing sfx at the start. The composable defaults to `coarse-only` so desktop clicks pass straight through. Wired into `ui-button` (opt-in), `deck-thumbnail` (animate:false — drives existing outline/scale CSS via `data-playing`), and the `mobile-sheet` close button.