### PR TITLE
feat(api): add src/api/lessons client domain

### DIFF
--- a/src/api/lessons/db/ai.ts
+++ b/src/api/lessons/db/ai.ts
@@ -1,0 +1,88 @@
+import { supabase } from '@/supabase-client'
+import logger from '@/utils/logger'
+
+export type TranscribeResult = {
+  text: string
+  segments: TranscriptSegment[]
+  words?: TranscriptWord[]
+  lang?: string
+}
+
+export type TranslationResult = {
+  translation: string
+  reading: string
+  pos: string
+  description: string
+}
+
+export type TranslateTermArgs = {
+  term: string
+  sentence: string
+  target_lang: string
+}
+
+export type TranslateTranscriptArgs = {
+  sentences: string[]
+  target_lang: string
+}
+
+export type TranscriptTranslation = {
+  translations: string[]
+}
+
+// The edge functions return a JSON body `{ code }` on failure (e.g.
+// 'output_truncated', 'file_too_large'). supabase-js surfaces non-2xx as a
+// FunctionsHttpError carrying the Response on `.context`; this re-throws a typed
+// error so the FE can switch on the code rather than parse a raw message.
+export class EdgeFunctionError extends Error {
+  constructor(public code: string) {
+    super(code)
+    this.name = 'EdgeFunctionError'
+  }
+}
+
+async function readErrorCode(error: unknown): Promise<string> {
+  const context = (error as { context?: Response }).context
+  if (!context || typeof context.json !== 'function') return 'unknown'
+
+  try {
+    const body = await context.json()
+    return typeof body?.code === 'string' ? body.code : 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+async function invokeEdge<T>(name: string, body: FormData | object): Promise<T> {
+  const { data, error } = await supabase.functions.invoke<T>(name, { body })
+
+  if (error) {
+    const code = await readErrorCode(error)
+    logger.error(`${name} failed: ${code}`)
+    throw new EdgeFunctionError(code)
+  }
+  if (!data) {
+    logger.error(`${name} returned no data`)
+    throw new EdgeFunctionError('no_data')
+  }
+
+  return data
+}
+
+export function transcribeAudio(
+  file: File,
+  script: TranscriptScript = 'original'
+): Promise<TranscribeResult> {
+  const form = new FormData()
+  form.append('file', file)
+  form.append('script', script)
+  return invokeEdge<TranscribeResult>('transcribe-audio', form)
+}
+
+export function translateTerm(args: TranslateTermArgs): Promise<TranslationResult> {
+  return invokeEdge<TranslationResult>('translate-term', args)
+}
+
+export function translateTranscript(args: TranslateTranscriptArgs): Promise<TranscriptTranslation> {
+  return invokeEdge<TranscriptTranslation>('translate-transcript', args)
+}

--- a/src/api/lessons/db/audio.ts
+++ b/src/api/lessons/db/audio.ts
@@ -1,0 +1,40 @@
+import { supabase } from '@/supabase-client'
+import logger from '@/utils/logger'
+
+const BUCKET = 'audio-lessons'
+
+// The bucket is private, so playback uses a short-lived signed URL rather than a
+// public URL (contrast with member-images). One hour is generous for a single
+// listening session; the reader re-mints if it expires.
+const SIGNED_URL_TTL_SECONDS = 60 * 60
+
+export async function uploadLessonAudio(path: string, file: File): Promise<void> {
+  const { error } = await supabase.storage.from(BUCKET).upload(path, file, { upsert: true })
+
+  if (error) {
+    logger.error(`Error uploading audio: ${error.message}`)
+    throw new Error(error.message)
+  }
+}
+
+export async function getLessonAudioSignedUrl(path: string): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrl(path, SIGNED_URL_TTL_SECONDS)
+
+  if (error || !data) {
+    logger.error(error?.message ?? 'Failed to sign audio url')
+    throw error ?? new Error('Failed to sign audio url')
+  }
+
+  return data.signedUrl
+}
+
+export async function deleteLessonAudio(path: string): Promise<void> {
+  const { error } = await supabase.storage.from(BUCKET).remove([path])
+
+  if (error) {
+    logger.error(`Error deleting audio: ${error.message}`)
+    throw new Error(error.message)
+  }
+}

--- a/src/api/lessons/db/index.ts
+++ b/src/api/lessons/db/index.ts
@@ -1,0 +1,3 @@
+export * from './lessons'
+export * from './audio'
+export * from './ai'

--- a/src/api/lessons/db/lessons.ts
+++ b/src/api/lessons/db/lessons.ts
@@ -1,0 +1,68 @@
+import { supabase } from '@/supabase-client'
+import { useMemberStore } from '@/stores/member'
+import logger from '@/utils/logger'
+
+export type CreateLessonParams = {
+  title: string
+  audio_path: string
+  transcript: LessonTranscript
+  lang?: string
+}
+
+export async function fetchMemberLessons(): Promise<Lesson[]> {
+  const { data, error } = await supabase
+    .from('lessons')
+    .select('*')
+    .eq('member_id', useMemberStore().id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    logger.error(error.message)
+    throw error
+  }
+
+  return data as Lesson[]
+}
+
+export async function fetchLesson(id: number): Promise<Lesson> {
+  const { data, error } = await supabase.from('lessons').select('*').eq('id', id).single()
+
+  if (error) {
+    logger.error(error.message)
+    throw error
+  }
+
+  return data as Lesson
+}
+
+export async function createLesson(params: CreateLessonParams): Promise<Lesson> {
+  // RPC inserts the lesson + its audio media row atomically (see the create_lesson
+  // migration). transcript is jsonb-serialized by supabase-js.
+  const { data, error } = await supabase
+    .rpc('create_lesson', {
+      p_title: params.title,
+      p_audio_path: params.audio_path,
+      p_transcript: params.transcript,
+      p_lang: params.lang ?? null
+    })
+    .single()
+
+  if (error) {
+    logger.error(error.message)
+    throw error
+  }
+
+  return data as Lesson
+}
+
+export async function deleteLesson(id: number): Promise<void> {
+  // Plain row delete. The lesson-delete trigger soft-deletes the audio media row,
+  // and the cleanup-media cron reaps the storage object — no client-side
+  // storage delete needed (and none possible for the member-cascade path anyway).
+  const { error } = await supabase.from('lessons').delete().eq('id', id)
+
+  if (error) {
+    logger.error(error.message)
+    throw error
+  }
+}

--- a/src/api/lessons/index.ts
+++ b/src/api/lessons/index.ts
@@ -1,0 +1,7 @@
+export * from './queries'
+export * from './mutations'
+
+// Types + the typed error the popover catches — re-exported so components import
+// them from the barrel rather than reaching into db/.
+export { EdgeFunctionError } from './db'
+export type { TranslationResult, TranscribeResult } from './db'

--- a/src/api/lessons/mutations/create.ts
+++ b/src/api/lessons/mutations/create.ts
@@ -1,0 +1,80 @@
+import { useMutation, useQueryCache } from '@pinia/colada'
+import { useMemberStore } from '@/stores/member'
+import uid from '@/utils/uid'
+import logger from '@/utils/logger'
+import { uploadLessonAudio, deleteLessonAudio } from '../db/audio'
+import { transcribeAudio, translateTranscript } from '../db/ai'
+import { createLesson } from '../db/lessons'
+
+// Interlinear translations are English-only in admin v1 (matches the term
+// popover's target). A per-member target language can replace this later.
+const TARGET_LANG = 'English'
+
+export type CreateLessonPhase = 'transcribing' | 'translating'
+
+export type CreateLessonVars = {
+  title: string
+  file: File
+  // Which Chinese script to convert the transcript to (Whisper tends to emit
+  // Traditional). 'original' leaves Whisper's output untouched.
+  script?: TranscriptScript
+  // Reports the long-running phase so the upload UI can label its progress.
+  onPhase?: (phase: CreateLessonPhase) => void
+}
+
+export function useCreateLessonMutation() {
+  const queryCache = useQueryCache()
+
+  return useMutation({
+    mutation: async ({ title, file, script, onPhase }: CreateLessonVars): Promise<Lesson> => {
+      const ext = (file.name.split('.').pop() || 'mp3').toLowerCase()
+      const path = `${useMemberStore().id}/${uid()}.${ext}`
+
+      await uploadLessonAudio(path, file)
+
+      try {
+        const { text, segments, words, lang } = await transcribeAudio(file, script)
+        const translated = await translateSegments(segments, onPhase)
+        return await createLesson({
+          title,
+          audio_path: path,
+          transcript: { text, segments: translated, words },
+          lang
+        })
+      } catch (error) {
+        // Transcription or the create RPC failed after the upload — there's no
+        // media row yet, so the cleanup cron won't reap it. Remove the orphan now.
+        await deleteLessonAudio(path).catch(() => {})
+        throw error
+      }
+    },
+    onSettled: () => {
+      queryCache.invalidateQueries({ key: ['lessons'] })
+    }
+  })
+}
+
+/**
+ * Best-effort: enrich each segment with its translation for the interlinear
+ * reader. A translation failure must NOT sink the upload — we already hold a
+ * valid transcript — so this swallows errors and returns the segments
+ * untranslated, leaving them for the backfill path.
+ */
+async function translateSegments(
+  segments: TranscriptSegment[],
+  onPhase?: (phase: CreateLessonPhase) => void
+): Promise<TranscriptSegment[]> {
+  if (segments.length === 0) return segments
+
+  onPhase?.('translating')
+  try {
+    const { translations } = await translateTranscript({
+      sentences: segments.map((s) => s.text),
+      target_lang: TARGET_LANG
+    })
+    return segments.map((segment, i) => ({ ...segment, translation: translations[i] }))
+  } catch (error) {
+    logger.error(`Lesson translation failed: ${(error as Error).message}`)
+    return segments
+  }
+}

--- a/src/api/lessons/mutations/delete.ts
+++ b/src/api/lessons/mutations/delete.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryCache } from '@pinia/colada'
+import { deleteLesson } from '../db'
+
+export function useDeleteLessonMutation() {
+  const queryCache = useQueryCache()
+
+  return useMutation({
+    mutation: (id: number) => deleteLesson(id),
+    onSettled: (_data, error, id) => {
+      queryCache.invalidateQueries({ key: ['lessons'] })
+      // On success the row is gone — drop the cached entry without a refetch
+      // (which would 404). On error the row still exists; leave its cache alone.
+      if (!error) queryCache.invalidateQueries({ key: ['lesson', id] }, false)
+    }
+  })
+}

