### PR TITLE
feat(audio-reader): synced reader with per-word highlighting

### DIFF
--- a/src/composables/audio-reader/use-audio-player.ts
+++ b/src/composables/audio-reader/use-audio-player.ts
@@ -1,0 +1,108 @@
+import { onUnmounted, ref, toValue, watch, type MaybeRefOrGetter } from 'vue'
+
+/**
+ * Wrap a native `<audio>` element with reactive playback state.
+ *
+ * Uses a requestAnimationFrame loop while playing so `current_time` updates
+ * smoothly for the transcript highlight (the `timeupdate` event alone fires too
+ * coarsely, ~4x/sec); it reconciles against `timeupdate` while paused/seeking.
+ * Native `<audio>` (not Howler) because it streams via HTTP range requests and
+ * gives free seeking — Howler is for short SFX.
+ *
+ * @param target - the audio element (template ref); binding follows it as it mounts/unmounts.
+ * @example
+ * const audio = useTemplateRef('audio')
+ * const { current_time, is_playing, seek } = useAudioPlayer(audio)
+ */
+export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>) {
+  const current_time = ref(0)
+  const duration = ref(0)
+  const is_playing = ref(false)
+
+  let el: HTMLAudioElement | null = null
+  let raf = 0
+
+  function tick() {
+    if (!el) return
+    current_time.value = el.currentTime
+    raf = requestAnimationFrame(tick)
+  }
+
+  function startTicking() {
+    cancelAnimationFrame(raf)
+    raf = requestAnimationFrame(tick)
+  }
+
+  function stopTicking() {
+    cancelAnimationFrame(raf)
+    raf = 0
+  }
+
+  function onLoaded() {
+    if (el) duration.value = el.duration || 0
+  }
+
+  function onPlay() {
+    is_playing.value = true
+    startTicking()
+  }
+
+  function onPause() {
+    is_playing.value = false
+    stopTicking()
+    if (el) current_time.value = el.currentTime
+  }
+
+  function onTimeUpdate() {
+    if (el && !is_playing.value) current_time.value = el.currentTime
+  }
+
+  function bind(next: HTMLAudioElement) {
+    el = next
+    el.addEventListener('loadedmetadata', onLoaded)
+    el.addEventListener('play', onPlay)
+    el.addEventListener('pause', onPause)
+    el.addEventListener('ended', onPause)
+    el.addEventListener('timeupdate', onTimeUpdate)
+    if (el.readyState >= 1) onLoaded()
+  }
+
+  function unbind() {
+    stopTicking()
+    if (!el) return
+    el.removeEventListener('loadedmetadata', onLoaded)
+    el.removeEventListener('play', onPlay)
+    el.removeEventListener('pause', onPause)
+    el.removeEventListener('ended', onPause)
+    el.removeEventListener('timeupdate', onTimeUpdate)
+    el = null
+  }
+
+  watch(
+    () => toValue(target),
+    (next) => {
+      unbind()
+      if (next) bind(next)
+    },
+    { immediate: true }
+  )
+
+  onUnmounted(unbind)
+
+  /** Move playback to `seconds` and reflect it immediately (don't wait for timeupdate). */
+  function seek(seconds: number) {
+    if (!el) return
+    el.currentTime = seconds
+    current_time.value = seconds
+  }
+
+  function play() {
+    el?.play()
+  }
+
+  function pause() {
+    el?.pause()
+  }
+
+  return { current_time, duration, is_playing, play, pause, seek }
+}

--- a/src/composables/audio-reader/use-lesson-reader.ts
+++ b/src/composables/audio-reader/use-lesson-reader.ts
@@ -1,0 +1,68 @@
+import { computed, ref, toValue, useTemplateRef, watch } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
+import { useToast } from '@/composables/toast'
+import { useLessonQuery, useLessonAudioUrlQuery } from '@/api/lessons'
+import { useAudioPlayer } from './use-audio-player'
+import { useTranscriptSync } from './use-transcript-sync'
+import { groupWordsBySentence, groupSentencesIntoParagraphs } from '@/utils/transcript'
+
+/**
+ * Orchestrate a lesson for reading: fetch it, shape its transcript into
+ * paragraphs, stream the audio, sync the active word to playback, and hold the
+ * term-translation popover state. The view binds the returned values to its
+ * template and otherwise stays presentation-only.
+ *
+ * Binds the audio element by name — the host template must declare `ref="audio"`.
+ *
+ * @param id - the lesson id (route param), reactive.
+ * @example
+ * const reader = useLessonReader(() => Number(props.id))
+ */
+export function useLessonReader(id: MaybeRefOrGetter<number>) {
+  const toast = useToast()
+
+  const lesson_id = computed(() => toValue(id))
+  const { data: lesson, error } = useLessonQuery(lesson_id)
+
+  const words = computed(() => lesson.value?.transcript.words ?? [])
+  const paragraphs = computed(() => {
+    const segments = lesson.value?.transcript.segments ?? []
+    const groups = groupWordsBySentence(segments, words.value, lesson.value?.transcript.text)
+    return groupSentencesIntoParagraphs(groups)
+  })
+
+  const audio_path = computed(() => lesson.value?.audio_path)
+  const { data: audio_url } = useLessonAudioUrlQuery(audio_path)
+
+  const audio_el = useTemplateRef<HTMLAudioElement>('audio')
+  const { current_time } = useAudioPlayer(audio_el)
+  const { active_index: active_word } = useTranscriptSync(words, current_time)
+
+  const selection = ref<TermSelection | null>(null)
+  const popover_open = ref(false)
+
+  watch(error, (err) => {
+    if (err) toast.error(err.message)
+  })
+
+  /** Open the translation popover anchored to a tapped/selected term. */
+  function openTerm(next: TermSelection) {
+    selection.value = next
+    popover_open.value = true
+  }
+
+  function closeTerm() {
+    popover_open.value = false
+  }
+
+  return {
+    lesson,
+    paragraphs,
+    audio_url,
+    active_word,
+    selection,
+    popover_open,
+    openTerm,
+    closeTerm
+  }
+}

