### PR TITLE
feat(functions): add lesson transcription and translation edge functions

### DIFF
--- a/supabase/functions/_shared/require-admin.ts
+++ b/supabase/functions/_shared/require-admin.ts
@@ -1,0 +1,56 @@
+// Shared auth gate for admin-only edge functions.
+//
+// Authenticates the caller from the request's Authorization header, then asserts
+// their members.role is 'admin'. The frontend useCan() gate is UX only — this is
+// the real security boundary, so every admin-only function calls this first.
+//
+// Returns either { user, admin } on success, or { error: Response } to return
+// verbatim (401 missing/invalid auth, 403 authenticated-but-not-admin).
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+export const cors = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type'
+}
+
+type RequireAdminResult =
+  | { user: { id: string; email?: string }; admin: SupabaseClient }
+  | { error: Response }
+
+export async function requireAdmin(req: Request): Promise<RequireAdminResult> {
+  const authHeader = req.headers.get('Authorization')
+  if (!authHeader) {
+    return { error: new Response('Unauthorized', { status: 401, headers: cors }) }
+  }
+
+  // User-scoped client: carries the caller's JWT, so auth.getUser() resolves to
+  // the real signed-in member and any reads run under their RLS.
+  const userClient = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_ANON_KEY')!,
+    { global: { headers: { Authorization: authHeader } } }
+  )
+
+  const {
+    data: { user },
+    error: authError
+  } = await userClient.auth.getUser()
+  if (authError || !user) {
+    return { error: new Response('Unauthorized', { status: 401, headers: cors }) }
+  }
+
+  // Service-role client bypasses RLS for the privileged role lookup.
+  const admin = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  )
+
+  const { data: member } = await admin.from('members').select('role').eq('id', user.id).single()
+
+  if (member?.role !== 'admin') {
+    return { error: new Response('Forbidden', { status: 403, headers: cors }) }
+  }
+
+  return { user, admin }
+}

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -3,7 +3,8 @@
   "specifiers": {
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.13",
-    "npm:@supabase/supabase-js@2": "2.105.1"
+    "npm:@supabase/supabase-js@2": "2.105.1",
+    "npm:opencc-js@1.0.5": "1.0.5"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -78,6 +79,9 @@
     },
     "iceberg-js@0.8.1": {
       "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "opencc-js@1.0.5": {
+      "integrity": "sha512-LD+1SoNnZdlRwtYTjnQdFrSVCAaYpuDqL5CkmOaHOkKoKh7mFxUicLTRVNLU5C+Jmi1vXQ3QL4jWdgSaa4sKjg=="
     },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="

