### PR TITLE
fix(card-editor): show reorder icon on hover only, not when card is active

### DIFF
--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -69,15 +69,9 @@ function onClick(e: MouseEvent) {
       <ui-icon
         src="reorder"
         class="hidden"
-        :class="{
-          'group-hover/listitem:block group-focus-within/listitem:block': !is_selecting
-        }"
+        :class="{ 'group-hover/listitem:block': !is_selecting }"
       />
-      <span
-        :class="{
-          'group-focus-within/listitem:hidden group-hover/listitem:hidden': !is_selecting
-        }"
-      >
+      <span :class="{ 'group-hover/listitem:hidden': !is_selecting }">
         {{ index + 1 }}
       </span>
     </button>


### PR DESCRIPTION
## Summary

The reorder pill in each card-list item swapped its position number for the grab/reorder icon whenever the item was **hovered or focus-within**. That meant an active card hid its number and showed the icon instead.

Now the swap only happens on hover — an active (focus-within) card keeps showing its position number, and the grab icon appears only while hovering.