--- a/src/composables/audio-reader/use-reader-highlights.ts
+++ b/src/composables/audio-reader/use-reader-highlights.ts
@@ -1,0 +1,263 @@
+import { onBeforeUnmount, onMounted, ref, toValue, useTemplateRef, watch } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
+import { cleanTerm } from '@/utils/transcript'
+import {
+  moveReaderCursor,
+  hideReaderCursor,
+  type CursorBox
+} from '@/utils/animations/reader-cursor'
+
+// How far each highlight bleeds past the text on every side, so it reads as a
+// padded pill rather than a tight box.
+const PAD_X = 3
+const PAD_Y = 2
+
+// The interaction pill answers the pointer, so it glides faster than the
+// audio-driven playhead (which keeps the slower, stretchy default).
+const HOVER_DURATION = 0.12
+
+// What a committed selection hands back: the bare term, the rect to anchor the
+// popover against, and the first word's element so the caller can resolve which
+// sentence it sits in (translator context).
+type ReaderSelection = { term: string; rect: DOMRect; anchor: HTMLElement }
+
+type WordRange = { lo: number; hi: number }
+
+/**
+ * Drive the floating highlight layers in the transcript reader: the audio-driven
+ * **playhead** (stretchy, follows `active_word`) and the pointer-driven
+ * **interaction** pill — which doubles as the hover indicator, the drag-to-select
+ * highlight, and the standing selection while its popover is open.
+ *
+ * The pill is the selection: press a word and the pill anchors there; drag and
+ * it stretches word by word to cover the range; release commits the term via
+ * `onSelect` (a plain click is a zero-width range, so it selects one word). The
+ * committed range stays lit — hover is held off — until `popover_open` flips
+ * false. The translation gloss carries no `data-word-index`, so it can never join
+ * a range; native text selection is left disabled by the host.
+ *
+ * "Which word" is JS state; the DOM is read only to measure "where is word N",
+ * located by its stable `data-word-index`. Pills live inside `content` and are
+ * positioned in its coordinate space, so they scroll with the column for free.
+ *
+ * Binds three template refs by name — the host must declare `ref="content"`,
+ * `ref="playhead"`, and `ref="hover"`.
+ *
+ * @param active_word - index of the word the audio is on, or -1 for none.
+ * @param onSelect - called on release with the committed range's term + rect.
+ * @param popover_open - whether the term popover is showing; the selection holds
+ *   while true and clears when it goes false.
+ * @example
+ * const { onPointerDown, onPointerMove, onPointerUp, onPointerLeave } =
+ *   useReaderHighlights(() => active_word, commitSelection, () => popover_open)
+ */
+export function useReaderHighlights(
+  active_word: MaybeRefOrGetter<number>,
+  onSelect: (selection: ReaderSelection) => void,
+  popover_open: MaybeRefOrGetter<boolean>
+) {
+  const content = useTemplateRef<HTMLElement>('content')
+  const playhead = useTemplateRef<HTMLElement>('playhead')
+  const hover = useTemplateRef<HTMLElement>('hover')
+
+  // The word under the pointer (hover) or, while dragging, the focus end of the
+  // range. `anchor_index` is the fixed end of a drag — null when not dragging.
+  // `committed` is the released range, kept lit while its popover is open.
+  const focus_index = ref<number | null>(null)
+  const anchor_index = ref<number | null>(null)
+  const committed = ref<WordRange | null>(null)
+
+  let resize_observer: ResizeObserver | null = null
+
+  onMounted(() => {
+    resize_observer = new ResizeObserver(reposition)
+    if (content.value) resize_observer.observe(content.value)
+    window.addEventListener('click', swallowGestureClick, true)
+  })
+
+  onBeforeUnmount(() => {
+    resize_observer?.disconnect()
+    window.removeEventListener('click', swallowGestureClick, true)
+  })
+
+  // A pointer tap inside the reader is a word selection, not a click — yet the
+  // browser still fires a compatibility `click` after `pointerup`. Swallow it in
+  // the capture phase (before document-level handlers run) so an open popover's
+  // outside-click dismiss never mistakes the selecting tap for a dismiss.
+  function swallowGestureClick(event: MouseEvent) {
+    if (content.value?.contains(event.target as Node)) event.stopPropagation()
+  }
+
+  /** Locate a word's element within the content by its stable index attribute. */
+  function wordEl(index: number): HTMLElement | null {
+    return content.value?.querySelector(`[data-word-index="${index}"]`) ?? null
+  }
+
+  /** The word index at viewport point (x, y), or null when none is there. */
+  function wordIndexAt(x: number, y: number): number | null {
+    const el = document.elementFromPoint(x, y)?.closest('[data-word-index]')
+    return el ? Number(el.getAttribute('data-word-index')) : null
+  }
+
+  /** A DOM range spanning whole words `lo`..`hi`, for measuring + reading text. */
+  function wordRange({ lo, hi }: WordRange): Range | null {
+    const first = wordEl(lo)
+    const last = wordEl(hi)
+    if (!first || !last) return null
+
+    const range = document.createRange()
+    range.setStartBefore(first)
+    range.setEndAfter(last)
+    return range
+  }
+
+  // Map a viewport rect onto the content's own coordinate space, where the
+  // absolutely-positioned pills live, padded out into a pill shape.
+  function boxOf(rect: DOMRect): CursorBox {
+    const base = content.value!.getBoundingClientRect()
+    return {
+      left: rect.left - base.left - PAD_X,
+      top: rect.top - base.top - PAD_Y,
+      width: rect.width + PAD_X * 2,
+      height: rect.height + PAD_Y * 2
+    }
+  }
+
+  function rangeBox(range: WordRange): CursorBox | null {
+    const dom = wordRange(range)
+    return dom ? boxOf(dom.getBoundingClientRect()) : null
+  }
+
+  function wordBox(index: number): CursorBox | null {
+    const el = wordEl(index)
+    return el ? boxOf(el.getBoundingClientRect()) : null
+  }
+
+  function playheadBox(): CursorBox | null {
+    const index = toValue(active_word)
+    return index < 0 ? null : wordBox(index)
+  }
+
+  // Priority: an in-progress drag, then a committed selection (popover open),
+  // then the plain hovered word.
+  function interactionBox(): CursorBox | null {
+    if (anchor_index.value !== null && focus_index.value !== null) {
+      return rangeBox(orderedRange(anchor_index.value, focus_index.value))
+    }
+    if (committed.value) return rangeBox(committed.value)
+    if (focus_index.value !== null) return wordBox(focus_index.value)
+    return null
+  }
+
+  function positionPlayhead() {
+    if (!playhead.value) return
+
+    const box = playheadBox()
+    if (!box) {
+      hideReaderCursor(playhead.value)
+      return
+    }
+
+    moveReaderCursor(playhead.value, box, { stretch: true })
+    wordEl(toValue(active_word))?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }
+
+  function positionInteraction() {
+    if (!hover.value) return
+
+    const box = interactionBox()
+    if (!box) {
+      hideReaderCursor(hover.value)
+      return
+    }
+
+    moveReaderCursor(hover.value, box, { stretch: false, duration: HOVER_DURATION })
+  }
+
+  function reposition() {
+    positionPlayhead()
+    positionInteraction()
+  }
+
+  function orderedRange(a: number, b: number): WordRange {
+    return { lo: Math.min(a, b), hi: Math.max(a, b) }
+  }
+
+  // Release commits the range as a term and lights it as the standing selection;
+  // an empty (punctuation-only) range is dropped so the popover never opens.
+  function commitSelection() {
+    if (anchor_index.value === null || focus_index.value === null) return
+
+    const range = orderedRange(anchor_index.value, focus_index.value)
+    const dom = wordRange(range)
+    const anchor = wordEl(range.lo)
+    if (!dom || !anchor) return
+
+    const term = cleanTerm(dom.toString())
+    if (!term) return
+
+    committed.value = range
+    onSelect({ term, rect: dom.getBoundingClientRect(), anchor })
+  }
+
+  function onPointerDown(event: PointerEvent) {
+    committed.value = null
+
+    const index = wordIndexAt(event.clientX, event.clientY)
+    if (index === null) return
+
+    // Own the gesture: stop native text selection and keep receiving moves even
+    // if the pointer strays outside the column mid-drag. Capture can reject a
+    // non-active pointer (e.g. synthetic events in tests), so it's best-effort.
+    event.preventDefault()
+    try {
+      ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
+    } catch {
+      // no capture — the drag still tracks while the pointer stays over the column
+    }
+
+    anchor_index.value = index
+    focus_index.value = index
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    const index = wordIndexAt(event.clientX, event.clientY)
+
+    // Mid-drag, ignore gaps (translation gloss, padding) so the range holds its
+    // last extent instead of collapsing.
+    if (anchor_index.value !== null) {
+      if (index !== null && index !== focus_index.value) focus_index.value = index
+      return
+    }
+
+    // A committed selection owns the pill while its popover is open; don't let
+    // hover steal it.
+    if (committed.value) return
+
+    if (index !== focus_index.value) focus_index.value = index
+  }
+
+  function onPointerUp() {
+    if (anchor_index.value === null) return
+
+    commitSelection()
+    anchor_index.value = null
+  }
+
+  function onPointerLeave() {
+    if (anchor_index.value !== null) return
+    focus_index.value = null
+  }
+
+  // flush: 'post' so any layout settling lands before we measure word rects.
+  watch(() => toValue(active_word), positionPlayhead, { flush: 'post' })
+  watch([focus_index, anchor_index, committed], positionInteraction, { flush: 'post' })
+  watch(
+    () => toValue(popover_open),
+    (open) => {
+      if (!open) committed.value = null
+    }
+  )
+
+  return { content, playhead, hover, onPointerDown, onPointerMove, onPointerUp, onPointerLeave }
+}

--- a/src/composables/audio-reader/use-transcript-sync.ts
+++ b/src/composables/audio-reader/use-transcript-sync.ts
@@ -1,0 +1,41 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+
+type Timed = { start: number }
+
+/**
+ * Count how many items have started by time `t` (start <= t), via an upper-bound
+ * binary search. Assumes `items` is sorted by start, so it stays cheap on every
+ * rAF tick even for long transcripts.
+ */
+function countStarted(items: Timed[], t: number): number {
+  let lo = 0
+  let hi = items.length
+
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (items[mid].start <= t) lo = mid + 1
+    else hi = mid
+  }
+
+  return lo
+}
+
+/**
+ * Map the audio's current time to the active timed item — a segment or a word.
+ *
+ * Returns the index of the latest item that has started (start <= t), so the
+ * item stays highlighted through the silent gap until the next one begins —
+ * smoother than going dark between them. Returns -1 before the first item starts.
+ *
+ * @example
+ * const { active_index } = useTranscriptSync(() => lesson.transcript.words ?? [], current_time)
+ */
+export function useTranscriptSync(
+  items: MaybeRefOrGetter<Timed[]>,
+  current_time: MaybeRefOrGetter<number>
+) {
+  // The active item is the last one that has started; -1 when none have yet.
+  const active_index = computed(() => countStarted(toValue(items), toValue(current_time)) - 1)
+
+  return { active_index }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useSessionStore } from '@/stores/session'
+import { useMemberStore } from '@/stores/member'
 import { prefetchMemberDecks } from '@/api/decks'
 import { prefetchMemberById } from '@/api/members'
 import WelcomeView from '@/views/welcome/welcome-view.vue'
@@ -10,6 +11,16 @@ import AuthCallbackView from '@/views/auth/callback.vue'
 
 const Dashboard = () => import('@/views/dashboard/index.vue')
 const DeckView = () => import('@/views/deck/index.vue')
+const AudioReaderLesson = () => import('@/views/audio-reader/index.vue')
+
+// Mirrors useCan().useAudioReader (admin-only). Awaits the member query so a
+// direct URL hit doesn't read an empty role mid-restore. The real boundary is
+// the edge functions; this just keeps non-admins out of the UI.
+async function requireAudioReader() {
+  const id = useSessionStore().user?.id
+  if (id) await prefetchMemberById(id)
+  if (useMemberStore().role !== 'admin') return { name: 'dashboard' }
+}
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -62,6 +73,13 @@ const router = createRouter({
           name: 'deck',
           component: DeckView,
           props: true
+        },
+        {
+          path: 'audio-reader/:id',
+          name: 'audio-reader-lesson',
+          component: AudioReaderLesson,
+          props: true,
+          beforeEnter: requireAudioReader
         }
       ]
     }

