### PR TITLE
Card editor tweaks

### DIFF
--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -339,6 +339,8 @@
   "deck-view.bulk-actions.cancel": "Cancel",
   "deck-view.card-editor.list-item.front-placeholder": "Front",
   "deck-view.card-editor.list-item.back-placeholder": "Back",
+  "deck-view.card-editor.list-item.add-above": "Add Card",
+  "deck-view.card-editor.list-item.add-below": "Add Card",
   "deck-view.actions.study-all": "Study <span>all</span> cards",
   "deck-view.actions.edit-cards": "Edit Cards",
   "deck-view.actions.stop-editing": "Stop Editing",

--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -72,20 +72,29 @@ async function onImageDelete(side: 'front' | 'back') {
   }
 }
 
-// focusin/focusout bubble from the editors, so relatedTarget tells us whether
-// focus moved within this card (front↔back) or crossed its edge — no
-// wall-clock wait for activeElement to settle. Gate the sfx on contenteditable
-// focus so the image button doesn't trigger it.
+// Whether a node lives inside any card in the editor (its own card or another).
+// Lets us tell "focus moved between cards" from "focus entered/left the editor".
+function withinAnyCard(node: EventTarget | null) {
+  return (node as HTMLElement | null)?.closest?.('[data-testid="list-item-card"]') != null
+}
+
+// Gate the sfx on contenteditable focus so the image button doesn't trigger it.
+// Arriving from another card (or the other side) clicks; arriving from outside
+// every card — i.e. activating a card when none was — slides up.
 function onFocusIn(e: FocusEvent) {
   if (!(e.target as HTMLElement | null)?.isContentEditable) return
 
-  const moved_within = list_item_card.value?.contains(e.relatedTarget as Node | null) ?? false
-  emitSfx(moved_within ? 'ui.click_04' : 'ui.slide_up')
+  emitSfx(withinAnyCard(e.relatedTarget) ? 'ui.click_04' : 'ui.slide_up')
   focused.value = true
 }
 