--- a/src/api/lessons/mutations/index.ts
+++ b/src/api/lessons/mutations/index.ts
@@ -1,0 +1,3 @@
+export * from './create'
+export * from './delete'
+export * from './translate-term'

--- a/src/api/lessons/mutations/translate-term.ts
+++ b/src/api/lessons/mutations/translate-term.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@pinia/colada'
+import { translateTerm, type TranslateTermArgs } from '../db'
+
+// A one-shot action, not cached server state — wrapped in useMutation only for
+// the built-in isLoading / error / data refs the popover needs. No onSettled
+// invalidation because there's nothing in the cache to touch.
+export function useTranslateTermMutation() {
+  return useMutation({
+    mutation: (args: TranslateTermArgs) => translateTerm(args)
+  })
+}

--- a/src/api/lessons/queries/audio-url.ts
+++ b/src/api/lessons/queries/audio-url.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@pinia/colada'
+import { toValue, type MaybeRefOrGetter } from 'vue'
+import { getLessonAudioSignedUrl } from '../db'
+
+// Signed URLs expire (1h TTL), so this is cached server state keyed by path.
+// The reader re-runs it on a fresh path; refresh() re-mints if a URL goes stale
+// mid-session.
+export function useLessonAudioUrlQuery(path: MaybeRefOrGetter<string | undefined>) {
+  return useQuery({
+    key: () => ['lesson-audio', toValue(path) ?? ''],
+    query: () => getLessonAudioSignedUrl(toValue(path) as string),
+    enabled: () => Boolean(toValue(path))
+  })
+}