--- a/src/utils/animations/reader-cursor.ts
+++ b/src/utils/animations/reader-cursor.ts
@@ -1,0 +1,101 @@
+import { gsap } from 'gsap'
+
+export type CursorBox = { left: number; top: number; width: number; height: number }
+
+// The leading edge snaps quickly while the trailing edge follows slower, so a
+// fast passage stretches the highlight across the words it sweeps past, then it
+// contracts snug around the active one once the audio settles.
+const LEAD = 0.16
+const TRAIL = 0.45
+const VERTICAL = 0.2
+const FADE = 0.2
+
+type Edges = { left: number; right: number }
+
+// Per-element edge state so each move animates from where the highlight
+// actually is, and stale tweens get killed cleanly (they target this object).
+const edgesByEl = new WeakMap<HTMLElement, Edges>()
+
+function paint(el: HTMLElement, edges: Edges) {
+  el.style.left = `${edges.left}px`
+  el.style.width = `${Math.max(0, edges.right - edges.left)}px`
+}
+
+/**
+ * Glide a floating highlight `el` to cover `box` (coordinates relative to its
+ * offset parent). With `stretch` (the default, used for audio-driven moves) the
+ * leading edge leads and the trailing edge lags, so the highlight elongates
+ * through fast passages then shrinks back to one word. With `stretch: false`
+ * (the hover layer) it moves both edges together to cover `box` directly;
+ * `duration` overrides the edge/vertical speed so the hover pill can answer the
+ * pointer faster than the audio playhead.
+ *
+ * A line change (different `top`) can't be stretched horizontally either, so it
+ * also slides straight across. The first call drops the highlight onto the box
+ * with no animation.
+ */
+export function moveReaderCursor(
+  el: HTMLElement,
+  box: CursorBox,
+  { stretch = true, duration }: { stretch?: boolean; duration?: number } = {}
+) {
+  const target_right = box.left + box.width
+  const edges = edgesByEl.get(el)
+
+  if (!edges) {
+    const next = { left: box.left, right: target_right }
+    edgesByEl.set(el, next)
+    gsap.set(el, { top: box.top, height: box.height, autoAlpha: 1 })
+    paint(el, next)
+    return
+  }
+
+  const line_jump = Math.abs(box.top - (gsap.getProperty(el, 'top') as number)) > 1
+
+  gsap.to(el, {
+    top: box.top,
+    height: box.height,
+    autoAlpha: 1,
+    duration: duration ?? VERTICAL,
+    ease: 'power2.out',
+    overwrite: 'auto'
+  })
+  gsap.killTweensOf(edges)
+
+  if (line_jump || !stretch) {
+    gsap.to(edges, {
+      left: box.left,
+      right: target_right,
+      duration: duration ?? LEAD,
+      ease: 'power2.out',
+      onUpdate: () => paint(el, edges)
+    })
+    return
+  }
+
+  const forward = target_right >= edges.right
+  gsap.to(edges, {
+    left: box.left,
+    duration: forward ? TRAIL : LEAD,
+    ease: 'power2.out',
+    onUpdate: () => paint(el, edges)
+  })
+  gsap.to(edges, {
+    right: target_right,
+    duration: forward ? LEAD : TRAIL,
+    ease: 'power2.out',
+    onUpdate: () => paint(el, edges)
+  })
+}
+
+/**
+ * Fade the highlight out and forget its position, so the next
+ * `moveReaderCursor` drops fresh onto the new word instead of sliding across
+ * the page from a stale spot.
+ */
+export function hideReaderCursor(el: HTMLElement) {
+  const edges = edgesByEl.get(el)
+  if (edges) gsap.killTweensOf(edges)
+  edgesByEl.delete(el)
+  gsap.to(el, { autoAlpha: 0, duration: FADE, ease: 'power2.out' })
+}

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -1,0 +1,143 @@
+export type DisplayWord = {
+  display: string
+  start: number
+  index: number
+}
+
+export type SentenceWords = {
+  index: number
+  sentence: string
+  // English (or target-language) translation of the sentence, shown
+  // interlinearly under it; absent until the lesson has been translated.
+  translation?: string
+  start: number
+  end: number
+  words: DisplayWord[]
+}
+
+// A silent gap longer than this between two sentences reads as a paragraph
+// break — a topic shift or a breath the speaker takes between thoughts.
+const PARAGRAPH_GAP_SECONDS = 0.8
+
+// Leading/trailing whitespace + punctuation. \p{P} spans Latin and CJK marks
+// alike, so this strips a trailing 。 or ? the same way. Anchored to both ends
+// only, so punctuation *inside* a term (don't, well-being) is left untouched.
+const SURROUNDING_PUNCTUATION = /^[\p{P}\s]+|[\p{P}\s]+$/gu
+
+/**
+ * Reduce a tapped or selected token to the bare term for the translator —
+ * "world" from "world.", "你好" from "你好，". Returns '' when the token is
+ * nothing but punctuation, so callers can skip opening the popover.
+ *
+ * @example
+ * cleanTerm('world.') // 'world'
+ */
+export function cleanTerm(text: string): string {
+  return text.replace(SURROUNDING_PUNCTUATION, '')
+}
+
+/**
+ * Group word tokens under the sentence (segment) that contains them, with each
+ * word's display text reconstructed — original spacing and punctuation intact —
+ * from the full transcript `text`. Partitioning the whole text (rather than each
+ * trimmed segment in isolation) preserves the spacing *between* sentences too,
+ * so it renders correctly in any language, including space-less scripts like
+ * Japanese where sentences butt straight up against each other. Each word keeps
+ * its global `index` (position in the flat `words` array) so the synced active
+ * word can be matched.
+ *
+ * `text` defaults to the segments joined by spaces; pass the real
+ * `transcript.text` so inter-sentence spacing matches the source exactly.
+ *
+ * @example
+ * const groups = groupWordsBySentence(t.segments, t.words ?? [], t.text)
+ */
+export function groupWordsBySentence(
+  segments: TranscriptSegment[],
+  words: TranscriptWord[],
+  text = segments.map((s) => s.text).join(' ')
+): SentenceWords[] {
+  const displayed = displayWords(text, words)
+
+  return segments.map((segment, i) => ({
+    index: i,
+    sentence: segment.text,
+    translation: segment.translation,
+    start: segment.start,
+    end: segment.end,
+    words: displayed.filter(inSegment(segments, i))
+  }))
+}
+
+/**
+ * Split sentences into paragraphs at long silent gaps, so the transcript reads
+ * as prose instead of one undivided block. Whisper gives no paragraph metadata,
+ * so the speaker's pauses stand in for it.
+ *
+ * @example
+ * const paragraphs = groupSentencesIntoParagraphs(groupWordsBySentence(segments, words))
+ */
+export function groupSentencesIntoParagraphs(
+  sentences: SentenceWords[],
+  gap = PARAGRAPH_GAP_SECONDS
+): SentenceWords[][] {
+  const paragraphs: SentenceWords[][] = []
+
+  sentences.forEach((sentence, i) => {
+    const prev = sentences[i - 1]
+    if (!prev || sentence.start - prev.end > gap) paragraphs.push([])
+    paragraphs[paragraphs.length - 1].push(sentence)
+  })
+
+  return paragraphs
+}
+
+/**
+ * Predicate: a word belongs to segment `i` when its start falls inside the
+ * segment's time span. The first segment also claims any words that start
+ * before it; the last segment claims any that start after it.
+ */
+function inSegment(segments: TranscriptSegment[], i: number) {
+  const lower = i === 0 ? -Infinity : segments[i].start
+  const upper = segments[i + 1]?.start ?? Infinity
+  return (word: DisplayWord) => word.start >= lower && word.start < upper
+}
+
+/**
+ * Reconstruct each word's display text by partitioning the transcript into
+ * contiguous slices between consecutive word positions. Every character —
+ * leading text, inter-word and inter-sentence spaces, and trailing punctuation —
+ * lands in exactly one slice, so the spans together reproduce the text verbatim
+ * in any language. A token that can't be located (a rare normalization mismatch
+ * between Whisper's word and the text) falls back to itself.
+ */
+function displayWords(text: string, words: TranscriptWord[]): DisplayWord[] {
+  const bounds = wordBoundaries(text, words)
+
+  return words.map((word, i) => ({
+    display: text.slice(bounds[i], bounds[i + 1]) || word.word.trim(),
+    start: word.start,
+    index: i
+  }))
+}
+
+/**
+ * Find where each word starts in the text, returning slice boundaries: the first
+ * word claims any leading text (boundary forced to 0) and the last claims the
+ * trailing tail (boundary at text length), so the slices tile the whole text.
+ */
+function wordBoundaries(text: string, words: TranscriptWord[]): number[] {
+  const bounds: number[] = []
+  let cursor = 0
+
+  words.forEach((word) => {
+    const token = word.word.trim()
+    const found = text.indexOf(token, cursor)
+    bounds.push(found === -1 ? cursor : found)
+    if (found !== -1) cursor = found + token.length
+  })
+
+  bounds.push(text.length)
+  if (bounds.length > 1) bounds[0] = 0
+  return bounds
+}

