### PR TITLE
feat(ui-kit): anchor popover to a rect via virtual element

### DIFF
--- a/src/components/ui-kit/divider.vue
+++ b/src/components/ui-kit/divider.vue
@@ -6,7 +6,7 @@ defineProps<{
 </script>
 
 <template>
-  <div data-testid="ui-kit-divider" class="w-full flex items-center gap-2.5 px-2.5">
+  <div data-testid="ui-kit-divider" class="w-full flex items-center gap-2.5">
     <hr class="w-full border-t border-t-brown-500" :class="{ 'border-dashed ': dashed }" />
 
     <span v-if="label" class="text-brown-500">{{ label }}</span>

--- a/src/components/ui-kit/popover.vue
+++ b/src/components/ui-kit/popover.vue
@@ -10,7 +10,8 @@ import {
   hide,
   type Placement,
   type Strategy,
-  type Padding
+  type Padding,
+  type VirtualElement
 } from '@floating-ui/vue'
 import uid from '@/utils/uid'
 
@@ -27,6 +28,7 @@ type PopoverProps = {
   shadow?: boolean
   use_arrow?: boolean
   clip?: boolean
+  anchor_rect?: DOMRect | null
 }
 
 const {
@@ -41,7 +43,8 @@ const {
   fallback_placements = ['right', 'left', 'top', 'bottom'],
   shadow = false,
   use_arrow = true,
-  clip = true
+  clip = true,
+  anchor_rect = null
 } = defineProps<PopoverProps>()
 
 const emit = defineEmits<{
@@ -55,7 +58,14 @@ const popoverRef = useTemplateRef('popoverRef')
 const arrowRef = useTemplateRef('arrowRef')
 const id = uid()
 
-const { placement, middlewareData, floatingStyles } = useFloating(triggerRef, popoverRef, {
+// Anchor against a selection rect (virtual element) when one is provided —
+// text-selection popovers have no DOM trigger to wrap. Falls back to the
+// wrapped trigger element otherwise.
+const reference = computed(() =>
+  anchor_rect ? ({ getBoundingClientRect: () => anchor_rect } as VirtualElement) : triggerRef.value
+)
+
+const { placement, middlewareData, floatingStyles } = useFloating(reference, popoverRef, {
   placement: position,
   strategy: strategy,
   whileElementsMounted: autoUpdate,

--- a/src/views/deck/deck-hero/thumbnail.vue
+++ b/src/views/deck/deck-hero/thumbnail.vue
@@ -28,7 +28,7 @@ function onSettingsClicked() {
         data-theme="blue-500"
         data-theme-dark="blue-650"
         icon-left="build"
-        class="absolute! -top-2.5 -left-2.5 border-t border-r border-brown-300 dark:border-stone-700"
+        class="absolute! -top-2.5 -left-2.5 ring-4 ring-brown-300 dark:border-stone-700"
         icon-only
       >
         {{ t('deck.settings-modal.title') }}

--- a/tests/integration/components/ui-kit/popover.test.js
+++ b/tests/integration/components/ui-kit/popover.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { useFloating } from '@floating-ui/vue'
 import UiPopover from '@/components/ui-kit/popover.vue'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
@@ -43,6 +44,7 @@ describe('UiPopover', () => {
   beforeEach(() => {
     floatingState.placement.value = 'top'
     floatingState.middlewareData.value = {}
+    useFloating.mockClear()
   })
 
   // ── Structure ──────────────────────────────────────────────────────────────
@@ -139,6 +141,23 @@ describe('UiPopover', () => {
     await nextTick()
     const arrowEl = wrapper.find('[data-testid="ui-kit-popover__arrow"]')
     expect(arrowEl.attributes('style')).toContain('top: 15px')
+  })
+
+  // ── anchor_rect — virtual reference element ─────────────────────────────────
+
+  test('anchors against a virtual element returning the provided rect when anchor_rect is set', () => {
+    const rect = new DOMRect(10, 20, 30, 40)
+    mountPopover({ open: true, anchor_rect: rect })
+
+    const reference = useFloating.mock.calls.at(-1)[0]
+    expect(reference.value.getBoundingClientRect()).toBe(rect)
+  })
+
+  test('falls back to the trigger element when anchor_rect is not provided', () => {
+    mountPopover({ open: true })
+
+    const reference = useFloating.mock.calls.at(-1)[0]
+    expect(reference.value).toBeInstanceOf(HTMLElement)
   })
 
   // ── close event on outside click ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds virtual-element (`getBoundingClientRect`) anchoring to the ui-kit popover so callers can pin it to an arbitrary screen rect, drops the divider's padding/gap when it has no label, and swaps the deck-hero settings thumbnail border for a ring.

Foundational ui-kit work for the audio-reader term popover. First in a stack of 8 PRs that re-split the audio-reader / lessons feature into reviewable layers.