### PR TITLE
fix(member): widen ResolvedMemberPreferences from literal-narrowed defaults

### DIFF
--- a/src/utils/member/preferences.ts
+++ b/src/utils/member/preferences.ts
@@ -1,12 +1,14 @@
-export const MEMBER_PREFERENCES_DEFAULTS = {
+export type ResolvedMemberPreferences = {
+  accessibility: {
+    left_hand: boolean
+  }
+}
+
+export const MEMBER_PREFERENCES_DEFAULTS: ResolvedMemberPreferences = {
   accessibility: {
     left_hand: false
   }
-} as const
-
-type DeepRequired<T> = { [K in keyof T]-?: T[K] extends object ? DeepRequired<T[K]> : T[K] }
-
-export type ResolvedMemberPreferences = DeepRequired<typeof MEMBER_PREFERENCES_DEFAULTS>
+}
 
 /** Merge a partial preferences blob over defaults, filling any missing namespace/key. */
 export function withMemberPreferencesDefaults(


### PR DESCRIPTION
## Summary

- Follow-up to #209. The deploy build was failing with `TS2322: Type 'boolean' is not assignable to type 'false'` because `MEMBER_PREFERENCES_DEFAULTS as const` narrowed `left_hand` to literal `false`, and `ResolvedMemberPreferences = DeepRequired<typeof DEFAULTS>` propagated that narrowing — any `true` write was rejected.
- Declare `ResolvedMemberPreferences` explicitly with `left_hand: boolean` and type the defaults constant to it. No runtime change.
- Note: local `vp check` runs oxlint only; `pnpm run type-check` (vue-tsc) is what caught this in CI. Worth wiring vue-tsc into the local check loop in a separate PR.