--- a/src/views/audio-reader/index.vue
+++ b/src/views/audio-reader/index.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import TranscriptView from './transcript/index.vue'
+import TermPopover from './term-popover/index.vue'
+import { useLessonReader } from '@/composables/audio-reader/use-lesson-reader'
+
+// Translate into the app language. A per-member target language can replace this
+// later; admin-only v1 is English.
+const TARGET_LANG = 'English'
+
+const { id } = defineProps<{ id: string }>()
+
+const { lesson, paragraphs, audio_url, active_word, selection, popover_open, openTerm, closeTerm } =
+  useLessonReader(computed(() => Number(id)))
+</script>
+
+<template>
+  <div
+    data-testid="audio-reader-lesson"
+    class="mx-auto flex h-full w-full max-w-168 flex-col gap-6 pb-12"
+  >
+    <h1
+      data-testid="audio-reader-lesson__title"
+      class="text-3xl text-brown-700 dark:text-brown-300"
+    >
+      {{ lesson?.title }}
+    </h1>
+
+    <audio
+      ref="audio"
+      data-testid="audio-reader-lesson__audio"
+      :src="audio_url ?? undefined"
+      controls
+      class="w-full"
+    />
+
+    <transcript-view
+      :paragraphs="paragraphs"
+      :active_word="active_word"
+      :popover_open="popover_open"
+      @select="openTerm"
+    />
+
+    <term-popover
+      v-if="selection"
+      :open="popover_open"
+      :rect="selection.rect"
+      :term="selection.term"
+      :sentence="selection.sentence"
+      :target_lang="TARGET_LANG"
+      @close="closeTerm"
+    />
+  </div>
+</template>

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { SentenceWords } from '@/utils/transcript'
+import { useReaderHighlights } from '@/composables/audio-reader/use-reader-highlights'
+import TranscriptSegment from './segment.vue'
+
+const {
+  paragraphs,
+  active_word,
+  popover_open = false
+} = defineProps<{
+  paragraphs: SentenceWords[][]
+  active_word: number
+  popover_open?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', selection: TermSelection): void
+}>()
+
+const { onPointerDown, onPointerMove, onPointerUp, onPointerLeave } = useReaderHighlights(
+  () => active_word,
+  commitSelection,
+  () => popover_open
+)
+
+const sentences = computed(() => paragraphs.flat())
+
+function sentenceIndexOf(node: Element): number | null {
+  const segment = node.closest('[data-testid="transcript-segment"]')
+  const index = segment?.getAttribute('data-index')
+  return index === null || index === undefined ? null : Number(index)
+}
+
+// A committed word-range carries its own term + rect; the sentence it starts in
+// (translator context) comes from the anchor word's segment.
+function commitSelection({ term, rect, anchor }: { term: string; rect: DOMRect; anchor: Element }) {
+  const index = sentenceIndexOf(anchor)
+  const sentence = (index !== null && sentences.value[index]?.sentence) || term
+  emit('select', { term, sentence, rect })
+}
+</script>
+
+<template>
+  <div data-testid="transcript-view" class="overflow-y-auto px-2 py-1">
+    <div
+      ref="content"
+      data-testid="transcript-view__content"
+      class="relative isolate flex select-none flex-col gap-7 text-2xl leading-relaxed text-brown-700 dark:text-brown-200"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointerleave="onPointerLeave"
+    >
+      <div
+        ref="playhead"
+        data-testid="transcript-view__playhead"
+        aria-hidden="true"
+        class="pointer-events-none absolute left-0 top-0 -z-10 rounded-2 bg-(--theme-primary) opacity-0"
+      />
+      <div
+        ref="hover"
+        data-testid="transcript-view__hover"
+        aria-hidden="true"
+        class="pointer-events-none absolute left-0 top-0 -z-10 rounded-2 bg-(--theme-primary) opacity-0"
+      />
+      <div
+        v-for="(paragraph, p) in paragraphs"
+        :key="p"
+        data-testid="transcript-view__paragraph"
+        class="flex flex-col gap-3"
+      >
+        <transcript-segment
+          v-for="sentence in paragraph"
+          :key="sentence.index"
+          :group="sentence"
+          :index="sentence.index"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/audio-reader/transcript/segment.vue
+++ b/src/views/audio-reader/transcript/segment.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { SentenceWords } from '@/utils/transcript'
+import TranscriptWord from './word.vue'
+
+const { group, index } = defineProps<{
+  group: SentenceWords
+  index: number
+}>()
+</script>
+
+<template>
+  <div data-testid="transcript-segment" :data-index="index">
+    <span data-testid="transcript-segment__source"
+      ><transcript-word
+        v-for="word in group.words"
+        :key="word.index"
+        :display="word.display"
+        :index="word.index"
+    /></span>
+    <span
+      v-if="group.translation"
+      data-testid="transcript-segment__translation"
+      class="mt-1 block text-lg text-brown-500 dark:text-brown-300"
+      >{{ group.translation }}</span
+    >
+  </div>
+</template>

--- a/src/views/audio-reader/transcript/word.vue
+++ b/src/views/audio-reader/transcript/word.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+const { display, index } = defineProps<{
+  display: string
+  index: number
+}>()
+</script>
+
+<template>
+  <span data-testid="transcript-word" :data-word-index="index" class="cursor-pointer">{{
+    display
+  }}</span>
+</template>