+// When an editor blurs to outside every card, the active card was deselected
+// with nothing new picked up — drop it.
 function onFocusOut(e: FocusEvent) {
   focused.value = list_item_card.value?.contains(e.relatedTarget as Node | null) ?? false
+
+  const left_editor = (e.target as HTMLElement | null)?.isContentEditable ?? false
+  if (left_editor && !withinAnyCard(e.relatedTarget)) emitSfx('ui.card_drop')
 }
 
 function hasFocusWithin() {

--- a/src/views/deck/card-editor/list-item-options.vue
+++ b/src/views/deck/card-editor/list-item-options.vue
@@ -18,6 +18,7 @@ const { t } = useI18n()
       icon-only
       icon-left="data-check"
       data-theme="brown-100"
+      data-theme-dark="grey-900"
       :sfx="{ hover: 'ui.pop_drip_mid' }"
     >
       {{ t('deck-view.item-options.select') }}
@@ -28,6 +29,7 @@ const { t } = useI18n()
       icon-only
       icon-left="move-item"
       data-theme="brown-100"
+      data-theme-dark="grey-900"
       :sfx="{ hover: 'ui.pop_drip_mid' }"
     >
       {{ t('deck-view.item-options.move') }}
@@ -38,6 +40,7 @@ const { t } = useI18n()
       icon-only
       icon-left="delete"
       data-theme="red-500"
+      data-theme-dark="red-600"
       :sfx="{ hover: 'ui.pop_drip_mid' }"
     >
       {{ t('deck-view.item-options.delete') }}

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -5,6 +5,7 @@ import UiButton from '@/components/ui-kit/button.vue'
 import UiRadio from '@/components/ui-kit/radio.vue'
 import { type CardListController } from '@/composables/card-editor/card-list-controller'
 import { inject, computed, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
 import ListItemCard from './list-item-card.vue'
 
 type ListItemProps = {
@@ -15,6 +16,7 @@ type ListItemProps = {
 
 const { card, index } = defineProps<ListItemProps>()
 
+const { t } = useI18n()
 const { list, selection, actions } = inject<CardListController>('card-editor')!
 const { appendCard, prependCard } = list
 const { is_selecting, isCardSelected } = selection
@@ -97,7 +99,9 @@ function onClick(e: MouseEvent) {
       size="sm"
       class="absolute! z-1 top-0 -translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="prependCard(card.id!)"
-    />
+    >
+      {{ t('deck-view.card-editor.list-item.add-above') }}
+    </ui-button>
     <ui-button
       v-if="!is_selecting"
       data-testid="card-list-item__add-below"
@@ -108,6 +112,8 @@ function onClick(e: MouseEvent) {
       size="sm"
       class="absolute! z-1 bottom-0 translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="appendCard(card.id!)"
-    />
+    >
+      {{ t('deck-view.card-editor.list-item.add-below') }}
+    </ui-button>
   </div>
 </template>

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -53,7 +53,7 @@ function onClick(e: MouseEvent) {
   <div
     data-testid="card-list-item"
     :data-id="card.id"
-    class="group/listitem relative grid w-full grid-cols-1 sm:grid-cols-[1fr_auto_1fr] sm:gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-colors duration-100 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-grey-700"
+    class="group/listitem relative grid w-full grid-cols-1 sm:grid-cols-[1fr_auto_1fr] sm:gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-colors duration-100 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-stone-900"
     :class="{
       'cursor-pointer': is_selecting,
       'focus-within:bg-brown-300 hover:focus-within:bg-brown-300 dark:focus-within:bg-blue-650 dark:hover:focus-within:bg-blue-650':
@@ -93,7 +93,7 @@ function onClick(e: MouseEvent) {
       icon-left="add"
       icon-only
       data-theme="brown-100"
-      data-theme-dark="stone-700"
+      data-theme-dark="grey-900"
       size="sm"
       class="absolute! z-1 top-0 -translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="prependCard(card.id!)"
@@ -104,7 +104,7 @@ function onClick(e: MouseEvent) {
       icon-left="add"
       icon-only
       data-theme="brown-100"
-      data-theme-dark="stone-700"
+      data-theme-dark="grey-900"
       size="sm"
       class="absolute! z-1 bottom-0 translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="appendCard(card.id!)"

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -69,15 +69,9 @@ function onClick(e: MouseEvent) {
       <ui-icon
         src="reorder"
         class="hidden"
-        :class="{
-          'group-hover/listitem:block group-focus-within/listitem:block': !is_selecting
-        }"
+        :class="{ 'group-hover/listitem:block': !is_selecting }"
       />
-      <span
-        :class="{
-          'group-focus-within/listitem:hidden group-hover/listitem:hidden': !is_selecting
-        }"
-      >
+      <span :class="{ 'group-hover/listitem:hidden': !is_selecting }">
         {{ index + 1 }}
       </span>
     </button>

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -63,7 +63,7 @@ function onClick(e: MouseEvent) {
   >
     <button
       data-testid="card-list-item__reorder"
-      class="hidden h-12 w-12 cursor-grab items-center justify-center rounded-full bg-brown-300 text-lg text-brown-700 sm:flex group-focus-within/listitem:bg-brown-100 row-span-2"
+      class="hidden h-12 w-12 cursor-grab items-center justify-center rounded-full bg-brown-300 text-lg text-brown-700 sm:flex group-focus-within/listitem:bg-brown-100 row-span-2 dark:bg-stone-700 dark:text-brown-100 dark:group-focus-within/listitem:bg-stone-900"
       @click.stop
     >
       <ui-icon
@@ -93,6 +93,7 @@ function onClick(e: MouseEvent) {
       icon-left="add"
       icon-only
       data-theme="brown-100"
+      data-theme-dark="stone-700"
       size="sm"
       class="absolute! z-1 top-0 -translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="prependCard(card.id!)"
@@ -103,6 +104,7 @@ function onClick(e: MouseEvent) {
       icon-left="add"
       icon-only
       data-theme="brown-100"
+      data-theme-dark="stone-700"
       size="sm"
       class="absolute! z-1 bottom-0 translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="appendCard(card.id!)"

--- a/src/views/deck/card-editor/list.vue
+++ b/src/views/deck/card-editor/list.vue
@@ -55,7 +55,7 @@ watchEffect(() => {
         v-for="vrow in virtualizer.getVirtualItems()"
         :key="vrow.key as number"
         data-testid="card-list__row"
-        class="absolute top-0 left-0 w-full flex justify-center"
+        class="absolute top-0 left-0 w-full flex justify-center hover:z-10 focus-within:z-10"
         :style="{
           height: `${vrow.size}px`,
           transform: `translateY(${vrow.start}px)`

--- a/src/views/deck/deck-hero/thumbnail.vue
+++ b/src/views/deck/deck-hero/thumbnail.vue
@@ -28,7 +28,7 @@ function onSettingsClicked() {
         data-theme="blue-500"
         data-theme-dark="blue-650"
         icon-left="build"
-        class="absolute! -top-2.5 -left-2.5"
+        class="absolute! -top-2.5 -left-2.5 border-t border-r border-brown-300 dark:border-stone-700"
         icon-only
       >
         {{ t('deck.settings-modal.title') }}

--- a/src/views/deck/image-button.vue
+++ b/src/views/deck/image-button.vue
@@ -40,7 +40,14 @@ function onImageDelete() {
     {{ t('deck-view.item-options.remove-image') }}
   </ui-button>
 
-  <ui-button v-else icon-only icon-left="add-image" data-theme="blue-500" @click.stop="onAddImage">
+  <ui-button
+    v-else
+    icon-only
+    icon-left="add-image"
+    data-theme="blue-500"
+    data-theme-dark="stone-700"
+    @click.stop="onAddImage"
+  >
     {{ t('deck-view.item-options.upload-image') }}
   </ui-button>
 </template>

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -279,6 +279,18 @@ describe('ListItemCard', () => {
     wrapper.unmount()
   })
 
+  test('does NOT emit ui.card_drop when a non-contenteditable element blurs to outside every card', async () => {
+    const wrapper = mountWithFocusStubs({ card: { id: 42 } })
+    // A non-contenteditable element (e.g. the image button) losing focus must not trigger the drop sfx.
+    const button = document.createElement('button')
+    wrapper.element.appendChild(button)
+    button.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }))
+    // e.target.isContentEditable is false → card_drop guard skipped
+    expect(mocks.emitSfxMock).not.toHaveBeenCalledWith('ui.card_drop')
+    button.remove()
+    wrapper.unmount()
+  })
+
   test('does NOT emit ui.card_drop when focus moves out to another card', async () => {
     const other = makeOtherCardEditor()
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -199,7 +199,19 @@ describe('ListItemCard', () => {
   // These tests use mountWithFocusStubs which renders contenteditable divs so
   // e.target.isContentEditable is true when events bubble to the root handler.
 
-  test('emits ui.slide_up when focus enters from outside the card (relatedTarget null)', async () => {
+  // A detached card editor used as relatedTarget to simulate focus arriving from
+  // or leaving to another card in the list.
+  function makeOtherCardEditor() {
+    const card = document.createElement('div')
+    card.dataset.testid = 'list-item-card'
+    const editor = document.createElement('div')
+    editor.contentEditable = 'true'
+    card.appendChild(editor)
+    document.body.appendChild(card)
+    return { card, editor }
+  }
+
+  test('emits ui.slide_up when a card is activated from outside every card (relatedTarget null)', async () => {
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     const contenteditable = wrapper.find('[data-testid="text-editor-stub"]').element
     contenteditable.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }))
@@ -207,7 +219,7 @@ describe('ListItemCard', () => {
     wrapper.unmount()
   })
 
-  test('emits ui.slide_up when focus enters from an element outside the card', async () => {
+  test('emits ui.slide_up when focus enters from an element outside every card', async () => {
     const external = document.createElement('div')
     document.body.appendChild(external)
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
@@ -220,20 +232,28 @@ describe('ListItemCard', () => {
     wrapper.unmount()
   })
 
-  test('emits ui.click_04 when focus moves within the card (relatedTarget inside root)', async () => {
+  test('emits ui.click_04 when focus moves within the card (between sides)', async () => {
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
-    const root = wrapper.element
     const editors = wrapper.findAll('[data-testid="text-editor-stub"]')
-    // Simulate focus moving from the first editor to the second — relatedTarget is
-    // the first editor, which is contained within the card root.
+    // Simulate focus moving from the first editor to the second.
     const first_editor = editors[0].element
     const second_editor = editors[1].element
     second_editor.dispatchEvent(
       new FocusEvent('focusin', { bubbles: true, relatedTarget: first_editor })
     )
-    // root.contains(first_editor) is true → moved_within = true → ui.click_04
-    expect(root.contains(first_editor)).toBe(true)
     expect(mocks.emitSfxMock).toHaveBeenCalledWith('ui.click_04')
+    wrapper.unmount()
+  })
+
+  test('emits ui.click_04 when focus moves in from another card', async () => {
+    const other = makeOtherCardEditor()
+    const wrapper = mountWithFocusStubs({ card: { id: 42 } })
+    const contenteditable = wrapper.find('[data-testid="text-editor-stub"]').element
+    contenteditable.dispatchEvent(
+      new FocusEvent('focusin', { bubbles: true, relatedTarget: other.editor })
+    )
+    expect(mocks.emitSfxMock).toHaveBeenCalledWith('ui.click_04')
+    other.card.remove()
     wrapper.unmount()
   })
 
@@ -249,6 +269,38 @@ describe('ListItemCard', () => {
     wrapper.unmount()
   })
 
+  test('emits ui.card_drop when an editor blurs to outside every card', async () => {
+    const wrapper = mountWithFocusStubs({ card: { id: 42 } })
+    const contenteditable = wrapper.find('[data-testid="text-editor-stub"]').element
+    contenteditable.dispatchEvent(
+      new FocusEvent('focusout', { bubbles: true, relatedTarget: null })
+    )
+    expect(mocks.emitSfxMock).toHaveBeenCalledWith('ui.card_drop')
+    wrapper.unmount()
+  })
+
+  test('does NOT emit ui.card_drop when focus moves out to another card', async () => {
+    const other = makeOtherCardEditor()
+    const wrapper = mountWithFocusStubs({ card: { id: 42 } })
+    const contenteditable = wrapper.find('[data-testid="text-editor-stub"]').element
+    contenteditable.dispatchEvent(
+      new FocusEvent('focusout', { bubbles: true, relatedTarget: other.editor })
+    )
+    expect(mocks.emitSfxMock).not.toHaveBeenCalledWith('ui.card_drop')
+    other.card.remove()
+    wrapper.unmount()
+  })
+
+  test('does NOT emit ui.card_drop when focus stays within the card (between sides)', async () => {
+    const wrapper = mountWithFocusStubs({ card: { id: 42 } })
+    const editors = wrapper.findAll('[data-testid="text-editor-stub"]')
+    editors[0].element.dispatchEvent(
+      new FocusEvent('focusout', { bubbles: true, relatedTarget: editors[1].element })
+    )
+    expect(mocks.emitSfxMock).not.toHaveBeenCalledWith('ui.card_drop')
+    wrapper.unmount()
+  })
+
   test('focusout with relatedTarget inside the card keeps focused true, so the next focusin emits click_04', async () => {
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     const editors = wrapper.findAll('[data-testid="text-editor-stub"]')
@@ -260,8 +312,7 @@ describe('ListItemCard', () => {
     first_editor.dispatchEvent(
       new FocusEvent('focusout', { bubbles: true, relatedTarget: second_editor })
     )
-    // 3. The second editor now fires focusin with relatedTarget = first_editor (still inside)
-    //    Because focused stayed true after step 2, moved_within=true → ui.click_04
+    // 3. The second editor now fires focusin — focus stayed within the card
     mocks.emitSfxMock.mockReset()
     second_editor.dispatchEvent(
       new FocusEvent('focusin', { bubbles: true, relatedTarget: first_editor })
@@ -282,7 +333,7 @@ describe('ListItemCard', () => {
     // wrapper.element.contains(null) === false → focused becomes false
     // A subsequent focusEditor() call should try to focus the front-input
     // (we can't assert wrapper.vm.focused directly per blackbox rules, but we can
-    // verify the side effect: emitSfx is called with slide_up next time focus enters)
+    // verify the side effect: emitSfx slides up again next time focus enters)
     mocks.emitSfxMock.mockReset()
     contenteditable.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }))
     expect(mocks.emitSfxMock).toHaveBeenCalledWith('ui.slide_up')

--- a/tests/integration/views/deck/card-editor/list-item.test.js
+++ b/tests/integration/views/deck/card-editor/list-item.test.js
@@ -1,0 +1,128 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h, ref, useAttrs } from 'vue'
+
+// Stub UiButton to render its default slot so label text is inspectable,
+// and forward attrs (including data-testid) for querying.
+const UiButtonStub = defineComponent({
+  name: 'UiButton',
+  inheritAttrs: false,
+  setup(_p, { slots }) {
+    const attrs = useAttrs()
+    return () => h('button', attrs, slots.default?.())
+  }
+})
+
+const mocks = vi.hoisted(() => ({
+  prependCardMock: vi.fn(),
+  appendCardMock: vi.fn(),
+  onDeleteCardsMock: vi.fn(),
+  onMoveCardsMock: vi.fn(),
+  onSelectCardMock: vi.fn(),
+  isCardSelectedMock: vi.fn()
+}))
+
+import ListItem from '@/views/deck/card-editor/list-item.vue'
+
+function makeCard(overrides = {}) {
+  return {
+    id: 1,
+    deck_id: 10,
+    front_text: 'Q',
+    back_text: 'A',
+    rank: 1000,
+    ...overrides
+  }
+}
+
+function makeProvide({ is_selecting = ref(false) } = {}) {
+  return {
+    'card-editor': {
+      list: {
+        appendCard: mocks.appendCardMock,
+        prependCard: mocks.prependCardMock
+      },
+      selection: {
+        is_selecting,
+        isCardSelected: mocks.isCardSelectedMock
+      },
+      actions: {
+        onDeleteCards: mocks.onDeleteCardsMock,
+        onMoveCards: mocks.onMoveCardsMock,
+        onSelectCard: mocks.onSelectCardMock
+      }
+    }
+  }
+}
+
+function mount({ card, index = 0, duplicate = false, is_selecting } = {}) {
+  return shallowMount(ListItem, {
+    props: { card: makeCard(card), index, duplicate },
+    global: {
+      stubs: { UiButton: UiButtonStub },
+      provide: makeProvide({ is_selecting })
+    }
+  })
+}
+
+beforeEach(() => {
+  mocks.prependCardMock.mockReset()
+  mocks.appendCardMock.mockReset()
+  mocks.onDeleteCardsMock.mockReset()
+  mocks.onMoveCardsMock.mockReset()
+  mocks.onSelectCardMock.mockReset()
+  mocks.isCardSelectedMock.mockReset()
+  mocks.isCardSelectedMock.mockReturnValue(false)
+})
+
+describe('ListItem', () => {
+  // ── Add-card buttons — label text ────────────────────────────────────────
+
+  test('add-above button carries the localized "Add Card" label text', () => {
+    const wrapper = mount()
+    const btn = wrapper.find('[data-testid="card-list-item__add-above"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.text()).toContain('Add Card')
+  })
+
+  test('add-below button carries the localized "Add Card" label text', () => {
+    const wrapper = mount()
+    const btn = wrapper.find('[data-testid="card-list-item__add-below"]')
+    expect(btn.exists()).toBe(true)
+    expect(btn.text()).toContain('Add Card')
+  })
+
+  // ── Add-card buttons — click wiring ──────────────────────────────────────
+
+  test('clicking add-above calls prependCard with the card id', async () => {
+    const wrapper = mount({ card: { id: 7 } })
+    await wrapper.find('[data-testid="card-list-item__add-above"]').trigger('click')
+    expect(mocks.prependCardMock).toHaveBeenCalledWith(7)
+  })
+
+  test('clicking add-below calls appendCard with the card id', async () => {
+    const wrapper = mount({ card: { id: 7 } })
+    await wrapper.find('[data-testid="card-list-item__add-below"]').trigger('click')
+    expect(mocks.appendCardMock).toHaveBeenCalledWith(7)
+  })
+
+  // ── Add-card buttons — hidden in selection mode ───────────────────────────
+
+  test('add-above and add-below buttons are hidden when is_selecting is true', () => {
+    const wrapper = mount({ is_selecting: ref(true) })
+    expect(wrapper.find('[data-testid="card-list-item__add-above"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="card-list-item__add-below"]').exists()).toBe(false)
+  })
+
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  test('renders the card-list-item root with the correct data-id', () => {
+    const wrapper = mount({ card: { id: 42 } })
+    expect(wrapper.find('[data-testid="card-list-item"]').attributes('data-id')).toBe('42')
+  })
+
+  test('renders the index number in the reorder pill', () => {
+    const wrapper = mount({ index: 3 })
+    expect(wrapper.find('[data-testid="card-list-item__reorder"]').text()).toContain('4')
+  })
+})


### PR DESCRIPTION
## Summary

A batch of card-editor tweaks and dark-mode polish:

**Focus sounds**
- Switching between sides of a card or between active cards now plays the same click (`ui.click_04`).
- Activating a card from outside the editor slides up (`ui.slide_up`); blurring an editor out to nothing drops the card (`ui.card_drop`).

**Reorder pill**
- The position number swaps for the grab icon on hover only, not when the card is active — an active card keeps showing its number.

**Hover leak fix**
- Each virtualized row is a transform-induced stacking context, so a row's add-card buttons (which overflow into the neighbouring row) were painted beneath the next row's body, letting hover leak to the wrong row. The hovered/active row is now elevated above its siblings so its own buttons stay the hit target.

**Dark mode**
- Add-card buttons and the `brown-100` item-options buttons → `grey-900`; the delete button → `red-600`.
- The reorder pill, add-card buttons, and upload-image button got dark surfaces (`stone-700` / `grey-900`).
- The list item's hover backdrop → `stone-900`.
- The deck-hero settings button gets a 1px top/right border (`brown-300` light, `stone-700` dark) so it reads apart from the preview when the deck theme is `blue-650` in dark mode.

**Add-card labels**
- The add-above/add-below icon buttons now carry an "Add Card" label (shown as a tooltip in icon-only mode), via dedicated i18n keys.