### PR TITLE
feat(storage): dedupe card images via content-addressed member-images bucket

### DIFF
--- a/src/api/cards/db/update.ts
+++ b/src/api/cards/db/update.ts
@@ -3,7 +3,7 @@ import logger from '@/utils/logger'
 import { isoNow } from '@/utils/date'
 import { uploadImage, insertMedia } from '@/api/media/db'
 import { useMemberStore } from '@/stores/member'
-import uid from '@/utils/uid'
+import { hashFile } from '@/utils/hash'
 import { buildCardPayload } from '@/utils/card/payload'
 import { type CardBase } from '@type/card'
 
@@ -62,12 +62,14 @@ export async function setCardImage(card_id: number, file: File, side: 'front' | 
   const member_id = useMemberStore().id
   if (!member_id) throw new Error('Not authenticated')
 
-  const bucket = 'cards'
+  const bucket = 'member-images'
   const slot = `card_${side}` as const
-  // Path includes member_id so any viewer (not just the owner) builds a
-  // correct storage URL. The storage policies enforce that only the owner
-  // can INSERT/UPDATE/DELETE under their own folder.
-  const path = `${member_id}/${card_id}/${side}/${uid()}.${file.type.split('/')[1]}`
+  // Content-addressed path: hashing the bytes means the same image reused
+  // across cards (or as a deck bg) collapses to one storage object. member_id
+  // stays the first segment — it scopes dedup per-member and satisfies the
+  // storage RLS foldername check. Which card/side uses the image lives in
+  // `media` (card_id + slot), not in the path.
+  const path = `${member_id}/${await hashFile(file)}.${file.type.split('/')[1]}`
 
   // Upload first so we don't soft-delete the previous image (via the DB
   // trigger on insertMedia) until the new file is actually in storage.

--- a/src/api/media/db/index.ts
+++ b/src/api/media/db/index.ts
@@ -25,9 +25,9 @@ export function getImageUrl(bucket: string, path: string): string {
   return supabase.storage.from(bucket).getPublicUrl(path).data.publicUrl
 }
 
-/** Public URL for a card-face image, which always lives in the `cards` bucket. */
+/** Public URL for a card-face image, which lives in the `member-images` bucket. */
 export function cardImageUrl(path: string): string {
-  return getImageUrl('cards', path)
+  return getImageUrl('member-images', path)
 }
 
 export async function insertMedia(params: Media): Promise<void> {

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,24 @@
+/**
+ * SHA-256 hex digest of a file's raw bytes.
+ *
+ * Used to content-address uploads: identical bytes produce an identical hash,
+ * so the same image reused across cards (or as a deck background) maps to a
+ * single storage object instead of one copy per use.
+ *
+ * Reads bytes via FileReader rather than `file.arrayBuffer()` for environment
+ * portability (jsdom's File predates `arrayBuffer`).
+ */
+export async function hashFile(file: File): Promise<string> {
+  const bytes = await readArrayBuffer(file)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+function readArrayBuffer(file: File): Promise<ArrayBuffer> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as ArrayBuffer)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsArrayBuffer(file)
+  })
+}

--- a/supabase/functions/_shared/test-utils.ts
+++ b/supabase/functions/_shared/test-utils.ts
@@ -3,7 +3,9 @@
 
 export type FakeSupabaseOpts<Row> = {
   rows?: Row[]
+  activeRows?: { bucket: string; path: string }[]
   selectError?: any
+  refcountError?: any
   removeErrors?: Map<string, any[]>
   deleteError?: any
 }
@@ -19,7 +21,9 @@ export type FakeSupabase = {
 }
 
 // Minimal supabase-js stand-in covering the surface our edge functions touch:
-// `.from(t).select().not().limit()`, `.from(t).delete().in()`, `.storage.from(b).remove()`.
+// `.from(t).select().not().limit()` (soft-deleted candidates),
+// `.from(t).select().is().in()` (active-row refcount lookup),
+// `.from(t).delete().in()`, `.storage.from(b).remove()`.
 // Storage `remove` errors are queued per bucket so retries can be exercised.
 export function makeFakeSupabase<Row>(opts: FakeSupabaseOpts<Row> = {}): {
   supabase: FakeSupabase
@@ -38,6 +42,14 @@ export function makeFakeSupabase<Row>(opts: FakeSupabaseOpts<Row> = {}): {
               opts.selectError
                 ? { data: null, error: opts.selectError }
                 : { data: opts.rows ?? [], error: null }
+            )
+        }),
+        is: () => ({
+          in: () =>
+            Promise.resolve(
+              opts.refcountError
+                ? { data: null, error: opts.refcountError }
+                : { data: opts.activeRows ?? [], error: null }
             )
         })
       }),

