### PR TITLE
Phone app tap feedback: animation, burst, sfx

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/node": "^22.19.17",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vitejs/plugin-vue-jsx": "^5.1.5",
-    "@vitest/browser-playwright": "^4.1.5",
+    "@vitest/browser-playwright": "4.1.4",
     "@vitest/coverage-v8": "^4.1.5",
     "@vitest/ui": "^4.1.5",
     "@vue/eslint-config-prettier": "^10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: ^5.1.5
         version: 5.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
       '@vitest/browser-playwright':
-        specifier: ^4.1.5
-        version: 4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))(playwright@1.59.1)
+        specifier: 4.1.4
+        version: 4.1.4(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))(playwright@1.59.1)
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(@vitest/browser@4.1.5)(@voidzero-dev/vite-plus-test@0.1.21)
@@ -1675,11 +1675,16 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/browser-playwright@4.1.5':
-    resolution: {integrity: sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==}
+  '@vitest/browser-playwright@4.1.4':
+    resolution: {integrity: sha512-q3PchVhZINX23Pv+RERgAtDlp6wzVkID/smOPnZ5YGWpeWUe3jMNYppeVh15j4il3G7JIJty1d1Kicpm0HSMig==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.5
+      vitest: 4.1.4
+
+  '@vitest/browser@4.1.4':
+    resolution: {integrity: sha512-TrNaY/yVOwxtrxNsDUC/wQ56xSwplpytTeRAqF/197xV/ZddxxulBsxR6TrhVMyniJmp9in8d5u0AcDaNRY30w==}
+    peerDependencies:
+      vitest: 4.1.4
 
   '@vitest/browser@4.1.5':
     resolution: {integrity: sha512-iCDGI8c4yg+xmjUg2VsygdAUSIIB4x5Rht/P68OXy1hPELKXHDkzh87lkuTcdYmemRChDkEpB426MmDjzC0ziA==}
@@ -1695,6 +1700,17 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/mocker@4.1.5':
     resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
@@ -1706,8 +1722,14 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
   '@vitest/pretty-format@4.1.5':
     resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
   '@vitest/spy@4.1.5':
     resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
@@ -1716,6 +1738,9 @@ packages:
     resolution: {integrity: sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==}
     peerDependencies:
       vitest: 4.1.5
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
@@ -5057,13 +5082,30 @@ snapshots:
       vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
       vue: 3.5.32(typescript@5.8.3)
 
-  '@vitest/browser-playwright@4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))(playwright@1.59.1)':
+  '@vitest/browser-playwright@4.1.4(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))(playwright@1.59.1)':
     dependencies:
-      '@vitest/browser': 4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
-      '@vitest/mocker': 4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
+      '@vitest/browser': 4.1.4(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
+      '@vitest/mocker': 4.1.4(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
       vitest: '@voidzero-dev/vite-plus-test@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.4(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.4(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: '@voidzero-dev/vite-plus-test@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -5086,6 +5128,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/coverage-v8@4.1.5(@vitest/browser@4.1.5)(@voidzero-dev/vite-plus-test@0.1.21)':
     dependencies:
@@ -5103,6 +5146,15 @@ snapshots:
     optionalDependencies:
       '@vitest/browser': 4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
 
+  '@vitest/mocker@4.1.4(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.4(@types/node@22.19.17)(typescript@5.8.3)
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+
   '@vitest/mocker@4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
@@ -5111,12 +5163,20 @@ snapshots:
     optionalDependencies:
       msw: 2.13.4(@types/node@22.19.17)(typescript@5.8.3)
       vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+    optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/spy@4.1.5': {}
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/spy@4.1.5':
+    optional: true
 
   '@vitest/ui@4.1.5(@voidzero-dev/vite-plus-test@0.1.21)':
     dependencies:
@@ -5128,6 +5188,12 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vitest: '@voidzero-dev/vite-plus-test@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.5':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         version: 1.16.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))
+        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))
       '@tsconfig/node18':
         specifier: ^18.2.6
         version: 18.2.6
@@ -114,19 +114,19 @@ importers:
         version: 22.19.17
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
-        version: 6.0.6(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
+        version: 6.0.6(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
       '@vitejs/plugin-vue-jsx':
         specifier: ^5.1.5
-        version: 5.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
+        version: 5.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.5
-        version: 4.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.20)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))(playwright@1.59.1)
+        version: 4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))(playwright@1.59.1)
       '@vitest/coverage-v8':
         specifier: ^4.1.5
-        version: 4.1.5(@vitest/browser@4.1.5)(@voidzero-dev/vite-plus-test@0.1.20)
+        version: 4.1.5(@vitest/browser@4.1.5)(@voidzero-dev/vite-plus-test@0.1.21)
       '@vitest/ui':
         specifier: ^4.1.5
-        version: 4.1.5(@voidzero-dev/vite-plus-test@0.1.20)
+        version: 4.1.5(@voidzero-dev/vite-plus-test@0.1.21)
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
         version: 10.2.0(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.1)
@@ -159,7 +159,7 @@ importers:
         version: 7.0.2
       oxlint:
         specifier: ^1.60.0
-        version: 1.60.0(oxlint-tsgolint@0.22.0)
+        version: 1.61.0(oxlint-tsgolint@0.22.1)
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
@@ -177,10 +177,10 @@ importers:
         version: 28.8.0(@babel/parser@7.29.2)(vue@3.5.32(typescript@5.8.3))
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@latest
-        version: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
       vite-plus:
         specifier: latest
-        version: 0.1.20(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)
+        version: 0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)
       vite-svg-loader:
         specifier: ^5.1.1
         version: 5.1.1(vue@3.5.32(typescript@5.8.3))
@@ -189,7 +189,7 @@ importers:
         version: 2.0.0-alpha.17(@types/node@22.19.17)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.10)(typescript@5.8.3)(yaml@2.8.3)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@latest
-        version: '@voidzero-dev/vite-plus-test@0.1.20(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
       vue-tsc:
         specifier: ^2.2.12
         version: 2.2.12(typescript@5.8.3)