--- a/supabase/functions/transcribe-audio/index.ts
+++ b/supabase/functions/transcribe-audio/index.ts
@@ -1,0 +1,99 @@
+// transcribe-audio: proxy an uploaded audio file to OpenAI Whisper and return
+// the transcript with sentence/segment-level timestamps.
+//
+// Request:  multipart/form-data with a single `file` field (the audio blob).
+// Response: { text: string, segments: { start, end, text }[], lang?: string }
+//
+// The OpenAI key never reaches the client — it lives in OPENAI_API_KEY here.
+// Admin-only: requireAdmin() runs before any work.
+
+import { cors, requireAdmin } from '../_shared/require-admin.ts'
+import { isTargetScript, scriptConverter } from './script.ts'
+
+const OPENAI_TRANSCRIBE_URL = 'https://api.openai.com/v1/audio/transcriptions'
+
+// Machine-readable failure codes the FE switches on (read from the error body).
+function jsonError(code: string, status: number): Response {
+  return new Response(JSON.stringify({ code }), {
+    status,
+    headers: { ...cors, 'Content-Type': 'application/json' }
+  })
+}
+
+type WhisperSegment = { start: number; end: number; text: string }
+type WhisperWord = { word: string; start: number; end: number }
+type WhisperResponse = {
+  text: string
+  language?: string
+  segments?: WhisperSegment[]
+  words?: WhisperWord[]
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors })
+  }
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: cors })
+  }
+
+  const auth = await requireAdmin(req)
+  if ('error' in auth) return auth.error
+
+  const inbound = await req.formData()
+  const file = inbound.get('file')
+  if (!(file instanceof File)) {
+    return jsonError('missing_file', 400)
+  }
+
+  const requested = inbound.get('script')
+  const script = isTargetScript(requested) ? requested : 'original'
+
+  // Rebuild the multipart body for OpenAI. verbose_json gives us timestamps;
+  // we request BOTH granularities — same price (Whisper bills per audio minute).
+  // Segments drive the sentence-level highlight (robust); words give precise
+  // boundaries for the click-to-select popover and future word-level features.
+  const openaiForm = new FormData()
+  openaiForm.append('file', file)
+  openaiForm.append('model', 'whisper-1')
+  openaiForm.append('response_format', 'verbose_json')
+  openaiForm.append('timestamp_granularities[]', 'segment')
+  openaiForm.append('timestamp_granularities[]', 'word')
+
+  const res = await fetch(OPENAI_TRANSCRIBE_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${Deno.env.get('OPENAI_API_KEY')}` },
+    body: openaiForm
+  })
+
+  if (!res.ok) {
+    console.error('Whisper error', res.status, await res.text())
+    // 413 = file over Whisper's ~25 MB cap; 400 = unsupported/corrupt audio.
+    // Both get their own code so the FE can tell the user what to fix.
+    if (res.status === 413) return jsonError('file_too_large', 413)
+    if (res.status === 400) return jsonError('invalid_audio', 422)
+    return jsonError('upstream_error', 502)
+  }
+
+  const data: WhisperResponse = await res.json()
+
+  // Convert to the requested script (no-op for 'original'). Applied to the full
+  // text, each segment, and each word with the same character-level converter so
+  // they stay mutually consistent and word timestamps remain aligned.
+  const convert = scriptConverter(script) ?? ((text: string) => text)
+  const text = convert(data.text)
+  const segments = (data.segments ?? []).map((s) => ({
+    start: s.start,
+    end: s.end,
+    text: convert(s.text.trim())
+  }))
+  const words = (data.words ?? []).map((w) => ({
+    word: convert(w.word),
+    start: w.start,
+    end: w.end
+  }))
+
+  return new Response(JSON.stringify({ text, segments, words, lang: data.language }), {
+    headers: { ...cors, 'Content-Type': 'application/json' }
+  })
+})

--- a/supabase/functions/transcribe-audio/script.ts
+++ b/supabase/functions/transcribe-audio/script.ts
@@ -1,0 +1,28 @@
+// Whisper has no script parameter and tends to emit Traditional characters for
+// Mandarin, so we convert the transcript to the requested script after the fact
+// with OpenCC. The standard t2s/s2t dictionaries map character-for-character
+// (1:1), so converting the full text, each segment, and each word independently
+// stays consistent — and Whisper's per-word timestamps remain aligned.
+
+import { Converter } from 'npm:opencc-js@1.0.5'
+
+export type TargetScript = 'original' | 'simplified' | 'traditional'
+
+const PRESETS = {
+  simplified: { from: 't', to: 'cn' },
+  traditional: { from: 'cn', to: 't' }
+} as const
+
+export function isTargetScript(value: unknown): value is TargetScript {
+  return value === 'original' || value === 'simplified' || value === 'traditional'
+}
+
+/**
+ * Build a character-level converter for the target script, or null for
+ * 'original' (no conversion). The returned function maps one string to its
+ * converted form.
+ */
+export function scriptConverter(script: TargetScript): ((text: string) => string) | null {
+  if (script === 'original') return null
+  return Converter(PRESETS[script])
+}

--- a/supabase/functions/translate-term/index.ts
+++ b/supabase/functions/translate-term/index.ts
@@ -1,0 +1,124 @@
+// translate-term: given a selected term and its surrounding sentence, ask Claude
+// for a contextual translation plus reading, part of speech, and a short note.
+//
+// Request:  { term: string, sentence: string, target_lang: string }
+// Response: { translation: string, reading: string, pos: string, description: string }
+//
+// The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
+// Admin-only: requireAdmin() runs before any work.
+
+import { cors, requireAdmin } from '../_shared/require-admin.ts'
+
+// Machine-readable failure codes the FE switches on (read from the error body).
+// `output_truncated` is split out so the UI can say "selection too long" rather
+// than a generic error.
+function jsonError(code: string, status: number): Response {
+  return new Response(JSON.stringify({ code }), {
+    status,
+    headers: { ...cors, 'Content-Type': 'application/json' }
+  })
+}
+
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
+const MODEL = 'claude-haiku-4-5'
+
+type TranslateRequest = { term: string; sentence: string; target_lang: string }
+type TranslationResult = {
+  translation: string
+  reading: string
+  pos: string
+  description: string
+}
+
+// Structured outputs (Haiku 4.5 supports output_config.format) constrain the
+// response to this exact schema, so the body is guaranteed-parseable JSON — far
+// more reliable than asking for "JSON only" in the prompt. Note the structured-
+// output constraints: every object needs additionalProperties:false, and string
+// length / numeric bounds are unsupported.
+const RESULT_SCHEMA = {
+  type: 'object',
+  properties: {
+    translation: { type: 'string' },
+    reading: { type: 'string' },
+    pos: { type: 'string' },
+    description: { type: 'string' }
+  },
+  required: ['translation', 'reading', 'pos', 'description'],
+  additionalProperties: false
+}
+
+// Not prompt-cached: Haiku's minimum cacheable prefix is 4096 tokens and this
+// system prompt is far shorter, so cache_control would silently never engage —
+// and call volume is low. Revisit if the prompt grows or volume spikes.
+const SYSTEM_PROMPT =
+  'You are a precise bilingual dictionary for language learners. ' +
+  'Given a term and the sentence it appears in, return its meaning in the requested target language. ' +
+  'translation: the meaning of the term in the target language, as used in this sentence. ' +
+  'reading: phonetic reading of the term in its own language (e.g. pinyin for Chinese, romaji for Japanese); empty string if not applicable. ' +
+  'pos: part of speech (noun, verb, etc.). ' +
+  'description: one short sentence of extra nuance or usage context.'
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors })
+  }
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: cors })
+  }
+
+  const auth = await requireAdmin(req)
+  if ('error' in auth) return auth.error
+
+  const { term, sentence, target_lang }: Partial<TranslateRequest> = await req
+    .json()
+    .catch(() => ({}))
+  if (!term || !target_lang) {
+    return jsonError('missing_fields', 400)
+  }
+
+  const userPrompt =
+    `Term: ${term}\n` + `Sentence: ${sentence ?? term}\n` + `Target language: ${target_lang}`
+
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': Deno.env.get('ANTHROPIC_API_KEY')!,
+      'anthropic-version': '2023-06-01'
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 400,
+      system: SYSTEM_PROMPT,
+      output_config: { format: { type: 'json_schema', schema: RESULT_SCHEMA } },
+      messages: [{ role: 'user', content: userPrompt }]
+    })
+  })
+
+  if (!res.ok) {
+    console.error('Anthropic error', res.status, await res.text())
+    return jsonError('upstream_error', 502)
+  }
+
+  const data = await res.json()
+
+  // max_tokens means the selection was too long to answer in full — its own code
+  // so the FE can prompt for a shorter selection. A refusal won't match the
+  // schema either; both are surfaced rather than half-parsed.
+  if (data?.stop_reason === 'max_tokens') return jsonError('output_truncated', 422)
+  if (data?.stop_reason === 'refusal') return jsonError('refused', 422)
+
+  const raw = data?.content?.[0]?.text ?? ''
+
+  let parsed: TranslationResult
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    console.error('Unparseable Claude response', raw)
+    return jsonError('unparseable', 502)
+  }
+
+  return new Response(JSON.stringify(parsed), {
+    headers: { ...cors, 'Content-Type': 'application/json' }
+  })
+})

--- a/supabase/functions/translate-transcript/index.ts
+++ b/supabase/functions/translate-transcript/index.ts
@@ -1,0 +1,46 @@
+// translate-transcript: translate a lesson's sentences into the target language
+// for the interlinear reader. Given the transcript's segment texts, return one
+// translation per sentence, aligned by index.
+//
+// Request:  { sentences: string[], target_lang: string }
+// Response: { translations: string[] }  // same length/order as `sentences`
+//
+// The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
+// Admin-only: requireAdmin() runs before any work.
+
+import { cors, requireAdmin } from '../_shared/require-admin.ts'
+import { translateSentences } from './translate.ts'
+
+type TranslateRequest = { sentences: string[]; target_lang: string }
+
+// Machine-readable failure codes the FE switches on (read from the error body).
+function jsonError(code: string, status: number): Response {
+  return new Response(JSON.stringify({ code }), {
+    status,
+    headers: { ...cors, 'Content-Type': 'application/json' }
+  })
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors })
+  }
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: cors })
+  }
+
+  const auth = await requireAdmin(req)
+  if ('error' in auth) return auth.error
+
+  const { sentences, target_lang }: Partial<TranslateRequest> = await req.json().catch(() => ({}))
+  if (!Array.isArray(sentences) || sentences.length === 0 || !target_lang) {
+    return jsonError('missing_fields', 400)
+  }
+
+  const translations = await translateSentences(sentences, target_lang)
+  if (!translations) return jsonError('translation_failed', 502)
+
+  return new Response(JSON.stringify({ translations }), {
+    headers: { ...cors, 'Content-Type': 'application/json' }
+  })
+})

--- a/supabase/functions/translate-transcript/translate.test.ts
+++ b/supabase/functions/translate-transcript/translate.test.ts
@@ -1,0 +1,120 @@
+import { assertEquals } from '@std/assert'
+import { translateSentences } from './translate.ts'
+
+// Anthropic's success envelope: a structured-output JSON string in content[0].text.
+function ok(translations: string[]): Response {
+  return new Response(JSON.stringify({ content: [{ text: JSON.stringify({ translations }) }] }), {
+    status: 200
+  })
+}
+
+// Replace global fetch with a responder that sees each batch's sentence count
+// (parsed from the prompt) and its 0-based call index, then restore afterwards.
+async function withFetch(
+  responder: (sentenceCount: number, callIndex: number) => Response,
+  run: () => Promise<void>
+) {
+  const realFetch = globalThis.fetch
+  let call = 0
+  globalThis.fetch = ((_url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(init!.body as string)
+    const prompt = body.messages[0].content as string
+    const count = Number(prompt.match(/Sentences \((\d+)\)/)?.[1] ?? 0)
+    return Promise.resolve(responder(count, call++))
+  }) as typeof fetch
+  try {
+    await run()
+  } finally {
+    globalThis.fetch = realFetch
+  }
+}
+
+Deno.test('returns one translation per sentence, in order', async () => {
+  await withFetch(
+    (count) => ok(Array.from({ length: count }, (_, k) => `t${k}`)),
+    async () => {
+      const result = await translateSentences(['a', 'b', 'c'], 'English')
+      assertEquals(result, ['t0', 't1', 't2'])
+    }
+  )
+})
+
+Deno.test('batches large inputs and concatenates in order (BATCH_SIZE = 25)', async () => {
+  const sentences = Array.from({ length: 30 }, (_, k) => `s${k}`)
+  let calls = 0
+
+  await withFetch(
+    (count, callIndex) => {
+      calls = callIndex + 1
+      return ok(Array.from({ length: count }, (_, k) => `c${callIndex}_${k}`))
+    },
+    async () => {
+      const result = await translateSentences(sentences, 'English')
+
+      assertEquals(calls, 2) // 25 + 5
+      assertEquals(result?.length, 30)
+      assertEquals(result?.[0], 'c0_0')
+      assertEquals(result?.[24], 'c0_24')
+      assertEquals(result?.[25], 'c1_0') // second batch picks up right after the first
+      assertEquals(result?.[29], 'c1_4')
+    }
+  )
+})
+
+Deno.test('returns null when a batch returns the wrong number of translations', async () => {
+  await withFetch(
+    (count) => ok(Array.from({ length: count - 1 }, (_, k) => `t${k}`)),
+    async () => {
+      assertEquals(await translateSentences(['a', 'b', 'c'], 'English'), null)
+    }
+  )
+})
+
+Deno.test('returns null on a truncated (max_tokens) response', async () => {
+  await withFetch(
+    () => new Response(JSON.stringify({ stop_reason: 'max_tokens', content: [] }), { status: 200 }),
+    async () => {
+      assertEquals(await translateSentences(['a'], 'English'), null)
+    }
+  )
+})
+
+Deno.test('returns null on a refusal', async () => {
+  await withFetch(
+    () => new Response(JSON.stringify({ stop_reason: 'refusal', content: [] }), { status: 200 }),
+    async () => {
+      assertEquals(await translateSentences(['a'], 'English'), null)
+    }
+  )
+})
+
+Deno.test('returns null on a non-2xx upstream response', async () => {
+  await withFetch(
+    () => new Response('upstream boom', { status: 500 }),
+    async () => {
+      assertEquals(await translateSentences(['a'], 'English'), null)
+    }
+  )
+})
+
+Deno.test('returns null when the model body is not parseable JSON', async () => {
+  await withFetch(
+    () => new Response(JSON.stringify({ content: [{ text: 'not json' }] }), { status: 200 }),
+    async () => {
+      assertEquals(await translateSentences(['a'], 'English'), null)
+    }
+  )
+})
+
+Deno.test('fails the whole request when a later batch fails (all-or-nothing)', async () => {
+  const sentences = Array.from({ length: 30 }, (_, k) => `s${k}`)
+
+  await withFetch(
+    // First batch (25) succeeds, second batch (5) returns the wrong count.
+    (count, callIndex) =>
+      callIndex === 0 ? ok(Array.from({ length: count }, (_, k) => `t${k}`)) : ok(['only-one']),
+    async () => {
+      assertEquals(await translateSentences(sentences, 'English'), null)
+    }
+  )
+})

--- a/supabase/functions/translate-transcript/translate.ts
+++ b/supabase/functions/translate-transcript/translate.ts
@@ -1,0 +1,98 @@
+// Translation core for the interlinear reader, kept separate from the HTTP
+// handler in index.ts so it can be unit-tested directly. Given source
+// sentences, returns one translation per sentence (aligned by index) using
+// Claude Haiku with structured output. Sentences are translated in batches so a
+// long lesson can't blow max_tokens.
+
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
+const MODEL = 'claude-haiku-4-5'
+
+// Few enough that a batch's translations comfortably fit under max_tokens, but
+// large enough to keep the number of round-trips (and cost) low.
+const BATCH_SIZE = 25
+
+// Structured outputs constrain the body to a guaranteed-parseable array of
+// strings. The schema can't pin the array length, so we instruct the count in
+// the prompt and verify it per batch (count drift => failure).
+const RESULT_SCHEMA = {
+  type: 'object',
+  properties: {
+    translations: { type: 'array', items: { type: 'string' } }
+  },
+  required: ['translations'],
+  additionalProperties: false
+}
+
+const SYSTEM_PROMPT =
+  'You translate transcript sentences for language learners. ' +
+  'Translate each numbered source sentence into the requested target language. ' +
+  'Return one translation per sentence, in the same order, with exactly as many ' +
+  'translations as sentences given. Keep each translation faithful and natural, ' +
+  'with no notes, numbering, or commentary.'
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = []
+  for (let i = 0; i < items.length; i += size) batches.push(items.slice(i, i + size))
+  return batches
+}
+
+// Translate one batch. Returns the aligned translations, or null on any failure
+// (upstream error, refusal, truncation, or a count that doesn't match the input).
+async function translateBatch(sentences: string[], target_lang: string): Promise<string[] | null> {
+  const numbered = sentences.map((s, i) => `${i + 1}. ${s}`).join('\n')
+  const userPrompt = `Target language: ${target_lang}\nSentences (${sentences.length}):\n${numbered}`
+
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': Deno.env.get('ANTHROPIC_API_KEY')!,
+      'anthropic-version': '2023-06-01'
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      output_config: { format: { type: 'json_schema', schema: RESULT_SCHEMA } },
+      messages: [{ role: 'user', content: userPrompt }]
+    })
+  })
+
+  if (!res.ok) {
+    console.error('Anthropic error', res.status, await res.text())
+    return null
+  }
+
+  const data = await res.json()
+  if (data?.stop_reason === 'max_tokens' || data?.stop_reason === 'refusal') return null
+
+  const raw = data?.content?.[0]?.text ?? ''
+
+  let translations: unknown
+  try {
+    translations = (JSON.parse(raw) as { translations?: unknown }).translations
+  } catch {
+    console.error('Unparseable Claude response', raw)
+    return null
+  }
+
+  if (!Array.isArray(translations) || translations.length !== sentences.length) return null
+  return translations.map(String)
+}
+
+// Translate every sentence, batching internally. Returns the full aligned list,
+// or null if any batch fails — so callers treat it as all-or-nothing.
+export async function translateSentences(
+  sentences: string[],
+  target_lang: string
+): Promise<string[] | null> {
+  const translations: string[] = []
+
+  for (const batch of chunk(sentences, BATCH_SIZE)) {
+    const result = await translateBatch(batch, target_lang)
+    if (!result) return null
+    translations.push(...result)
+  }
+
+  return translations
+}


### PR DESCRIPTION
## Summary

Adds the Deno edge functions for the audio reader: `transcribe-audio` (speech-to-text + script selection), `translate-term` (single-term lookup), and `translate-transcript` (batched sentence translation), plus a shared `require-admin` guard.

Stacked on #230.