--- a/supabase/functions/cleanup-media/index.test.ts
+++ b/supabase/functions/cleanup-media/index.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from '@std/assert'
 import { makeFakeSupabase, noSleep } from '../_shared/test-utils.ts'
 import { handler } from './index.ts'
 
-type MediaRow = { id: number; bucket: string; path: string; member_id: string }
+type MediaRow = { id: number; bucket: string; path: string }
 
 Deno.test('returns 200 with no-rows message when nothing to clean', async () => {
   const { supabase, calls } = makeFakeSupabase({ rows: [] })
@@ -24,44 +24,80 @@ Deno.test('returns 500 on select error', async () => {
   assertEquals(await res.json(), { error: 'select_failed' })
 })
 
-Deno.test('groups by bucket+member, removes storage, deletes rows', async () => {
+Deno.test('returns 500 on refcount error', async () => {
+  const rows: MediaRow[] = [{ id: 1, bucket: 'member-images', path: 'm1/a.png' }]
+  const { supabase, calls } = makeFakeSupabase({ rows, refcountError: { message: 'boom' } })
+
+  const res = await handler({ supabase, sleep: noSleep })
+
+  assertEquals(res.status, 500)
+  assertEquals(await res.json(), { error: 'refcount_failed' })
+  assertEquals(calls.removed.length, 0)
+})
+
+Deno.test('removes orphaned objects grouped by bucket, uses path as-is, deletes rows', async () => {
   const rows: MediaRow[] = [
-    { id: 1, bucket: 'cards', path: 'a.png', member_id: 'm1' },
-    { id: 2, bucket: 'cards', path: 'b.png', member_id: 'm1' },
-    { id: 3, bucket: 'cards', path: 'c.png', member_id: 'm2' },
-    { id: 4, bucket: 'avatars', path: 'd.png', member_id: 'm1' }
+    { id: 1, bucket: 'member-images', path: 'm1/a.png' },
+    { id: 2, bucket: 'member-images', path: 'm1/b.png' },
+    { id: 3, bucket: 'avatars', path: 'm1/c.png' }
   ]
-  const { supabase, calls } = makeFakeSupabase({ rows })
+  const { supabase, calls } = makeFakeSupabase({ rows, activeRows: [] })
 
   const res = await handler({ supabase, sleep: noSleep })
 
   assertEquals(res.status, 200)
-  assertEquals(await res.json(), { message: 'Media cleanup complete', processed: 4, skipped: 0 })
+  assertEquals(await res.json(), { message: 'Media cleanup complete', processed: 3, skipped: 0 })
 
-  assertEquals(calls.removed.length, 3)
-  const cardsM1 = calls.removed.find((r) => r.bucket === 'cards' && r.paths[0].startsWith('m1/'))
-  assertEquals(cardsM1?.paths, ['m1/a.png', 'm1/b.png'])
-  const cardsM2 = calls.removed.find((r) => r.bucket === 'cards' && r.paths[0].startsWith('m2/'))
-  assertEquals(cardsM2?.paths, ['m2/c.png'])
+  assertEquals(calls.removed.length, 2)
+  const images = calls.removed.find((r) => r.bucket === 'member-images')
+  assertEquals(images?.paths, ['m1/a.png', 'm1/b.png'])
   const avatars = calls.removed.find((r) => r.bucket === 'avatars')
-  assertEquals(avatars?.paths, ['m1/d.png'])
+  assertEquals(avatars?.paths, ['m1/c.png'])
 
   assertEquals(calls.deletedIds.length, 1)
   assertEquals(
     [...calls.deletedIds[0]].sort((a, b) => a - b),
-    [1, 2, 3, 4]
+    [1, 2, 3]
   )
 })
 
-Deno.test('skipped group does not block others, returns 207', async () => {
+Deno.test('keeps a shared object when an active row still references it, but deletes the stale row', async () => {
+  const rows: MediaRow[] = [{ id: 1, bucket: 'member-images', path: 'm1/shared.png' }]
+  const activeRows = [{ bucket: 'member-images', path: 'm1/shared.png' }]
+  const { supabase, calls } = makeFakeSupabase({ rows, activeRows })
+
+  const res = await handler({ supabase, sleep: noSleep })
+
+  assertEquals(res.status, 200)
+  assertEquals(await res.json(), { message: 'Media cleanup complete', processed: 1, skipped: 0 })
+  assertEquals(calls.removed.length, 0)
+  assertEquals(calls.deletedIds, [[1]])
+})
+
+Deno.test('dedupes paths: two stale rows sharing an orphaned object trigger one remove', async () => {
   const rows: MediaRow[] = [
-    { id: 1, bucket: 'cards', path: 'a.png', member_id: 'm1' },
-    { id: 2, bucket: 'avatars', path: 'b.png', member_id: 'm1' }
+    { id: 1, bucket: 'member-images', path: 'm1/dup.png' },
+    { id: 2, bucket: 'member-images', path: 'm1/dup.png' }
+  ]
+  const { supabase, calls } = makeFakeSupabase({ rows, activeRows: [] })
+
+  const res = await handler({ supabase, sleep: noSleep })
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.removed.length, 1)
+  assertEquals(calls.removed[0].paths, ['m1/dup.png'])
+  assertEquals(calls.deletedIds, [[1, 2]])
+})
+
+Deno.test('skipped bucket does not block others, returns 207', async () => {
+  const rows: MediaRow[] = [
+    { id: 1, bucket: 'member-images', path: 'm1/a.png' },
+    { id: 2, bucket: 'avatars', path: 'm1/b.png' }
   ]
   const removeErrors = new Map([
-    ['cards', [{ message: 'fail' }, { message: 'fail' }, { message: 'fail' }]]
+    ['member-images', [{ message: 'fail' }, { message: 'fail' }, { message: 'fail' }]]
   ])
-  const { supabase, calls } = makeFakeSupabase({ rows, removeErrors })
+  const { supabase, calls } = makeFakeSupabase({ rows, activeRows: [], removeErrors })
 
   const res = await handler({ supabase, sleep: noSleep })
 
@@ -75,9 +111,11 @@ Deno.test('skipped group does not block others, returns 207', async () => {
 })
 
 Deno.test('retries transient storage failures before succeeding', async () => {
-  const rows: MediaRow[] = [{ id: 1, bucket: 'cards', path: 'a.png', member_id: 'm1' }]
-  const removeErrors = new Map([['cards', [{ message: 'transient' }, { message: 'transient' }]]])
-  const { supabase, calls } = makeFakeSupabase({ rows, removeErrors })
+  const rows: MediaRow[] = [{ id: 1, bucket: 'member-images', path: 'm1/a.png' }]
+  const removeErrors = new Map([
+    ['member-images', [{ message: 'transient' }, { message: 'transient' }]]
+  ])
+  const { supabase, calls } = makeFakeSupabase({ rows, activeRows: [], removeErrors })
 
   const res = await handler({ supabase, sleep: noSleep })
 
@@ -87,8 +125,12 @@ Deno.test('retries transient storage failures before succeeding', async () => {
 })
 
 Deno.test('returns 500 when DB delete fails after storage success', async () => {
-  const rows: MediaRow[] = [{ id: 1, bucket: 'cards', path: 'a.png', member_id: 'm1' }]
-  const { supabase } = makeFakeSupabase({ rows, deleteError: { message: 'db down' } })
+  const rows: MediaRow[] = [{ id: 1, bucket: 'member-images', path: 'm1/a.png' }]
+  const { supabase } = makeFakeSupabase({
+    rows,
+    activeRows: [],
+    deleteError: { message: 'db down' }
+  })
 
   const res = await handler({ supabase, sleep: noSleep })
 

--- a/supabase/functions/cleanup-media/index.ts
+++ b/supabase/functions/cleanup-media/index.ts
@@ -3,8 +3,8 @@ import { createClient } from '@supabase/supabase-js'
 
 const BATCH_SIZE = 500
 
-type MediaRow = { id: number; bucket: string; path: string; member_id: string }
-type Group = { bucket: string; memberId: string; paths: string[]; ids: number[] }
+type MediaRow = { id: number; bucket: string; path: string }
+type RemovalGroup = { paths: string[]; ids: number[] }
 
 export type Sleep = (ms: number) => Promise<void>
 export type SupabaseLike = {
@@ -33,48 +33,64 @@ async function withRetry<T>(fn: () => Promise<T>, attempts: number, sleep: Sleep
   throw lastError
 }
 
-function groupByBucketAndMember(rows: MediaRow[]): Group[] {
-  const groups = new Map<string, Group>()
+// Content-addressed storage means one object can back many cards (the same
+// image reused across cards / as a deck bg). A soft-deleted row only means
+// "this card no longer uses the image" — the object must survive as long as
+// any *active* row still references its (bucket, path). Partition the
+// candidates accordingly:
+//   - keepObjectIds: stale rows whose object is still referenced → delete the
+//     row, leave the object.
+//   - byBucket: orphaned objects (no active reference) → remove from storage,
+//     then delete the rows. Paths are deduped per bucket so two stale rows
+//     sharing an object trigger a single remove.
+function partitionCandidates(rows: MediaRow[], stillReferenced: Set<string>) {
+  const keepObjectIds: number[] = []
+  const byBucket = new Map<string, RemovalGroup>()
+  const seenPaths = new Set<string>()
 
   for (const row of rows) {
-    const key = `${row.bucket}::${row.member_id}`
-    if (!groups.has(key)) {
-      groups.set(key, { bucket: row.bucket, memberId: row.member_id, paths: [], ids: [] })
+    const key = `${row.bucket}::${row.path}`
+    if (stillReferenced.has(key)) {
+      keepObjectIds.push(row.id)
+      continue
     }
-    const g = groups.get(key)!
-    g.paths.push(row.path)
-    g.ids.push(row.id)
+
+    const group = byBucket.get(row.bucket) ?? { paths: [], ids: [] }
+    group.ids.push(row.id)
+    if (!seenPaths.has(key)) {
+      group.paths.push(row.path)
+      seenPaths.add(key)
+    }
+    byBucket.set(row.bucket, group)
   }
 
-  return [...groups.values()]
+  return { keepObjectIds, byBucket }
 }
 
-async function removeGroupFromStorage(
+async function removeBucketObjects(
   supabase: SupabaseLike,
-  group: Group,
+  bucket: string,
+  paths: string[],
   attempts: number,
   sleep: Sleep
-): Promise<{ ids: number[]; error: string | null }> {
-  const fullPaths = group.paths.map((p) => `${group.memberId}/${p}`)
-
+): Promise<string | null> {
+  // media.path is the full storage key (`<member_id>/<sha256>.<ext>`), so it's
+  // passed to storage.remove as-is — no member_id re-prefixing.
   try {
     await withRetry(
       () =>
         supabase.storage
-          .from(group.bucket)
-          .remove(fullPaths)
+          .from(bucket)
+          .remove(paths)
           .then(({ error }) => {
             if (error) throw error
           }),
       attempts,
       sleep
     )
-    return { ids: group.ids, error: null }
+    return null
   } catch (err: any) {
-    return {
-      ids: [],
-      error: `bucket=${group.bucket} member=${group.memberId}: ${err?.message ?? err}`
-    }
+    return `bucket=${bucket}: ${err?.message ?? err}`
   }
 }
 
@@ -83,7 +99,7 @@ export async function handler({ supabase, sleep, retryAttempts = 3 }: Deps): Pro
 
   const { data: mediaRows, error: selectError } = await supabase
     .from('media')
-    .select('id, bucket, path, member_id')
+    .select('id, bucket, path')
     .not('deleted_at', 'is', null)
     .limit(BATCH_SIZE)
 
@@ -96,23 +112,40 @@ export async function handler({ supabase, sleep, retryAttempts = 3 }: Deps): Pro
     return new Response(JSON.stringify({ message: 'No media to clean' }), { status: 200 })
   }
 
-  const groups = groupByBucketAndMember(mediaRows)
+  const candidatePaths = [...new Set(mediaRows.map((r: MediaRow) => r.path))]
+  const { data: activeRows, error: refcountError } = await supabase
+    .from('media')
+    .select('bucket, path')
+    .is('deleted_at', null)
+    .in('path', candidatePaths)
 
-  const successfulIds: number[] = []
+  if (refcountError) {
+    console.error('Error refcounting media:', refcountError)
+    return new Response(JSON.stringify({ error: 'refcount_failed' }), { status: 500 })
+  }
+
+  const stillReferenced = new Set<string>(
+    (activeRows ?? []).map((r: { bucket: string; path: string }) => `${r.bucket}::${r.path}`)
+  )
+  const { keepObjectIds, byBucket } = partitionCandidates(mediaRows, stillReferenced)
+
+  const removedIds: number[] = []
   const storageErrors: string[] = []
 
-  for (const group of groups) {
-    const { ids, error } = await removeGroupFromStorage(supabase, group, retryAttempts, wait)
+  for (const [bucket, group] of byBucket) {
+    const error = await removeBucketObjects(supabase, bucket, group.paths, retryAttempts, wait)
     if (error) {
       console.error('Storage delete failed after retries:', error)
       storageErrors.push(error)
       continue
     }
-    successfulIds.push(...ids)
+    removedIds.push(...group.ids)
   }
 
-  if (successfulIds.length > 0) {
-    const { error: deleteError } = await supabase.from('media').delete().in('id', successfulIds)
+  const deletableIds = [...keepObjectIds, ...removedIds]
+
+  if (deletableIds.length > 0) {
+    const { error: deleteError } = await supabase.from('media').delete().in('id', deletableIds)
 
     if (deleteError) {
       console.error('Error deleting media rows:', deleteError)
@@ -127,8 +160,8 @@ export async function handler({ supabase, sleep, retryAttempts = 3 }: Deps): Pro
   return new Response(
     JSON.stringify({
       message: 'Media cleanup complete',
-      processed: successfulIds.length,
-      skipped: mediaRows.length - successfulIds.length,
+      processed: deletableIds.length,
+      skipped: mediaRows.length - deletableIds.length,
       ...(storageErrors.length > 0 && { storage_errors: storageErrors })
     }),
     { status }

--- a/supabase/migrations/20260601000000_replace-cards-bucket-with-member-images.sql
+++ b/supabase/migrations/20260601000000_replace-cards-bucket-with-member-images.sql
@@ -1,0 +1,107 @@
+-- =============================================================================
+-- Replace the per-card `cards` bucket with a general `member-images` bucket
+-- =============================================================================
+--
+-- Old scheme: every card face uploaded a unique object at
+--   cards/<member_id>/<card_id>/<side>/<uid>.<ext>
+-- Baking card_id + a random uid into the path guaranteed one physical object
+-- per card face, so reusing the same image (deck bg, card bg) wasted storage.
+--
+-- New scheme: content-addressed, member-scoped, usage-neutral:
+--   member-images/<member_id>/<sha256-of-bytes>.<ext>
+-- Identical bytes for the same member collapse to a single object. Which card
+-- (and side) uses it is recorded in public.media (card_id + slot), not in the
+-- path. The bucket is now a dumb content store shared across card images and
+-- (later) deck backgrounds.
+--
+-- Fresh start (no backfill): existing card-image media rows are discarded here.
+-- The old bucket's storage objects + the bucket row itself can't be removed
+-- from SQL (storage.protect_delete blocks direct deletes of storage tables) —
+-- they're emptied + dropped via the Storage API out-of-band. The dedupe-slot
+-- trigger and the (card_id, slot) unique index from earlier migrations carry
+-- over unchanged.
+-- =============================================================================
+
+BEGIN;
+
+-- Fresh start: discard old card-image references. public.media is our own
+-- table (no storage guard), so this is a plain DELETE. The orphaned objects in
+-- the `cards` bucket are emptied via the Storage API separately.
+DELETE FROM public.media WHERE bucket = 'cards';
+
+-- Retire the old bucket's RLS policies (the bucket row is dropped via the
+-- Storage API, since SQL can't delete storage tables).
+DROP POLICY IF EXISTS "cards_bucket_authenticated_select" ON storage.objects;
+DROP POLICY IF EXISTS "cards_bucket_authenticated_insert" ON storage.objects;
+DROP POLICY IF EXISTS "cards_bucket_authenticated_update" ON storage.objects;
+DROP POLICY IF EXISTS "cards_bucket_authenticated_delete" ON storage.objects;
+
+-- -----------------------------------------------------------------------------
+-- New general, per-member image bucket.
+-- -----------------------------------------------------------------------------
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'member-images',
+  'member-images',
+  true,
+  10485760, -- 10 MiB
+  ARRAY['image/png', 'image/jpeg', 'image/webp', 'image/gif']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public             = EXCLUDED.public,
+  file_size_limit    = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- -----------------------------------------------------------------------------
+-- storage.objects RLS for `member-images`.
+--
+-- Path shape: `<member_id>/<sha256>.<ext>`; foldername(name)[1] is the
+-- uploader's member_id. All four ops gated on auth.uid() = that segment, so a
+-- member can only touch their own folder.
+--
+-- The SELECT policy is load-bearing for uploads: supabase-js upsert-upload
+-- emits `INSERT ... ON CONFLICT DO UPDATE`, which needs SELECT for the conflict
+-- check. Re-uploading identical bytes (same hash → same path) hits that UPDATE
+-- branch, so the UPDATE policy matters too.
+-- -----------------------------------------------------------------------------
+CREATE POLICY "member_images_authenticated_select"
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (
+  bucket_id = 'member-images'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "member_images_authenticated_insert"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'member-images'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "member_images_authenticated_update"
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'member-images'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+)
+WITH CHECK (
+  bucket_id = 'member-images'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "member_images_authenticated_delete"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'member-images'
+  AND (auth.uid())::text = (storage.foldername(name))[1]
+);
+
+COMMIT;

--- a/supabase/tests/00006_triggers.sql
+++ b/supabase/tests/00006_triggers.sql
@@ -52,10 +52,10 @@ SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
 SET LOCAL role = 'authenticated';
 
 INSERT INTO public.media (card_id, slot, bucket, path)
-VALUES (1000, 'card_front'::public.media_slot, 'cards', 'first.png');
+VALUES (1000, 'card_front'::public.media_slot, 'member-images', 'first.png');
 
 INSERT INTO public.media (card_id, slot, bucket, path)
-VALUES (1000, 'card_front'::public.media_slot, 'cards', 'second.png');
+VALUES (1000, 'card_front'::public.media_slot, 'member-images', 'second.png');
 
 SET LOCAL role = 'postgres';
 
@@ -75,7 +75,7 @@ SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
 SET LOCAL role = 'authenticated';
 
 INSERT INTO public.media (card_id, slot, bucket, path)
-VALUES (1000, 'card_back'::public.media_slot, 'cards', 'back.png');
+VALUES (1000, 'card_back'::public.media_slot, 'member-images', 'back.png');
 
 SET LOCAL role = 'postgres';
 
@@ -97,7 +97,7 @@ SET LOCAL role = 'authenticated';
 SELECT throws_ok(
   $$
     INSERT INTO public.media (card_id, slot, bucket, path)
-    VALUES (1000, 'card_front'::public.media_slot, 'cards', 'bypass.png')
+    VALUES (1000, 'card_front'::public.media_slot, 'member-images', 'bypass.png')
   $$,
   '23505',
   NULL,

--- a/supabase/tests/00010_member_images_storage_rls.sql
+++ b/supabase/tests/00010_member_images_storage_rls.sql
@@ -1,10 +1,12 @@
 -- =============================================================================
--- RLS tests: storage.objects policies for the `cards` bucket
+-- RLS tests: storage.objects policies for the `member-images` bucket
 --
--- Enforces per-member isolation via owner::text = foldername[1]. The SELECT
--- policy is required even on pure INSERTs because supabase-js's
--- upload-with-upsert flow emits INSERT ... ON CONFLICT DO UPDATE, which
--- needs SELECT privilege for the conflict-check step.
+-- Enforces per-member isolation via auth.uid()::text = foldername[1]. Paths are
+-- content-addressed (`<member_id>/<sha256>.<ext>`), so only the first segment —
+-- the owner's member_id — is policy-relevant. The SELECT policy is required
+-- even on pure INSERTs because supabase-js's upload-with-upsert flow emits
+-- INSERT ... ON CONFLICT DO UPDATE, which needs SELECT privilege for the
+-- conflict-check step.
 -- =============================================================================
 
 BEGIN;
@@ -26,8 +28,8 @@ SELECT lives_ok(
   $$
     INSERT INTO storage.objects (bucket_id, name, owner, owner_id)
     VALUES (
-      'cards',
-      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png',
+      'member-images',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/abc123.png',
       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
     )
@@ -40,8 +42,8 @@ SELECT throws_ok(
   $$
     INSERT INTO storage.objects (bucket_id, name, owner, owner_id)
     VALUES (
-      'cards',
-      'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb/42/front/hack.png',
+      'member-images',
+      'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb/hack.png',
       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
     )
@@ -53,14 +55,16 @@ SELECT throws_ok(
 
 -- Test 3: UPSERT (INSERT ... ON CONFLICT DO UPDATE) succeeds for Alice's own
 -- row. This is the shape supabase-js emits when upload({ upsert: true }) is
--- called. Without the SELECT policy this would fail even with no conflicting
--- row, because Postgres needs SELECT for the conflict check.
+-- called — and content-addressing makes it the common path, since re-uploading
+-- identical bytes resolves to the same name. Without the SELECT policy this
+-- would fail even with no conflicting row, because Postgres needs SELECT for
+-- the conflict check.
 SELECT lives_ok(
   $$
     INSERT INTO storage.objects (bucket_id, name, owner, owner_id, version)
     VALUES (
-      'cards',
-      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png',
+      'member-images',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/abc123.png',
       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       'v2'
@@ -81,8 +85,8 @@ SET LOCAL role = 'authenticated';
 -- programmatic SELECT path used by list()/download()/upsert-conflict-check.)
 SELECT is(
   (SELECT count(*) FROM storage.objects
-   WHERE name = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png'
-     AND bucket_id = 'cards')::int,
+   WHERE name = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/abc123.png'
+     AND bucket_id = 'member-images')::int,
   0,
   'Bob cannot SELECT Alice''s object through storage.objects RLS'
 );
@@ -90,14 +94,14 @@ SELECT is(
 -- Test 5: Bob cannot UPDATE a row in Alice's folder.
 UPDATE storage.objects
 SET version = 'hacked'
-WHERE name = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png'
-  AND bucket_id = 'cards';
+WHERE name = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/abc123.png'
+  AND bucket_id = 'member-images';
 
 SET LOCAL role = 'postgres';
 SELECT isnt(
   (SELECT version FROM storage.objects
-   WHERE name = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/42/front/a.png'
-     AND bucket_id = 'cards'),
+   WHERE name = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/abc123.png'
+     AND bucket_id = 'member-images'),
   'hacked',
   'Bob cannot UPDATE rows in Alice''s folder'
 );

--- a/tests/contract/api/media.test.js
+++ b/tests/contract/api/media.test.js
@@ -22,22 +22,22 @@ afterEach(async () => {
 
 describe('uploadImage / deleteImage / getImageUrl (contract)', () => {
   test('uploads a file under the member folder, returns a public URL, then deletes it', async () => {
-    const path = `${session.userId}/${card.id}/front/test.png`
-    const url = await uploadImage('cards', path, makeImageFile())
+    const path = `${session.userId}/contract-upload.png`
+    const url = await uploadImage('member-images', path, makeImageFile())
     expect(url).toContain(path)
 
-    expect(getImageUrl('cards', path)).toBe(url)
+    expect(getImageUrl('member-images', path)).toBe(url)
 
-    await deleteImage('cards', path)
+    await deleteImage('member-images', path)
   })
 })
 
 describe('insertMedia / deleteMedia (contract)', () => {
   test('inserts a media row and soft-deletes via deleteMedia', async () => {
-    const path = `${session.userId}/${card.id}/front/im.png`
-    await uploadImage('cards', path, makeImageFile())
+    const path = `${session.userId}/contract-media.png`
+    await uploadImage('member-images', path, makeImageFile())
 
-    await insertMedia({ bucket: 'cards', path, card_id: card.id, slot: 'card_front' })
+    await insertMedia({ bucket: 'member-images', path, card_id: card.id, slot: 'card_front' })
 
     const { data: rows } = await session.client
       .from('media')
@@ -56,12 +56,12 @@ describe('insertMedia / deleteMedia (contract)', () => {
       .single()
     expect(after.deleted_at).not.toBeNull()
 
-    await deleteImage('cards', path)
+    await deleteImage('member-images', path)
   })
 
   test('rejects when neither card_id nor deck_id is provided', async () => {
     await expect(
-      insertMedia({ bucket: 'cards', path: 'x/y.png', slot: 'card_front' })
+      insertMedia({ bucket: 'member-images', path: 'x/y.png', slot: 'card_front' })
     ).rejects.toThrow(/card_id or deck_id/)
   })
 })

--- a/tests/unit/api/cards/update.test.js
+++ b/tests/unit/api/cards/update.test.js
@@ -53,8 +53,8 @@ vi.mock('@/stores/member', () => ({
 
 vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
 
-// Deterministic uid so path assertions are stable.
-vi.mock('@/utils/uid', () => ({ default: () => 'FIXED_UID' }))
+// Deterministic content hash so path assertions are stable.
+vi.mock('@/utils/hash', () => ({ hashFile: () => Promise.resolve('FIXED_HASH') }))
 
 import { saveCard, upsertCard, upsertCards, setCardImage } from '@/api/cards/db/update'
 
@@ -152,7 +152,7 @@ describe('upsertCards', () => {
 })
 
 describe('setCardImage', () => {
-  test('builds the path with member_id/card_id/side/uid.ext and uploads first, then inserts media', async () => {
+  test('builds a content-addressed member_id/hash.ext path and uploads first, then inserts media', async () => {
     const call_order = []
     mocks.uploadImageMock.mockImplementationOnce(async () => call_order.push('upload'))
     mocks.insertMediaMock.mockImplementationOnce(async () => call_order.push('insert'))
@@ -161,24 +161,32 @@ describe('setCardImage', () => {
     await setCardImage(42, file, 'front')
 
     expect(mocks.uploadImageMock).toHaveBeenCalledWith(
-      'cards',
-      'member-uuid-1/42/front/FIXED_UID.png',
+      'member-images',
+      'member-uuid-1/FIXED_HASH.png',
       file
     )
     expect(mocks.insertMediaMock).toHaveBeenCalledWith({
-      bucket: 'cards',
-      path: 'member-uuid-1/42/front/FIXED_UID.png',
+      bucket: 'member-images',
+      path: 'member-uuid-1/FIXED_HASH.png',
       card_id: 42,
       slot: 'card_front'
     })
     expect(call_order).toEqual(['upload', 'insert'])
   })
 
+  test('path is independent of card_id/side so identical bytes dedupe across cards', async () => {
+    const file = new File(['x'], 'f.png', { type: 'image/png' })
+    await setCardImage(42, file, 'front')
+    await setCardImage(99, file, 'back')
+    const [, frontPath] = mocks.uploadImageMock.mock.calls[0]
+    const [, backPath] = mocks.uploadImageMock.mock.calls[1]
+    expect(frontPath).toBe('member-uuid-1/FIXED_HASH.png')
+    expect(backPath).toBe('member-uuid-1/FIXED_HASH.png')
+  })
+
   test('uses card_back slot for back images', async () => {
     const file = new File(['x'], 'f.png', { type: 'image/png' })
     await setCardImage(42, file, 'back')
-    const [, path] = mocks.uploadImageMock.mock.calls[0]
-    expect(path).toContain('/back/')
     const [params] = mocks.insertMediaMock.mock.calls[0]
     expect(params.slot).toBe('card_back')
   })

--- a/tests/unit/api/media.test.js
+++ b/tests/unit/api/media.test.js
@@ -106,11 +106,11 @@ describe('cardImageUrl', () => {
     mocks.getPublicUrlMock.mockReset()
   })
 
-  test('resolves the path against the cards bucket', () => {
+  test('resolves the path against the member-images bucket', () => {
     mocks.getPublicUrlMock.mockReturnValueOnce({ data: { publicUrl: 'https://cdn/card' } })
-    const url = cardImageUrl('member/card/front/abc.png')
-    expect(supabase.storage.from).toHaveBeenCalledWith('cards')
-    expect(mocks.getPublicUrlMock).toHaveBeenCalledWith('member/card/front/abc.png')
+    const url = cardImageUrl('member-uuid/abc123.png')
+    expect(supabase.storage.from).toHaveBeenCalledWith('member-images')
+    expect(mocks.getPublicUrlMock).toHaveBeenCalledWith('member-uuid/abc123.png')
     expect(url).toBe('https://cdn/card')
   })
 })

--- a/tests/unit/utils/hash.test.js
+++ b/tests/unit/utils/hash.test.js
@@ -1,0 +1,21 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { hashFile } from '@/utils/hash'
+
+describe('hashFile', () => {
+  test('returns the SHA-256 hex digest of the file bytes', async () => {
+    const hash = await hashFile(new File(['abc'], 'a.txt', { type: 'text/plain' }))
+    expect(hash).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+  })
+
+  test('identical bytes hash identically regardless of filename or type', async () => {
+    const a = await hashFile(new File(['same'], 'one.png', { type: 'image/png' }))
+    const b = await hashFile(new File(['same'], 'two.webp', { type: 'image/webp' }))
+    expect(a).toBe(b)
+  })
+
+  test('different bytes produce different hashes', async () => {
+    const a = await hashFile(new File(['x'], 'a.png', { type: 'image/png' }))
+    const b = await hashFile(new File(['y'], 'b.png', { type: 'image/png' }))
+    expect(a).not.toBe(b)
+  })
+})


### PR DESCRIPTION
## Summary

Replaces the per-card `cards` storage bucket with a general, per-member `member-images` bucket addressed by the SHA-256 of the file bytes:

```
member-images/<member_id>/<sha256>.<ext>
```

The old path baked `card_id`/`side`/`uid` in, so every upload was a unique object — reusing one image across cards (or as a deck background) wasted storage. Now identical bytes for the same member collapse to a single object. Usage (which card + side) stays in `media` (`card_id` + `slot`); the bucket is a dumb content store. Dedup is scoped per-member via the `member_id` prefix, which also satisfies the storage RLS `foldername` check.

`cleanup-media` is reworked to **reference-count**: an object is removed only when no active `media` row still references its `(bucket, path)` — so deleting one card never yanks an image another card shares.

## Notes

- **Fresh start, no backfill** (per decision): old `cards` media rows are dropped in the migration. SQL can't delete storage tables (`storage.protect_delete`), so the old `cards` bucket + objects are emptied/deleted via the Storage API out-of-band — already done locally; **prod needs the same one-time `POST /bucket/cards/empty` + `DELETE /bucket/cards`**.
- Verified locally: unit (api + hash), the media **contract** test against the live `member-images` bucket (confirms RLS incl. the upsert-needs-SELECT policy), and deck-settings integration all green.