--- a/tests/integration/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/integration/composables/audio-reader/use-reader-highlights.test.js
@@ -1,0 +1,226 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { useReaderHighlights } from '@/composables/audio-reader/use-reader-highlights'
+
+const { moveMock, hideMock } = vi.hoisted(() => ({ moveMock: vi.fn(), hideMock: vi.fn() }))
+
+// Mock the animator so positioning is observable as calls (real geometry is zero
+// in the test DOM anyway); selection behaviour is asserted via these.
+vi.mock('@/utils/animations/reader-cursor', () => ({
+  moveReaderCursor: moveMock,
+  hideReaderCursor: hideMock
+}))
+
+// Host wiring the composable's pointer handlers + template refs, with words
+// carrying the stable data-word-index handle (including a punctuation-only one).
+const Host = defineComponent({
+  props: {
+    activeWord: { type: Number, default: -1 },
+    open: { type: Boolean, default: false },
+    onSelect: { type: Function, default: () => {} }
+  },
+  setup(props) {
+    return useReaderHighlights(
+      () => props.activeWord,
+      props.onSelect,
+      () => props.open
+    )
+  },
+  render() {
+    return h(
+      'div',
+      {
+        ref: 'content',
+        'data-testid': 'content',
+        onPointerdown: this.onPointerDown,
+        onPointermove: this.onPointerMove,
+        onPointerup: this.onPointerUp,
+        onPointerleave: this.onPointerLeave
+      },
+      [
+        h('div', { ref: 'playhead' }),
+        h('div', { ref: 'hover' }),
+        h('span', { 'data-testid': 'w0', 'data-word-index': '0' }, 'Hello '),
+        h('span', { 'data-testid': 'w1', 'data-word-index': '1' }, 'world'),
+        h('span', { 'data-testid': 'w2', 'data-word-index': '2' }, '. ')
+      ]
+    )
+  }
+})
+
+describe('useReaderHighlights', () => {
+  let words
+  let scroll_into_view
+
+  // The composable hit-tests via elementFromPoint; map a synthetic clientX (the
+  // word index) onto its element so the gesture is deterministic, not layout-bound.
+  function mountHost(onSelect) {
+    const wrapper = mount(Host, { props: { onSelect } })
+    words = ['w0', 'w1', 'w2'].map((id) => wrapper.find(`[data-testid="${id}"]`).element)
+    vi.spyOn(document, 'elementFromPoint').mockImplementation((x) => words[x] ?? null)
+    return wrapper
+  }
+
+  function pointer(wrapper, type, index, buttons) {
+    words[index].dispatchEvent(
+      new PointerEvent(type, { bubbles: true, pointerId: 1, buttons, clientX: index, clientY: 0 })
+    )
+    return wrapper.vm.$nextTick()
+  }
+
+  beforeEach(() => {
+    moveMock.mockClear()
+    hideMock.mockClear()
+    scroll_into_view = vi.fn()
+    Element.prototype.scrollIntoView = scroll_into_view
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('click-to-select one word', () => {
+    test('a press and release on a word commits its cleaned term', async () => {
+      const onSelect = vi.fn()
+      const wrapper = mountHost(onSelect)
+
+      await pointer(wrapper, 'pointerdown', 1, 1)
+      await pointer(wrapper, 'pointerup', 1, 0)
+
+      expect(onSelect).toHaveBeenCalledTimes(1)
+      expect(onSelect.mock.calls[0][0].term).toBe('world')
+      expect(onSelect.mock.calls[0][0].anchor).toBe(words[1])
+    })
+
+    test('does not commit a punctuation-only word', async () => {
+      const onSelect = vi.fn()
+      const wrapper = mountHost(onSelect)
+
+      await pointer(wrapper, 'pointerdown', 2, 1)
+      await pointer(wrapper, 'pointerup', 2, 0)
+
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('drag-to-select a range', () => {
+    test('a drag across words commits the joined term', async () => {
+      const onSelect = vi.fn()
+      const wrapper = mountHost(onSelect)
+
+      await pointer(wrapper, 'pointerdown', 0, 1)
+      await pointer(wrapper, 'pointermove', 1, 1)
+      await pointer(wrapper, 'pointerup', 1, 0)
+
+      expect(onSelect.mock.calls[0][0].term).toBe('Hello world')
+    })
+
+    test('strips trailing punctuation swept into the range', async () => {
+      const onSelect = vi.fn()
+      const wrapper = mountHost(onSelect)
+
+      await pointer(wrapper, 'pointerdown', 0, 1)
+      await pointer(wrapper, 'pointermove', 2, 1)
+      await pointer(wrapper, 'pointerup', 2, 0)
+
+      expect(onSelect.mock.calls[0][0].term).toBe('Hello world')
+    })
+
+    test('anchors the term to the first word of the range regardless of drag direction', async () => {
+      const onSelect = vi.fn()
+      const wrapper = mountHost(onSelect)
+
+      // drag right-to-left: press word 1, drag back to word 0
+      await pointer(wrapper, 'pointerdown', 1, 1)
+      await pointer(wrapper, 'pointermove', 0, 1)
+      await pointer(wrapper, 'pointerup', 0, 0)
+
+      expect(onSelect.mock.calls[0][0].term).toBe('Hello world')
+      expect(onSelect.mock.calls[0][0].anchor).toBe(words[0])
+    })
+  })
+
+  describe('selection persists while the popover is open', () => {
+    test('hover does not steal the pill from a committed selection', async () => {
+      const wrapper = mountHost(vi.fn())
+
+      await pointer(wrapper, 'pointerdown', 0, 1)
+      await pointer(wrapper, 'pointerup', 0, 0)
+      await wrapper.setProps({ open: true })
+
+      moveMock.mockClear()
+      await pointer(wrapper, 'pointermove', 2, 0)
+
+      expect(moveMock).not.toHaveBeenCalled()
+    })
+
+    test('hover resumes once the popover closes', async () => {
+      const wrapper = mountHost(vi.fn())
+
+      await pointer(wrapper, 'pointerdown', 0, 1)
+      await pointer(wrapper, 'pointerup', 0, 0)
+      await wrapper.setProps({ open: true })
+      await wrapper.setProps({ open: false })
+
+      moveMock.mockClear()
+      await pointer(wrapper, 'pointermove', 2, 0)
+
+      expect(moveMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('gesture guards', () => {
+    test('a press that does not land on a word commits nothing', async () => {
+      const onSelect = vi.fn()
+      const wrapper = mountHost(onSelect)
+      document.elementFromPoint.mockReturnValue(null)
+
+      wrapper
+        .find('[data-testid="content"]')
+        .element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }))
+      await pointer(wrapper, 'pointerup', 1, 0)
+
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('swallows the gesture compatibility click', () => {
+    test('stops a click originating inside the reader from reaching document handlers', () => {
+      const wrapper = mountHost(vi.fn())
+      const onDocClick = vi.fn()
+      document.addEventListener('click', onDocClick, true)
+
+      words[1].dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+      document.removeEventListener('click', onDocClick, true)
+      wrapper.unmount()
+      expect(onDocClick).not.toHaveBeenCalled()
+    })
+
+    test('lets a click outside the reader reach document handlers', () => {
+      const wrapper = mountHost(vi.fn())
+      const onDocClick = vi.fn()
+      document.addEventListener('click', onDocClick, true)
+
+      const outside = document.createElement('button')
+      document.body.appendChild(outside)
+      outside.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+      document.removeEventListener('click', onDocClick, true)
+      outside.remove()
+      wrapper.unmount()
+      expect(onDocClick).toHaveBeenCalled()
+    })
+  })
+
+  describe('playhead from active word', () => {
+    test('scrolls the active word into view when active_word changes', async () => {
+      const wrapper = mountHost()
+
+      await wrapper.setProps({ activeWord: 1 })
+
+      expect(scroll_into_view).toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/integration/views/audio-reader/transcript/index.test.js
+++ b/tests/integration/views/audio-reader/transcript/index.test.js
@@ -1,0 +1,147 @@
+import { describe, test, expect, vi, afterEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import TranscriptView from '@/views/audio-reader/transcript/index.vue'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const word = (display, index, start = index) => ({ display, start, index })
+
+const sentence = (index, sentenceText, words, extra = {}) => ({
+  index,
+  sentence: sentenceText,
+  start: index,
+  end: index + 1,
+  words,
+  ...extra
+})
+
+// Two paragraphs: [[s0], [s1, s2]]
+function makeParagraphs() {
+  return [
+    [sentence(0, 'Hello world.', [word('Hello ', 0), word('world.', 1)])],
+    [
+      sentence(1, 'How are you?', [word('How ', 2), word('are ', 3), word('you?', 4)]),
+      sentence(2, 'Fine thanks.', [word('Fine ', 5), word('thanks.', 6)])
+    ]
+  ]
+}
+
+function mountView(props = {}) {
+  return mount(TranscriptView, {
+    props: {
+      paragraphs: makeParagraphs(),
+      active_word: -1,
+      ...props
+    }
+  })
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('TranscriptView', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('paragraph rendering', () => {
+    test('renders one paragraph element per paragraph', () => {
+      const wrapper = mountView()
+      expect(wrapper.findAll('[data-testid="transcript-view__paragraph"]')).toHaveLength(2)
+    })
+
+    test('renders one transcript-segment per sentence across all paragraphs', () => {
+      const wrapper = mountView()
+      expect(wrapper.findAll('[data-testid="transcript-segment"]')).toHaveLength(3)
+    })
+
+    test('assigns data-index matching each sentence index', () => {
+      const wrapper = mountView()
+      const segments = wrapper.findAll('[data-testid="transcript-segment"]')
+      expect(segments[0].attributes('data-index')).toBe('0')
+      expect(segments[1].attributes('data-index')).toBe('1')
+      expect(segments[2].attributes('data-index')).toBe('2')
+    })
+  })
+
+  describe('highlight layers', () => {
+    test('renders a playhead and a hover layer as separate coexisting elements', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('[data-testid="transcript-view__playhead"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="transcript-view__hover"]').exists()).toBe(true)
+    })
+
+    test('words expose a stable data-word-index for the layers to target', () => {
+      const wrapper = mountView()
+      const words = wrapper.findAll('[data-testid="transcript-word"]')
+      expect(words.map((w) => w.attributes('data-word-index'))).toEqual([
+        '0',
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6'
+      ])
+    })
+  })
+
+  describe('word-range selection → select emit', () => {
+    // Drag (or click, when from === to) word indices via pointer events. The
+    // composable hit-tests with elementFromPoint, mapped here onto each word so
+    // the gesture is deterministic, not layout-bound.
+    function select(wrapper, from, to) {
+      const wordEls = wrapper.findAll('[data-testid="transcript-word"]').map((w) => w.element)
+      vi.spyOn(document, 'elementFromPoint').mockImplementation((x) => wordEls[x] ?? null)
+
+      const fire = (type, index, buttons) =>
+        wordEls[index].dispatchEvent(
+          new PointerEvent(type, {
+            bubbles: true,
+            pointerId: 1,
+            buttons,
+            clientX: index,
+            clientY: 0
+          })
+        )
+
+      fire('pointerdown', from, 1)
+      if (to !== from) fire('pointermove', to, 1)
+      fire('pointerup', to, 0)
+      return wrapper.vm.$nextTick()
+    }
+
+    test('a drag across words emits the joined term, anchor sentence, and a rect', async () => {
+      const wrapper = mountView()
+
+      await select(wrapper, 0, 1)
+
+      expect(wrapper.emitted('select')).toBeTruthy()
+      const [payload] = wrapper.emitted('select')[0]
+      expect(payload.term).toBe('Hello world')
+      expect(payload.sentence).toBe('Hello world.')
+      expect(payload.rect).toBeDefined()
+    })
+
+    test('a click on a single word emits that word and its sentence', async () => {
+      const wrapper = mountView()
+
+      await select(wrapper, 2, 2)
+
+      const [payload] = wrapper.emitted('select')[0]
+      expect(payload.term).toBe('How')
+      expect(payload.sentence).toBe('How are you?')
+    })
+
+    test('does NOT emit when the press lands off any word', async () => {
+      const wrapper = mountView()
+      vi.spyOn(document, 'elementFromPoint').mockReturnValue(null)
+
+      const content = wrapper.find('[data-testid="transcript-view__content"]').element
+      content.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }))
+      content.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }))
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.emitted('select')).toBeFalsy()
+    })
+  })
+})

--- a/tests/integration/views/audio-reader/transcript/segment.test.js
+++ b/tests/integration/views/audio-reader/transcript/segment.test.js
@@ -1,0 +1,69 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import TranscriptSegment from '@/views/audio-reader/transcript/segment.vue'
+import TranscriptWord from '@/views/audio-reader/transcript/word.vue'
+
+const word = (display, index, start = index) => ({ display, start, index })
+
+const group = (words = [word('Hello ', 0), word('world', 1)], extra = {}) => ({
+  sentence: 'Hello world',
+  start: 0,
+  end: 2,
+  words,
+  ...extra
+})
+
+function mountSegment(props = {}) {
+  return shallowMount(TranscriptSegment, {
+    props: {
+      group: group(),
+      index: 0,
+      ...props
+    }
+  })
+}
+
+describe('TranscriptSegment', () => {
+  describe('rendering', () => {
+    test('exposes data-index matching the index prop', () => {
+      const wrapper = mountSegment({ index: 3 })
+      expect(wrapper.find('[data-testid="transcript-segment"]').attributes('data-index')).toBe('3')
+    })
+
+    test('renders one TranscriptWord per word in the group', () => {
+      const wrapper = mountSegment()
+      expect(wrapper.findAllComponents(TranscriptWord)).toHaveLength(2)
+    })
+
+    test('passes each word display through to TranscriptWord', () => {
+      const wrapper = mountSegment()
+      const words = wrapper.findAllComponents(TranscriptWord)
+      expect(words[0].props('display')).toBe('Hello ')
+      expect(words[1].props('display')).toBe('world')
+    })
+  })
+
+  describe('word identity', () => {
+    test('passes each word global index through to TranscriptWord', () => {
+      const wrapper = mountSegment({ group: group([word('is ', 4), word('here.', 5)]) })
+      const words = wrapper.findAllComponents(TranscriptWord)
+      expect(words[0].props('index')).toBe(4)
+      expect(words[1].props('index')).toBe(5)
+    })
+  })
+
+  describe('translation line', () => {
+    test('renders translation element when group.translation is set', () => {
+      const wrapper = mountSegment({ group: group(undefined, { translation: 'こんにちは世界' }) })
+      expect(wrapper.find('[data-testid="transcript-segment__translation"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="transcript-segment__translation"]').text()).toBe(
+        'こんにちは世界'
+      )
+    })
+
+    test('omits translation element when group.translation is absent', () => {
+      const wrapper = mountSegment()
+      expect(wrapper.find('[data-testid="transcript-segment__translation"]').exists()).toBe(false)
+    })
+  })
+})

--- a/tests/integration/views/audio-reader/transcript/word.test.js
+++ b/tests/integration/views/audio-reader/transcript/word.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import TranscriptWord from '@/views/audio-reader/transcript/word.vue'
+
+function mountWord(props = {}) {
+  return shallowMount(TranscriptWord, {
+    props: {
+      display: 'cat ',
+      index: 0,
+      ...props
+    }
+  })
+}
+
+describe('TranscriptWord', () => {
+  test('renders the display text verbatim', () => {
+    const wrapper = mountWord({ display: '猫' })
+    expect(wrapper.find('[data-testid="transcript-word"]').text()).toBe('猫')
+  })
+
+  test('exposes its global index as a stable data-word-index handle', () => {
+    const wrapper = mountWord({ index: 7 })
+    expect(wrapper.find('[data-testid="transcript-word"]').attributes('data-word-index')).toBe('7')
+  })
+})

--- a/tests/unit/composables/audio-reader/use-audio-player.test.js
+++ b/tests/unit/composables/audio-reader/use-audio-player.test.js
@@ -1,0 +1,333 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { ref, nextTick } from 'vue'
+import { createApp } from 'vue'
+
+// Stub rAF/cAF so tick() doesn't spin in jsdom
+let rafCallback = null
+vi.stubGlobal(
+  'requestAnimationFrame',
+  vi.fn((cb) => {
+    rafCallback = cb
+    return 1
+  })
+)
+vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+const { useAudioPlayer } = await import('@/composables/audio-reader/use-audio-player')
+
+// Helper: run the composable inside a real Vue app so watch() + onUnmounted work
+function withSetup(composable) {
+  let result
+  const app = createApp({
+    setup() {
+      result = composable()
+      return () => null
+    }
+  })
+  app.mount(document.createElement('div'))
+  return [result, app]
+}
+
+// Helper: create a minimal fake HTMLAudioElement
+function makeAudioEl() {
+  const handlers = {}
+  return {
+    currentTime: 0,
+    duration: 120,
+    readyState: 0, // HAVE_NOTHING — won't trigger onLoaded on bind
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    addEventListener: vi.fn((event, cb) => {
+      handlers[event] = cb
+    }),
+    removeEventListener: vi.fn((event) => {
+      delete handlers[event]
+    }),
+    _emit(event) {
+      handlers[event]?.()
+    }
+  }
+}
+
+describe('useAudioPlayer', () => {
+  let app
+
+  afterEach(() => {
+    app?.unmount()
+    rafCallback = null
+    requestAnimationFrame.mockClear()
+    cancelAnimationFrame.mockClear()
+  })
+
+  describe('initial state', () => {
+    test('current_time starts at 0', () => {
+      const target = ref(null)
+      ;[, app] = withSetup(() => useAudioPlayer(target))
+      const [result] = withSetup(() => useAudioPlayer(ref(null)))
+      expect(result.current_time.value).toBe(0)
+    })
+
+    test('is_playing starts as false', () => {
+      const [result, a] = withSetup(() => useAudioPlayer(ref(null)))
+      app = a
+      expect(result.is_playing.value).toBe(false)
+    })
+
+    test('duration starts at 0', () => {
+      const [result, a] = withSetup(() => useAudioPlayer(ref(null)))
+      app = a
+      expect(result.duration.value).toBe(0)
+    })
+  })
+
+  describe('binding to an audio element', () => {
+    test('attaches event listeners when target ref is set', async () => {
+      const target = ref(null)
+      const [, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      expect(el.addEventListener).toHaveBeenCalledWith('loadedmetadata', expect.any(Function))
+      expect(el.addEventListener).toHaveBeenCalledWith('play', expect.any(Function))
+      expect(el.addEventListener).toHaveBeenCalledWith('pause', expect.any(Function))
+      expect(el.addEventListener).toHaveBeenCalledWith('ended', expect.any(Function))
+      expect(el.addEventListener).toHaveBeenCalledWith('timeupdate', expect.any(Function))
+    })
+
+    test('removes event listeners when target ref becomes null', async () => {
+      const target = ref(null)
+      const [, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      target.value = null
+      await nextTick()
+
+      expect(el.removeEventListener).toHaveBeenCalledWith('loadedmetadata', expect.any(Function))
+      expect(el.removeEventListener).toHaveBeenCalledWith('play', expect.any(Function))
+      expect(el.removeEventListener).toHaveBeenCalledWith('pause', expect.any(Function))
+      expect(el.removeEventListener).toHaveBeenCalledWith('ended', expect.any(Function))
+      expect(el.removeEventListener).toHaveBeenCalledWith('timeupdate', expect.any(Function))
+    })
+
+    test('removes event listeners on unmount', async () => {
+      const target = ref(null)
+      const [, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      a.unmount()
+      app = null
+
+      expect(el.removeEventListener).toHaveBeenCalledWith('play', expect.any(Function))
+    })
+
+    test('reads duration from element when readyState >= 1 on bind', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      el.readyState = 1
+      el.duration = 180
+      target.value = el
+      await nextTick()
+
+      expect(result.duration.value).toBe(180)
+    })
+  })
+
+  describe('play and pause events', () => {
+    test('sets is_playing to true when play event fires', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      el._emit('play')
+      expect(result.is_playing.value).toBe(true)
+    })
+
+    test('sets is_playing to false when pause event fires', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      el._emit('play')
+      el._emit('pause')
+      expect(result.is_playing.value).toBe(false)
+    })
+
+    test('sets is_playing to false when ended event fires', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      el._emit('play')
+      el._emit('ended')
+      expect(result.is_playing.value).toBe(false)
+    })
+
+    test('starts rAF loop when play fires', async () => {
+      const target = ref(null)
+      const [, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      requestAnimationFrame.mockClear()
+      el._emit('play')
+
+      expect(requestAnimationFrame).toHaveBeenCalled()
+    })
+
+    test('cancels rAF loop when pause fires', async () => {
+      const target = ref(null)
+      const [, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      el._emit('play')
+      cancelAnimationFrame.mockClear()
+      el._emit('pause')
+
+      expect(cancelAnimationFrame).toHaveBeenCalled()
+    })
+  })
+
+  describe('seek()', () => {
+    test('sets el.currentTime to the given seconds', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      result.seek(42)
+      expect(el.currentTime).toBe(42)
+    })
+
+    test('updates current_time immediately without waiting for timeupdate', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      result.seek(55)
+      expect(result.current_time.value).toBe(55)
+    })
+
+    test('is a no-op when no element is bound', () => {
+      const [result, a] = withSetup(() => useAudioPlayer(ref(null)))
+      app = a
+      // Must not throw
+      result.seek(10)
+      expect(result.current_time.value).toBe(0)
+    })
+  })
+
+  describe('play() and pause() call-through', () => {
+    test('play() calls el.play()', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      result.play()
+      expect(el.play).toHaveBeenCalled()
+    })
+
+    test('pause() calls el.pause()', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      result.pause()
+      expect(el.pause).toHaveBeenCalled()
+    })
+
+    test('play() is a no-op when no element is bound', () => {
+      const [result, a] = withSetup(() => useAudioPlayer(ref(null)))
+      app = a
+      // Must not throw
+      result.play()
+    })
+
+    test('pause() is a no-op when no element is bound', () => {
+      const [result, a] = withSetup(() => useAudioPlayer(ref(null)))
+      app = a
+      // Must not throw
+      result.pause()
+    })
+  })
+
+  describe('timeupdate event', () => {
+    test('updates current_time from el.currentTime while paused', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      el.currentTime = 30
+      el._emit('timeupdate')
+      expect(result.current_time.value).toBe(30)
+    })
+
+    test('does NOT update current_time from timeupdate while playing (rAF handles it)', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      el._emit('play') // is_playing = true
+      result.seek(0) // reset current_time to 0
+      el.currentTime = 99
+      el._emit('timeupdate')
+      // timeupdate is ignored while playing; current_time stays 0
+      expect(result.current_time.value).toBe(0)
+    })
+  })
+})

--- a/tests/unit/composables/audio-reader/use-lesson-reader.test.js
+++ b/tests/unit/composables/audio-reader/use-lesson-reader.test.js
@@ -1,0 +1,140 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
+import { createApp, ref, nextTick } from 'vue'
+
+const { lessonQueryMock, audioUrlQueryMock, audioPlayerMock, transcriptSyncMock, toastErrorMock } =
+  vi.hoisted(() => ({
+    lessonQueryMock: vi.fn(),
+    audioUrlQueryMock: vi.fn(),
+    audioPlayerMock: vi.fn(),
+    transcriptSyncMock: vi.fn(),
+    toastErrorMock: vi.fn()
+  }))
+
+vi.mock('@/api/lessons', () => ({
+  useLessonQuery: lessonQueryMock,
+  useLessonAudioUrlQuery: audioUrlQueryMock
+}))
+vi.mock('@/composables/toast', () => ({ useToast: () => ({ error: toastErrorMock }) }))
+vi.mock('@/composables/audio-reader/use-audio-player', () => ({ useAudioPlayer: audioPlayerMock }))
+vi.mock('@/composables/audio-reader/use-transcript-sync', () => ({
+  useTranscriptSync: transcriptSyncMock
+}))
+
+// The transcript utils are pure and left real, so paragraph shaping is tested end to end.
+import { useLessonReader } from '@/composables/audio-reader/use-lesson-reader'
+
+function makeLesson(overrides = {}) {
+  return {
+    id: 1,
+    title: 'Lesson 1',
+    audio_path: 'lessons/1.mp3',
+    transcript: {
+      text: 'Hello world. How are you?',
+      segments: [
+        { start: 0, end: 1, text: 'Hello world.' },
+        { start: 1, end: 2, text: 'How are you?' }
+      ],
+      words: [
+        { word: 'Hello', start: 0, end: 0.5 },
+        { word: 'world', start: 0.5, end: 1 },
+        { word: 'How', start: 1, end: 1.3 },
+        { word: 'are', start: 1.3, end: 1.6 },
+        { word: 'you', start: 1.6, end: 2 }
+      ]
+    },
+    ...overrides
+  }
+}
+
+// useTemplateRef + watch need a component instance, so drive the composable
+// through a mounted host (see testing-composables rule).
+function withReader(id = () => 1) {
+  let reader
+  const app = createApp({
+    setup() {
+      reader = useLessonReader(id)
+      return () => {}
+    }
+  })
+  app.mount(document.createElement('div'))
+  return [reader, app]
+}
+
+describe('useLessonReader', () => {
+  let app
+
+  beforeEach(() => {
+    lessonQueryMock.mockReturnValue({ data: ref(makeLesson()), error: ref(null) })
+    audioUrlQueryMock.mockReturnValue({ data: ref('https://cdn/1.mp3') })
+    audioPlayerMock.mockReturnValue({ current_time: ref(0) })
+    transcriptSyncMock.mockReturnValue({ active_index: ref(-1) })
+    toastErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    app?.unmount()
+  })
+
+  describe('transcript shaping', () => {
+    test('shapes the lesson transcript into paragraphs of sentences', () => {
+      let reader
+      ;[reader, app] = withReader()
+
+      const paragraphs = reader.paragraphs.value
+      const sentences = paragraphs.flat()
+      expect(sentences).toHaveLength(2)
+      expect(sentences[0].sentence).toBe('Hello world.')
+      expect(sentences.flatMap((s) => s.words)).toHaveLength(5)
+    })
+
+    test('is empty before the lesson resolves', () => {
+      lessonQueryMock.mockReturnValue({ data: ref(undefined), error: ref(null) })
+
+      let reader
+      ;[reader, app] = withReader()
+
+      expect(reader.paragraphs.value).toEqual([])
+    })
+  })
+
+  describe('playback wiring', () => {
+    test('exposes the streamed audio url and the synced active word', () => {
+      transcriptSyncMock.mockReturnValue({ active_index: ref(3) })
+
+      let reader
+      ;[reader, app] = withReader()
+
+      expect(reader.audio_url.value).toBe('https://cdn/1.mp3')
+      expect(reader.active_word.value).toBe(3)
+    })
+  })
+
+  describe('term popover', () => {
+    test('openTerm stores the selection and opens; closeTerm closes', () => {
+      let reader
+      ;[reader, app] = withReader()
+      const term = { term: 'world', sentence: 'Hello world.', rect: new DOMRect() }
+
+      reader.openTerm(term)
+      expect(reader.selection.value).toEqual(term)
+      expect(reader.popover_open.value).toBe(true)
+
+      reader.closeTerm()
+      expect(reader.popover_open.value).toBe(false)
+    })
+  })
+
+  describe('error handling', () => {
+    test('surfaces a fetch error through the toast', async () => {
+      const error = ref(null)
+      lessonQueryMock.mockReturnValue({ data: ref(makeLesson()), error })
+
+      ;[, app] = withReader()
+
+      error.value = new Error('lesson exploded')
+      await nextTick()
+
+      expect(toastErrorMock).toHaveBeenCalledWith('lesson exploded')
+    })
+  })
+})

--- a/tests/unit/composables/audio-reader/use-transcript-sync.test.js
+++ b/tests/unit/composables/audio-reader/use-transcript-sync.test.js
@@ -1,0 +1,139 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { ref } from 'vue'
+import { useTranscriptSync } from '@/composables/audio-reader/use-transcript-sync'
+
+const seg = (start, end, text = '') => ({ start, end, text })
+
+describe('useTranscriptSync', () => {
+  describe('empty segments', () => {
+    test('returns -1 when segments array is empty', () => {
+      const { active_index } = useTranscriptSync([], 0)
+      expect(active_index.value).toBe(-1)
+    })
+
+    test('returns -1 for any time when segments array is empty', () => {
+      const { active_index } = useTranscriptSync(() => [], 99)
+      expect(active_index.value).toBe(-1)
+    })
+  })
+
+  describe('t before first segment', () => {
+    test('returns -1 when current_time is before the first segment start', () => {
+      const { active_index } = useTranscriptSync([seg(5, 10)], 4.9)
+      expect(active_index.value).toBe(-1)
+    })
+
+    test('returns -1 when current_time is 0 and first segment starts at 1', () => {
+      const { active_index } = useTranscriptSync([seg(1, 3), seg(5, 8)], 0)
+      expect(active_index.value).toBe(-1)
+    })
+  })
+
+  describe('t exactly at a segment start', () => {
+    test('returns that segment index when t equals start of first segment', () => {
+      const { active_index } = useTranscriptSync([seg(5, 10)], 5)
+      expect(active_index.value).toBe(0)
+    })
+
+    test('returns the correct index when t equals start of a middle segment', () => {
+      const segs = [seg(0, 2), seg(5, 8), seg(10, 15)]
+      const { active_index } = useTranscriptSync(segs, 5)
+      expect(active_index.value).toBe(1)
+    })
+
+    test('returns the last index when t equals start of the last segment', () => {
+      const segs = [seg(0, 2), seg(5, 8), seg(10, 15)]
+      const { active_index } = useTranscriptSync(segs, 10)
+      expect(active_index.value).toBe(2)
+    })
+  })
+
+  describe('t inside a segment', () => {
+    test('returns the active segment index when t is between start and end', () => {
+      const segs = [seg(0, 3), seg(5, 10), seg(12, 20)]
+      const { active_index } = useTranscriptSync(segs, 7)
+      expect(active_index.value).toBe(1)
+    })
+
+    test('returns 0 when t is inside the first and only segment', () => {
+      const { active_index } = useTranscriptSync([seg(0, 10)], 5)
+      expect(active_index.value).toBe(0)
+    })
+  })
+
+  describe('t in a gap after a segment has started', () => {
+    test('holds the last started segment active through a silent gap', () => {
+      // Segment 0 ends at 3, segment 1 starts at 8 — gap is [3, 8)
+      const segs = [seg(0, 3), seg(8, 12)]
+      const { active_index } = useTranscriptSync(segs, 5)
+      // Segment 0 has started (start=0 <= 5), segment 1 has not (start=8 > 5)
+      expect(active_index.value).toBe(0)
+    })
+
+    test('transitions to the next segment when t reaches its start', () => {
+      const segs = [seg(0, 3), seg(8, 12)]
+      const { active_index } = useTranscriptSync(segs, 8)
+      expect(active_index.value).toBe(1)
+    })
+  })
+
+  describe('t past the last segment', () => {
+    test('holds the last segment active when t exceeds its end', () => {
+      const segs = [seg(0, 2), seg(5, 8)]
+      const { active_index } = useTranscriptSync(segs, 100)
+      expect(active_index.value).toBe(1)
+    })
+
+    test('returns 0 (last segment index) when only one segment and t is past it', () => {
+      const { active_index } = useTranscriptSync([seg(2, 5)], 99)
+      expect(active_index.value).toBe(0)
+    })
+  })
+
+  describe('reactivity', () => {
+    test('active_index updates when current_time ref changes', () => {
+      const segs = [seg(0, 3), seg(5, 8), seg(10, 15)]
+      const t = ref(0)
+      const { active_index } = useTranscriptSync(segs, t)
+
+      expect(active_index.value).toBe(0)
+
+      t.value = 5
+      expect(active_index.value).toBe(1)
+
+      t.value = 10
+      expect(active_index.value).toBe(2)
+    })
+
+    test('active_index updates when segments getter returns new array', () => {
+      const segs = ref([seg(0, 3)])
+      const { active_index } = useTranscriptSync(() => segs.value, 10)
+
+      // Only one segment so far — index 0 is the latest started
+      expect(active_index.value).toBe(0)
+
+      segs.value = [seg(0, 3), seg(5, 8), seg(8, 15)]
+      expect(active_index.value).toBe(2)
+    })
+
+    test('returns -1 reactively when segments become empty', () => {
+      const segs = ref([seg(0, 5)])
+      const { active_index } = useTranscriptSync(() => segs.value, 2)
+
+      expect(active_index.value).toBe(0)
+
+      segs.value = []
+      expect(active_index.value).toBe(-1)
+    })
+
+    test('accepts a getter for current_time and reacts to its backing ref', () => {
+      const t = ref(0)
+      const { active_index } = useTranscriptSync([seg(10, 20)], () => t.value)
+
+      expect(active_index.value).toBe(-1)
+
+      t.value = 10
+      expect(active_index.value).toBe(0)
+    })
+  })
+})

--- a/tests/unit/utils/transcript.test.js
+++ b/tests/unit/utils/transcript.test.js
@@ -1,0 +1,291 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { groupWordsBySentence, groupSentencesIntoParagraphs, cleanTerm } from '@/utils/transcript'
+
+const seg = (start, end, text) => ({ start, end, text })
+const w = (word, start) => ({ word, start, end: start + 0.3 })
+
+describe('groupWordsBySentence', () => {
+  describe('grouping words under their sentence', () => {
+    test('returns one group per segment, in order', () => {
+      const segments = [seg(0, 2, 'The cat'), seg(2, 4, 'is here.')]
+      const words = [w('The', 0), w('cat', 0.6), w('is', 2), w('here', 2.5)]
+
+      const groups = groupWordsBySentence(segments, words)
+
+      expect(groups).toHaveLength(2)
+      expect(groups.map((g) => g.sentence)).toEqual(['The cat', 'is here.'])
+      expect(groups.map((g) => g.start)).toEqual([0, 2])
+    })
+
+    test('assigns each word to the segment whose time span contains its start', () => {
+      const segments = [seg(0, 2, 'The cat'), seg(2, 4, 'is here.')]
+      const words = [w('The', 0), w('cat', 0.6), w('is', 2), w('here', 2.5)]
+
+      const groups = groupWordsBySentence(segments, words)
+
+      expect(groups[0].words.map((x) => x.display.trim())).toEqual(['The', 'cat'])
+      expect(groups[1].words.map((x) => x.display.trim())).toEqual(['is', 'here.'])
+    })
+
+    test('keeps each word global index (its position in the flat words array)', () => {
+      const segments = [seg(0, 2, 'The cat'), seg(2, 4, 'is here.')]
+      const words = [w('The', 0), w('cat', 0.6), w('is', 2), w('here', 2.5)]
+
+      const groups = groupWordsBySentence(segments, words)
+
+      expect(groups[0].words.map((x) => x.index)).toEqual([0, 1])
+      expect(groups[1].words.map((x) => x.index)).toEqual([2, 3])
+    })
+
+    test('first segment claims words that start before it; last claims words after it', () => {
+      const segments = [seg(1, 2, 'one'), seg(2, 3, 'two')]
+      const words = [w('one', 0.4), w('two', 5)]
+
+      const groups = groupWordsBySentence(segments, words)
+
+      expect(groups[0].words.map((x) => x.index)).toEqual([0])
+      expect(groups[1].words.map((x) => x.index)).toEqual([1])
+    })
+  })
+
+  describe('display reconstruction preserves the sentence verbatim', () => {
+    test('keeps spaces between space-delimited words', () => {
+      const groups = groupWordsBySentence(
+        [seg(0, 2, 'The quick fox')],
+        [w('The', 0), w('quick', 0.5), w('fox', 1)]
+      )
+
+      expect(groups[0].words.map((x) => x.display)).toEqual(['The ', 'quick ', 'fox'])
+    })
+
+    test('retains sentence-final punctuation on the last word', () => {
+      const groups = groupWordsBySentence([seg(0, 2, 'is here.')], [w('is', 0), w('here', 0.5)])
+
+      expect(groups[0].words.map((x) => x.display)).toEqual(['is ', 'here.'])
+    })
+
+    test('keeps mid-sentence punctuation attached to a word', () => {
+      const groups = groupWordsBySentence(
+        [seg(0, 2, 'Hello, world')],
+        [w('Hello', 0), w('world', 0.5)]
+      )
+
+      expect(groups[0].words.map((x) => x.display)).toEqual(['Hello, ', 'world'])
+    })
+
+    test('inserts no spaces for space-less scripts (Japanese)', () => {
+      const groups = groupWordsBySentence(
+        [seg(0, 2, '猫がいる')],
+        [w('猫', 0), w('が', 0.3), w('いる', 0.6)]
+      )
+
+      expect(groups[0].words.map((x) => x.display)).toEqual(['猫', 'が', 'いる'])
+    })
+
+    test('slices tile the whole sentence with nothing lost', () => {
+      const text = 'A B, c.'
+      const groups = groupWordsBySentence([seg(0, 2, text)], [w('A', 0), w('B', 0.3), w('c', 0.6)])
+
+      expect(groups[0].words.map((x) => x.display).join('')).toBe(text)
+    })
+  })
+
+  describe('edge cases', () => {
+    test('returns no groups when there are no segments', () => {
+      expect(groupWordsBySentence([], [w('hi', 0)])).toEqual([])
+    })
+
+    test('yields a group with no words when the transcript has no word timings', () => {
+      const groups = groupWordsBySentence([seg(0, 2, 'no words')], [])
+
+      expect(groups).toHaveLength(1)
+      expect(groups[0].words).toEqual([])
+    })
+
+    test('still renders the sentence verbatim when a word is not found in the text', () => {
+      const groups = groupWordsBySentence([seg(0, 2, 'five apples')], [w('5', 0), w('apples', 0.5)])
+
+      const displays = groups[0].words.map((x) => x.display)
+      expect(displays).toHaveLength(2)
+      expect(displays.join('')).toBe('five apples')
+    })
+  })
+})
+
+describe('groupWordsBySentence — translation passthrough', () => {
+  test('copies translation from the segment onto the sentence group', () => {
+    const segments = [
+      { start: 0, end: 2, text: 'Hello world', translation: 'こんにちは世界' },
+      { start: 2, end: 4, text: 'How are you', translation: 'お元気ですか' }
+    ]
+    const words = [w('Hello', 0), w('world', 0.6), w('How', 2), w('are', 2.4), w('you', 2.8)]
+
+    const groups = groupWordsBySentence(segments, words)
+
+    expect(groups[0].translation).toBe('こんにちは世界')
+    expect(groups[1].translation).toBe('お元気ですか')
+  })
+
+  test('leaves translation undefined when the segment has none', () => {
+    const groups = groupWordsBySentence([seg(0, 2, 'The cat')], [w('The', 0), w('cat', 0.6)])
+
+    expect(groups[0].translation).toBeUndefined()
+  })
+})
+
+describe('groupWordsBySentence — inter-sentence spacing invariant', () => {
+  test('preserves the space between sentences in the word display slices', () => {
+    // "Hello world. How are you?" — ". " between sentences stays on the last
+    // word of sentence 1, not dropped.
+    const text = 'Hello world. How are you?'
+    const segments = [
+      { start: 0, end: 1.5, text: 'Hello world.' },
+      { start: 1.5, end: 3, text: 'How are you?' }
+    ]
+    const words = [w('Hello', 0), w('world', 0.6), w('How', 1.5), w('are', 1.9), w('you', 2.3)]
+
+    const groups = groupWordsBySentence(segments, words, text)
+
+    // The two groups together reproduce the full text verbatim
+    const allDisplay = groups.flatMap((g) => g.words.map((x) => x.display)).join('')
+    expect(allDisplay).toBe(text)
+
+    // The period + space that sits between sentences belongs to sentence 1's last word
+    expect(groups[0].words.at(-1).display).toBe('world. ')
+    // Sentence 2 starts clean, no leading space swallowed
+    expect(groups[1].words[0].display).toBe('How ')
+  })
+
+  test('inserts no space between sentences for space-less scripts (Japanese)', () => {
+    // "猫がいる。犬もいる。" — no space separating the sentences
+    const text = '猫がいる。犬もいる。'
+    const segments = [
+      { start: 0, end: 1, text: '猫がいる。' },
+      { start: 1, end: 2, text: '犬もいる。' }
+    ]
+    const words = [
+      w('猫', 0),
+      w('が', 0.2),
+      w('いる', 0.4),
+      w('犬', 1),
+      w('も', 1.2),
+      w('いる', 1.4)
+    ]
+
+    const groups = groupWordsBySentence(segments, words, text)
+
+    const allDisplay = groups.flatMap((g) => g.words.map((x) => x.display)).join('')
+    expect(allDisplay).toBe(text)
+
+    // Last word of sentence 1 takes the closing punctuation with no trailing space
+    expect(groups[0].words.at(-1).display).toBe('いる。')
+    // First word of sentence 2 has no leading space
+    expect(groups[1].words[0].display).toBe('犬')
+  })
+})
+
+describe('groupSentencesIntoParagraphs', () => {
+  const sentence = (index, start, end) => ({
+    index,
+    sentence: `sentence ${index}`,
+    start,
+    end,
+    words: []
+  })
+
+  test('the first sentence always starts a new paragraph', () => {
+    const sentences = [sentence(0, 0, 1)]
+    const paragraphs = groupSentencesIntoParagraphs(sentences)
+
+    expect(paragraphs).toHaveLength(1)
+    expect(paragraphs[0]).toHaveLength(1)
+  })
+
+  test('returns an empty array for an empty input', () => {
+    expect(groupSentencesIntoParagraphs([])).toEqual([])
+  })
+
+  test('keeps sentences with a gap <= threshold in the same paragraph', () => {
+    // gap = 0.5, threshold default = 0.8 → same paragraph
+    const sentences = [sentence(0, 0, 1), sentence(1, 1.5, 2.5), sentence(2, 3, 4)]
+    const paragraphs = groupSentencesIntoParagraphs(sentences)
+
+    expect(paragraphs).toHaveLength(1)
+    expect(paragraphs[0]).toHaveLength(3)
+  })
+
+  test('starts a new paragraph when the gap exceeds the threshold', () => {
+    // gap = 1.2 > 0.8 → new paragraph
+    const sentences = [sentence(0, 0, 1), sentence(1, 2.2, 3)]
+    const paragraphs = groupSentencesIntoParagraphs(sentences)
+
+    expect(paragraphs).toHaveLength(2)
+    expect(paragraphs[0]).toHaveLength(1)
+    expect(paragraphs[1]).toHaveLength(1)
+  })
+
+  test('does NOT split when gap equals exactly the threshold', () => {
+    // gap = 0.8, threshold = 0.8 — "> gap" is strict, equal stays together
+    const sentences = [sentence(0, 0, 1), sentence(1, 1.8, 2.5)]
+    const paragraphs = groupSentencesIntoParagraphs(sentences)
+
+    expect(paragraphs).toHaveLength(1)
+  })
+
+  test('splits at the right sentence when only one gap in many exceeds threshold', () => {
+    const sentences = [
+      sentence(0, 0, 1),
+      sentence(1, 1.3, 2.1),
+      sentence(2, 2.3, 3), // gap from s1: 0.2 — same paragraph
+      sentence(3, 4.5, 5.5) // gap from s2: 1.5 > 0.8 — new paragraph
+    ]
+    const paragraphs = groupSentencesIntoParagraphs(sentences)
+
+    expect(paragraphs).toHaveLength(2)
+    expect(paragraphs[0]).toHaveLength(3)
+    expect(paragraphs[1]).toHaveLength(1)
+    expect(paragraphs[1][0].index).toBe(3)
+  })
+
+  test('respects a custom gap threshold', () => {
+    // gap = 0.5 — below default 0.8 but above custom 0.3
+    const sentences = [sentence(0, 0, 1), sentence(1, 1.5, 2)]
+    const paragraphs = groupSentencesIntoParagraphs(sentences, 0.3)
+
+    expect(paragraphs).toHaveLength(2)
+  })
+
+  test('preserves all sentences across paragraphs', () => {
+    const sentences = [sentence(0, 0, 1), sentence(1, 2, 3), sentence(2, 4, 5), sentence(3, 5.2, 6)]
+    const flat = groupSentencesIntoParagraphs(sentences).flat()
+
+    expect(flat).toHaveLength(4)
+    expect(flat.map((s) => s.index)).toEqual([0, 1, 2, 3])
+  })
+})
+
+describe('cleanTerm', () => {
+  test('strips trailing punctuation and whitespace', () => {
+    expect(cleanTerm('world. ')).toBe('world')
+    expect(cleanTerm('you?')).toBe('you')
+  })
+
+  test('strips leading punctuation', () => {
+    expect(cleanTerm('"Hello')).toBe('Hello')
+  })
+
+  test('strips CJK punctuation', () => {
+    expect(cleanTerm('你好，')).toBe('你好')
+    expect(cleanTerm('吗？')).toBe('吗')
+  })
+
+  test('keeps punctuation inside a term', () => {
+    expect(cleanTerm("don't.")).toBe("don't")
+    expect(cleanTerm('well-being,')).toBe('well-being')
+  })
+
+  test('returns empty string for punctuation-only tokens', () => {
+    expect(cleanTerm('…')).toBe('')
+    expect(cleanTerm('  ')).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Adds the audio-reader lesson view: transcript grouping utils, an audio-player composable, transcript-sync with a floating highlight cursor, and independent playhead/hover highlight layers rendered over a paragraph transcript. Registers the `audio-reader/:id` route.

Stacked on #233.