### PR TITLE
fix(db): make account deletion cascade auth.users → all member data

### DIFF
--- a/supabase/migrations/20260601000001_member-auth-cascade-delete.sql
+++ b/supabase/migrations/20260601000001_member-auth-cascade-delete.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- Cascade member (and all member-owned data) when an auth.users row is deleted
+-- =============================================================================
+--
+-- `public.members` is the profile projection of an `auth.users` row (members.id
+-- == auth.users.id, stamped by the on-signup trigger). That FK was NO ACTION,
+-- so deleting an auth user was *blocked* by the member row — and nothing below
+-- got cleaned up. Everything under `members` already cascades:
+--
+--   members ─(CASCADE)→ decks ─(CASCADE)→ cards ─(CASCADE)→ reviews / review_logs / media
+--           ─(CASCADE)→ cards
+--           ─(CASCADE)→ reviews / review_logs
+--           ─(CASCADE)→ purchases
+--
+-- Making members.id → auth.users ON DELETE CASCADE wires the top of that chain:
+-- deleting an auth user now erases the member and all their data in one shot
+-- (account-deletion / GDPR erasure semantics). The media BEFORE DELETE trigger
+-- still fires first to soft-delete storage rows for the cleanup-media cron.
+-- =============================================================================
+
+BEGIN;
+
+-- An FK's ON DELETE action can't be altered in place — drop and re-add it.
+-- Both actions in one ALTER TABLE so it's a single atomic change. The
+-- constraint name is mixed-case, so it must stay double-quoted.
+ALTER TABLE public.members
+  DROP CONSTRAINT "Users_id_fkey",
+  ADD  CONSTRAINT "Users_id_fkey"
+       FOREIGN KEY (id) REFERENCES auth.users (id) ON DELETE CASCADE;
+
+-- Drop the redundant direct decks → auth.users FK. decks.member_id already
+-- references members(id) ON DELETE CASCADE (decks_member_id_fkey); this second
+-- constraint on the same column only added a NO ACTION block on auth-user
+-- deletion, duplicating the relationship that now cascades through members.
+ALTER TABLE public.decks
+  DROP CONSTRAINT decks_user_id_fkey;
+
+COMMIT;

--- a/supabase/migrations/20260601000002_harden-media-soft-delete-triggers.sql
+++ b/supabase/migrations/20260601000002_harden-media-soft-delete-triggers.sql
@@ -1,0 +1,56 @@
+-- =============================================================================
+-- Harden the media soft-delete triggers so parent deletes never FK-block
+-- =============================================================================
+--
+-- media.card_id -> cards and media.deck_id -> decks are NO ACTION, so before a
+-- card/deck row is deleted its BEFORE DELETE trigger must clear that column on
+-- every media row pointing at it. Two latent bugs surfaced once account
+-- deletion started cascading auth.users -> members -> decks -> cards
+-- (20260601000001) — before that, auth-user deletion was blocked outright and
+-- the cascade never ran:
+--
+-- 1. soft_delete_media_before_card_delete referenced `media` UNQUALIFIED, so it
+--    broke under roles whose search_path lacks public — notably
+--    supabase_auth_admin, which runs the cascade on auth-user deletion:
+--      "relation media does not exist".
+--    (Its deck/member siblings already qualify public.media.)
+--
+-- 2. Both the card and deck triggers only touched rows WHERE deleted_at IS NULL,
+--    so an already soft-deleted media row kept its card_id/deck_id and then
+--    FK-blocked the parent delete:
+--      "update or delete on table cards violates media_card_id_fkey".
+--
+-- Fix: fully qualify public.media, and clear the FK column for ALL referencing
+-- media regardless of deleted_at. COALESCE(deleted_at, now()) stamps still-live
+-- rows for the cleanup-media cron while preserving an existing soft-delete time.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.soft_delete_media_before_card_delete()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE public.media
+  SET
+    deleted_at = COALESCE(deleted_at, now()),
+    card_id    = NULL
+  WHERE card_id = OLD.id;
+
+  RETURN OLD;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.soft_delete_media_before_deck_delete()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE public.media
+  SET
+    deleted_at = COALESCE(deleted_at, now()),
+    deck_id    = NULL
+  WHERE deck_id = OLD.id;
+
+  RETURN OLD;
+END;
+$$;

