### PR TITLE
feat(audio-reader): dashboard library section and upload flow

### DIFF
--- a/src/components/modals/upload-lesson/index.vue
+++ b/src/components/modals/upload-lesson/index.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import UiButton from '@/components/ui-kit/button.vue'
+import UiInput from '@/components/ui-kit/input.vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
+import MobileSheet from '@/components/layout-kit/modal/mobile-sheet.vue'
+import ScriptSelect from './script-select.vue'
+import { useCreateLessonMutation, EdgeFunctionError, type CreateLessonPhase } from '@/api/lessons'
+
+export type UploadLessonResponse = Lesson | undefined
+
+// Whisper's per-file cap (also the bucket's file_size_limit). Validated here so
+// an over-cap file fails instantly instead of after an upload round-trip.
+const MAX_BYTES = 26214400
+
+const { close } = defineProps<{
+  close: (response?: UploadLessonResponse) => void
+}>()
+
+const { t } = useI18n()
+const create = useCreateLessonMutation()
+
+const title = ref('')
+const file = ref<File | null>(null)
+const script = ref<TranscriptScript>('original')
+const error_key = ref<string | null>(null)
+const phase = ref<CreateLessonPhase | null>(null)
+
+const can_submit = computed(() => title.value.trim().length > 0 && file.value !== null)
+const is_uploading = computed(() => phase.value !== null)
+const submit_label = computed(() => {
+  if (phase.value === 'translating') return 'audio-reader.upload.translating-button'
+  if (phase.value === 'transcribing') return 'audio-reader.upload.uploading-button'
+  return 'audio-reader.upload.submit-button'
+})
+
+function onFileChange(event: Event) {
+  error_key.value = null
+  const picked = (event.target as HTMLInputElement).files?.[0] ?? null
+
+  if (picked && picked.size > MAX_BYTES) {
+    file.value = null
+    error_key.value = 'audio-reader.upload.too-large-error'
+    return
+  }
+
+  file.value = picked
+  if (picked && !title.value) title.value = picked.name.replace(/\.[^.]+$/, '')
+}
+
+async function onSubmit() {
+  if (!can_submit.value || !file.value) return
+
+  error_key.value = null
+  phase.value = 'transcribing'
+  try {
+    const lesson = await create.mutateAsync({
+      title: title.value.trim(),
+      file: file.value,
+      script: script.value,
+      onPhase: (next) => (phase.value = next)
+    })
+    close(lesson)
+  } catch (error) {
+    error_key.value = errorKeyFor(error)
+  } finally {
+    phase.value = null
+  }
+}
+
+function errorKeyFor(error: unknown): string {
+  if (!(error instanceof EdgeFunctionError)) return 'audio-reader.upload.generic-error'
+  if (error.code === 'file_too_large') return 'audio-reader.upload.too-large-error'
+  if (error.code === 'invalid_audio') return 'audio-reader.upload.invalid-error'
+  return 'audio-reader.upload.generic-error'
+}
+</script>
+
+<template>
+  <mobile-sheet
+    data-testid="upload-lesson-container"
+    data-theme="blue-500"
+    data-theme-dark="blue-650"
+    class="sm:w-150"
+    :title="t('audio-reader.upload.title')"
+    @close="close(undefined)"
+  >
+    <div data-testid="upload-lesson__body" class="flex flex-col gap-5 p-6">
+      <ui-input
+        data-testid="upload-lesson__title"
+        :placeholder="t('audio-reader.upload.title-placeholder')"
+        size="lg"
+        v-model:value="title"
+      />
+
+      <label
+        data-testid="upload-lesson__file"
+        class="flex cursor-pointer items-center gap-3 rounded-7 border-2 border-dashed border-brown-400 p-4 text-brown-600 dark:border-grey-600 dark:text-grey-300"
+      >
+        <ui-icon src="music-note" class="h-5" />
+        <span data-testid="upload-lesson__file-name">
+          {{ file?.name ?? t('audio-reader.upload.file-placeholder') }}
+        </span>
+        <input type="file" accept="audio/*" class="hidden" @change="onFileChange" />
+      </label>
+
+      <script-select v-model="script" />
+
+      <p
+        v-if="error_key"
+        data-testid="upload-lesson__error"
+        class="text-sm text-red-500 dark:text-red-400"
+      >
+        {{ t(error_key) }}
+      </p>
+
+      <div data-testid="upload-lesson__actions" class="flex gap-3">
+        <ui-button
+          data-theme="grey-400"
+          icon-left="close"
+          size="lg"
+          full-width
+          :disabled="is_uploading"
+          @click="close(undefined)"
+        >
+          {{ t('audio-reader.upload.cancel-button') }}
+        </ui-button>
+
+        <ui-button
+          data-theme="blue-500"
+          data-theme-dark="blue-650"
+          icon-left="add"
+          size="lg"
+          full-width
+          :disabled="!can_submit || is_uploading"
+          @click="onSubmit"
+        >
+          {{ t(submit_label) }}
+        </ui-button>
+      </div>
+    </div>
+  </mobile-sheet>
+</template>