--- a/src/api/lessons/queries/by-id.ts
+++ b/src/api/lessons/queries/by-id.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@pinia/colada'
+import { toValue, type MaybeRefOrGetter } from 'vue'
+import { fetchLesson } from '../db'
+
+export function useLessonQuery(id: MaybeRefOrGetter<number>) {
+  return useQuery({
+    key: () => ['lesson', toValue(id)],
+    query: () => fetchLesson(toValue(id))
+  })
+}

--- a/src/api/lessons/queries/index.ts
+++ b/src/api/lessons/queries/index.ts
@@ -1,0 +1,3 @@
+export * from './list'
+export * from './by-id'
+export * from './audio-url'

--- a/src/api/lessons/queries/list.ts
+++ b/src/api/lessons/queries/list.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@pinia/colada'
+import { fetchMemberLessons } from '../db'
+
+export function useLessonsQuery() {
+  return useQuery({
+    key: ['lessons'],
+    query: fetchMemberLessons
+  })
+}

--- a/src/composables/use-can.ts
+++ b/src/composables/use-can.ts
@@ -36,5 +36,9 @@ export function useCan() {
 
   const useCardImages = computed(() => member.plan === 'paid')
 
-  return { useProFeature, createDeck, useCardImages }
+  // Admin-only for now (the audio reader is unreleased). Re-enforced server-side
+  // in the transcribe-audio / translate-term edge functions — this gate is UX.
+  const useAudioReader = computed(() => member.role === 'admin')
+
+  return { useProFeature, createDeck, useCardImages, useAudioReader }
 }