--- a/supabase/tests/00013_delete_deck.sql
+++ b/supabase/tests/00013_delete_deck.sql
@@ -5,15 +5,17 @@
 --   • owner can delete their own deck
 --   • non-owner cannot delete someone else's deck
 --   • cards in the deck are cascade-deleted
+--   • reviews / review_logs of those cards are cascade-deleted
 --   • media rows tied to the deck (via deck_id or via card_id) are tombstoned
 --     and have their FK columns NULLed — not hard-deleted (so cleanup-media
 --     can still reap their storage objects)
 --   • pre-existing tombstones preserve their original deleted_at (COALESCE)
+--   • reviews / review_logs of unrelated decks are untouched
 -- =============================================================================
 
 BEGIN;
 
-SELECT plan(8);
+SELECT plan(11);
 
 -- ── Setup ─────────────────────────────────────────────────────────────────────
 
@@ -42,6 +44,17 @@ INSERT INTO public.media (id, member_id, card_id, deck_id, bucket, path, slot, d
   (930001, '11111111-1111-1111-1111-111111111111'::uuid, 93001, NULL, 'cards', 'p/b', 'card_back'::public.media_slot, '2020-01-01 00:00:00+00'),
   (930002, '11111111-1111-1111-1111-111111111111'::uuid, NULL, 9300, 'decks', 'p/cover', NULL, NULL),
   (930100, '11111111-1111-1111-1111-111111111111'::uuid, 3100, NULL, 'cards', 'p/c', 'card_front'::public.media_slot, NULL);
+
+-- Reviews + review_logs: one set on a card of the delete-target deck (9300),
+-- one set on the control deck's card (3100). reviews.member_id is auto-stamped
+-- by set_member_id (claims are Alice's); review_logs has no such trigger, so its
+-- NOT NULL member_id is set explicitly.
+INSERT INTO public.reviews (id, card_id, due) VALUES
+  (9301001, 93000, now()),   -- target deck card
+  (9301002, 3100, now());    -- control deck card
+INSERT INTO public.review_logs (id, card_id, member_id, rating, state, due, review) VALUES
+  (9301001, 93000, '11111111-1111-1111-1111-111111111111'::uuid, 3, 2, now(), now()),
+  (9301002, 3100,  '11111111-1111-1111-1111-111111111111'::uuid, 3, 2, now(), now());
 
 SELECT tests.set_claims('22222222-2222-2222-2222-222222222222'::uuid);
 INSERT INTO public.decks (id, title, is_public) VALUES (9400, 'Bob Deck', false);
@@ -119,6 +132,28 @@ SELECT ok(
   (SELECT card_id = 3100 AND deck_id IS NULL AND deleted_at IS NULL
      FROM public.media WHERE id = 930100),
   'media belonging to unrelated decks is untouched'
+);
+
+-- Test 9: reviews of the deleted deck's cards are cascade-removed
+-- (reviews.card_id -> cards ON DELETE CASCADE, fired by the card cascade).
+SELECT is(
+  (SELECT count(*) FROM public.reviews WHERE card_id IN (93000, 93001))::int,
+  0,
+  'reviews of the deleted deck''s cards are cascade-removed'
+);
+
+-- Test 10: review_logs of the deleted deck's cards are cascade-removed.
+SELECT is(
+  (SELECT count(*) FROM public.review_logs WHERE card_id IN (93000, 93001))::int,
+  0,
+  'review_logs of the deleted deck''s cards are cascade-removed'
+);
+
+-- Test 11: the control deck's review + review_log are untouched.
+SELECT ok(
+  (SELECT count(*) FROM public.reviews WHERE id = 9301002) = 1
+    AND (SELECT count(*) FROM public.review_logs WHERE id = 9301002) = 1,
+  'reviews/review_logs of unrelated decks are untouched'
 );
 
 

--- a/supabase/tests/00017_member_auth_cascade.sql
+++ b/supabase/tests/00017_member_auth_cascade.sql
@@ -1,0 +1,72 @@
+-- =============================================================================
+-- Cascade test: deleting an auth.users row erases the member and all their data
+--
+-- Guards the account-deletion contract end to end:
+--   * members.id -> auth.users is ON DELETE CASCADE (20260601000001), and every
+--     table below members already cascades, so removing the auth user takes the
+--     member, decks, and cards with it.
+--   * the media soft-delete triggers (20260601000002) must not FK-block that
+--     cascade — even for an already soft-deleted media row — and must work under
+--     an empty search_path (the shape supabase_auth_admin runs the cascade in).
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(4);
+
+-- Setup: a user (helper inserts auth.users + fires the signup trigger that
+-- creates the member row), then a deck + card owned by them.
+SELECT tests.create_user('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid, 'cascade_user');
+SELECT tests.set_claims('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid);
+SET LOCAL role = 'authenticated';
+
+INSERT INTO public.decks (id, title, is_public) VALUES (990001, 'Cascade Deck', false);
+INSERT INTO public.cards (id, deck_id, front_text, back_text, rank)
+VALUES (990001, 990001, 'Q', 'A', 1);
+
+SET LOCAL role = 'postgres';
+
+-- A previously soft-deleted media row still pointing at the card. Before the
+-- trigger fix this kept card_id set and FK-blocked the card's cascade delete.
+INSERT INTO public.media (member_id, card_id, bucket, path, slot, deleted_at)
+VALUES (
+  'cccccccc-cccc-cccc-cccc-cccccccccccc', 990001, 'member-images',
+  'cccccccc-cccc-cccc-cccc-cccccccccccc/abc.png', 'card_front', now()
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.cards WHERE id = 990001)::int,
+  1,
+  'card exists before the auth user is deleted'
+);
+
+-- Empty search_path mimics supabase_auth_admin running the cascade: an
+-- unqualified `media` reference in a trigger would raise "relation media does
+-- not exist" here.
+SET LOCAL search_path = '';
+DELETE FROM auth.users WHERE id = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+RESET search_path;
+
+SELECT is(
+  (SELECT count(*) FROM public.members WHERE id = 'cccccccc-cccc-cccc-cccc-cccccccccccc')::int,
+  0,
+  'member row is cascade-deleted with its auth user'
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.cards WHERE id = 990001)::int,
+  0,
+  'card is cascade-deleted despite a lingering soft-deleted media row'
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.media
+    WHERE path = 'cccccccc-cccc-cccc-cccc-cccccccccccc/abc.png'
+      AND card_id IS NULL
+      AND deleted_at IS NOT NULL)::int,
+  1,
+  'media row survives as a soft-deleted orphan with card_id cleared (for the cron)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/00017_member_auth_cascade.sql
+++ b/supabase/tests/00017_member_auth_cascade.sql
@@ -12,7 +12,7 @@
 
 BEGIN;
 
-SELECT plan(4);
+SELECT plan(6);
 
 -- Setup: a user (helper inserts auth.users + fires the signup trigger that
 -- creates the member row), then a deck + card owned by them.
@@ -33,6 +33,14 @@ VALUES (
   'cccccccc-cccc-cccc-cccc-cccccccccccc', 990001, 'member-images',
   'cccccccc-cccc-cccc-cccc-cccccccccccc/abc.png', 'card_front', now()
 );
+
+-- A review + review_log for the card. Both cascade to the member two ways
+-- (reviews/review_logs -> members and -> cards are ON DELETE CASCADE), so the
+-- account-deletion cascade must remove them.
+INSERT INTO public.reviews (id, card_id, member_id, due)
+VALUES (990001, 990001, 'cccccccc-cccc-cccc-cccc-cccccccccccc', now());
+INSERT INTO public.review_logs (id, card_id, member_id, rating, state, due, review)
+VALUES (990001, 990001, 'cccccccc-cccc-cccc-cccc-cccccccccccc', 3, 2, now(), now());
 
 SELECT is(
   (SELECT count(*) FROM public.cards WHERE id = 990001)::int,
@@ -57,6 +65,18 @@ SELECT is(
   (SELECT count(*) FROM public.cards WHERE id = 990001)::int,
   0,
   'card is cascade-deleted despite a lingering soft-deleted media row'
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.reviews WHERE id = 990001)::int,
+  0,
+  'review is cascade-deleted with the auth user'
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.review_logs WHERE id = 990001)::int,
+  0,
+  'review_log is cascade-deleted with the auth user'
 );
 
 SELECT is(

--- a/supabase/tests/00018_card_delete_cascade.sql
+++ b/supabase/tests/00018_card_delete_cascade.sql
@@ -1,0 +1,91 @@
+-- =============================================================================
+-- Cascade test: deleting a single card
+-- =============================================================================
+-- Mirrors the app's card-delete path (a raw DELETE on cards as the owner).
+-- Covers:
+--   • the card's reviews are cascade-deleted (reviews.card_id -> cards CASCADE)
+--   • the card's review_logs are cascade-deleted (review_logs.card_id CASCADE)
+--   • the card's media are tombstoned with card_id NULLed — not hard-deleted —
+--     so cleanup-media can still reap their storage objects
+--   • a sibling card in the same deck (and its reviews/logs) is untouched
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(6);
+
+-- ── Setup ─────────────────────────────────────────────────────────────────────
+
+SELECT tests.create_user('11111111-1111-1111-1111-111111111111'::uuid, 'alice_cd');
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+
+-- One deck, two cards: 95000 (delete target) and 95001 (sibling, must survive).
+INSERT INTO public.decks (id, title, is_public) VALUES (9500, 'Alice Card-Cascade', false);
+INSERT INTO public.cards (id, deck_id, front_text, back_text, rank) VALUES
+  (95000, 9500, 'Q1', 'A1', 1000),
+  (95001, 9500, 'Q2', 'A2', 2000);
+
+-- Reviews + review_logs on each card. reviews.member_id is auto-stamped by
+-- set_member_id (Alice's claims are set); review_logs needs it explicitly.
+INSERT INTO public.reviews (id, card_id, due) VALUES
+  (95000, 95000, now()),
+  (95001, 95001, now());
+INSERT INTO public.review_logs (id, card_id, member_id, rating, state, due, review) VALUES
+  (95000, 95000, '11111111-1111-1111-1111-111111111111'::uuid, 3, 2, now(), now()),
+  (95001, 95001, '11111111-1111-1111-1111-111111111111'::uuid, 3, 2, now(), now());
+
+-- Media for the target card: one active, one already tombstoned. Both must
+-- survive the delete with card_id NULLed (for the cleanup-media cron).
+INSERT INTO public.media (id, member_id, card_id, bucket, path, slot, deleted_at) VALUES
+  (950000, '11111111-1111-1111-1111-111111111111'::uuid, 95000, 'member-images', 'p/a', 'card_front'::public.media_slot, NULL),
+  (950001, '11111111-1111-1111-1111-111111111111'::uuid, 95000, 'member-images', 'p/b', 'card_back'::public.media_slot, now());
+
+-- ── Delete the target card via the owner (app path) ────────────────────────────
+
+SET LOCAL role = 'authenticated';
+DELETE FROM public.cards WHERE id = 95000;
+SET LOCAL role = 'postgres';
+
+-- ── Assertions ────────────────────────────────────────────────────────────────
+
+SELECT is(
+  (SELECT count(*) FROM public.cards WHERE id = 95000)::int,
+  0,
+  'the target card is deleted'
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.cards WHERE id = 95001)::int,
+  1,
+  'a sibling card in the same deck is untouched'
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.reviews WHERE card_id = 95000)::int,
+  0,
+  'the card''s reviews are cascade-deleted'
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.review_logs WHERE card_id = 95000)::int,
+  0,
+  'the card''s review_logs are cascade-deleted'
+);
+
+SELECT ok(
+  (SELECT count(*) FROM public.reviews WHERE id = 95001) = 1
+    AND (SELECT count(*) FROM public.review_logs WHERE id = 95001) = 1,
+  'the sibling card''s reviews/review_logs are untouched'
+);
+
+-- Both media rows survive (not hard-deleted) with card_id cleared, so the
+-- cascade couldn't violate media_card_id_fkey.
+SELECT is(
+  (SELECT count(*) FROM public.media
+    WHERE id IN (950000, 950001) AND card_id IS NULL)::int,
+  2,
+  'the card''s media are tombstoned with card_id NULLed (kept for the cron)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/contract/setup.js
+++ b/tests/contract/setup.js
@@ -109,7 +109,14 @@ export async function signInAsTestUser() {
     cleanup: async () => {
       ctx.client = null
       ctx.memberId = null
-      await adminClient.auth.admin.deleteUser(userId).catch(() => {})
+      // Deleting the auth user cascades to members -> decks/cards/reviews/etc.
+      // (members.id -> auth.users ON DELETE CASCADE). Surface failures instead
+      // of swallowing them — a silent .catch() here previously let thousands of
+      // test users + their data leak into the local DB run after run.
+      const { error } = await adminClient.auth.admin.deleteUser(userId)
+      if (error) {
+        throw new Error(`Contract cleanup failed to delete test user ${userId}: ${error.message}`)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Deleting an `auth.users` row didn't clean up the member's data — and the test harness that relied on it was silently leaking thousands of users into the local DB. Three coupled fixes:

1. **`members.id → auth.users` becomes `ON DELETE CASCADE`** (was `NO ACTION`). Everything under `members` already cascades (decks → cards → reviews/review_logs/media, purchases), so this wires the top of the chain: deleting an auth user now erases the member and all their data — the account-deletion / GDPR-erasure behavior. Also drops the redundant `decks_user_id_fkey` (a second `decks.member_id → auth.users` NO ACTION FK that only added another block).

2. **Hardens the media soft-delete triggers** for the cascade path — two latent bugs that only surfaced once the cascade could actually run:
   - `soft_delete_media_before_card_delete` referenced `media` **unqualified**, breaking under `supabase_auth_admin` (empty `search_path`) which runs the cascade: *"relation media does not exist"*.
   - card + deck triggers only cleared the FK column for `deleted_at IS NULL` rows, so an already soft-deleted media row kept its `card_id`/`deck_id` and FK-blocked the parent delete.

3. **Stops the contract harness leaking** — `cleanup()` did `deleteUser(...).catch(() => {})`, hiding the FK-block error and leaking every test user run after run. Now it surfaces the error and throws.

## Why this existed

The `NO ACTION` FK blocked auth-user deletion outright, so the cascade (and the buggy triggers) never ran — the harness's swallowed error hid the resulting leak. Fixing the FK exposed the trigger bugs underneath.

## Verification

- New pgTAP test `00017_member_auth_cascade` — asserts the full cascade with a lingering soft-deleted media row and an empty `search_path` (reproduces both trigger bugs). Full pgTAP suite passes.
- Full contract suite (6 files / 31 tests) passes with **zero leaked users** (`auth.users` steady at the 10 real users before/after).
- Note: this also relates to a one-time local cleanup of ~3,932 previously-leaked `contract-*` test users (done separately, not in this diff).