--- a/src/components/modals/upload-lesson/script-select.vue
+++ b/src/components/modals/upload-lesson/script-select.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+type ScriptOption = { value: TranscriptScript; label: string }
+
+const OPTIONS: ScriptOption[] = [
+  { value: 'original', label: 'audio-reader.upload.script-original' },
+  { value: 'simplified', label: 'audio-reader.upload.script-simplified' },
+  { value: 'traditional', label: 'audio-reader.upload.script-traditional' }
+]
+
+const script = defineModel<TranscriptScript>({ required: true })
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div data-testid="upload-lesson__script" class="flex flex-col gap-2">
+    <span class="text-sm text-brown-600 dark:text-grey-300">
+      {{ t('audio-reader.upload.script-label') }}
+    </span>
+
+    <div class="flex gap-1 rounded-5 bg-brown-100 p-1 dark:bg-grey-800">
+      <button
+        v-for="option in OPTIONS"
+        :key="option.value"
+        type="button"
+        data-testid="upload-lesson__script-option"
+        :data-value="option.value"
+        :data-active="script === option.value"
+        class="flex-1 cursor-pointer rounded-4 px-3 py-2 text-sm transition-colors data-[active=false]:text-brown-600 data-[active=true]:bg-(--theme-primary) data-[active=true]:text-(--theme-on-primary) data-[active=false]:hover:bg-(--theme-primary)/10 dark:data-[active=false]:text-grey-300"
+        v-sfx="{ hover: 'ui.click_07', click: 'ui.select' }"
+        @click="script = option.value"
+      >
+        {{ t(option.label) }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/composables/modals/use-upload-lesson-modal.ts
+++ b/src/composables/modals/use-upload-lesson-modal.ts
@@ -1,0 +1,25 @@
+import { defineAsyncComponent } from 'vue'
+import { useModal } from '@/composables/modal'
+import { emitSfx } from '@/sfx/bus'
+import type { UploadLessonResponse } from '@/components/modals/upload-lesson/index.vue'
+
+const UploadLesson = defineAsyncComponent(
+  () => import('@/components/modals/upload-lesson/index.vue')
+)
+
+/** Open the upload-lesson modal. Resolves to the created Lesson, or undefined if cancelled. */
+export function useUploadLessonModal() {
+  const modal = useModal()
+
+  function open() {
+    emitSfx('ui.alert_clicks_wooden')
+    const result = modal.open<UploadLessonResponse>(UploadLesson, {
+      backdrop: true,
+      mode: 'mobile-sheet'
+    })
+    result.response.then(() => emitSfx('ui.pop_up_close'))
+    return result
+  }
+
+  return { open }
+}

--- a/src/views/audio-reader/lesson-card.vue
+++ b/src/views/audio-reader/lesson-card.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import UiButton from '@/components/ui-kit/button.vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
+import { formatShortDate } from '@/utils/date'
+
+const { lesson } = defineProps<{ lesson: Lesson }>()
+
+const emit = defineEmits<{
+  (e: 'open'): void
+  (e: 'delete'): void
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    data-testid="lesson-card"
+    class="group relative flex w-56 flex-col gap-3 rounded-7 bg-brown-200 p-4 text-left dark:bg-grey-700"
+  >
+    <button
+      data-testid="lesson-card__open"
+      type="button"
+      class="flex flex-col gap-3"
+      @click="emit('open')"
+    >
+      <span
+        data-testid="lesson-card__icon"
+        class="flex size-10 items-center justify-center rounded-full bg-blue-500 text-white dark:bg-blue-650"
+      >
+        <ui-icon src="music-note" class="h-5" />
+      </span>
+
+      <span
+        data-testid="lesson-card__title"
+        class="line-clamp-2 text-xl text-brown-700 dark:text-brown-200"
+      >
+        {{ lesson.title }}
+      </span>
+
+      <span data-testid="lesson-card__date" class="text-sm text-brown-500 dark:text-grey-400">
+        {{ formatShortDate(lesson.created_at ?? '') }}
+      </span>
+    </button>
+
+    <ui-button
+      data-testid="lesson-card__delete"
+      data-theme="grey-400"
+      icon-left="delete"
+      icon-only
+      size="sm"
+      class="absolute top-3 right-3 opacity-0 group-hover:opacity-100"
+      @click="emit('delete')"
+    >
+      {{ t('audio-reader.lesson-card.delete-button') }}
+    </ui-button>
+  </div>
+</template>

--- a/src/views/dashboard/audio-reader-section.vue
+++ b/src/views/dashboard/audio-reader-section.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import { useLessonsQuery, useDeleteLessonMutation } from '@/api/lessons'
+import { useToast } from '@/composables/toast'
+import { useAlert } from '@/composables/alert'
+import { useUploadLessonModal } from '@/composables/modals/use-upload-lesson-modal'
+import UiButton from '@/components/ui-kit/button.vue'
+import LessonCard from '@/views/audio-reader/lesson-card.vue'
+
+const { t } = useI18n()
+const router = useRouter()
+const toast = useToast()
+const alert = useAlert()
+const upload_modal = useUploadLessonModal()
+const delete_lesson = useDeleteLessonMutation()
+
+const { data: lessons_data, error: lessons_error } = useLessonsQuery()
+const lessons = computed(() => lessons_data.value ?? [])
+
+watch(lessons_error, (err) => {
+  if (err) toast.error(err.message)
+})
+
+function onOpen(lesson: Lesson) {
+  router.push({ name: 'audio-reader-lesson', params: { id: lesson.id } })
+}
+
+async function onUpload() {
+  const lesson = await upload_modal.open().response
+  if (lesson) router.push({ name: 'audio-reader-lesson', params: { id: lesson.id } })
+}
+
+async function onDelete(lesson: Lesson) {
+  const confirmed = await alert.warn({
+    title: t('alert.delete-lesson.title'),
+    message: t('alert.delete-lesson.message'),
+    confirmLabel: t('alert.delete-lesson.confirm'),
+    confirmAudio: 'ui.trash_crumple_short'
+  }).response
+  if (!confirmed) return
+
+  try {
+    await delete_lesson.mutateAsync(lesson.id)
+  } catch {
+    toast.error(t('audio-reader.section.delete-error'))
+  }
+}
+</script>
+
+<template>
+  <section data-testid="audio-reader-section" class="flex flex-col gap-6">
+    <header data-testid="audio-reader-section__header" class="flex items-center justify-between">
+      <h2 class="text-3xl text-brown-700 dark:text-brown-300">
+        {{ t('audio-reader.section.heading') }}
+      </h2>
+
+      <ui-button
+        data-testid="audio-reader-section__new"
+        data-theme="blue-500"
+        data-theme-dark="blue-650"
+        icon-left="add"
+        size="lg"
+        @click="onUpload"
+      >
+        {{ t('audio-reader.section.new-button') }}
+      </ui-button>
+    </header>
+
+    <p
+      v-if="lessons.length === 0"
+      data-testid="audio-reader-section__empty"
+      class="text-brown-500 dark:text-grey-400"
+    >
+      {{ t('audio-reader.section.empty-fallback') }}
+    </p>
+
+    <div v-else data-testid="audio-reader-section__list" class="flex flex-wrap gap-6">
+      <lesson-card
+        v-for="lesson in lessons"
+        :key="lesson.id"
+        :lesson="lesson"
+        @open="onOpen(lesson)"
+        @delete="onDelete(lesson)"
+      />
+    </div>
+  </section>
+</template>

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -8,13 +8,16 @@ import { useI18n } from 'vue-i18n'
 import UiButton from '@/components/ui-kit/button.vue'
 import { useMediaQuery } from '@/composables/use-media-query'
 import ReviewInbox from './review-inbox.vue'
+import AudioReaderSection from './audio-reader-section.vue'
 import { useDeckCreateModal } from '@/composables/modals/use-deck-create-modal'
 import { useDeckActions } from '@/composables/deck/use-deck-actions'
+import { useCan } from '@/composables/use-can'
 
 const { t } = useI18n()
 const toast = useToast()
 const router = useRouter()
 const is_md = useMediaQuery('md')
+const can = useCan()
 
 const deck_create_modal = useDeckCreateModal()
 const deck_actions = useDeckActions()
@@ -72,5 +75,7 @@ async function onCreateDeckClicked() {
         @click="onDeckClicked(deck)"
       />
     </div>
+
+    <audio-reader-section v-if="can.useAudioReader.value" class="md:col-span-2" />
   </div>
 </template>


### PR DESCRIPTION
## Summary

Adds the dashboard audio-reader section listing lessons as cards, with an upload-lesson modal (audio + per-upload script selection) wired to the create-lesson mutation.

Stacked on #234.