@@ -783,170 +783,164 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-project/runtime@0.127.0':
-    resolution: {integrity: sha512-UQYLxAhDDPHm++szfa4z0RTdcPq5vaywrAoEA2n1YaAKeanXQdjHsoT6x1gP3U97RN8LZ7yHsSOrKPCcA6mCqw==}
+  '@oxc-project/runtime@0.129.0':
+    resolution: {integrity: sha512-0+S67blQakgeNqoKGozOUp5rQBrz2ynXZ2QIINXZPiafsD0YL0UogB9hAWc1S7k6VSNwKYC/N7MqT0V6IzpHkQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@oxc-project/types@0.127.0':
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+  '@oxc-project/types@0.129.0':
+    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
-  '@oxfmt/binding-android-arm-eabi@0.46.0':
-    resolution: {integrity: sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==}
+  '@oxfmt/binding-android-arm-eabi@0.48.0':
+    resolution: {integrity: sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.46.0':
-    resolution: {integrity: sha512-v6+HhjsoV3GO0u2u9jLSAZrvWfTraDxKofUIQ7/ktS7tzS+epVsxdHmeM+XxuNcAY/nWxxU1Sg4JcGTNRXraBA==}
+  '@oxfmt/binding-android-arm64@0.48.0':
+    resolution: {integrity: sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.46.0':
-    resolution: {integrity: sha512-3eeooJGrqGIlI5MyryDZsAcKXSmKIgAD4yYtfRrRJzXZ0UTFZtiSveIur56YPrGMYZwT4XyVhHsMqrNwr1XeFA==}
+  '@oxfmt/binding-darwin-arm64@0.48.0':
+    resolution: {integrity: sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.46.0':
-    resolution: {integrity: sha512-QG8BDM0CXWbu84k2SKmCqfEddPQPFiBicwtYnLqHRWZZl57HbtOLRMac/KTq2NO4AEc4ICCBpFxJIV9zcqYfkQ==}
+  '@oxfmt/binding-darwin-x64@0.48.0':
+    resolution: {integrity: sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.46.0':
-    resolution: {integrity: sha512-9DdCqS/n2ncu/Chazvt3cpgAjAmIGQDz7hFKSrNItMApyV/Ja9mz3hD4JakIE3nS8PW9smEbPWnb389QLBY4nw==}
+  '@oxfmt/binding-freebsd-x64@0.48.0':
+    resolution: {integrity: sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
-    resolution: {integrity: sha512-Dgs7VeE2jT0LHMhw6tPEt0xQYe54kBqHEovmWsv4FVQlegCOvlIJNx0S8n4vj8WUtpT+Z6BD2HhKJPLglLxvZg==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
+    resolution: {integrity: sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
-    resolution: {integrity: sha512-Zxn3adhTH13JKnU4xXJj8FeEfF680XjXh3gSShKl57HCMBRde2tUJTgogV/1MSHA80PJEVrDa7r66TLVq3Ia7Q==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
+    resolution: {integrity: sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
-    resolution: {integrity: sha512-+TWipjrgVM8D7aIdDD0tlr3teLTTvQTn7QTE5BpT10H1Fj82gfdn9X6nn2sDgx/MepuSCfSnzFNJq2paLL0OiA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.48.0':
+    resolution: {integrity: sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.46.0':
-    resolution: {integrity: sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==}
+  '@oxfmt/binding-linux-arm64-musl@0.48.0':
+    resolution: {integrity: sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
-    resolution: {integrity: sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
+    resolution: {integrity: sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
-    resolution: {integrity: sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
+    resolution: {integrity: sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
-    resolution: {integrity: sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==}
+  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
+    resolution: {integrity: sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
-    resolution: {integrity: sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==}
+  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
+    resolution: {integrity: sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.46.0':
-    resolution: {integrity: sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==}
+  '@oxfmt/binding-linux-x64-gnu@0.48.0':
+    resolution: {integrity: sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.46.0':
-    resolution: {integrity: sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==}
+  '@oxfmt/binding-linux-x64-musl@0.48.0':
+    resolution: {integrity: sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.46.0':
-    resolution: {integrity: sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==}
+  '@oxfmt/binding-openharmony-arm64@0.48.0':
+    resolution: {integrity: sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
-    resolution: {integrity: sha512-/5ktYUliP89RhgC37DBH1x20U5zPSZMy3cMEcO0j3793rbHP9MWsknBwQB6eozRzWmYrh0IFM/p20EbPvDlYlg==}
+  '@oxfmt/binding-win32-arm64-msvc@0.48.0':
+    resolution: {integrity: sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
-    resolution: {integrity: sha512-3WTnoiuIr8XvV0DIY7SN+1uJSwKf4sPpcbHfobcRT9JutGcLaef/miyBB87jxd3aqH+mS0+G5lsgHuXLUwjjpQ==}
+  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
+    resolution: {integrity: sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.46.0':
-    resolution: {integrity: sha512-IXxiQpkYnOwNfP23vzwSfhdpxJzyiPTY7eTn6dn3DsriKddESzM8i6kfq9R7CD/PUJwCvQT22NgtygBeug3KoA==}
+  '@oxfmt/binding-win32-x64-msvc@0.48.0':
+    resolution: {integrity: sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.22.0':
-    resolution: {integrity: sha512-/exgXceakHbQrzaHTtKOe7MuDATaWMCCWpsCDQCZKeYhLGXzComipTrCYnHzAXrdnNBb5r5K+RRf5A6ormrhMA==}
+  '@oxlint-tsgolint/darwin-arm64@0.22.1':
+    resolution: {integrity: sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.22.0':
-    resolution: {integrity: sha512-xFGdIahlmUbK+/MpZ5y08D0ewMGLDbd2Vki5wxVFYg50lSrtgPAtdDl+kqKZLNaFu0zpMar8n9wv1le05sL/jw==}
+  '@oxlint-tsgolint/darwin-x64@0.22.1':
+    resolution: {integrity: sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.22.0':
-    resolution: {integrity: sha512-53RvC9f77eUo+V1dfQNwGVnsIfPJFMibRR0ee128EUpYNDOZe/ojmCfuXJeU7cY91V7r7fZSm42KPJocXUX8og==}
+  '@oxlint-tsgolint/linux-arm64@0.22.1':
+    resolution: {integrity: sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.22.0':
-    resolution: {integrity: sha512-evZcJAZ9hjNyuN69RnXwbt+U2pAOcYt+yvqukgugiCkRm4iBZ0R0CvpY1tgfG2XcGUhEPh8dljO+nPZTEVGpCQ==}
+  '@oxlint-tsgolint/linux-x64@0.22.1':
+    resolution: {integrity: sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.22.0':
-    resolution: {integrity: sha512-7jTO+k1mr5BxRAI2fxc1NRcE3MAbHNZ0Vef9SD1yAR6d1E6qEv5D/D7yuHpQpw6AO3qoecSVo2Jzr+JirN61+w==}
+  '@oxlint-tsgolint/win32-arm64@0.22.1':
+    resolution: {integrity: sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.22.0':
-    resolution: {integrity: sha512-7lbl9XFcqO+scsynxMzTQdl0XUe6sBUCyY/oGWvCB+JmV4U+70vzSyZJdTEzzxtkZiNnUVFFh9RJLmoiQSne+w==}
+  '@oxlint-tsgolint/win32-x64@0.22.1':
+    resolution: {integrity: sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg==}
     cpu: [x64]
     os: [win32]
-
-  '@oxlint/binding-android-arm-eabi@1.60.0':
-    resolution: {integrity: sha512-YdeJKaZckDQL1qa62a1aKq/goyq48aX3yOxaaWqWb4sau4Ee4IiLbamftNLU3zbePky6QsDj6thnSSzHRBjDfA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
 
   '@oxlint/binding-android-arm-eabi@1.61.0':
     resolution: {integrity: sha512-6eZBPgiigK5txqoVgRqxbaxiom4lM8AP8CyKPPvpzKnQ3iFRFOIDc+0AapF+qsUSwjOzr5SGk4SxQDpQhkSJMQ==}
@@ -954,10 +948,10 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.60.0':
-    resolution: {integrity: sha512-7ANS7PpXCfq84xZQ8E5WPs14gwcuPcl+/8TFNXfpSu0CQBXz3cUo2fDpHT8v8HJN+Ut02eacvMAzTnc9s6X4tw==}
+  '@oxlint/binding-android-arm-eabi@1.63.0':
+    resolution: {integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
+    cpu: [arm]
     os: [android]
 
   '@oxlint/binding-android-arm64@1.61.0':
@@ -966,11 +960,11 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.60.0':
-    resolution: {integrity: sha512-pJsgd9AfplLGBm1fIr25V6V14vMrayhx4uIQvlfH7jWs2SZwSrvi3TfgfJySB8T+hvyEH8K2zXljQiUnkgUnfQ==}
+  '@oxlint/binding-android-arm64@1.63.0':
+    resolution: {integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
+    os: [android]
 
   '@oxlint/binding-darwin-arm64@1.61.0':
     resolution: {integrity: sha512-8JbefTkbmvqkqWjmQrHke+MdpgT2UghhD/ktM4FOQSpGeCgbMToJEKdl9zwhr/YWTl92i4QI1KiTwVExpcUN8A==}
@@ -978,10 +972,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.60.0':
-    resolution: {integrity: sha512-Ue1aXHX49ivwflKqGJc7zcd/LeLgbhaTcDCQStgx5x06AXgjEAZmvrlMuIkWd4AL4FHQe6QJ9f33z04Cg448VQ==}
+  '@oxlint/binding-darwin-arm64@1.63.0':
+    resolution: {integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [arm64]
     os: [darwin]
 
   '@oxlint/binding-darwin-x64@1.61.0':
@@ -990,11 +984,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.60.0':
-    resolution: {integrity: sha512-YCyQzsQtusQw+gNRW9rRTifSO+Dt/+dtCl2NHoDMZqJlRTEZ/Oht9YnuporI9yiTx7+cB+eqzX3MtHHVHGIWhg==}
+  '@oxlint/binding-darwin-x64@1.63.0':
+    resolution: {integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
-    os: [freebsd]
+    os: [darwin]
 
   '@oxlint/binding-freebsd-x64@1.61.0':
     resolution: {integrity: sha512-K/o4hEyW7flfMel0iBVznmMBt7VIMHGdjADocHKpK1DUF9erpWnJ+BSSWd2W0c8K3mPtpph+CuHzRU6CI3l9jQ==}
@@ -1002,11 +996,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.60.0':
-    resolution: {integrity: sha512-c7dxM2Zksa45Qw16i2iGY3Fti2NirJ38FrsBsKw+qcJ0OtqTsBgKJLF0xV+yLG56UH01Z8WRPgsw31e0MoRoGQ==}
+  '@oxlint/binding-freebsd-x64@1.63.0':
+    resolution: {integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
+    cpu: [x64]
+    os: [freebsd]
 
   '@oxlint/binding-linux-arm-gnueabihf@1.61.0':
     resolution: {integrity: sha512-P6040ZkcyweJ0Po9yEFqJCdvZnf3VNCGs1SIHgXDf8AAQNC6ID/heXQs9iSgo2FH7gKaKq32VWc59XZwL34C5Q==}
@@ -1014,8 +1008,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.60.0':
-    resolution: {integrity: sha512-ZWALoA42UYqBEP1Tbw9OWURgFGS1nWj2AAvLdY6ZcGx/Gj93qVCBKjcvwXMupZibYwFbi9s/rzqkZseb/6gVtQ==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
+    resolution: {integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1026,12 +1020,11 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.60.0':
-    resolution: {integrity: sha512-tpy+1w4p9hN5CicMCxqNy6ymfRtV5ayE573vFNjp1k1TN/qhLFgflveZoE/0++RlkHikBz2vY545NWm/hp7big==}
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
+    resolution: {integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
+    cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-gnu@1.61.0':
     resolution: {integrity: sha512-vkhb9/wKguMkLlrm3FoJW/Xmdv31GgYAE+x8lxxQ+7HeOxXUySI0q36a3NTVIuQUdLzxCI1zzMGsk1o37FOe3w==}
@@ -1040,12 +1033,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.60.0':
-    resolution: {integrity: sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg==}
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
+    resolution: {integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.61.0':
     resolution: {integrity: sha512-bl1dQh8LnVqsj6oOQAcxwbuOmNJkwc4p6o//HTBZhNTzJy21TLDwAviMqUFNUxDHkPGpmdKTSN4tWTjLryP8xg==}
@@ -1054,12 +1047,12 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.60.0':
-    resolution: {integrity: sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA==}
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
+    resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
+    cpu: [arm64]
     os: [linux]
-    libc: [glibc]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.61.0':
     resolution: {integrity: sha512-QoOX6KB2IiEpyOj/HKqaxi+NQHPnOgNgnr22n9N4ANJCzXkUlj1UmeAbFb4PpqdlHIzvGDM5xZ0OKtcLq9RhiQ==}
@@ -1068,10 +1061,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.60.0':
-    resolution: {integrity: sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw==}
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+    resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
+    cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
@@ -1082,12 +1075,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.60.0':
-    resolution: {integrity: sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A==}
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+    resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.61.0':
     resolution: {integrity: sha512-65wXEmZIrX2ADwC8i/qFL4EWLSbeuBpAm3suuX1vu4IQkKd+wLT/HU/BOl84kp91u2SxPkPDyQgu4yrqp8vwVA==}
@@ -1096,12 +1089,12 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.60.0':
-    resolution: {integrity: sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g==}
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+    resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
+    cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.61.0':
     resolution: {integrity: sha512-TVvhgMvor7Qa6COeXxCJ7ENOM+lcAOGsQ0iUdPSCv2hxb9qSHLQ4XF1h50S6RE1gBOJ0WV3rNukg4JJJP1LWRA==}
@@ -1110,10 +1103,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.60.0':
-    resolution: {integrity: sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA==}
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+    resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -1124,12 +1117,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.60.0':
-    resolution: {integrity: sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg==}
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
+    resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.61.0':
     resolution: {integrity: sha512-gGfAeGD4sNJGILZbc/yKcIimO9wQnPMoYp9swAaKeEtwsSQAbU+rsdQze5SBtIP6j0QDzeYd4XSSUCRCF+LIeQ==}
@@ -1138,11 +1131,12 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.60.0':
-    resolution: {integrity: sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA==}
+  '@oxlint/binding-linux-x64-musl@1.63.0':
+    resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.61.0':
     resolution: {integrity: sha512-OlVT0LrG/ct33EVtWRyR+B/othwmDWeRxfi13wUdPeb3lAT5TgTcFDcfLfarZtzB4W1nWF/zICMgYdkggX2WmQ==}
@@ -1150,11 +1144,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.60.0':
-    resolution: {integrity: sha512-WA/yc7f7ZfCefBXVzNHn1Ztulb1EFwNBb4jMZ6pjML0zz6pHujlF3Q3jySluz3XHl/GNeMTntG1seUBWVMlMag==}
+  '@oxlint/binding-openharmony-arm64@1.63.0':
+    resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [win32]
+    os: [openharmony]
 
   '@oxlint/binding-win32-arm64-msvc@1.61.0':
     resolution: {integrity: sha512-vI//NZPJk6DToiovPtaiwD4iQ7kO1r5ReWQD0sOOyKRtP3E2f6jxin4uvwi3OvDzHA2EFfd7DcZl5dtkQh7g1w==}
@@ -1162,10 +1156,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.60.0':
-    resolution: {integrity: sha512-33YxL1sqwYNZXtn3MD/4dno6s0xeedXOJlT1WohkVD565WvohClZUr7vwKdAk954n4xiEWJkewiCr+zLeq7AeA==}
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
+    resolution: {integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
+    cpu: [arm64]
     os: [win32]
 
   '@oxlint/binding-win32-ia32-msvc@1.61.0':
@@ -1174,14 +1168,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.60.0':
-    resolution: {integrity: sha512-JOro4ZcfBLamJCyfURQmOQByoorgOdx3ZjAkSqnb/CyG/i+lN3KoV5LAgk5ZAW6DPq7/Cx7n23f8DuTWXTWgyQ==}
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+    resolution: {integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
+    cpu: [ia32]
     os: [win32]
 
   '@oxlint/binding-win32-x64-msvc@1.61.0':
     resolution: {integrity: sha512-0xgSiyeqDLDZxXoe9CVJrOx3TUVsfyoOY7cNi03JbItNcC9WCZqrSNdrAbHONxhSPaVh/lzfnDcON1RqSUMhHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
+    resolution: {integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1659,6 +1659,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-vue-jsx@5.1.5':
     resolution: {integrity: sha512-jIAsvHOEtWpslLOI2MeElGFxH7M8pM83BU/Tor4RLyiwH0FM4nUW3xdvbw20EeU9wc5IspQwMq225K3CMnJEpA==}
@@ -1719,19 +1720,19 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
-  '@voidzero-dev/vite-plus-core@0.1.20':
-    resolution: {integrity: sha512-4KmzRfzwTeG3JuvDijrdqWusSgRvLMKDPrVsDdtbDVVjEMq0VnM8lSH+Nvepd6Pg+SuSVUP212OIfH/3Yn1bfA==}
+  '@voidzero-dev/vite-plus-core@0.1.21':
+    resolution: {integrity: sha512-BEnqw8h2vxgKkzBjmmW4e1kwPwzoWc+jXJQB+7e0Dm1/1AkdTaQ9FgUMFzDfYrwTDkGzCZHSSsHDOl3RERQFTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.21.10
-      '@tsdown/exe': 0.21.10
+      '@tsdown/css': 0.22.0
+      '@tsdown/exe': 0.22.0
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
+      '@vitejs/devtools': ^0.1.18
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      publint: ^0.3.0
+      publint: ^0.3.8
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -1740,6 +1741,7 @@ packages:
       tsx: ^4.8.1
       typescript: ^5.0.0 || ^6.0.0
       unplugin-unused: ^0.5.0
+      unrun: '*'
       yaml: ^2.4.2
     peerDependenciesMeta:
       '@arethetypeswrong/core':
@@ -1776,51 +1778,53 @@ packages:
         optional: true
       unplugin-unused:
         optional: true
+      unrun:
+        optional: true
       yaml:
         optional: true
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.1.20':
-    resolution: {integrity: sha512-ykCOJk91h0IEMvljYGTauI4Svxr/CatZAitofvtEFqaTCLE3n06QCHD8qWphMM784VnPz1G/J2xuewxbQduNlg==}
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.21':
+    resolution: {integrity: sha512-T7mPiDbE7VtjpegtJJ/e/uQOjOA/ufMo7npAaP9WVHxUEWLaR/OjVXXL9ALiW+CfKEQ0Qk/iWDB0mI6YMndzNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.1.20':
-    resolution: {integrity: sha512-5XxNW9cYEh85Z4BErALyWh/tLP/NZmxNXzUQ0FanhHreI2Zq7FfgbSqQNvC7/sYsPYTWf74RlxmIjzV7R/Lb5Q==}
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.21':
+    resolution: {integrity: sha512-DqS0ZJ0sRtXu55loEIz/mkX99fl1HQ0b9UUj+Qm13NoMfh6JC8d0g6J+Dbu/EJy0TEU7QLjCXoALLQ7ZrsW34g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.20':
-    resolution: {integrity: sha512-Mc7npPBd9t/h0haURVCZGae+TfB0Yx2Ex8HbPKOVA4hnN9ynlMhMpLRFfTQAicDKYbEGDhfBcbCIX0vVv4vacA==}
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.21':
+    resolution: {integrity: sha512-PoW375e3pSayRuN43agoe8LdItEa82bPhcaW7elPxoiO8puynB+4x5Xy5ozU5XgjEuCB3nYKE6R/b9peWsaFEQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.20':
-    resolution: {integrity: sha512-Oh/pxMdTLR/wsDl/OONjItjLOeTewFBLuKkH5RQmcI9g3AVqKzLj1/uawujgysBI5E25tonRRK7I2q/zu8Uqvg==}
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.21':
+    resolution: {integrity: sha512-Q5c6i1TyRuMELDcGozuI5Y0JhIZsSbAJ067Okty6XmoJ5tSmUnMzEO5HKRmgjfGryjJpn5dpUKXzj2eWsdx+6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.20':
-    resolution: {integrity: sha512-msO1ZoUX5aSK8L6kN1C3XQO4CcH9aFsNPRSNcO1cjk1kTnaLyVYzkVxgvbh3vk7nzZAAMkmyZ4SlMpqJrdahrg==}
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.21':
+    resolution: {integrity: sha512-DquiIAvGIUIJBfqOnqAtBPoyhNIGLM1DzswzDPddO5kjg6NCE4hPbFr5ncjhSKqyp88Kd1YWYD93yg3FAdr/EA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.20':
-    resolution: {integrity: sha512-U93urREvg23ZFDkxKkkfWWIOI4GI9erhbWAZpXG+GeYqygWKrVC6PUTXiuexVg3/CFg2sSMTdm1W6V7TFG5hYA==}
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.21':
+    resolution: {integrity: sha512-/nVT+eFySYwf3uEv+n9FrdJ0bg3SbfqUkAnIxH7XMQ/hhmU4lAE2dH4SiUqk6h70gESaFHfJmhWtp5Qzt/W7Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@voidzero-dev/vite-plus-test@0.1.20':
-    resolution: {integrity: sha512-vy2dJYw1bhgQ/+BrQrfwPlSKzQ2mm3YLJ9kGF7Yo0UJ2P3XKpshtgFIWLjSg/IASnC93OAx0c/7j3NM0I1RMuA==}
+  '@voidzero-dev/vite-plus-test@0.1.21':
+    resolution: {integrity: sha512-kRUh2rELGFg9Agv2OhoaNCSRfy7XUFCL9n+aNEvSStI/p8C5iPMMe2auZCfbLbUcvpsDFvNVOwtY4XQRDFJiJQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@edge-runtime/vm': '*'
@@ -1850,14 +1854,14 @@ packages:
       jsdom:
         optional: true
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.20':
-    resolution: {integrity: sha512-deXfe3h2OpzKV88s1PMUgVOJfN9LlnDDpIEVH6y2+YAXwlTSO7YeKBj2QmyS6ALZCI4Rfp4HOsB0OKMVBfEqww==}
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.21':
+    resolution: {integrity: sha512-KhEqfRKlfuuVJb2eY8ZCmmXcxUqy8/ZBZPWPipxcB1QDWIykyN5F4zbewLxXw18JL/Q0ISP0p7V8RIldAh4Gyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.20':
-    resolution: {integrity: sha512-ygdgQgo0N9oUI1Q2IdYBcvr+KLY6riaqLY/bkWNYtvHS4uk8a4GuEd0F08znWt2E8sFm29i35bYIzI6fFY2EBg==}
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.21':
+    resolution: {integrity: sha512-lH8d2qElBfUUpejZhYvK3CrP6kHTz0z2jff/ZowlY6jkr1pQkYj3EVhRi5r81DXcbXZs9yAbXbBPw8mVZtG9FA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3056,17 +3060,17 @@ packages:
     resolution: {integrity: sha512-xOmqaUG+zxCEq98fsEnLODO05HmnyQM4tkwKFKtELfHCZFOAoI9U4x8hdNeeWQvrVb/BXu6cr8zPbhixRYo3tA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  oxfmt@0.46.0:
-    resolution: {integrity: sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==}
+  oxfmt@0.48.0:
+    resolution: {integrity: sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-tsgolint@0.22.0:
-    resolution: {integrity: sha512-ku4MecLmCQIj1ScCtzNAqTuyl0BJQ02B36fJT+c5XQihHpYSFak+FC3GYO5fPyYk4oDwi0w0S7hTvrpNzuZhig==}
+  oxlint-tsgolint@0.22.1:
+    resolution: {integrity: sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg==}
     hasBin: true
 
-  oxlint@1.60.0:
-    resolution: {integrity: sha512-tnRzTWiWJ9pg3ftRWnD0+Oqh78L6ZSwcEudvCZaER0PIqiAnNyXj5N1dPwjmNpDalkKS9m/WMLN1CTPUBPmsgw==}
+  oxlint@1.61.0:
+    resolution: {integrity: sha512-ZC0ALuhDZ6ivOFG+sy0D0pEDN49EvsId98zVlmYdkcXHsEM14m/qTNUEsUpiFiCVbpIxYtVBmmLE87nsbUHohQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3075,12 +3079,12 @@ packages:
       oxlint-tsgolint:
         optional: true
 
-  oxlint@1.61.0:
-    resolution: {integrity: sha512-ZC0ALuhDZ6ivOFG+sy0D0pEDN49EvsId98zVlmYdkcXHsEM14m/qTNUEsUpiFiCVbpIxYtVBmmLE87nsbUHohQ==}
+  oxlint@1.63.0:
+    resolution: {integrity: sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.18.0'
+      oxlint-tsgolint: '>=0.22.1'
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
@@ -3570,8 +3574,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-plus@0.1.20:
-    resolution: {integrity: sha512-hxJqXTxiiFhszwAeD0MvKlztVuXE4TztTdJ64BPxGqgY67F0PDa5eZkUsrN91Ae8aYUMfweW6V/J57OUO9/0zw==}
+  vite-plus@0.1.21:
+    resolution: {integrity: sha512-7MLc9abMelE8g5/vj/xEY8joWT9PLnN/XjX3FhwOliB75WOX3YADcMEFrufmvnl+D4UhrMNZQa2k3A5CSuFJhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4414,197 +4418,197 @@ snapshots:
   '@oxc-minify/binding-win32-x64-msvc@0.125.0':
     optional: true
 
-  '@oxc-project/runtime@0.127.0': {}
+  '@oxc-project/runtime@0.129.0': {}
 
-  '@oxc-project/types@0.127.0': {}
+  '@oxc-project/types@0.129.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.46.0':
+  '@oxfmt/binding-android-arm-eabi@0.48.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.46.0':
+  '@oxfmt/binding-android-arm64@0.48.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.46.0':
+  '@oxfmt/binding-darwin-arm64@0.48.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.46.0':
+  '@oxfmt/binding-darwin-x64@0.48.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.46.0':
+  '@oxfmt/binding-freebsd-x64@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.46.0':
+  '@oxfmt/binding-linux-arm64-musl@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.46.0':
+  '@oxfmt/binding-linux-x64-gnu@0.48.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.46.0':
+  '@oxfmt/binding-linux-x64-musl@0.48.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.46.0':
+  '@oxfmt/binding-openharmony-arm64@0.48.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.48.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.48.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.46.0':
+  '@oxfmt/binding-win32-x64-msvc@0.48.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.22.0':
+  '@oxlint-tsgolint/darwin-arm64@0.22.1':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.22.0':
+  '@oxlint-tsgolint/darwin-x64@0.22.1':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.22.0':
+  '@oxlint-tsgolint/linux-arm64@0.22.1':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.22.0':
+  '@oxlint-tsgolint/linux-x64@0.22.1':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.22.0':
+  '@oxlint-tsgolint/win32-arm64@0.22.1':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.22.0':
-    optional: true
-
-  '@oxlint/binding-android-arm-eabi@1.60.0':
+  '@oxlint-tsgolint/win32-x64@0.22.1':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.61.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.60.0':
+  '@oxlint/binding-android-arm-eabi@1.63.0':
     optional: true
 
   '@oxlint/binding-android-arm64@1.61.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.60.0':
+  '@oxlint/binding-android-arm64@1.63.0':
     optional: true
 
   '@oxlint/binding-darwin-arm64@1.61.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.60.0':
+  '@oxlint/binding-darwin-arm64@1.63.0':
     optional: true
 
   '@oxlint/binding-darwin-x64@1.61.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.60.0':
+  '@oxlint/binding-darwin-x64@1.63.0':
     optional: true
 
   '@oxlint/binding-freebsd-x64@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.60.0':
+  '@oxlint/binding-freebsd-x64@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-arm-gnueabihf@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.60.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-arm-musleabihf@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.60.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-gnu@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.60.0':
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-musl@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.60.0':
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-ppc64-gnu@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.60.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-gnu@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.60.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-musl@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.60.0':
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-s390x-gnu@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.60.0':
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-x64-gnu@1.61.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.60.0':
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
     optional: true
 
   '@oxlint/binding-linux-x64-musl@1.61.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.60.0':
+  '@oxlint/binding-linux-x64-musl@1.63.0':
     optional: true
 
   '@oxlint/binding-openharmony-arm64@1.61.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.60.0':
+  '@oxlint/binding-openharmony-arm64@1.63.0':
     optional: true
 
   '@oxlint/binding-win32-arm64-msvc@1.61.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.60.0':
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
     optional: true
 
   '@oxlint/binding-win32-ia32-msvc@1.61.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.60.0':
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.61.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
     optional: true
 
   '@pinia/colada@1.2.0(pinia@3.0.4(typescript@5.8.3)(vue@3.5.32(typescript@5.8.3)))(vue@3.5.32(typescript@5.8.3))':
@@ -4861,12 +4865,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
 
   '@tanstack/virtual-core@3.14.0': {}
 
@@ -5035,47 +5039,47 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue-jsx@5.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
+  '@vitejs/plugin-vue-jsx@5.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@rolldown/pluginutils': 1.0.0-rc.16
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
-      vite: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
       vue: 3.5.32(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.6(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
+  '@vitejs/plugin-vue@6.0.6(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
       vue: 3.5.32(typescript@5.8.3)
 
-  '@vitest/browser-playwright@4.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.20)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))(playwright@1.59.1)':
+  '@vitest/browser-playwright@4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))(playwright@1.59.1)':
     dependencies:
-      '@vitest/browser': 4.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.20)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
-      '@vitest/mocker': 4.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
+      '@vitest/browser': 4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
+      '@vitest/mocker': 4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.20(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.20)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))':
+  '@vitest/browser@4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
+      '@vitest/mocker': 4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
       '@vitest/utils': 4.1.5
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.20(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -5083,7 +5087,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.1.5(@vitest/browser@4.1.5)(@voidzero-dev/vite-plus-test@0.1.20)':
+  '@vitest/coverage-v8@4.1.5(@vitest/browser@4.1.5)(@voidzero-dev/vite-plus-test@0.1.21)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.5
@@ -5095,18 +5099,18 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.20(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
     optionalDependencies:
-      '@vitest/browser': 4.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.20)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
+      '@vitest/browser': 4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(@voidzero-dev/vite-plus-test@0.1.21)(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))
 
-  '@vitest/mocker@4.1.5(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))':
+  '@vitest/mocker@4.1.5(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(msw@2.13.4(@types/node@22.19.17)(typescript@5.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.4(@types/node@22.19.17)(typescript@5.8.3)
-      vite: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -5114,7 +5118,7 @@ snapshots:
 
   '@vitest/spy@4.1.5': {}
 
-  '@vitest/ui@4.1.5(@voidzero-dev/vite-plus-test@0.1.20)':
+  '@vitest/ui@4.1.5(@voidzero-dev/vite-plus-test@0.1.21)':
     dependencies:
       '@vitest/utils': 4.1.5
       fflate: 0.8.2
@@ -5123,7 +5127,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.20(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)'
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -5131,10 +5135,10 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)':
     dependencies:
-      '@oxc-project/runtime': 0.127.0
-      '@oxc-project/types': 0.127.0
+      '@oxc-project/runtime': 0.129.0
+      '@oxc-project/types': 0.129.0
       lightningcss: 1.32.0
       postcss: 8.5.10
     optionalDependencies:
@@ -5144,29 +5148,29 @@ snapshots:
       typescript: 5.8.3
       yaml: 2.8.3
 
-  '@voidzero-dev/vite-plus-darwin-arm64@0.1.20':
+  '@voidzero-dev/vite-plus-darwin-arm64@0.1.21':
     optional: true
 
-  '@voidzero-dev/vite-plus-darwin-x64@0.1.20':
+  '@voidzero-dev/vite-plus-darwin-x64@0.1.21':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.20':
+  '@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.21':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.20':
+  '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.21':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.20':
+  '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.21':
     optional: true
 
-  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.20':
+  '@voidzero-dev/vite-plus-linux-x64-musl@0.1.21':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.20(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -5176,12 +5180,12 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      vite: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
       ws: 8.20.0
     optionalDependencies:
       '@types/node': 22.19.17
-      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(@voidzero-dev/vite-plus-test@0.1.20)
-      '@vitest/ui': 4.1.5(@voidzero-dev/vite-plus-test@0.1.20)
+      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(@voidzero-dev/vite-plus-test@0.1.21)
+      '@vitest/ui': 4.1.5(@voidzero-dev/vite-plus-test@0.1.21)
       happy-dom: 20.9.0
       jsdom: 26.1.0
     transitivePeerDependencies:
@@ -5202,13 +5206,14 @@ snapshots:
       - tsx
       - typescript
       - unplugin-unused
+      - unrun
       - utf-8-validate
       - yaml
 
-  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.20':
+  '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.21':
     optional: true
 
-  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.20':
+  '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.21':
     optional: true
 
   '@volar/language-core@2.4.15':
@@ -6427,63 +6432,40 @@ snapshots:
       '@oxc-minify/binding-win32-ia32-msvc': 0.125.0
       '@oxc-minify/binding-win32-x64-msvc': 0.125.0
 
-  oxfmt@0.46.0:
+  oxfmt@0.48.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.46.0
-      '@oxfmt/binding-android-arm64': 0.46.0
-      '@oxfmt/binding-darwin-arm64': 0.46.0
-      '@oxfmt/binding-darwin-x64': 0.46.0
-      '@oxfmt/binding-freebsd-x64': 0.46.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.46.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.46.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.46.0
-      '@oxfmt/binding-linux-arm64-musl': 0.46.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.46.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.46.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.46.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.46.0
-      '@oxfmt/binding-linux-x64-gnu': 0.46.0
-      '@oxfmt/binding-linux-x64-musl': 0.46.0
-      '@oxfmt/binding-openharmony-arm64': 0.46.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.46.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.46.0
-      '@oxfmt/binding-win32-x64-msvc': 0.46.0
+      '@oxfmt/binding-android-arm-eabi': 0.48.0
+      '@oxfmt/binding-android-arm64': 0.48.0
+      '@oxfmt/binding-darwin-arm64': 0.48.0
+      '@oxfmt/binding-darwin-x64': 0.48.0
+      '@oxfmt/binding-freebsd-x64': 0.48.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.48.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.48.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.48.0
+      '@oxfmt/binding-linux-arm64-musl': 0.48.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.48.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.48.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.48.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.48.0
+      '@oxfmt/binding-linux-x64-gnu': 0.48.0
+      '@oxfmt/binding-linux-x64-musl': 0.48.0
+      '@oxfmt/binding-openharmony-arm64': 0.48.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.48.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.48.0
+      '@oxfmt/binding-win32-x64-msvc': 0.48.0
 
-  oxlint-tsgolint@0.22.0:
+  oxlint-tsgolint@0.22.1:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.22.0
-      '@oxlint-tsgolint/darwin-x64': 0.22.0
-      '@oxlint-tsgolint/linux-arm64': 0.22.0
-      '@oxlint-tsgolint/linux-x64': 0.22.0
-      '@oxlint-tsgolint/win32-arm64': 0.22.0
-      '@oxlint-tsgolint/win32-x64': 0.22.0
+      '@oxlint-tsgolint/darwin-arm64': 0.22.1
+      '@oxlint-tsgolint/darwin-x64': 0.22.1
+      '@oxlint-tsgolint/linux-arm64': 0.22.1
+      '@oxlint-tsgolint/linux-x64': 0.22.1
+      '@oxlint-tsgolint/win32-arm64': 0.22.1
+      '@oxlint-tsgolint/win32-x64': 0.22.1
 
-  oxlint@1.60.0(oxlint-tsgolint@0.22.0):
-    optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.60.0
-      '@oxlint/binding-android-arm64': 1.60.0
-      '@oxlint/binding-darwin-arm64': 1.60.0
-      '@oxlint/binding-darwin-x64': 1.60.0
-      '@oxlint/binding-freebsd-x64': 1.60.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.60.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.60.0
-      '@oxlint/binding-linux-arm64-gnu': 1.60.0
-      '@oxlint/binding-linux-arm64-musl': 1.60.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.60.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.60.0
-      '@oxlint/binding-linux-riscv64-musl': 1.60.0
-      '@oxlint/binding-linux-s390x-gnu': 1.60.0
-      '@oxlint/binding-linux-x64-gnu': 1.60.0
-      '@oxlint/binding-linux-x64-musl': 1.60.0
-      '@oxlint/binding-openharmony-arm64': 1.60.0
-      '@oxlint/binding-win32-arm64-msvc': 1.60.0
-      '@oxlint/binding-win32-ia32-msvc': 1.60.0
-      '@oxlint/binding-win32-x64-msvc': 1.60.0
-      oxlint-tsgolint: 0.22.0
-
-  oxlint@1.61.0(oxlint-tsgolint@0.22.0):
+  oxlint@1.61.0(oxlint-tsgolint@0.22.1):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.61.0
       '@oxlint/binding-android-arm64': 1.61.0
@@ -6504,7 +6486,30 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.61.0
       '@oxlint/binding-win32-ia32-msvc': 1.61.0
       '@oxlint/binding-win32-x64-msvc': 1.61.0
-      oxlint-tsgolint: 0.22.0
+      oxlint-tsgolint: 0.22.1
+
+  oxlint@1.63.0(oxlint-tsgolint@0.22.1):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.63.0
+      '@oxlint/binding-android-arm64': 1.63.0
+      '@oxlint/binding-darwin-arm64': 1.63.0
+      '@oxlint/binding-darwin-x64': 1.63.0
+      '@oxlint/binding-freebsd-x64': 1.63.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.63.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.63.0
+      '@oxlint/binding-linux-arm64-gnu': 1.63.0
+      '@oxlint/binding-linux-arm64-musl': 1.63.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-musl': 1.63.0
+      '@oxlint/binding-linux-s390x-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-musl': 1.63.0
+      '@oxlint/binding-openharmony-arm64': 1.63.0
+      '@oxlint/binding-win32-arm64-msvc': 1.63.0
+      '@oxlint/binding-win32-ia32-msvc': 1.63.0
+      '@oxlint/binding-win32-x64-msvc': 1.63.0
+      oxlint-tsgolint: 0.22.1
 
   p-limit@3.1.0:
     dependencies:
@@ -6978,23 +6983,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.1.20(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3):
+  vite-plus@0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3):
     dependencies:
-      '@oxc-project/types': 0.127.0
-      '@voidzero-dev/vite-plus-core': 0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.20(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)
-      oxfmt: 0.46.0
-      oxlint: 1.61.0(oxlint-tsgolint@0.22.0)
-      oxlint-tsgolint: 0.22.0
+      '@oxc-project/types': 0.129.0
+      '@voidzero-dev/vite-plus-core': 0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.21(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@26.1.0)(typescript@5.8.3)(yaml@2.8.3)
+      oxfmt: 0.48.0
+      oxlint: 1.63.0(oxlint-tsgolint@0.22.1)
+      oxlint-tsgolint: 0.22.1
     optionalDependencies:
-      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.20
-      '@voidzero-dev/vite-plus-darwin-x64': 0.1.20
-      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.20
-      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.20
-      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.20
-      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.20
-      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.20
-      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.20
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.21
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.21
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.21
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.21
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.21
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.21
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.21
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.21
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@edge-runtime/vm'
@@ -7021,6 +7026,7 @@ snapshots:
       - tsx
       - typescript
       - unplugin-unused
+      - unrun
       - utf-8-validate
       - vite
       - yaml
@@ -7043,7 +7049,7 @@ snapshots:
       '@shikijs/transformers': 3.23.0
       '@shikijs/types': 3.23.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.6(@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
+      '@vitejs/plugin-vue': 6.0.6(@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3))(vue@3.5.32(typescript@5.8.3))
       '@vue/devtools-api': 8.1.1
       '@vue/shared': 3.5.32
       '@vueuse/core': 14.2.1(vue@3.5.32(typescript@5.8.3))
@@ -7052,7 +7058,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 3.23.0
-      vite: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@22.19.17)(jiti@2.6.1)(typescript@5.8.3)(yaml@2.8.3)'
       vue: 3.5.32(typescript@5.8.3)
     optionalDependencies:
       oxc-minify: 0.125.0
@@ -7086,6 +7092,7 @@ snapshots:
       - typescript
       - universal-cookie
       - unplugin-unused
+      - unrun
       - yaml
 
   vscode-uri@3.1.0: {}

--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -20,19 +20,19 @@ const {
 
 const attrs = useAttrs()
 
-const { playing, interceptClick } = usePlayOnTap({
-  animate: false,
-  beforePlay: () => {
-    if (click_sfx) emitSfx(click_sfx)
-  }
-})
+const { playing, interceptClick } = usePlayOnTap({ animate: false })
 
 function onCaptureClick(e: MouseEvent) {
   const handler = attrs.onClick as ((ev: MouseEvent) => void) | undefined
 
   if (!handler) return
 
-  interceptClick(e, handler)
+  interceptClick(e, {
+    beforePlay: () => {
+      if (click_sfx) emitSfx(click_sfx)
+    },
+    onAfter: handler
+  })
 }
 </script>
 

--- a/src/components/ui-kit/burst.vue
+++ b/src/components/ui-kit/burst.vue
@@ -4,11 +4,12 @@ export type BurstSize = 'xs' | 'sm' | 'base' | 'lg' | 'xl'
 const {
   size = 'base',
   duration = 350,
-  color = 'white'
+  width
 } = defineProps<{
   size?: BurstSize
   duration?: number
-  color?: string
+  /** Streak width in px. Defaults to 6. */
+  width?: number
 }>()
 
 const emit = defineEmits<{ done: [] }>()
@@ -17,18 +18,22 @@ const emit = defineEmits<{ done: [] }>()
 <template>
   <div
     class="burst"
+    data-theme="brown-100"
     :class="`burst--${size}`"
-    :style="{ '--burst-dur': `${duration}ms`, '--burst-dot-color': color }"
+    :style="{
+      '--burst-dur': `${duration}ms`,
+      ...(width !== undefined && { '--burst-dot-size': `${width}px` })
+    }"
     @animationend.once="emit('done')"
   >
-    <div class="spoke" style="--i: 0"><span class="dot"></span></div>
-    <div class="spoke" style="--i: 1"><span class="dot"></span></div>
-    <div class="spoke" style="--i: 2"><span class="dot"></span></div>
-    <div class="spoke" style="--i: 3"><span class="dot"></span></div>
-    <div class="spoke" style="--i: 4"><span class="dot"></span></div>
-    <div class="spoke" style="--i: 5"><span class="dot"></span></div>
-    <div class="spoke" style="--i: 6"><span class="dot"></span></div>
-    <div class="spoke" style="--i: 7"><span class="dot"></span></div>
+    <div class="spoke" style="--i: 0"><span class="dot bg-(--theme-primary)"></span></div>
+    <div class="spoke" style="--i: 1"><span class="dot bg-(--theme-primary)"></span></div>
+    <div class="spoke" style="--i: 2"><span class="dot bg-(--theme-primary)"></span></div>
+    <div class="spoke" style="--i: 3"><span class="dot bg-(--theme-primary)"></span></div>
+    <div class="spoke" style="--i: 4"><span class="dot bg-(--theme-primary)"></span></div>
+    <div class="spoke" style="--i: 5"><span class="dot bg-(--theme-primary)"></span></div>
+    <div class="spoke" style="--i: 6"><span class="dot bg-(--theme-primary)"></span></div>
+    <div class="spoke" style="--i: 7"><span class="dot bg-(--theme-primary)"></span></div>
   </div>
 </template>
 
@@ -51,7 +56,7 @@ const emit = defineEmits<{ done: [] }>()
 
 .burst {
   --n: 8;
-  --dot-size: 6px;
+  --dot-size: var(--burst-dot-size, 6px);
   --spoke-min: var(--dot-size);
   --spoke-max: 25px;
 
@@ -103,7 +108,6 @@ const emit = defineEmits<{ done: [] }>()
   top: 0;
   width: var(--dot-size);
   height: var(--spoke-length);
-  background: var(--burst-dot-color, white);
   border-radius: 9999px;
   transform-origin: 50% 0%;
   translate: calc(-0.5 * var(--dot-size)) 0;

--- a/src/components/ui-kit/burst.vue
+++ b/src/components/ui-kit/burst.vue
@@ -17,6 +17,7 @@ const emit = defineEmits<{ done: [] }>()
 
 <template>
   <div
+    data-testid="ui-kit-burst"
     class="burst"
     data-theme="brown-100"
     :class="`burst--${size}`"

--- a/src/components/ui-kit/burst.vue
+++ b/src/components/ui-kit/burst.vue
@@ -3,7 +3,7 @@ export type BurstSize = 'xs' | 'sm' | 'base' | 'lg' | 'xl'
 
 const {
   size = 'base',
-  duration = 500,
+  duration = 350,
   color = 'white'
 } = defineProps<{
   size?: BurstSize
@@ -113,12 +113,15 @@ const emit = defineEmits<{ done: [] }>()
 @keyframes burstProgress {
   0% {
     --p: 0;
+    opacity: 1;
   }
-  50% {
+  60% {
     --p: 1;
+    opacity: 1;
   }
   100% {
     --p: 1;
+    opacity: 0;
   }
 }
 </style>

--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -40,17 +40,7 @@ const {
 const slots = useSlots()
 const attrs = useAttrs()
 
-const { playing, interceptClick } = usePlayOnTap({
-  reset: false,
-  beforePlay: () => {
-    const click_sfx = merged_sfx.value.click
-    if (!click_sfx) return
-    emitSfx(click_sfx, {
-      debounce: merged_sfx.value.debounce,
-      blocking: merged_sfx.value.click_blocking
-    })
-  }
-})
+const { playing, interceptClick } = usePlayOnTap({ reset: false })
 
 const merged_sfx = computed(() => {
   return {
@@ -65,7 +55,20 @@ function onCaptureClick(e: MouseEvent) {
   if (!playOnTap) return
   const handler = attrs.onClick as ((ev: MouseEvent) => void) | undefined
   if (!handler) return
-  interceptClick(e, handler)
+
+  interceptClick(e, {
+    beforePlay: emitClickSfx,
+    onAfter: handler
+  })
+}
+
+function emitClickSfx() {
+  const click_sfx = merged_sfx.value.click
+  if (!click_sfx) return
+  emitSfx(click_sfx, {
+    debounce: merged_sfx.value.debounce,
+    blocking: merged_sfx.value.click_blocking
+  })
 }
 </script>
 

--- a/src/composables/use-play-on-tap.ts
+++ b/src/composables/use-play-on-tap.ts
@@ -5,6 +5,10 @@ import { BUTTON_TAP_DURATION, playButtonTap } from '@/utils/animations/button-ta
 type Options = {
   /** Run GSAP scale/rotate tween on the element. When false, just hold `playing` for the same duration so consumers can drive their own CSS via `[data-playing]`. Defaults to true. */
   animate?: boolean
+  /** Animate back to neutral after peaking instead of leaving the inline transform applied. Defaults to false. */
+  yoyo?: boolean
+  /** Seconds to hold at peak before resolving + returning. Yoyo-only. Defaults to 0.1. */
+  hold?: number
   /** Flip `playing` back to false after `onAfter` runs. Defaults to true. Set false to hold the active state (e.g. when a GSAP transform should remain applied until unmount). */
   reset?: boolean
   /** How long (in seconds) the tap state holds — also the duration handed to GSAP when `animate` is true. Defaults to `BUTTON_TAP_DURATION`. */
@@ -32,21 +36,24 @@ export function usePlayOnTap(options: Options = {}) {
   async function interceptClick(e: MouseEvent, onAfter: (e: MouseEvent) => void) {
     if (playing.value) return
 
+    options.beforePlay?.(e)
+
     if (active_on === 'coarse-only' && !is_coarse.value) return
+
+    const target = e.currentTarget as HTMLElement
 
     e.stopImmediatePropagation()
     e.preventDefault()
 
-    options.beforePlay?.(e)
-
     playing.value = true
     if (animate) {
-      await playButtonTap(e.currentTarget as HTMLElement, duration)
+      await playButtonTap(target, duration, { yoyo: options.yoyo, hold: options.hold })
     } else {
       await new Promise((resolve) => setTimeout(resolve, duration * 1000))
     }
 
     onAfter(e)
+    target.blur()
 
     if (reset) playing.value = false
   }

--- a/src/composables/use-play-on-tap.ts
+++ b/src/composables/use-play-on-tap.ts
@@ -7,20 +7,29 @@ type Options = {
   animate?: boolean
   /** Animate back to neutral after peaking instead of leaving the inline transform applied. Defaults to false. */
   yoyo?: boolean
-  /** Seconds to hold at peak before resolving + returning. Yoyo-only. Defaults to 0.1. */
+  /** Seconds to hold at peak between up and down tweens. Yoyo-only. Defaults to 0.1. */
   hold?: number
-  /** Flip `playing` back to false after `onAfter` runs. Defaults to true. Set false to hold the active state (e.g. when a GSAP transform should remain applied until unmount). */
+  /** Flip `playing` back to false after the animation finishes. Defaults to true. Set false to hold the active state (e.g. when a GSAP transform should remain applied until unmount). */
   reset?: boolean
-  /** How long (in seconds) the tap state holds — also the duration handed to GSAP when `animate` is true. Defaults to `BUTTON_TAP_DURATION`. */
+  /** Duration (seconds) handed to GSAP when `animate` is true. Defaults to `BUTTON_TAP_DURATION`. */
   duration?: number
   /** Pointer environments where the intercept is active. Defaults to 'coarse-only' so desktop clicks pass straight through; 'always' forces the tap on every pointer type. */
   activeOn?: 'coarse-only' | 'always'
-  /** Hook fired at the start of the intercept (after stop/preventDefault, before the tween). Use for sfx or other side-effects. */
+}
+
+type Hooks = {
+  /** Fires synchronously on every tap, before any intercept decision. Runs even when intercept bails (already playing, or fine pointer in coarse-only mode). */
+  onTap?: (e: MouseEvent) => void
+  /** Fires once the intercept has committed to playing the animation, after stop/preventDefault and before the first tween frame. Skipped when the intercept bails. */
   beforePlay?: (e: MouseEvent) => void
+  /** Fires at the peak of the tap animation. For non-yoyo tweens this coincides with `onAfter`. */
+  onPeak?: (e: MouseEvent) => void
+  /** Fires after the full tap animation finishes (including the yoyo return, if any). */
+  onAfter?: (e: MouseEvent) => void
 }
 
 /**
- * Intercepts a click, plays (or waits out) the button-tap animation, then invokes the original handler.
+ * Intercepts a click, plays the button-tap animation, and fires lifecycle hooks at tap / peak / end.
  * The MouseEvent is preserved end-to-end so downstream handlers still see `isTrusted=true` within the
  * browser's user-activation window.
  */
@@ -32,12 +41,11 @@ export function usePlayOnTap(options: Options = {}) {
   const active_on = options.activeOn ?? 'coarse-only'
   const is_coarse = useMediaQuery('coarse')
 
-  /** Stop the click, run the tap (or its delay), then invoke `onAfter` with the original event. No-op while already playing. */
-  async function interceptClick(e: MouseEvent, onAfter: (e: MouseEvent) => void) {
+  /** Run the tap lifecycle for `e`. `onTap` always fires; the rest fire only when the intercept actually plays. */
+  async function interceptClick(e: MouseEvent, hooks: Hooks = {}) {
+    hooks.onTap?.(e)
+
     if (playing.value) return
-
-    options.beforePlay?.(e)
-
     if (active_on === 'coarse-only' && !is_coarse.value) return
 
     const target = e.currentTarget as HTMLElement
@@ -45,14 +53,24 @@ export function usePlayOnTap(options: Options = {}) {
     e.stopImmediatePropagation()
     e.preventDefault()
 
+    hooks.beforePlay?.(e)
+
     playing.value = true
+
     if (animate) {
-      await playButtonTap(target, duration, { yoyo: options.yoyo, hold: options.hold })
+      const { peak, done } = playButtonTap(target, duration, {
+        yoyo: options.yoyo,
+        hold: options.hold
+      })
+      await peak
+      hooks.onPeak?.(e)
+      await done
     } else {
       await new Promise((resolve) => setTimeout(resolve, duration * 1000))
+      hooks.onPeak?.(e)
     }
 
-    onAfter(e)
+    hooks.onAfter?.(e)
     target.blur()
 
     if (reset) playing.value = false

--- a/src/phone/apps/darkmode/component.vue
+++ b/src/phone/apps/darkmode/component.vue
@@ -32,7 +32,7 @@ function cycleMode() {
 </script>
 
 <template>
-  <widget :theme="theme" :title="title" tap-burst="base" @click="cycleMode">
+  <widget :theme="theme" :title="title" tap-burst="base" instant-action @click="cycleMode">
     <ui-image v-if="mode === 'system'" src="darkmode-system" />
     <ui-image v-else-if="mode === 'light'" src="darkmode-light" />
     <ui-image v-else src="darkmode-dark" />

--- a/src/phone/apps/darkmode/component.vue
+++ b/src/phone/apps/darkmode/component.vue
@@ -32,7 +32,7 @@ function cycleMode() {
 </script>
 
 <template>
-  <widget :theme="theme" :title="title" @click="cycleMode">
+  <widget :theme="theme" :title="title" tap-burst="base" @click="cycleMode">
     <ui-image v-if="mode === 'system'" src="darkmode-system" />
     <ui-image v-else-if="mode === 'light'" src="darkmode-light" />
     <ui-image v-else src="darkmode-dark" />

--- a/src/phone/components/app-launcher.vue
+++ b/src/phone/components/app-launcher.vue
@@ -37,7 +37,11 @@ shortcuts.register([
   },
   {
     combo: 'enter',
-    handler: () => openApp()
+    handler: () => {
+      const app = apps[active_app.value]
+      if (app) onTapApp(app)
+      openApp()
+    }
   }
 ])
 
@@ -73,10 +77,10 @@ function openApp(app?: PhoneApp) {
   if (found.type === 'widget') return
 
   phone.open(found.id)
+}
 
-  if (found.type === 'view') {
-    emitSfx('ui.toggle_on')
-  }
+function onTapApp(app: PhoneApp) {
+  if (app.type === 'view') emitSfx('ui.toggle_on')
 }
 
 // If the hovered app is not the active app,
@@ -113,7 +117,7 @@ function _getActiveApp() {
     </div>
 
     <div
-      class="w-full grid grid-cols-[auto_auto_auto] grid-rows-[auto_auto_auto] gap-2 pointer-coarse:gap-y-4 justify-center content-center"
+      class="w-full grid grid-cols-[auto_auto_auto] grid-rows-[auto_auto_auto] gap-2 justify-center content-center"
     >
       <template v-for="app in apps">
         <view-app
@@ -122,6 +126,7 @@ function _getActiveApp() {
           :key="app.id"
           :app="app"
           @click="openApp(app)"
+          @tap-start="onTapApp(app)"
           @mouseenter="onHoverApp(app)"
         />
 

--- a/src/phone/components/app-wrapper.vue
+++ b/src/phone/components/app-wrapper.vue
@@ -1,22 +1,80 @@
 <script setup lang="ts">
+import { ref, useAttrs } from 'vue'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
+import UiBurst, { type BurstSize } from '@/components/ui-kit/burst.vue'
 import { useMediaQuery } from '@/composables/use-media-query'
+import { usePlayOnTap } from '@/composables/use-play-on-tap'
 
-defineProps<{ title: string; theme: Theme }>()
+type AppWrapperProps = {
+  title: string
+  theme: Theme
+  tapHold?: number
+  tapDuration?: number
+  tapBurst?: BurstSize | false
+}
+const { tapHold = 0.1, tapDuration = 0.1, tapBurst = false } = defineProps<AppWrapperProps>()
+const emit = defineEmits<{ (e: 'tapStart'): void }>()
+defineOptions({ inheritAttrs: false })
 
+const attrs = useAttrs()
 const is_coarse = useMediaQuery('coarse')
+const burst_id = ref(0)
+
+const { playing, interceptClick } = usePlayOnTap({
+  yoyo: true,
+  duration: tapDuration,
+  hold: tapHold
+})
+
+type ClickHandler = (ev: MouseEvent) => void
+
+function onCaptureClick(e: MouseEvent) {
+  emit('tapStart')
+  spawnBurst()
+
+  const handler = resolveClickHandler()
+  if (!handler) return
+
+  interceptClick(e, handler)
+}
+
+function resolveClickHandler(): ClickHandler | undefined {
+  const raw = attrs.onClick as ClickHandler | ClickHandler[] | undefined
+  if (!raw) return
+  return Array.isArray(raw) ? (ev) => raw.forEach((fn) => fn(ev)) : raw
+}
+
+function spawnBurst() {
+  if (!tapBurst || !is_coarse.value) return
+  burst_id.value++
+}
 </script>
 
 <template>
-  <ui-tooltip
-    :text="title"
-    position="bottom"
-    :data-theme="theme"
-    :gap="is_coarse ? -16 : -5"
-    element="button"
-    data-testid="phone-app"
-    static_on_mobile
-  >
-    <slot></slot>
-  </ui-tooltip>
+  <div data-testid="app-wrapper-container" class="flex flex-col items-center gap-0.5">
+    <ui-tooltip
+      :text="title"
+      position="bottom"
+      :data-theme="theme"
+      :gap="is_coarse ? -16 : -5"
+      element="button"
+      data-testid="phone-app"
+      v-bind="$attrs"
+      :data-playing="playing || null"
+      @click.capture="onCaptureClick"
+    >
+      <slot></slot>
+      <ui-burst
+        v-if="burst_id"
+        :key="burst_id"
+        :size="tapBurst || 'base'"
+        class="left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        @done="burst_id = 0"
+      />
+    </ui-tooltip>
+
+    <span data-testid="app-wrapper__title" class="text-brown-500 dark:text-brown-100 text-sm">{{
+      title
+    }}</span>
+  </div>
 </template>

--- a/src/phone/components/app-wrapper.vue
+++ b/src/phone/components/app-wrapper.vue
@@ -66,26 +66,29 @@ function spawnBurst() {
 
 <template>
   <div data-testid="app-wrapper-container" class="flex flex-col items-center gap-0.5">
-    <ui-tooltip
-      :text="title"
-      position="bottom"
-      :data-theme="theme"
-      :gap="is_coarse ? -16 : -5"
-      element="button"
-      data-testid="phone-app"
-      v-bind="$attrs"
-      :data-playing="playing || null"
-      @click.capture="onCaptureClick"
-    >
-      <slot></slot>
+    <div class="relative">
+      <ui-tooltip
+        :text="title"
+        position="bottom"
+        :data-theme="theme"
+        :gap="is_coarse ? -16 : -5"
+        element="button"
+        data-testid="phone-app"
+        v-bind="$attrs"
+        :data-playing="playing || null"
+        @click.capture="onCaptureClick"
+      >
+        <slot></slot>
+      </ui-tooltip>
       <ui-burst
         v-if="burst_id"
         :key="burst_id"
         :size="tapBurst || 'base'"
-        class="left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        :width="5"
+        class="pointer-events-none left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
         @done="burst_id = 0"
       />
-    </ui-tooltip>
+    </div>
 
     <span data-testid="app-wrapper__title" class="text-brown-500 dark:text-brown-100 text-sm">{{
       title

--- a/src/phone/components/app-wrapper.vue
+++ b/src/phone/components/app-wrapper.vue
@@ -11,8 +11,15 @@ type AppWrapperProps = {
   tapHold?: number
   tapDuration?: number
   tapBurst?: BurstSize | false
+  /** Run the click handler synchronously on tap instead of waiting for the animation peak. */
+  instantAction?: boolean
 }
-const { tapHold = 0.1, tapDuration = 0.1, tapBurst = false } = defineProps<AppWrapperProps>()
+const {
+  tapHold = 0.1,
+  tapDuration = 0.1,
+  tapBurst = false,
+  instantAction = false
+} = defineProps<AppWrapperProps>()
 const emit = defineEmits<{ (e: 'tapStart'): void }>()
 defineOptions({ inheritAttrs: false })
 
@@ -29,13 +36,20 @@ const { playing, interceptClick } = usePlayOnTap({
 type ClickHandler = (ev: MouseEvent) => void
 
 function onCaptureClick(e: MouseEvent) {
-  emit('tapStart')
-  spawnBurst()
-
   const handler = resolveClickHandler()
-  if (!handler) return
 
-  interceptClick(e, handler)
+  interceptClick(e, {
+    onTap: () => {
+      emit('tapStart')
+      spawnBurst()
+    },
+    beforePlay: () => {
+      if (instantAction) handler?.(e)
+    },
+    onPeak: () => {
+      if (!instantAction) handler?.(e)
+    }
+  })
 }
 
 function resolveClickHandler(): ClickHandler | undefined {

--- a/src/phone/components/view-app.vue
+++ b/src/phone/components/view-app.vue
@@ -10,7 +10,8 @@ defineProps<{ app: ViewApp | TriggerApp }>()
   <app-wrapper
     :title="app.title"
     :theme="app.launcher.theme"
-    class="rounded-6 pointer-fine:rounded-5.5 w-16.5 pointer-fine:w-15 aspect-square cursor-pointer hover:scale-110 focus:scale-110 transition-transform duration-50 flex items-center justify-center text-white group outline-none bg-(--theme-primary) hover:bgx-diagonal-stripes animation-safe:hover:bgx-slide animation-safe:focus:bgx-slide focus:bgx-diagonal-stripes"
+    tap-burst="base"
+    class="rounded-6 pointer-fine:rounded-5.5 w-16.5 pointer-fine:w-15 aspect-square cursor-pointer hover:scale-110 focus:scale-110 transition-transform duration-50 flex items-center justify-center text-white group outline-none bg-(--theme-primary) tap:bgx-diagonal-stripes animation-safe:tap:bgx-slide"
   >
     <ui-image
       :src="app.launcher.icon_src"

--- a/src/phone/components/view-app.vue
+++ b/src/phone/components/view-app.vue
@@ -16,12 +16,15 @@ defineProps<{ app: ViewApp | TriggerApp }>()
     <ui-image
       :src="app.launcher.icon_src"
       class="pointer-events-none"
-      :class="{ 'group-hover:hidden group-focus:hidden': app.launcher.hover_icon_src }"
+      :class="{
+        'group-hover:hidden group-focus:hidden group-data-[playing=true]:hidden':
+          app.launcher.hover_icon_src
+      }"
     />
     <ui-image
       v-if="app.launcher.hover_icon_src"
       :src="app.launcher.hover_icon_src"
-      class="hidden group-hover:block group-focus:block pointer-events-none"
+      class="hidden group-hover:block group-focus:block group-data-[playing=true]:block pointer-events-none"
     />
   </app-wrapper>
 </template>

--- a/src/phone/components/widget.vue
+++ b/src/phone/components/widget.vue
@@ -6,7 +6,8 @@ const {
   hoverEffect = true,
   tapHold = 0,
   tapDuration = 0.2,
-  tapBurst = false
+  tapBurst = false,
+  instantAction = true
 } = defineProps<{
   theme: Theme
   title: string
@@ -14,6 +15,7 @@ const {
   tapHold?: number
   tapDuration?: number
   tapBurst?: BurstSize | false
+  instantAction?: boolean
 }>()
 </script>
 
@@ -24,6 +26,7 @@ const {
     :tap-hold="tapHold"
     :tap-duration="tapDuration"
     :tap-burst="tapBurst"
+    :instant-action="instantAction"
     class="rounded-6 pointer-fine:rounded-5.5 w-16.5 pointer-fine:w-15 aspect-square cursor-pointer hover:scale-110 focus:scale-110 transition-transform duration-50 flex items-center justify-center text-white outline-none bg-(--theme-primary)"
     :class="{ 'tap:bgx-diagonal-stripes animation-safe:tap:bgx-slide': hoverEffect }"
   >

--- a/src/phone/components/widget.vue
+++ b/src/phone/components/widget.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
 import AppWrapper from '@/phone/components/app-wrapper.vue'
-import UiTooltip from '@/components/ui-kit/tooltip.vue'
+import { type BurstSize } from '@/components/ui-kit/burst.vue'
 
-const { hoverEffect = true } = defineProps<{
+const {
+  hoverEffect = true,
+  tapHold = 0,
+  tapDuration = 0.2,
+  tapBurst = false
+} = defineProps<{
   theme: Theme
   title: string
   hoverEffect?: boolean
+  tapHold?: number
+  tapDuration?: number
+  tapBurst?: BurstSize | false
 }>()
 </script>
 
@@ -13,11 +21,11 @@ const { hoverEffect = true } = defineProps<{
   <app-wrapper
     :title="title"
     :theme="theme"
+    :tap-hold="tapHold"
+    :tap-duration="tapDuration"
+    :tap-burst="tapBurst"
     class="rounded-6 pointer-fine:rounded-5.5 w-16.5 pointer-fine:w-15 aspect-square cursor-pointer hover:scale-110 focus:scale-110 transition-transform duration-50 flex items-center justify-center text-white outline-none bg-(--theme-primary)"
-    :class="{
-      [`hover:bgx-diagonal-stripes animation-safe:hover:bgx-slide animation-safe:focus:bgx-slide
-      focus:bgx-diagonal-stripes`]: hoverEffect
-    }"
+    :class="{ 'tap:bgx-diagonal-stripes animation-safe:tap:bgx-slide': hoverEffect }"
   >
     <slot></slot>
   </app-wrapper>

--- a/src/styles/custom-variants.css
+++ b/src/styles/custom-variants.css
@@ -12,6 +12,17 @@
   }
 }
 
+@custom-variant tap {
+  &:where(:focus-visible, [data-playing='true']) {
+    @slot;
+  }
+  @media (hover: hover) {
+    &:where(:hover) {
+      @slot;
+    }
+  }
+}
+
 @custom-variant left-hand {
   &:where([data-left-hand='true'] *, [data-left-hand='true']) {
     @slot;

--- a/src/utils/animations/button-tap.ts
+++ b/src/utils/animations/button-tap.ts
@@ -9,31 +9,40 @@ type Options = {
   hold?: number
 }
 
+type PlayHandles = { peak: Promise<void>; done: Promise<void> }
+
 export function playButtonTap(
   el: Element,
   duration: number = BUTTON_TAP_DURATION,
   options: Options = {}
-) {
+): PlayHandles {
+  let resolvePeak!: () => void
+  let resolveDone!: () => void
+  const peak = new Promise<void>((r) => (resolvePeak = r))
+  const done = new Promise<void>((r) => (resolveDone = r))
+
   if (!options.yoyo) {
-    return new Promise<void>((resolve) => {
-      gsap.to(el, {
-        scale: 1.2,
-        rotate: 3,
-        duration,
-        ease: 'expo.out',
-        onComplete: resolve
-      })
+    gsap.to(el, {
+      scale: 1.2,
+      rotate: 3,
+      duration,
+      ease: 'expo.out',
+      onComplete: () => {
+        resolvePeak()
+        resolveDone()
+      }
     })
+    return { peak, done }
   }
 
-  return new Promise<void>((resolve) => {
-    const up = duration * 0.5
-    const hold = options.hold ?? 0.1
-    const down = duration * 0.5
-    gsap
-      .timeline()
-      .to(el, { scale: 1.3, rotate: 3, duration: up, ease: 'back.out' })
-      .call(resolve, undefined, `+=${hold}`)
-      .to(el, { scale: 1, rotate: 0, duration: down, ease: 'back.out(3)' })
-  })
+  const up = duration * 0.5
+  const hold = options.hold ?? 0.1
+  const down = duration * 0.5
+  gsap
+    .timeline({ onComplete: resolveDone })
+    .to(el, { scale: 1.3, rotate: 3, duration: up, ease: 'back.out' })
+    .call(resolvePeak, undefined, `+=${hold}`)
+    .to(el, { scale: 1, rotate: 0, duration: down, ease: 'back.out(3)' })
+
+  return { peak, done }
 }

--- a/src/utils/animations/button-tap.ts
+++ b/src/utils/animations/button-tap.ts
@@ -2,14 +2,38 @@ import { gsap } from 'gsap'
 
 export const BUTTON_TAP_DURATION = 0.1
 
-export function playButtonTap(el: Element, duration: number = BUTTON_TAP_DURATION) {
-  return new Promise<void>((resolve) => {
-    gsap.to(el, {
-      scale: 1.2,
-      rotate: 3,
-      duration,
-      ease: 'power2.out',
-      onComplete: resolve
+type Options = {
+  /** Animate back to neutral after peaking. Total runtime is `duration` regardless. */
+  yoyo?: boolean
+  /** Seconds to hold at peak before resolving + returning. Yoyo-only. Defaults to 0.1. */
+  hold?: number
+}
+
+export function playButtonTap(
+  el: Element,
+  duration: number = BUTTON_TAP_DURATION,
+  options: Options = {}
+) {
+  if (!options.yoyo) {
+    return new Promise<void>((resolve) => {
+      gsap.to(el, {
+        scale: 1.2,
+        rotate: 3,
+        duration,
+        ease: 'expo.out',
+        onComplete: resolve
+      })
     })
+  }
+
+  return new Promise<void>((resolve) => {
+    const up = duration * 0.5
+    const hold = options.hold ?? 0.1
+    const down = duration * 0.5
+    gsap
+      .timeline()
+      .to(el, { scale: 1.3, rotate: 3, duration: up, ease: 'back.out' })
+      .call(resolve, undefined, `+=${hold}`)
+      .to(el, { scale: 1, rotate: 0, duration: down, ease: 'back.out(3)' })
   })
 }

--- a/tests/integration/components/ui-kit/burst.test.js
+++ b/tests/integration/components/ui-kit/burst.test.js
@@ -1,0 +1,50 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import UiBurst from '@/components/ui-kit/burst.vue'
+
+function mountBurst(props = {}) {
+  return shallowMount(UiBurst, { props })
+}
+
+describe('UiBurst', () => {
+  test('renders a burst root', () => {
+    const wrapper = mountBurst()
+    expect(wrapper.find('[data-testid="ui-kit-burst"]').exists()).toBe(true)
+  })
+
+  test('renders 8 spokes by default', () => {
+    const wrapper = mountBurst()
+    expect(wrapper.findAll('.spoke')).toHaveLength(8)
+  })
+
+  test('applies the size modifier class', () => {
+    const wrapper = mountBurst({ size: 'lg' })
+    expect(wrapper.classes()).toContain('burst--lg')
+  })
+
+  test('defaults to base size when no size prop is passed', () => {
+    const wrapper = mountBurst()
+    expect(wrapper.classes()).toContain('burst--base')
+  })
+
+  test('sets --burst-dur from the duration prop', () => {
+    const wrapper = mountBurst({ duration: 420 })
+    expect(wrapper.attributes('style')).toContain('--burst-dur: 420ms')
+  })
+
+  test('sets --burst-dot-size from the width prop when provided', () => {
+    const wrapper = mountBurst({ width: 4 })
+    expect(wrapper.attributes('style')).toContain('--burst-dot-size: 4px')
+  })
+
+  test('omits --burst-dot-size when width is not provided', () => {
+    const wrapper = mountBurst()
+    expect(wrapper.attributes('style') ?? '').not.toContain('--burst-dot-size')
+  })
+
+  test('emits done on animationend', async () => {
+    const wrapper = mountBurst()
+    await wrapper.find('[data-testid="ui-kit-burst"]').trigger('animationend')
+    expect(wrapper.emitted('done')).toBeTruthy()
+  })
+})

--- a/tests/unit/composables/use-play-on-tap.test.js
+++ b/tests/unit/composables/use-play-on-tap.test.js
@@ -7,7 +7,10 @@ const { coarseRef, mockUseMediaQuery, mockPlayButtonTap } = vi.hoisted(() => {
   return {
     coarseRef,
     mockUseMediaQuery: vi.fn(() => coarseRef),
-    mockPlayButtonTap: vi.fn(() => Promise.resolve())
+    mockPlayButtonTap: vi.fn(() => ({
+      peak: Promise.resolve(),
+      done: Promise.resolve()
+    }))
   }
 })
 
@@ -30,11 +33,15 @@ function makeEvent(target = document.createElement('div')) {
   return e
 }
 
+function resolvedHandles() {
+  return { peak: Promise.resolve(), done: Promise.resolve() }
+}
+
 describe('usePlayOnTap', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     coarseRef.value = true
-    mockPlayButtonTap.mockImplementation(() => Promise.resolve())
+    mockPlayButtonTap.mockImplementation(resolvedHandles)
   })
 
   describe('coarse-only gating (default)', () => {
@@ -43,42 +50,56 @@ describe('usePlayOnTap', () => {
       expect(playing.value).toBe(false)
     })
 
-    test('runs animation when pointer is coarse', async () => {
+    test('runs animation when pointer is coarse and fires lifecycle hooks', async () => {
       const { interceptClick, playing } = usePlayOnTap()
-      const onAfter = vi.fn()
+      const hooks = {
+        onTap: vi.fn(),
+        beforePlay: vi.fn(),
+        onPeak: vi.fn(),
+        onAfter: vi.fn()
+      }
       const e = makeEvent()
 
-      await interceptClick(e, onAfter)
+      await interceptClick(e, hooks)
 
       expect(mockPlayButtonTap).toHaveBeenCalled()
-      expect(onAfter).toHaveBeenCalledWith(e)
-      expect(playing.value).toBe(false) // reset defaults true
+      expect(hooks.onTap).toHaveBeenCalledWith(e)
+      expect(hooks.beforePlay).toHaveBeenCalledWith(e)
+      expect(hooks.onPeak).toHaveBeenCalledWith(e)
+      expect(hooks.onAfter).toHaveBeenCalledWith(e)
+      expect(playing.value).toBe(false)
     })
 
-    test('skips intercept on pointer:fine and does not call onAfter', async () => {
+    test('skips intercept on pointer:fine but still fires onTap', async () => {
       coarseRef.value = false
       const { interceptClick, playing } = usePlayOnTap()
-      const onAfter = vi.fn()
+      const hooks = {
+        onTap: vi.fn(),
+        beforePlay: vi.fn(),
+        onPeak: vi.fn(),
+        onAfter: vi.fn()
+      }
       const e = makeEvent()
 
-      await interceptClick(e, onAfter)
+      await interceptClick(e, hooks)
 
+      expect(hooks.onTap).toHaveBeenCalledWith(e)
+      expect(hooks.beforePlay).not.toHaveBeenCalled()
+      expect(hooks.onPeak).not.toHaveBeenCalled()
+      expect(hooks.onAfter).not.toHaveBeenCalled()
       expect(e.stopImmediatePropagation).not.toHaveBeenCalled()
       expect(e.preventDefault).not.toHaveBeenCalled()
       expect(mockPlayButtonTap).not.toHaveBeenCalled()
-      expect(onAfter).not.toHaveBeenCalled()
       expect(playing.value).toBe(false)
     })
   })
 
   describe('activeOn: "always"', () => {
-    test('runs on pointer:fine when activeOn=always', async () => {
+    test('runs the intercept on pointer:fine when activeOn=always', async () => {
       coarseRef.value = false
       const { interceptClick } = usePlayOnTap({ activeOn: 'always' })
       const onAfter = vi.fn()
-      const e = makeEvent()
-
-      await interceptClick(e, onAfter)
+      await interceptClick(makeEvent(), { onAfter })
 
       expect(mockPlayButtonTap).toHaveBeenCalled()
       expect(onAfter).toHaveBeenCalled()
@@ -89,7 +110,7 @@ describe('usePlayOnTap', () => {
     test('stops propagation and prevents default before animation', async () => {
       const { interceptClick } = usePlayOnTap()
       const e = makeEvent()
-      await interceptClick(e, vi.fn())
+      await interceptClick(e, {})
 
       expect(e.stopImmediatePropagation).toHaveBeenCalled()
       expect(e.preventDefault).toHaveBeenCalled()
@@ -99,29 +120,34 @@ describe('usePlayOnTap', () => {
       let playingDuringTween
       mockPlayButtonTap.mockImplementation(() => {
         playingDuringTween = playing.value
-        return Promise.resolve()
+        return resolvedHandles()
       })
       const { interceptClick, playing } = usePlayOnTap()
-      await interceptClick(makeEvent(), vi.fn())
+      await interceptClick(makeEvent(), {})
       expect(playingDuringTween).toBe(true)
     })
   })
 
   describe('re-entrancy', () => {
-    test('is a no-op while already playing', async () => {
-      let resolveTween
-      mockPlayButtonTap.mockImplementation(() => new Promise((r) => (resolveTween = r)))
+    test('is a no-op while already playing (but still fires onTap)', async () => {
+      let resolvePeak
+      mockPlayButtonTap.mockImplementation(() => ({
+        peak: new Promise((r) => (resolvePeak = r)),
+        done: Promise.resolve()
+      }))
       const { interceptClick, playing } = usePlayOnTap()
       const onAfter = vi.fn()
+      const onTap = vi.fn()
 
-      const first = interceptClick(makeEvent(), onAfter)
+      const first = interceptClick(makeEvent(), { onAfter, onTap })
       await nextTick()
       expect(playing.value).toBe(true)
 
-      await interceptClick(makeEvent(), onAfter)
+      await interceptClick(makeEvent(), { onAfter, onTap })
       expect(mockPlayButtonTap).toHaveBeenCalledTimes(1)
+      expect(onTap).toHaveBeenCalledTimes(2)
 
-      resolveTween()
+      resolvePeak()
       await first
       await flushPromises()
     })
@@ -132,19 +158,19 @@ describe('usePlayOnTap', () => {
       const beforePlay = vi.fn()
       mockPlayButtonTap.mockImplementation(() => {
         expect(beforePlay).toHaveBeenCalledTimes(1)
-        return Promise.resolve()
+        return resolvedHandles()
       })
-      const { interceptClick } = usePlayOnTap({ beforePlay })
+      const { interceptClick } = usePlayOnTap()
       const e = makeEvent()
-      await interceptClick(e, vi.fn())
+      await interceptClick(e, { beforePlay })
       expect(beforePlay).toHaveBeenCalledWith(e)
     })
 
-    test('is not called when intercept is skipped', async () => {
+    test('is not called when intercept is skipped on fine pointer', async () => {
       coarseRef.value = false
       const beforePlay = vi.fn()
-      const { interceptClick } = usePlayOnTap({ beforePlay })
-      await interceptClick(makeEvent(), vi.fn())
+      const { interceptClick } = usePlayOnTap()
+      await interceptClick(makeEvent(), { beforePlay })
       expect(beforePlay).not.toHaveBeenCalled()
     })
   })
@@ -152,13 +178,13 @@ describe('usePlayOnTap', () => {
   describe('reset', () => {
     test('resets playing to false after onAfter when reset=true (default)', async () => {
       const { interceptClick, playing } = usePlayOnTap()
-      await interceptClick(makeEvent(), vi.fn())
+      await interceptClick(makeEvent(), {})
       expect(playing.value).toBe(false)
     })
 
     test('holds playing=true after onAfter when reset=false', async () => {
       const { interceptClick, playing } = usePlayOnTap({ reset: false })
-      await interceptClick(makeEvent(), vi.fn())
+      await interceptClick(makeEvent(), {})
       expect(playing.value).toBe(true)
     })
   })
@@ -166,7 +192,7 @@ describe('usePlayOnTap', () => {
   describe('animate option', () => {
     test('uses GSAP when animate is true (default)', async () => {
       const { interceptClick } = usePlayOnTap()
-      await interceptClick(makeEvent(), vi.fn())
+      await interceptClick(makeEvent(), {})
       expect(mockPlayButtonTap).toHaveBeenCalled()
     })
 
@@ -175,7 +201,7 @@ describe('usePlayOnTap', () => {
       const { interceptClick, playing } = usePlayOnTap({ animate: false, duration: 0.25 })
       const onAfter = vi.fn()
 
-      const p = interceptClick(makeEvent(), onAfter)
+      const p = interceptClick(makeEvent(), { onAfter })
       await nextTick()
       expect(playing.value).toBe(true)
       expect(mockPlayButtonTap).not.toHaveBeenCalled()
@@ -188,11 +214,40 @@ describe('usePlayOnTap', () => {
     })
   })
 
-  describe('duration option', () => {
+  describe('duration / yoyo / hold options', () => {
     test('forwards duration to playButtonTap', async () => {
       const { interceptClick } = usePlayOnTap({ duration: 0.4 })
-      await interceptClick(makeEvent(), vi.fn())
-      expect(mockPlayButtonTap).toHaveBeenCalledWith(expect.any(HTMLElement), 0.4)
+      await interceptClick(makeEvent(), {})
+      expect(mockPlayButtonTap).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        0.4,
+        expect.any(Object)
+      )
+    })
+
+    test('passes yoyo and hold through to playButtonTap', async () => {
+      const { interceptClick } = usePlayOnTap({ yoyo: true, hold: 0.2 })
+      await interceptClick(makeEvent(), {})
+      expect(mockPlayButtonTap).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.any(Number),
+        expect.objectContaining({ yoyo: true, hold: 0.2 })
+      )
+    })
+  })
+
+  describe('blur', () => {
+    test('blurs the target after the animation', async () => {
+      const target = document.createElement('button')
+      document.body.appendChild(target)
+      target.focus()
+      const blur = vi.spyOn(target, 'blur')
+
+      const { interceptClick } = usePlayOnTap()
+      await interceptClick(makeEvent(target), {})
+
+      expect(blur).toHaveBeenCalled()
+      document.body.removeChild(target)
     })
   })
 })

--- a/tests/unit/utils/animations/button-tap.test.js
+++ b/tests/unit/utils/animations/button-tap.test.js
@@ -1,10 +1,39 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 
-const { mockTo } = vi.hoisted(() => ({
-  mockTo: vi.fn((_el, opts) => opts?.onComplete?.())
-}))
+const { mockTo, mockTimeline, mockTimelineCall } = vi.hoisted(() => {
+  const mockTimelineCall = vi.fn()
+  return {
+    mockTo: vi.fn((_el, opts) => opts?.onComplete?.()),
+    mockTimelineCall,
+    mockTimeline: vi.fn(() => {
+      const tl = {}
+      tl.to = vi.fn(() => tl)
+      tl.call = vi.fn((fn) => {
+        mockTimelineCall(fn)
+        fn?.()
+        return tl
+      })
+      return tl
+    })
+  }
+})
 
-vi.mock('gsap', () => ({ gsap: { to: mockTo } }))
+vi.mock('gsap', () => ({
+  gsap: {
+    to: mockTo,
+    timeline: (opts) => {
+      const tl = mockTimeline(opts)
+      tl.to = vi.fn(() => tl)
+      tl.call = vi.fn((fn) => {
+        fn?.()
+        return tl
+      })
+      // fire timeline-level onComplete
+      queueMicrotask(() => opts?.onComplete?.())
+      return tl
+    }
+  }
+}))
 
 import { BUTTON_TAP_DURATION, playButtonTap } from '@/utils/animations/button-tap'
 
@@ -15,28 +44,50 @@ describe('playButtonTap', () => {
     vi.clearAllMocks()
   })
 
-  test('tweens scale and rotate on the element', () => {
-    playButtonTap(el)
-    expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ scale: 1.2, rotate: 3 }))
+  describe('non-yoyo (default)', () => {
+    test('tweens scale and rotate on the element', () => {
+      playButtonTap(el)
+      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ scale: 1.2, rotate: 3 }))
+    })
+
+    test('defaults duration to BUTTON_TAP_DURATION', () => {
+      playButtonTap(el)
+      expect(mockTo.mock.calls[0][1].duration).toBe(BUTTON_TAP_DURATION)
+    })
+
+    test('forwards the duration argument', () => {
+      playButtonTap(el, 0.5)
+      expect(mockTo.mock.calls[0][1].duration).toBe(0.5)
+    })
+
+    test('uses expo.out easing', () => {
+      playButtonTap(el)
+      expect(mockTo.mock.calls[0][1].ease).toBe('expo.out')
+    })
+
+    test('returns peak and done promises that both resolve on onComplete', async () => {
+      const { peak, done } = playButtonTap(el)
+      await expect(peak).resolves.toBeUndefined()
+      await expect(done).resolves.toBeUndefined()
+    })
   })
 
-  test('defaults duration to BUTTON_TAP_DURATION', () => {
-    playButtonTap(el)
-    expect(mockTo.mock.calls[0][1].duration).toBe(BUTTON_TAP_DURATION)
-  })
+  describe('yoyo', () => {
+    test('uses a timeline with up + return tweens', () => {
+      playButtonTap(el, 0.4, { yoyo: true })
+      expect(mockTimeline).toHaveBeenCalled()
+    })
 
-  test('forwards the duration argument', () => {
-    playButtonTap(el, 0.5)
-    expect(mockTo.mock.calls[0][1].duration).toBe(0.5)
-  })
+    test('returns peak and done promises (peak resolves before timeline complete)', async () => {
+      const { peak, done } = playButtonTap(el, 0.4, { yoyo: true })
+      await expect(peak).resolves.toBeUndefined()
+      await expect(done).resolves.toBeUndefined()
+    })
 
-  test('resolves the returned promise via onComplete', async () => {
-    await expect(playButtonTap(el)).resolves.toBeUndefined()
-  })
-
-  test('uses power2.out easing', () => {
-    playButtonTap(el)
-    expect(mockTo.mock.calls[0][1].ease).toBe('power2.out')
+    test('forwards a custom hold option', () => {
+      playButtonTap(el, 0.4, { yoyo: true, hold: 0.5 })
+      expect(mockTimeline).toHaveBeenCalled()
+    })
   })
 
   test('BUTTON_TAP_DURATION is a positive number', () => {


### PR DESCRIPTION
## Summary

Adds a unified tap-feedback layer to phone apps and widgets — coarse-pointer taps trigger a snappy scale/rotate animation, a centered burst, and click sfx. Desktop clicks pass through with sfx only.

## Changes

- `playButtonTap` gains `yoyo` (animate back to neutral) and `hold` (peak dwell) options; resolves at peak so action runs while the springback plays out.
- `usePlayOnTap` threads both options through, captures `currentTarget` pre-await, and blurs the target after the action so focus/hover doesn't latch.
- New \`tap\` Tailwind variant: matches \`:focus-visible\`, \`[data-playing="true"]\`, and \`:hover\` (gated by \`@media (hover: hover)\` to avoid sticky touch hover).
- \`ui-kit/burst\` fades opacity to 0 in its keyframes and shortens the default duration to 350ms so \`done\` fires when invisible.
- \`app-wrapper\` owns the tap intercept, emits \`tap-start\` synchronously on every click, spawns a single keyed burst on coarse pointers, and exposes \`tap-hold\` / \`tap-duration\` / \`tap-burst\` props.
- \`view-app\` and \`widget\` opt in to the burst; \`darkmode\` widget passes \`tap-burst="base"\`.
- \`app-launcher\` moves the open sfx to a \`@tap-start\` listener so it fires synchronously, and keyboard Enter calls the same handler.

## Test plan

- [ ] Coarse pointer: tapping any phone app plays scale/rotate, burst fans out and fades, sfx fires immediately, app opens after peak.
- [ ] Fine pointer (desktop): clicking an app plays sfx and opens immediately, no animation, no burst.
- [ ] Keyboard arrow nav focuses an app and shows the bgx stripes via \`:focus-visible\`; Enter opens with sfx.
- [ ] Darkmode widget tap shows burst on coarse pointer but no hold delay; widgets with default \`tap-hold\` skip the dwell.
- [ ] No stuck focus/hover stripes after tapping multiple apps in succession.