--- a/tests/unit/api/lessons/db/ai.test.js
+++ b/tests/unit/api/lessons/db/ai.test.js
@@ -1,0 +1,157 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn()
+}))
+
+vi.mock('@/supabase-client', () => ({
+  supabase: {
+    functions: {
+      invoke: invokeMock
+    }
+  }
+}))
+
+vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
+
+import { transcribeAudio, translateTerm, EdgeFunctionError } from '@/api/lessons/db/ai'
+
+beforeEach(() => {
+  invokeMock.mockReset()
+})
+
+// Helper: build a fake FunctionsHttpError-like object with a context Response
+function makeErrorWithContext(body) {
+  return {
+    context: {
+      json: () => Promise.resolve(body)
+    }
+  }
+}
+
+function makeErrorWithBadContext() {
+  return {
+    context: {
+      json: () => Promise.reject(new SyntaxError('bad json'))
+    }
+  }
+}
+
+function makeErrorWithNoContext() {
+  return {}
+}
+
+describe('transcribeAudio', () => {
+  test('returns data on success', async () => {
+    const data = { text: 'Hello', segments: [], lang: 'ja' }
+    invokeMock.mockResolvedValueOnce({ data, error: null })
+
+    const result = await transcribeAudio(new File(['x'], 'a.mp3'))
+    expect(result).toEqual(data)
+  })
+
+  test('throws EdgeFunctionError with parsed code when error has a context body', async () => {
+    invokeMock.mockResolvedValueOnce({
+      data: null,
+      error: makeErrorWithContext({ code: 'output_truncated' })
+    })
+
+    await expect(transcribeAudio(new File(['x'], 'a.mp3'))).rejects.toSatisfy(
+      (e) => e instanceof EdgeFunctionError && e.code === 'output_truncated'
+    )
+  })
+
+  test('throws EdgeFunctionError with code "unknown" when context body is unparseable', async () => {
+    invokeMock.mockResolvedValueOnce({
+      data: null,
+      error: makeErrorWithBadContext()
+    })
+
+    await expect(transcribeAudio(new File(['x'], 'a.mp3'))).rejects.toSatisfy(
+      (e) => e instanceof EdgeFunctionError && e.code === 'unknown'
+    )
+  })
+
+  test('throws EdgeFunctionError with code "unknown" when error has no context', async () => {
+    invokeMock.mockResolvedValueOnce({
+      data: null,
+      error: makeErrorWithNoContext()
+    })
+
+    await expect(transcribeAudio(new File(['x'], 'a.mp3'))).rejects.toSatisfy(
+      (e) => e instanceof EdgeFunctionError && e.code === 'unknown'
+    )
+  })
+
+  test('throws EdgeFunctionError with code "no_data" when data is null and error is null', async () => {
+    invokeMock.mockResolvedValueOnce({ data: null, error: null })
+
+    await expect(transcribeAudio(new File(['x'], 'a.mp3'))).rejects.toSatisfy(
+      (e) => e instanceof EdgeFunctionError && e.code === 'no_data'
+    )
+  })
+
+  test('invokes the transcribe-audio edge function with a FormData body', async () => {
+    const data = { text: 'hi', segments: [] }
+    invokeMock.mockResolvedValueOnce({ data, error: null })
+
+    const file = new File(['audio'], 'clip.mp3')
+    await transcribeAudio(file)
+
+    const [name, opts] = invokeMock.mock.calls[0]
+    expect(name).toBe('transcribe-audio')
+    expect(opts.body).toBeInstanceOf(FormData)
+    expect(opts.body.get('file')).toBe(file)
+  })
+})
+
+describe('translateTerm', () => {
+  const args = { term: '猫', sentence: '猫がいる', target_lang: 'en' }
+
+  test('returns data on success', async () => {
+    const data = { translation: 'cat', reading: 'ねこ', pos: 'noun', description: 'A cat.' }
+    invokeMock.mockResolvedValueOnce({ data, error: null })
+
+    const result = await translateTerm(args)
+    expect(result).toEqual(data)
+  })
+
+  test('invokes the translate-term edge function with the args as body', async () => {
+    invokeMock.mockResolvedValueOnce({ data: { translation: 'cat' }, error: null })
+    await translateTerm(args)
+
+    const [name, opts] = invokeMock.mock.calls[0]
+    expect(name).toBe('translate-term')
+    expect(opts.body).toEqual(args)
+  })
+
+  test('throws EdgeFunctionError with parsed code on failure', async () => {
+    invokeMock.mockResolvedValueOnce({
+      data: null,
+      error: makeErrorWithContext({ code: 'file_too_large' })
+    })
+
+    await expect(translateTerm(args)).rejects.toSatisfy(
+      (e) => e instanceof EdgeFunctionError && e.code === 'file_too_large'
+    )
+  })
+
+  test('throws EdgeFunctionError with code "unknown" when context body has no code field', async () => {
+    invokeMock.mockResolvedValueOnce({
+      data: null,
+      error: makeErrorWithContext({ message: 'something else' })
+    })
+
+    await expect(translateTerm(args)).rejects.toSatisfy(
+      (e) => e instanceof EdgeFunctionError && e.code === 'unknown'
+    )
+  })
+
+  test('throws EdgeFunctionError with code "no_data" when data is null and error is null', async () => {
+    invokeMock.mockResolvedValueOnce({ data: null, error: null })
+
+    await expect(translateTerm(args)).rejects.toSatisfy(
+      (e) => e instanceof EdgeFunctionError && e.code === 'no_data'
+    )
+  })
+})

--- a/tests/unit/api/lessons/mutations/create.test.js
+++ b/tests/unit/api/lessons/mutations/create.test.js
@@ -1,0 +1,299 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+const {
+  useMutationSpy,
+  invalidateSpy,
+  uploadLessonAudioMock,
+  deleteLessonAudioMock,
+  transcribeAudioMock,
+  translateTranscriptMock,
+  createLessonMock
+} = vi.hoisted(() => ({
+  useMutationSpy: vi.fn((cfg) => cfg),
+  invalidateSpy: vi.fn(),
+  uploadLessonAudioMock: vi.fn().mockResolvedValue(undefined),
+  deleteLessonAudioMock: vi.fn().mockResolvedValue(undefined),
+  transcribeAudioMock: vi.fn(),
+  translateTranscriptMock: vi.fn(),
+  createLessonMock: vi.fn()
+}))
+
+vi.mock('@pinia/colada', () => ({
+  useMutation: useMutationSpy,
+  useQueryCache: () => ({ invalidateQueries: invalidateSpy })
+}))
+
+vi.mock('@/api/lessons/db/audio', () => ({
+  uploadLessonAudio: uploadLessonAudioMock,
+  deleteLessonAudio: deleteLessonAudioMock
+}))
+
+vi.mock('@/api/lessons/db/ai', () => ({
+  transcribeAudio: transcribeAudioMock,
+  translateTranscript: translateTranscriptMock
+}))
+
+vi.mock('@/api/lessons/db/lessons', () => ({
+  createLesson: createLessonMock
+}))
+
+vi.mock('@/stores/member', () => ({
+  useMemberStore: () => ({ id: 'member-uuid-1' })
+}))
+
+vi.mock('@/utils/uid', () => ({ default: () => 'fixed-uid' }))
+
+import { useCreateLessonMutation } from '@/api/lessons/mutations/create'
+
+beforeEach(() => {
+  useMutationSpy.mockClear()
+  invalidateSpy.mockClear()
+  uploadLessonAudioMock.mockClear()
+  deleteLessonAudioMock.mockClear()
+  transcribeAudioMock.mockReset()
+  translateTranscriptMock.mockReset()
+  createLessonMock.mockReset()
+})
+
+function configFrom(hook) {
+  hook()
+  return useMutationSpy.mock.calls.at(-1)[0]
+}
+
+describe('useCreateLessonMutation', () => {
+  const file = new File(['audio'], 'lesson.mp3', { type: 'audio/mpeg' })
+  const transcribeResult = {
+    text: 'Hello world',
+    segments: [{ start: 0, end: 1, text: 'Hello world' }],
+    words: [],
+    lang: 'en'
+  }
+  const lesson = { id: 1, title: 'My Lesson', audio_path: 'member-uuid-1/fixed-uid.mp3' }
+  // Default translation response used by tests that don't care about translation details
+  const translateResult = { translations: ['こんにちは世界'] }
+
+  describe('mutation', () => {
+    test('calls uploadLessonAudio first with the constructed path', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockResolvedValueOnce(translateResult)
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      expect(uploadLessonAudioMock).toHaveBeenCalledWith('member-uuid-1/fixed-uid.mp3', file)
+    })
+
+    test('calls transcribeAudio after upload succeeds', async () => {
+      const callOrder = []
+      uploadLessonAudioMock.mockImplementationOnce(async () => {
+        callOrder.push('upload')
+      })
+      transcribeAudioMock.mockImplementationOnce(async () => {
+        callOrder.push('transcribe')
+        return transcribeResult
+      })
+      translateTranscriptMock.mockImplementationOnce(async () => {
+        callOrder.push('translate')
+        return translateResult
+      })
+      createLessonMock.mockImplementationOnce(async () => {
+        callOrder.push('create')
+        return lesson
+      })
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      expect(callOrder).toEqual(['upload', 'transcribe', 'translate', 'create'])
+    })
+
+    test('calls translateTranscript with each segment text after transcribing', async () => {
+      const multiSegmentTranscribe = {
+        text: 'Hello world. How are you?',
+        segments: [
+          { start: 0, end: 1, text: 'Hello world.' },
+          { start: 1, end: 2, text: 'How are you?' }
+        ],
+        words: [],
+        lang: 'en'
+      }
+      transcribeAudioMock.mockResolvedValueOnce(multiSegmentTranscribe)
+      translateTranscriptMock.mockResolvedValueOnce({
+        translations: ['こんにちは世界。', 'お元気ですか？']
+      })
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      expect(translateTranscriptMock).toHaveBeenCalledWith({
+        sentences: ['Hello world.', 'How are you?'],
+        target_lang: 'English'
+      })
+    })
+
+    test('merges translations onto segments before calling createLesson', async () => {
+      const multiSegmentTranscribe = {
+        text: 'Hello world. How are you?',
+        segments: [
+          { start: 0, end: 1, text: 'Hello world.' },
+          { start: 1, end: 2, text: 'How are you?' }
+        ],
+        words: [],
+        lang: 'en'
+      }
+      transcribeAudioMock.mockResolvedValueOnce(multiSegmentTranscribe)
+      translateTranscriptMock.mockResolvedValueOnce({
+        translations: ['こんにちは世界。', 'お元気ですか？']
+      })
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      const call = createLessonMock.mock.calls[0][0]
+      expect(call.transcript.segments[0].translation).toBe('こんにちは世界。')
+      expect(call.transcript.segments[1].translation).toBe('お元気ですか？')
+    })
+
+    test('calls createLesson with transcript data and audio_path', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockResolvedValueOnce(translateResult)
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      const call = createLessonMock.mock.calls[0][0]
+      expect(call.title).toBe('My Lesson')
+      expect(call.audio_path).toBe('member-uuid-1/fixed-uid.mp3')
+      expect(call.transcript.text).toBe(transcribeResult.text)
+      expect(call.transcript.words).toEqual(transcribeResult.words)
+      expect(call.lang).toBe(transcribeResult.lang)
+    })
+
+    test('returns the created lesson', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockResolvedValueOnce(translateResult)
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      const result = await mutation({ title: 'My Lesson', file })
+
+      expect(result).toEqual(lesson)
+    })
+
+    test('uses the file extension to build the storage path', async () => {
+      const wavFile = new File(['audio'], 'lesson.wav', { type: 'audio/wav' })
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockResolvedValueOnce(translateResult)
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file: wavFile })
+
+      expect(uploadLessonAudioMock).toHaveBeenCalledWith('member-uuid-1/fixed-uid.wav', wavFile)
+    })
+  })
+
+  describe('translation best-effort guard', () => {
+    test('still creates the lesson when translateTranscript rejects', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockRejectedValueOnce(new Error('AI unavailable'))
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      const result = await mutation({ title: 'My Lesson', file })
+
+      expect(createLessonMock).toHaveBeenCalledTimes(1)
+      expect(result).toEqual(lesson)
+    })
+
+    test('passes segments WITHOUT translation to createLesson when translateTranscript rejects', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockRejectedValueOnce(new Error('AI unavailable'))
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      const call = createLessonMock.mock.calls[0][0]
+      expect(call.transcript.segments[0].translation).toBeUndefined()
+    })
+
+    test('does NOT delete the audio when translateTranscript rejects', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockRejectedValueOnce(new Error('AI unavailable'))
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      expect(deleteLessonAudioMock).not.toHaveBeenCalled()
+    })
+
+    test('does NOT throw when translateTranscript rejects', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockRejectedValueOnce(new Error('AI unavailable'))
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await expect(mutation({ title: 'My Lesson', file })).resolves.not.toThrow()
+    })
+  })
+
+  describe('error cleanup', () => {
+    test('calls deleteLessonAudio when transcribeAudio throws', async () => {
+      const transcribeError = new Error('transcribe failed')
+      transcribeAudioMock.mockRejectedValueOnce(transcribeError)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await expect(mutation({ title: 'My Lesson', file })).rejects.toThrow('transcribe failed')
+
+      expect(deleteLessonAudioMock).toHaveBeenCalledWith('member-uuid-1/fixed-uid.mp3')
+    })
+
+    test('calls deleteLessonAudio when createLesson throws', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockResolvedValueOnce(translateResult)
+      createLessonMock.mockRejectedValueOnce(new Error('db error'))
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await expect(mutation({ title: 'My Lesson', file })).rejects.toThrow('db error')
+
+      expect(deleteLessonAudioMock).toHaveBeenCalledWith('member-uuid-1/fixed-uid.mp3')
+    })
+
+    test('rethrows the original error after cleanup', async () => {
+      const transcribeError = new Error('edge function bombed')
+      transcribeAudioMock.mockRejectedValueOnce(transcribeError)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await expect(mutation({ title: 'My Lesson', file })).rejects.toBe(transcribeError)
+    })
+
+    test('does not call createLesson when transcribeAudio fails', async () => {
+      transcribeAudioMock.mockRejectedValueOnce(new Error('fail'))
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await expect(mutation({ title: 'My Lesson', file })).rejects.toThrow()
+
+      expect(createLessonMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('onSettled', () => {
+    test('invalidates ["lessons"] query on success', () => {
+      const { onSettled } = configFrom(useCreateLessonMutation)
+      onSettled(lesson, undefined, { title: 'My Lesson', file })
+      expect(invalidateSpy).toHaveBeenCalledWith({ key: ['lessons'] })
+    })
+
+    test('invalidates ["lessons"] query on error', () => {
+      const { onSettled } = configFrom(useCreateLessonMutation)
+      onSettled(undefined, new Error('boom'), { title: 'My Lesson', file })
+      expect(invalidateSpy).toHaveBeenCalledWith({ key: ['lessons'] })
+    })
+  })
+})

--- a/tests/unit/api/lessons/mutations/delete.test.js
+++ b/tests/unit/api/lessons/mutations/delete.test.js
@@ -1,0 +1,67 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+const { useMutationSpy, invalidateSpy, deleteLessonMock } = vi.hoisted(() => ({
+  useMutationSpy: vi.fn((cfg) => cfg),
+  invalidateSpy: vi.fn(),
+  deleteLessonMock: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@pinia/colada', () => ({
+  useMutation: useMutationSpy,
+  useQueryCache: () => ({ invalidateQueries: invalidateSpy })
+}))
+
+vi.mock('@/api/lessons/db', () => ({
+  deleteLesson: deleteLessonMock
+}))
+
+import { useDeleteLessonMutation } from '@/api/lessons/mutations/delete'
+
+beforeEach(() => {
+  useMutationSpy.mockClear()
+  invalidateSpy.mockClear()
+  deleteLessonMock.mockClear()
+})
+
+function configFrom(hook) {
+  hook()
+  return useMutationSpy.mock.calls.at(-1)[0]
+}
+
+describe('useDeleteLessonMutation', () => {
+  describe('mutation', () => {
+    test('delegates to deleteLesson with the id', async () => {
+      const { mutation } = configFrom(useDeleteLessonMutation)
+      await mutation(42)
+      expect(deleteLessonMock).toHaveBeenCalledWith(42)
+    })
+  })
+
+  describe('onSettled', () => {
+    test('invalidates ["lessons"] so the dashboard list refreshes', () => {
+      const { onSettled } = configFrom(useDeleteLessonMutation)
+      onSettled(undefined, undefined, 42)
+      expect(invalidateSpy).toHaveBeenCalledWith({ key: ['lessons'] })
+    })
+
+    test('on success: invalidates ["lesson", id] with refetchActive=false so no 404 refetch', () => {
+      const { onSettled } = configFrom(useDeleteLessonMutation)
+      onSettled(undefined, undefined, 42)
+      expect(invalidateSpy).toHaveBeenCalledWith({ key: ['lesson', 42] }, false)
+    })
+
+    test('on error: does not invalidate ["lesson", id] (row still exists, keep cache)', () => {
+      const { onSettled } = configFrom(useDeleteLessonMutation)
+      onSettled(undefined, new Error('denied'), 42)
+
+      const detailCalls = invalidateSpy.mock.calls.filter((c) => c[0]?.key?.[0] === 'lesson')
+      expect(detailCalls).toHaveLength(0)
+    })
+
+    test('on error: still invalidates ["lessons"] list', () => {
+      const { onSettled } = configFrom(useDeleteLessonMutation)
+      onSettled(undefined, new Error('denied'), 42)
+      expect(invalidateSpy).toHaveBeenCalledWith({ key: ['lessons'] })
+    })
+  })
+})

--- a/tests/unit/composables/use-can.test.js
+++ b/tests/unit/composables/use-can.test.js
@@ -2,14 +2,19 @@ import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 
 let planRef
 let deckCountRef
+let roleRef
 
 vi.mock('@/stores/member', async () => {
   const { ref } = await vi.importActual('vue')
   planRef = ref(null)
+  roleRef = ref(null)
   return {
     useMemberStore: () => ({
       get plan() {
         return planRef.value
+      },
+      get role() {
+        return roleRef.value
       }
     })
   }
@@ -29,6 +34,7 @@ describe('useCan', () => {
   beforeEach(() => {
     planRef.value = null
     deckCountRef.value = 0
+    roleRef.value = null
   })
 
   describe('useProFeature', () => {
@@ -125,6 +131,33 @@ describe('useCan', () => {
       expect(can.useCardImages.value).toBe(true)
       planRef.value = 'free'
       expect(can.useCardImages.value).toBe(false)
+    })
+  })
+
+  describe('useAudioReader', () => {
+    test('true when member role is admin', () => {
+      roleRef.value = 'admin'
+      expect(useCan().useAudioReader.value).toBe(true)
+    })
+
+    test('false when member role is not admin', () => {
+      roleRef.value = 'member'
+      expect(useCan().useAudioReader.value).toBe(false)
+    })
+
+    test('false when member role is null', () => {
+      roleRef.value = null
+      expect(useCan().useAudioReader.value).toBe(false)
+    })
+
+    test('is a ComputedRef that re-evaluates when role changes', () => {
+      const can = useCan()
+      roleRef.value = 'member'
+      expect(can.useAudioReader.value).toBe(false)
+      roleRef.value = 'admin'
+      expect(can.useAudioReader.value).toBe(true)
+      roleRef.value = 'member'
+      expect(can.useAudioReader.value).toBe(false)
     })
   })
 })

--- a/types/lesson.d.ts
+++ b/types/lesson.d.ts
@@ -1,0 +1,42 @@
+// Which Chinese script the transcript text is converted to after Whisper runs.
+// 'original' keeps Whisper's own output (it tends to emit Traditional).
+type TranscriptScript = 'original' | 'simplified' | 'traditional'
+
+type TranscriptSegment = {
+  start: number
+  end: number
+  text: string
+  // Target-language translation of this sentence, added after transcription.
+  translation?: string
+}
+
+type TranscriptWord = {
+  word: string
+  start: number
+  end: number
+}
+
+type LessonTranscript = {
+  text: string
+  segments: TranscriptSegment[]
+  words?: TranscriptWord[]
+}
+
+type Lesson = {
+  id: number
+  member_id?: string
+  title: string
+  audio_path: string
+  transcript: LessonTranscript
+  lang?: string
+  created_at?: string
+  updated_at?: string
+}
+
+// A term the reader tapped or selected, with the sentence it sits in (translator
+// context) and the rect to anchor the details popover against.
+type TermSelection = {
+  term: string
+  sentence: string
+  rect: DOMRect
+}


### PR DESCRIPTION
## Summary

Adds the `src/api/lessons` server-state domain (db helpers, queries, mutations) for listing, fetching, creating, and deleting lessons and translating terms, plus lesson types and a `use-can` capability gate for the audio-reader feature.

Stacked on #231.