### PR TITLE
feat(audio-reader): per-word readings (furigana)

### DIFF
--- a/src/api/lessons/db/ai.ts
+++ b/src/api/lessons/db/ai.ts
@@ -30,6 +30,15 @@ export type TranscriptTranslation = {
   translations: string[]
 }
 
+export type TransliterateTranscriptArgs = {
+  words: string[]
+  lang: string
+}
+
+export type TranscriptReadings = {
+  readings: string[]
+}
+
 // The edge functions return a JSON body `{ code }` on failure (e.g.
 // 'output_truncated', 'file_too_large'). supabase-js surfaces non-2xx as a
 // FunctionsHttpError carrying the Response on `.context`; this re-throws a typed
@@ -85,4 +94,10 @@ export function translateTerm(args: TranslateTermArgs): Promise<TranslationResul
 
 export function translateTranscript(args: TranslateTranscriptArgs): Promise<TranscriptTranslation> {
   return invokeEdge<TranscriptTranslation>('translate-transcript', args)
+}
+
+export function transliterateTranscript(
+  args: TransliterateTranscriptArgs
+): Promise<TranscriptReadings> {
+  return invokeEdge<TranscriptReadings>('transliterate-transcript', args)
 }

--- a/src/api/lessons/db/ai.ts
+++ b/src/api/lessons/db/ai.ts
@@ -30,8 +30,13 @@ export type TranscriptTranslation = {
   translations: string[]
 }
 
-export type TransliterateTranscriptArgs = {
+export type ReadingSentence = {
+  text: string
   words: string[]
+}
+
+export type TransliterateTranscriptArgs = {
+  sentences: ReadingSentence[]
   lang: string
 }
 

--- a/src/api/lessons/mutations/create.ts
+++ b/src/api/lessons/mutations/create.ts
@@ -3,14 +3,14 @@ import { useMemberStore } from '@/stores/member'
 import uid from '@/utils/uid'
 import logger from '@/utils/logger'
 import { uploadLessonAudio, deleteLessonAudio } from '../db/audio'
-import { transcribeAudio, translateTranscript } from '../db/ai'
+import { transcribeAudio, translateTranscript, transliterateTranscript } from '../db/ai'
 import { createLesson } from '../db/lessons'
 
 // Interlinear translations are English-only in admin v1 (matches the term
 // popover's target). A per-member target language can replace this later.
 const TARGET_LANG = 'English'
 
-export type CreateLessonPhase = 'transcribing' | 'translating'
+export type CreateLessonPhase = 'transcribing' | 'translating' | 'transliterating'
 
 export type CreateLessonVars = {
   title: string
@@ -35,10 +35,11 @@ export function useCreateLessonMutation() {
       try {
         const { text, segments, words, lang } = await transcribeAudio(file, script)
         const translated = await translateSegments(segments, onPhase)
+        const read = await transliterateWords(words, lang, onPhase)
         return await createLesson({
           title,
           audio_path: path,
-          transcript: { text, segments: translated, words },
+          transcript: { text, segments: translated, words: read },
           lang
         })
       } catch (error) {
@@ -76,5 +77,28 @@ async function translateSegments(
   } catch (error) {
     logger.error(`Lesson translation failed: ${(error as Error).message}`)
     return segments
+  }
+}
+
+/**
+ * Best-effort: enrich each word with its phonetic reading for the furigana
+ * layer. Like translation, a failure must NOT sink the upload — we already hold
+ * a valid transcript — so this swallows errors and returns the words unread.
+ * Empty readings are dropped so only words that need one carry it.
+ */
+async function transliterateWords(
+  words: TranscriptWord[] | undefined,
+  lang: string | undefined,
+  onPhase?: (phase: CreateLessonPhase) => void
+): Promise<TranscriptWord[] | undefined> {
+  if (!words || words.length === 0 || !lang) return words
+
+  onPhase?.('transliterating')
+  try {
+    const { readings } = await transliterateTranscript({ words: words.map((w) => w.word), lang })
+    return words.map((word, i) => ({ ...word, reading: readings[i] || undefined }))
+  } catch (error) {
+    logger.error(`Lesson transliteration failed: ${(error as Error).message}`)
+    return words
   }
 }

--- a/src/api/lessons/mutations/create.ts
+++ b/src/api/lessons/mutations/create.ts
@@ -5,6 +5,7 @@ import logger from '@/utils/logger'
 import { uploadLessonAudio, deleteLessonAudio } from '../db/audio'
 import { transcribeAudio, translateTranscript, transliterateTranscript } from '../db/ai'
 import { createLesson } from '../db/lessons'
+import { groupWordsBySentence } from '@/utils/transcript'
 
 // Interlinear translations are English-only in admin v1 (matches the term
 // popover's target). A per-member target language can replace this later.
@@ -35,7 +36,7 @@ export function useCreateLessonMutation() {
       try {
         const { text, segments, words, lang } = await transcribeAudio(file, script)
         const translated = await translateSegments(segments, onPhase)
-        const read = await transliterateWords(words, lang, onPhase)
+        const read = await transliterateWords(words, segments, text, lang, onPhase)
         return await createLesson({
           title,
           audio_path: path,
@@ -88,6 +89,8 @@ async function translateSegments(
  */
 async function transliterateWords(
   words: TranscriptWord[] | undefined,
+  segments: TranscriptSegment[],
+  text: string,
   lang: string | undefined,
   onPhase?: (phase: CreateLessonPhase) => void
 ): Promise<TranscriptWord[] | undefined> {
@@ -95,8 +98,20 @@ async function transliterateWords(
 
   onPhase?.('transliterating')
   try {
-    const { readings } = await transliterateTranscript({ words: words.map((w) => w.word), lang })
-    return words.map((word, i) => ({ ...word, reading: readings[i] || undefined }))
+    // Group words under their sentence so the model reads each in context, then
+    // scatter the flat, send-order readings back onto the words by global index.
+    const grouped = groupWordsBySentence(segments, words, text)
+    const sentences = grouped.map((group) => ({
+      text: group.sentence,
+      words: group.words.map((word) => words[word.index].word)
+    }))
+    const ids = grouped.flatMap((group) => group.words.map((word) => word.index))
+
+    const { readings } = await transliterateTranscript({ sentences, lang })
+
+    const read = words.map((word) => ({ ...word }))
+    ids.forEach((id, i) => (read[id].reading = readings[i] || undefined))
+    return read
   } catch (error) {
     logger.error(`Lesson transliteration failed: ${(error as Error).message}`)
     return words

--- a/src/composables/audio-reader/use-reader-highlights.ts
+++ b/src/composables/audio-reader/use-reader-highlights.ts
@@ -99,16 +99,45 @@ export function useReaderHighlights(
     return el ? Number(el.getAttribute('data-word-index')) : null
   }
 
-  /** A DOM range spanning whole words `lo`..`hi`, for measuring + reading text. */
-  function wordRange({ lo, hi }: WordRange): Range | null {
-    const first = wordEl(lo)
-    const last = wordEl(hi)
-    if (!first || !last) return null
+  /**
+   * The selected term, reconstructed from each word's `data-word-text` rather
+   * than the DOM range's text — a range's `.toString()` would also pull in the
+   * furigana `<rt>` annotations and corrupt the term.
+   */
+  function rangeText({ lo, hi }: WordRange): string {
+    let text = ''
+    for (let i = lo; i <= hi; i++) text += wordEl(i)?.dataset.wordText ?? ''
+    return text
+  }
 
-    const range = document.createRange()
-    range.setStartBefore(first)
-    range.setEndAfter(last)
-    return range
+  // The word's base-text element — the ruby minus its `<rt>` reading — so
+  // measurements cover only the main text, not the furigana band above it.
+  // Falls back to the word element itself when there's no base marker.
+  function wordBaseEl(index: number): HTMLElement | null {
+    const el = wordEl(index)
+    return el?.querySelector<HTMLElement>('[data-word-base]') ?? el
+  }
+
+  function unionRect(a: DOMRect, b: DOMRect): DOMRect {
+    const left = Math.min(a.left, b.left)
+    const top = Math.min(a.top, b.top)
+    const right = Math.max(a.right, b.right)
+    const bottom = Math.max(a.bottom, b.bottom)
+    return new DOMRect(left, top, right - left, bottom - top)
+  }
+
+  // Bounding rect of words `lo`..`hi` over their base text only. Each base rect
+  // is unioned individually — a DOM range across the rubies would re-include the
+  // intermediate `<rt>` annotations and inflate the box upward.
+  function rangeRect({ lo, hi }: WordRange): DOMRect | null {
+    let box: DOMRect | null = null
+    for (let i = lo; i <= hi; i++) {
+      const el = wordBaseEl(i)
+      if (!el) continue
+      const rect = el.getBoundingClientRect()
+      box = box ? unionRect(box, rect) : rect
+    }
+    return box
   }
 
   // Map a viewport rect onto the content's own coordinate space, where the
@@ -124,12 +153,12 @@ export function useReaderHighlights(
   }
 
   function rangeBox(range: WordRange): CursorBox | null {
-    const dom = wordRange(range)
-    return dom ? boxOf(dom.getBoundingClientRect()) : null
+    const rect = rangeRect(range)
+    return rect ? boxOf(rect) : null
   }
 
   function wordBox(index: number): CursorBox | null {
-    const el = wordEl(index)
+    const el = wordBaseEl(index)
     return el ? boxOf(el.getBoundingClientRect()) : null
   }
 
@@ -189,15 +218,15 @@ export function useReaderHighlights(
     if (anchor_index.value === null || focus_index.value === null) return
 
     const range = orderedRange(anchor_index.value, focus_index.value)
-    const dom = wordRange(range)
+    const rect = rangeRect(range)
     const anchor = wordEl(range.lo)
-    if (!dom || !anchor) return
+    if (!rect || !anchor) return
 
-    const term = cleanTerm(dom.toString())
+    const term = cleanTerm(rangeText(range))
     if (!term) return
 
     committed.value = range
-    onSelect({ term, rect: dom.getBoundingClientRect(), anchor })
+    onSelect({ term, rect, anchor })
   }
 
   function onPointerDown(event: PointerEvent) {

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -2,6 +2,8 @@ export type DisplayWord = {
   display: string
   start: number
   index: number
+  // Phonetic reading rendered above the word (furigana, pinyin, …), when present.
+  reading?: string
 }
 
 export type SentenceWords = {
@@ -117,7 +119,8 @@ function displayWords(text: string, words: TranscriptWord[]): DisplayWord[] {
   return words.map((word, i) => ({
     display: text.slice(bounds[i], bounds[i + 1]) || word.word.trim(),
     start: word.start,
-    index: i
+    index: i,
+    reading: word.reading
   }))
 }
 

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -46,7 +46,7 @@ function commitSelection({ term, rect, anchor }: { term: string; rect: DOMRect; 
     <div
       ref="content"
       data-testid="transcript-view__content"
-      class="relative isolate flex select-none flex-col gap-7 text-2xl leading-relaxed text-brown-700 dark:text-brown-200"
+      class="relative isolate flex select-none flex-col gap-7 text-4xl leading-[2.5] text-brown-700 dark:text-brown-200"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"

--- a/src/views/audio-reader/transcript/segment.vue
+++ b/src/views/audio-reader/transcript/segment.vue
@@ -16,6 +16,7 @@ const { group, index } = defineProps<{
         :key="word.index"
         :display="word.display"
         :index="word.index"
+        :reading="word.reading"
     /></span>
     <span
       v-if="group.translation"

--- a/src/views/audio-reader/transcript/segment.vue
+++ b/src/views/audio-reader/transcript/segment.vue
@@ -21,7 +21,7 @@ const { group, index } = defineProps<{
     <span
       v-if="group.translation"
       data-testid="transcript-segment__translation"
-      class="mt-1 block text-lg text-brown-500 dark:text-brown-300"
+      class="block text-lg text-brown-500 dark:text-brown-300 leading-[1.5]"
       >{{ group.translation }}</span
     >
   </div>

--- a/src/views/audio-reader/transcript/word.vue
+++ b/src/views/audio-reader/transcript/word.vue
@@ -16,7 +16,7 @@ const { display, index, reading } = defineProps<{
     ><rt
       v-if="reading"
       data-testid="transcript-word__reading"
-      class="select-none text-base text-brown-500 dark:text-grey-400"
+      class="-translate-y-1 select-none text-base text-brown-500 dark:text-grey-400"
       >{{ reading }}</rt
     ></ruby
   >

--- a/src/views/audio-reader/transcript/word.vue
+++ b/src/views/audio-reader/transcript/word.vue
@@ -1,12 +1,23 @@
 <script setup lang="ts">
-const { display, index } = defineProps<{
+const { display, index, reading } = defineProps<{
   display: string
   index: number
+  reading?: string
 }>()
 </script>
 
 <template>
-  <span data-testid="transcript-word" :data-word-index="index" class="cursor-pointer">{{
-    display
-  }}</span>
+  <ruby
+    data-testid="transcript-word"
+    :data-word-index="index"
+    :data-word-text="display"
+    class="cursor-pointer"
+    ><span data-word-base>{{ display }}</span
+    ><rt
+      v-if="reading"
+      data-testid="transcript-word__reading"
+      class="select-none text-base text-brown-500 dark:text-grey-400"
+      >{{ reading }}</rt
+    ></ruby
+  >
 </template>

--- a/supabase/functions/transliterate-transcript/index.ts
+++ b/supabase/functions/transliterate-transcript/index.ts
@@ -1,0 +1,46 @@
+// transliterate-transcript: produce per-word phonetic readings for a lesson's
+// interlinear reader. Given the transcript's word tokens, return one reading per
+// word, aligned by index (empty string where a word needs none).
+//
+// Request:  { words: string[], lang: string }
+// Response: { readings: string[] }  // same length/order as `words`
+//
+// The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
+// Admin-only: requireAdmin() runs before any work.
+
+import { cors, requireAdmin } from '../_shared/require-admin.ts'
+import { readWords } from './transliterate.ts'
+
+type TransliterateRequest = { words: string[]; lang: string }
+
+// Machine-readable failure codes the FE switches on (read from the error body).
+function jsonError(code: string, status: number): Response {
+  return new Response(JSON.stringify({ code }), {
+    status,
+    headers: { ...cors, 'Content-Type': 'application/json' }
+  })
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors })
+  }
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: cors })
+  }
+
+  const auth = await requireAdmin(req)
+  if ('error' in auth) return auth.error
+
+  const { words, lang }: Partial<TransliterateRequest> = await req.json().catch(() => ({}))
+  if (!Array.isArray(words) || words.length === 0 || !lang) {
+    return jsonError('missing_fields', 400)
+  }
+
+  const readings = await readWords(words, lang)
+  if (!readings) return jsonError('transliteration_failed', 502)
+
+  return new Response(JSON.stringify({ readings }), {
+    headers: { ...cors, 'Content-Type': 'application/json' }
+  })
+})

--- a/supabase/functions/transliterate-transcript/index.ts
+++ b/supabase/functions/transliterate-transcript/index.ts
@@ -1,17 +1,18 @@
 // transliterate-transcript: produce per-word phonetic readings for a lesson's
-// interlinear reader. Given the transcript's word tokens, return one reading per
-// word, aligned by index (empty string where a word needs none).
+// interlinear reader. Given the transcript's words grouped under their sentence
+// (context for disambiguating readings), return one reading per word, flat and
+// aligned to the words in send order (empty string where a word needs none).
 //
-// Request:  { words: string[], lang: string }
-// Response: { readings: string[] }  // same length/order as `words`
+// Request:  { sentences: { text: string, words: string[] }[], lang: string }
+// Response: { readings: string[] }  // flat, aligned to the sentences' words
 //
 // The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
 // Admin-only: requireAdmin() runs before any work.
 
 import { cors, requireAdmin } from '../_shared/require-admin.ts'
-import { readWords } from './transliterate.ts'
+import { readSentences, type ReadingSentence } from './transliterate.ts'
 
-type TransliterateRequest = { words: string[]; lang: string }
+type TransliterateRequest = { sentences: ReadingSentence[]; lang: string }
 
 // Machine-readable failure codes the FE switches on (read from the error body).
 function jsonError(code: string, status: number): Response {
@@ -32,12 +33,12 @@ Deno.serve(async (req) => {
   const auth = await requireAdmin(req)
   if ('error' in auth) return auth.error
 
-  const { words, lang }: Partial<TransliterateRequest> = await req.json().catch(() => ({}))
-  if (!Array.isArray(words) || words.length === 0 || !lang) {
+  const { sentences, lang }: Partial<TransliterateRequest> = await req.json().catch(() => ({}))
+  if (!Array.isArray(sentences) || sentences.length === 0 || !lang) {
     return jsonError('missing_fields', 400)
   }
 
-  const readings = await readWords(words, lang)
+  const readings = await readSentences(sentences, lang)
   if (!readings) return jsonError('transliteration_failed', 502)
 
   return new Response(JSON.stringify({ readings }), {

--- a/supabase/functions/transliterate-transcript/index.ts
+++ b/supabase/functions/transliterate-transcript/index.ts
@@ -38,8 +38,9 @@ Deno.serve(async (req) => {
     return jsonError('missing_fields', 400)
   }
 
+  // Resilient by design: failed batches come back as blank readings, so this
+  // always returns a full aligned array rather than erroring the whole lesson.
   const readings = await readSentences(sentences, lang)
-  if (!readings) return jsonError('transliteration_failed', 502)
 
   return new Response(JSON.stringify({ readings }), {
     headers: { ...cors, 'Content-Type': 'application/json' }

--- a/supabase/functions/transliterate-transcript/transliterate.test.ts
+++ b/supabase/functions/transliterate-transcript/transliterate.test.ts
@@ -106,52 +106,56 @@ Deno.test('batches by token count and concatenates in order (cap 80)', async () 
   )
 })
 
-Deno.test('returns null when a batch returns the wrong number of readings', async () => {
+Deno.test('blanks a batch that returns the wrong number of readings', async () => {
   await withFetch(
     (count) => ok(Array.from({ length: count - 1 }, (_, k) => `r${k}`)),
     async () => {
-      assertEquals(await readSentences([{ text: 'x', words: ['a', 'b', 'c'] }], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a', 'b', 'c'] }], 'Japanese'), [
+        '',
+        '',
+        ''
+      ])
     }
   )
 })
 
-Deno.test('returns null on a truncated (max_tokens) response', async () => {
+Deno.test('blanks a batch on a truncated (max_tokens) response', async () => {
   await withFetch(
     () => new Response(JSON.stringify({ stop_reason: 'max_tokens', content: [] }), { status: 200 }),
     async () => {
-      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), [''])
     }
   )
 })
 
-Deno.test('returns null on a refusal', async () => {
+Deno.test('blanks a batch on a refusal', async () => {
   await withFetch(
     () => new Response(JSON.stringify({ stop_reason: 'refusal', content: [] }), { status: 200 }),
     async () => {
-      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), [''])
     }
   )
 })
 
-Deno.test('returns null on a non-2xx upstream response', async () => {
+Deno.test('blanks a batch on a non-2xx upstream response', async () => {
   await withFetch(
     () => new Response('upstream boom', { status: 500 }),
     async () => {
-      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), [''])
     }
   )
 })
 
-Deno.test('returns null when the model body is not parseable JSON', async () => {
+Deno.test('blanks a batch when the model body is not parseable JSON', async () => {
   await withFetch(
     () => new Response(JSON.stringify({ content: [{ text: 'not json' }] }), { status: 200 }),
     async () => {
-      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), [''])
     }
   )
 })
 
-Deno.test('fails the whole request when a later batch fails (all-or-nothing)', async () => {
+Deno.test('a failed batch yields blanks while other batches survive', async () => {
   const sentences = [sentence('a', 50), sentence('b', 50)]
 
   await withFetch(
@@ -159,7 +163,12 @@ Deno.test('fails the whole request when a later batch fails (all-or-nothing)', a
     (count, callIndex) =>
       callIndex === 0 ? ok(Array.from({ length: count }, (_, k) => `r${k}`)) : ok(['only-one']),
     async () => {
-      assertEquals(await readSentences(sentences, 'Japanese'), null)
+      const result = await readSentences(sentences, 'Japanese')
+      assertEquals(result.length, 100)
+      assertEquals(result[0], 'r0')
+      assertEquals(result[49], 'r49')
+      assertEquals(result[50], '') // second batch blanked, not the whole lesson
+      assertEquals(result[99], '')
     }
   )
 })

--- a/supabase/functions/transliterate-transcript/transliterate.test.ts
+++ b/supabase/functions/transliterate-transcript/transliterate.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from '@std/assert'
-import { readWords } from './transliterate.ts'
+import { readSentences } from './transliterate.ts'
 
 // Anthropic's success envelope: a structured-output JSON string in content[0].text.
 function ok(readings: string[]): Response {
@@ -8,10 +8,15 @@ function ok(readings: string[]): Response {
   })
 }
 
-// Replace global fetch with a responder that sees each batch's word count
+// A sentence carrying `n` synthetic word tokens.
+function sentence(text: string, n: number) {
+  return { text, words: Array.from({ length: n }, (_, k) => `${text}${k}`) }
+}
+
+// Replace global fetch with a responder that sees each batch's token count
 // (parsed from the prompt) and its 0-based call index, then restore afterwards.
 async function withFetch(
-  responder: (wordCount: number, callIndex: number) => Response,
+  responder: (tokenCount: number, callIndex: number) => Response,
   run: () => Promise<void>
 ) {
   const realFetch = globalThis.fetch
@@ -19,7 +24,7 @@ async function withFetch(
   globalThis.fetch = ((_url: string | URL | Request, init?: RequestInit) => {
     const body = JSON.parse(init!.body as string)
     const prompt = body.messages[0].content as string
-    const count = Number(prompt.match(/Words \((\d+)\)/)?.[1] ?? 0)
+    const count = Number(prompt.match(/Return (\d+) readings/)?.[1] ?? 0)
     return Promise.resolve(responder(count, call++))
   }) as typeof fetch
   try {
@@ -29,18 +34,58 @@ async function withFetch(
   }
 }
 
-Deno.test('returns one reading per word, in order', async () => {
+Deno.test('returns one reading per token, in order', async () => {
   await withFetch(
     (count) => ok(Array.from({ length: count }, (_, k) => `r${k}`)),
     async () => {
-      const result = await readWords(['食べる', '猫', '。'], 'Japanese')
+      const result = await readSentences(
+        [{ text: '猫が好き', words: ['猫', 'が', '好き'] }],
+        'Japanese'
+      )
       assertEquals(result, ['r0', 'r1', 'r2'])
     }
   )
 })
 
-Deno.test('batches large inputs and concatenates in order (BATCH_SIZE = 50)', async () => {
-  const words = Array.from({ length: 60 }, (_, k) => `w${k}`)
+Deno.test('flattens readings across sentences in order', async () => {
+  await withFetch(
+    (count) => ok(Array.from({ length: count }, (_, k) => `r${k}`)),
+    async () => {
+      const result = await readSentences(
+        [
+          { text: 'A', words: ['a1', 'a2'] },
+          { text: 'B', words: ['b1'] }
+        ],
+        'Japanese'
+      )
+      assertEquals(result, ['r0', 'r1', 'r2'])
+    }
+  )
+})
+
+Deno.test('skips empty sentences so output aligns to non-empty words', async () => {
+  let calls = 0
+  await withFetch(
+    (count, callIndex) => {
+      calls = callIndex + 1
+      return ok(Array.from({ length: count }, (_, k) => `r${k}`))
+    },
+    async () => {
+      const result = await readSentences(
+        [
+          { text: 'empty', words: [] },
+          { text: '猫', words: ['猫'] }
+        ],
+        'Japanese'
+      )
+      assertEquals(calls, 1)
+      assertEquals(result, ['r0'])
+    }
+  )
+})
+
+Deno.test('batches by token count and concatenates in order (cap 80)', async () => {
+  const sentences = [sentence('a', 50), sentence('b', 50)] // 100 tokens
   let calls = 0
 
   await withFetch(
@@ -49,14 +94,14 @@ Deno.test('batches large inputs and concatenates in order (BATCH_SIZE = 50)', as
       return ok(Array.from({ length: count }, (_, k) => `c${callIndex}_${k}`))
     },
     async () => {
-      const result = await readWords(words, 'Japanese')
+      const result = await readSentences(sentences, 'Japanese')
 
-      assertEquals(calls, 2) // 50 + 10
-      assertEquals(result?.length, 60)
+      assertEquals(calls, 2) // 50 + 50, the cap forces a split
+      assertEquals(result?.length, 100)
       assertEquals(result?.[0], 'c0_0')
       assertEquals(result?.[49], 'c0_49')
       assertEquals(result?.[50], 'c1_0') // second batch picks up right after the first
-      assertEquals(result?.[59], 'c1_9')
+      assertEquals(result?.[99], 'c1_49')
     }
   )
 })
@@ -65,7 +110,7 @@ Deno.test('returns null when a batch returns the wrong number of readings', asyn
   await withFetch(
     (count) => ok(Array.from({ length: count - 1 }, (_, k) => `r${k}`)),
     async () => {
-      assertEquals(await readWords(['a', 'b', 'c'], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a', 'b', 'c'] }], 'Japanese'), null)
     }
   )
 })
@@ -74,7 +119,7 @@ Deno.test('returns null on a truncated (max_tokens) response', async () => {
   await withFetch(
     () => new Response(JSON.stringify({ stop_reason: 'max_tokens', content: [] }), { status: 200 }),
     async () => {
-      assertEquals(await readWords(['a'], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), null)
     }
   )
 })
@@ -83,7 +128,7 @@ Deno.test('returns null on a refusal', async () => {
   await withFetch(
     () => new Response(JSON.stringify({ stop_reason: 'refusal', content: [] }), { status: 200 }),
     async () => {
-      assertEquals(await readWords(['a'], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), null)
     }
   )
 })
@@ -92,7 +137,7 @@ Deno.test('returns null on a non-2xx upstream response', async () => {
   await withFetch(
     () => new Response('upstream boom', { status: 500 }),
     async () => {
-      assertEquals(await readWords(['a'], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), null)
     }
   )
 })
@@ -101,20 +146,20 @@ Deno.test('returns null when the model body is not parseable JSON', async () => 
   await withFetch(
     () => new Response(JSON.stringify({ content: [{ text: 'not json' }] }), { status: 200 }),
     async () => {
-      assertEquals(await readWords(['a'], 'Japanese'), null)
+      assertEquals(await readSentences([{ text: 'x', words: ['a'] }], 'Japanese'), null)
     }
   )
 })
 
 Deno.test('fails the whole request when a later batch fails (all-or-nothing)', async () => {
-  const words = Array.from({ length: 60 }, (_, k) => `w${k}`)
+  const sentences = [sentence('a', 50), sentence('b', 50)]
 
   await withFetch(
-    // First batch (50) succeeds, second batch (10) returns the wrong count.
+    // First batch (50) succeeds, second batch (50) returns the wrong count.
     (count, callIndex) =>
       callIndex === 0 ? ok(Array.from({ length: count }, (_, k) => `r${k}`)) : ok(['only-one']),
     async () => {
-      assertEquals(await readWords(words, 'Japanese'), null)
+      assertEquals(await readSentences(sentences, 'Japanese'), null)
     }
   )
 })

--- a/supabase/functions/transliterate-transcript/transliterate.test.ts
+++ b/supabase/functions/transliterate-transcript/transliterate.test.ts
@@ -1,0 +1,120 @@
+import { assertEquals } from '@std/assert'
+import { readWords } from './transliterate.ts'
+
+// Anthropic's success envelope: a structured-output JSON string in content[0].text.
+function ok(readings: string[]): Response {
+  return new Response(JSON.stringify({ content: [{ text: JSON.stringify({ readings }) }] }), {
+    status: 200
+  })
+}
+
+// Replace global fetch with a responder that sees each batch's word count
+// (parsed from the prompt) and its 0-based call index, then restore afterwards.
+async function withFetch(
+  responder: (wordCount: number, callIndex: number) => Response,
+  run: () => Promise<void>
+) {
+  const realFetch = globalThis.fetch
+  let call = 0
+  globalThis.fetch = ((_url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(init!.body as string)
+    const prompt = body.messages[0].content as string
+    const count = Number(prompt.match(/Words \((\d+)\)/)?.[1] ?? 0)
+    return Promise.resolve(responder(count, call++))
+  }) as typeof fetch
+  try {
+    await run()
+  } finally {
+    globalThis.fetch = realFetch
+  }
+}
+
+Deno.test('returns one reading per word, in order', async () => {
+  await withFetch(
+    (count) => ok(Array.from({ length: count }, (_, k) => `r${k}`)),
+    async () => {
+      const result = await readWords(['食べる', '猫', '。'], 'Japanese')
+      assertEquals(result, ['r0', 'r1', 'r2'])
+    }
+  )
+})
+
+Deno.test('batches large inputs and concatenates in order (BATCH_SIZE = 50)', async () => {
+  const words = Array.from({ length: 60 }, (_, k) => `w${k}`)
+  let calls = 0
+
+  await withFetch(
+    (count, callIndex) => {
+      calls = callIndex + 1
+      return ok(Array.from({ length: count }, (_, k) => `c${callIndex}_${k}`))
+    },
+    async () => {
+      const result = await readWords(words, 'Japanese')
+
+      assertEquals(calls, 2) // 50 + 10
+      assertEquals(result?.length, 60)
+      assertEquals(result?.[0], 'c0_0')
+      assertEquals(result?.[49], 'c0_49')
+      assertEquals(result?.[50], 'c1_0') // second batch picks up right after the first
+      assertEquals(result?.[59], 'c1_9')
+    }
+  )
+})
+
+Deno.test('returns null when a batch returns the wrong number of readings', async () => {
+  await withFetch(
+    (count) => ok(Array.from({ length: count - 1 }, (_, k) => `r${k}`)),
+    async () => {
+      assertEquals(await readWords(['a', 'b', 'c'], 'Japanese'), null)
+    }
+  )
+})
+
+Deno.test('returns null on a truncated (max_tokens) response', async () => {
+  await withFetch(
+    () => new Response(JSON.stringify({ stop_reason: 'max_tokens', content: [] }), { status: 200 }),
+    async () => {
+      assertEquals(await readWords(['a'], 'Japanese'), null)
+    }
+  )
+})
+
+Deno.test('returns null on a refusal', async () => {
+  await withFetch(
+    () => new Response(JSON.stringify({ stop_reason: 'refusal', content: [] }), { status: 200 }),
+    async () => {
+      assertEquals(await readWords(['a'], 'Japanese'), null)
+    }
+  )
+})
+
+Deno.test('returns null on a non-2xx upstream response', async () => {
+  await withFetch(
+    () => new Response('upstream boom', { status: 500 }),
+    async () => {
+      assertEquals(await readWords(['a'], 'Japanese'), null)
+    }
+  )
+})
+
+Deno.test('returns null when the model body is not parseable JSON', async () => {
+  await withFetch(
+    () => new Response(JSON.stringify({ content: [{ text: 'not json' }] }), { status: 200 }),
+    async () => {
+      assertEquals(await readWords(['a'], 'Japanese'), null)
+    }
+  )
+})
+
+Deno.test('fails the whole request when a later batch fails (all-or-nothing)', async () => {
+  const words = Array.from({ length: 60 }, (_, k) => `w${k}`)
+
+  await withFetch(
+    // First batch (50) succeeds, second batch (10) returns the wrong count.
+    (count, callIndex) =>
+      callIndex === 0 ? ok(Array.from({ length: count }, (_, k) => `r${k}`)) : ok(['only-one']),
+    async () => {
+      assertEquals(await readWords(words, 'Japanese'), null)
+    }
+  )
+})

--- a/supabase/functions/transliterate-transcript/transliterate.ts
+++ b/supabase/functions/transliterate-transcript/transliterate.ts
@@ -131,18 +131,17 @@ async function readBatch(batch: ReadingSentence[], lang: string): Promise<string
 }
 
 // Read every word, batching internally. Returns the full flat list aligned to
-// the words in send order (skipping empty sentences), or null if any batch fails
-// — so callers treat it as all-or-nothing.
-export async function readSentences(
-  sentences: ReadingSentence[],
-  lang: string
-): Promise<string[] | null> {
+// the words in send order (skipping empty sentences). A batch that fails
+// (upstream error, refusal, truncation, or a count mismatch) contributes blank
+// readings for its own words rather than sinking the whole lesson — so a single
+// hiccup costs that batch's furigana, not all of it.
+export async function readSentences(sentences: ReadingSentence[], lang: string): Promise<string[]> {
   const readings: string[] = []
 
   for (const batch of batchSentences(sentences)) {
+    const total = batch.reduce((sum, sentence) => sum + sentence.words.length, 0)
     const result = await readBatch(batch, lang)
-    if (!result) return null
-    readings.push(...result)
+    readings.push(...(result ?? new Array<string>(total).fill('')))
   }
 
   return readings

--- a/supabase/functions/transliterate-transcript/transliterate.ts
+++ b/supabase/functions/transliterate-transcript/transliterate.ts
@@ -1,24 +1,25 @@
 // Reading core for the interlinear reader, kept separate from the HTTP handler
-// in index.ts so it can be unit-tested directly. Given the transcript's word
-// tokens, returns one phonetic reading per word (aligned by index) using Claude
-// Haiku with structured output. Words are processed in batches so a long lesson
-// can't blow max_tokens.
+// in index.ts so it can be unit-tested directly. Given the transcript's words
+// grouped under the sentence they belong to, returns one phonetic reading per
+// word — flat and aligned to the words in the order they were sent — using
+// Claude Haiku with structured output.
 //
-// Readings are pronunciation aids in the conventional system for the source
-// language — hiragana furigana over Japanese kanji, pinyin over Mandarin, etc.
-// A word that needs none (punctuation, numbers, already-phonetic/Latin text)
-// gets an empty string, so Latin-script lessons come back all-empty.
+// The sentence is passed only as context so the model can pick the reading that
+// fits how a polyphonic character is actually used; the reading itself is for
+// the source language's conventional system (hiragana furigana over Japanese
+// kanji, pinyin over Mandarin, etc.). A word that needs none (pure punctuation,
+// Arabic numerals, already-phonetic/Latin text) comes back empty.
 //
-// Words are sent without surrounding sentence context, which is enough for most
-// scripts; context-sensitive kanji readings may suffer and could be improved
-// later by batching per sentence with the sentence text as context.
+// Words are batched so a long lesson can't blow max_tokens; numbering runs
+// continuously across a batch so the output stays a single flat array.
 
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
 const MODEL = 'claude-haiku-4-5'
 
-// Readings are short, so a larger batch than translation still fits comfortably
-// under max_tokens while keeping round-trips (and cost) low.
-const BATCH_SIZE = 50
+// Cap words per request so the readings array stays well under max_tokens.
+const MAX_WORDS_PER_BATCH = 80
+
+export type ReadingSentence = { text: string; words: string[] }
 
 // Structured outputs constrain the body to a guaranteed-parseable array of
 // strings. The schema can't pin the array length, so we instruct the count in
@@ -33,26 +34,63 @@ const RESULT_SCHEMA = {
 }
 
 const SYSTEM_PROMPT =
-  'You provide pronunciation readings for language learners. ' +
-  'For each numbered word in the given source language, return its phonetic ' +
-  'reading in that language’s conventional system (hiragana for Japanese kanji, ' +
-  'pinyin with tone marks for Mandarin, and so on). ' +
-  'Return an empty string for any word that needs no reading: punctuation, ' +
-  'numbers, or text already written in a phonetic or Latin script. ' +
-  'Return one reading per word, in the same order, with exactly as many ' +
-  'readings as words given, and no notes, numbering, or commentary.'
+  'You provide pronunciation readings for language learners. You are given ' +
+  'numbered word tokens, each grouped under the sentence it comes from; the ' +
+  'sentence is context only, for choosing the reading that fits how the token is ' +
+  'used. For each numbered token return its phonetic reading in the source ' +
+  'language’s conventional system (hiragana for Japanese kanji, pinyin with tone ' +
+  'marks for Mandarin, and so on). Every token containing logographic characters ' +
+  'MUST get a reading — including numbers written as characters such as 一, 二, ' +
+  '三, 十, 百. Return an empty string ONLY for a token that is purely punctuation, ' +
+  'an Arabic numeral, whitespace, or already written in a phonetic or Latin ' +
+  'script (kana, hangul, romaji, Latin letters). Return exactly one reading per ' +
+  'numbered token, in number order, with no notes, numbering, or commentary.'
 
-function chunk<T>(items: T[], size: number): T[][] {
-  const batches: T[][] = []
-  for (let i = 0; i < items.length; i += size) batches.push(items.slice(i, i + size))
+// Pack sentences into batches whose combined word count stays within the cap.
+// Empty sentences carry no tokens to read, so they're dropped here (and on the
+// caller's side), keeping the flat output aligned.
+function batchSentences(sentences: ReadingSentence[]): ReadingSentence[][] {
+  const batches: ReadingSentence[][] = []
+  let current: ReadingSentence[] = []
+  let count = 0
+
+  for (const sentence of sentences) {
+    if (sentence.words.length === 0) continue
+    if (count > 0 && count + sentence.words.length > MAX_WORDS_PER_BATCH) {
+      batches.push(current)
+      current = []
+      count = 0
+    }
+    current.push(sentence)
+    count += sentence.words.length
+  }
+
+  if (current.length > 0) batches.push(current)
   return batches
+}
+
+// Render a batch as context-grouped, continuously-numbered tokens, and report
+// how many tokens it holds so the response count can be verified.
+function renderBatch(batch: ReadingSentence[]): { prompt: string; total: number } {
+  const lines: string[] = []
+  let n = 0
+
+  for (const sentence of batch) {
+    lines.push(`Context: ${sentence.text}`)
+    for (const word of sentence.words) lines.push(`${++n}. ${word}`)
+    lines.push('')
+  }
+
+  return { prompt: lines.join('\n'), total: n }
 }
 
 // Read one batch. Returns the aligned readings, or null on any failure (upstream
 // error, refusal, truncation, or a count that doesn't match the input).
-async function readBatch(words: string[], lang: string): Promise<string[] | null> {
-  const numbered = words.map((w, i) => `${i + 1}. ${w}`).join('\n')
-  const userPrompt = `Source language: ${lang}\nWords (${words.length}):\n${numbered}`
+async function readBatch(batch: ReadingSentence[], lang: string): Promise<string[] | null> {
+  const { prompt, total } = renderBatch(batch)
+  const userPrompt =
+    `Source language: ${lang}\n\n${prompt}\n` +
+    `Return ${total} readings, one per numbered token, in order.`
 
   const res = await fetch(ANTHROPIC_URL, {
     method: 'POST',
@@ -88,16 +126,20 @@ async function readBatch(words: string[], lang: string): Promise<string[] | null
     return null
   }
 
-  if (!Array.isArray(readings) || readings.length !== words.length) return null
+  if (!Array.isArray(readings) || readings.length !== total) return null
   return readings.map(String)
 }
 
-// Read every word, batching internally. Returns the full aligned list, or null
-// if any batch fails — so callers treat it as all-or-nothing.
-export async function readWords(words: string[], lang: string): Promise<string[] | null> {
+// Read every word, batching internally. Returns the full flat list aligned to
+// the words in send order (skipping empty sentences), or null if any batch fails
+// — so callers treat it as all-or-nothing.
+export async function readSentences(
+  sentences: ReadingSentence[],
+  lang: string
+): Promise<string[] | null> {
   const readings: string[] = []
 
-  for (const batch of chunk(words, BATCH_SIZE)) {
+  for (const batch of batchSentences(sentences)) {
     const result = await readBatch(batch, lang)
     if (!result) return null
     readings.push(...result)

--- a/supabase/functions/transliterate-transcript/transliterate.ts
+++ b/supabase/functions/transliterate-transcript/transliterate.ts
@@ -1,0 +1,107 @@
+// Reading core for the interlinear reader, kept separate from the HTTP handler
+// in index.ts so it can be unit-tested directly. Given the transcript's word
+// tokens, returns one phonetic reading per word (aligned by index) using Claude
+// Haiku with structured output. Words are processed in batches so a long lesson
+// can't blow max_tokens.
+//
+// Readings are pronunciation aids in the conventional system for the source
+// language — hiragana furigana over Japanese kanji, pinyin over Mandarin, etc.
+// A word that needs none (punctuation, numbers, already-phonetic/Latin text)
+// gets an empty string, so Latin-script lessons come back all-empty.
+//
+// Words are sent without surrounding sentence context, which is enough for most
+// scripts; context-sensitive kanji readings may suffer and could be improved
+// later by batching per sentence with the sentence text as context.
+
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
+const MODEL = 'claude-haiku-4-5'
+
+// Readings are short, so a larger batch than translation still fits comfortably
+// under max_tokens while keeping round-trips (and cost) low.
+const BATCH_SIZE = 50
+
+// Structured outputs constrain the body to a guaranteed-parseable array of
+// strings. The schema can't pin the array length, so we instruct the count in
+// the prompt and verify it per batch (count drift => failure).
+const RESULT_SCHEMA = {
+  type: 'object',
+  properties: {
+    readings: { type: 'array', items: { type: 'string' } }
+  },
+  required: ['readings'],
+  additionalProperties: false
+}
+
+const SYSTEM_PROMPT =
+  'You provide pronunciation readings for language learners. ' +
+  'For each numbered word in the given source language, return its phonetic ' +
+  'reading in that language’s conventional system (hiragana for Japanese kanji, ' +
+  'pinyin with tone marks for Mandarin, and so on). ' +
+  'Return an empty string for any word that needs no reading: punctuation, ' +
+  'numbers, or text already written in a phonetic or Latin script. ' +
+  'Return one reading per word, in the same order, with exactly as many ' +
+  'readings as words given, and no notes, numbering, or commentary.'
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = []
+  for (let i = 0; i < items.length; i += size) batches.push(items.slice(i, i + size))
+  return batches
+}
+
+// Read one batch. Returns the aligned readings, or null on any failure (upstream
+// error, refusal, truncation, or a count that doesn't match the input).
+async function readBatch(words: string[], lang: string): Promise<string[] | null> {
+  const numbered = words.map((w, i) => `${i + 1}. ${w}`).join('\n')
+  const userPrompt = `Source language: ${lang}\nWords (${words.length}):\n${numbered}`
+
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': Deno.env.get('ANTHROPIC_API_KEY')!,
+      'anthropic-version': '2023-06-01'
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      output_config: { format: { type: 'json_schema', schema: RESULT_SCHEMA } },
+      messages: [{ role: 'user', content: userPrompt }]
+    })
+  })
+
+  if (!res.ok) {
+    console.error('Anthropic error', res.status, await res.text())
+    return null
+  }
+
+  const data = await res.json()
+  if (data?.stop_reason === 'max_tokens' || data?.stop_reason === 'refusal') return null
+
+  const raw = data?.content?.[0]?.text ?? ''
+
+  let readings: unknown
+  try {
+    readings = (JSON.parse(raw) as { readings?: unknown }).readings
+  } catch {
+    console.error('Unparseable Claude response', raw)
+    return null
+  }
+
+  if (!Array.isArray(readings) || readings.length !== words.length) return null
+  return readings.map(String)
+}
+
+// Read every word, batching internally. Returns the full aligned list, or null
+// if any batch fails — so callers treat it as all-or-nothing.
+export async function readWords(words: string[], lang: string): Promise<string[] | null> {
+  const readings: string[] = []
+
+  for (const batch of chunk(words, BATCH_SIZE)) {
+    const result = await readBatch(batch, lang)
+    if (!result) return null
+    readings.push(...result)
+  }
+
+  return readings
+}

--- a/tests/integration/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/integration/composables/audio-reader/use-reader-highlights.test.js
@@ -41,9 +41,17 @@ const Host = defineComponent({
       [
         h('div', { ref: 'playhead' }),
         h('div', { ref: 'hover' }),
-        h('span', { 'data-testid': 'w0', 'data-word-index': '0' }, 'Hello '),
-        h('span', { 'data-testid': 'w1', 'data-word-index': '1' }, 'world'),
-        h('span', { 'data-testid': 'w2', 'data-word-index': '2' }, '. ')
+        h(
+          'span',
+          { 'data-testid': 'w0', 'data-word-index': '0', 'data-word-text': 'Hello ' },
+          'Hello '
+        ),
+        h(
+          'span',
+          { 'data-testid': 'w1', 'data-word-index': '1', 'data-word-text': 'world' },
+          'world'
+        ),
+        h('span', { 'data-testid': 'w2', 'data-word-index': '2', 'data-word-text': '. ' }, '. ')
       ]
     )
   }

--- a/tests/integration/views/audio-reader/transcript/segment.test.js
+++ b/tests/integration/views/audio-reader/transcript/segment.test.js
@@ -41,6 +41,13 @@ describe('TranscriptSegment', () => {
       expect(words[0].props('display')).toBe('Hello ')
       expect(words[1].props('display')).toBe('world')
     })
+
+    test('passes each word reading through to TranscriptWord', () => {
+      const wrapper = mountSegment({
+        group: group([{ display: '猫', start: 0, index: 0, reading: 'ねこ' }])
+      })
+      expect(wrapper.findAllComponents(TranscriptWord)[0].props('reading')).toBe('ねこ')
+    })
   })
 
   describe('word identity', () => {

--- a/tests/integration/views/audio-reader/transcript/word.test.js
+++ b/tests/integration/views/audio-reader/transcript/word.test.js
@@ -22,4 +22,28 @@ describe('TranscriptWord', () => {
     const wrapper = mountWord({ index: 7 })
     expect(wrapper.find('[data-testid="transcript-word"]').attributes('data-word-index')).toBe('7')
   })
+
+  test('exposes the bare display text as data-word-text for selection extraction', () => {
+    const wrapper = mountWord({ display: '猫 ', reading: 'ねこ' })
+    expect(wrapper.find('[data-testid="transcript-word"]').attributes('data-word-text')).toBe('猫 ')
+  })
+
+  test('wraps the base text in a data-word-base element, separate from the reading', () => {
+    const wrapper = mountWord({ display: '猫', reading: 'ねこ' })
+    const base = wrapper.find('[data-word-base]')
+    expect(base.exists()).toBe(true)
+    expect(base.text()).toBe('猫')
+    // the reading lives outside the base element so it isn't measured with it
+    expect(base.find('[data-testid="transcript-word__reading"]').exists()).toBe(false)
+  })
+
+  test('renders the reading in an rt annotation when provided', () => {
+    const wrapper = mountWord({ display: '猫', reading: 'ねこ' })
+    expect(wrapper.find('[data-testid="transcript-word__reading"]').text()).toBe('ねこ')
+  })
+
+  test('omits the rt annotation when there is no reading', () => {
+    const wrapper = mountWord({ display: 'cat ' })
+    expect(wrapper.find('[data-testid="transcript-word__reading"]').exists()).toBe(false)
+  })
 })

--- a/tests/unit/api/lessons/db/ai.test.js
+++ b/tests/unit/api/lessons/db/ai.test.js
@@ -162,7 +162,7 @@ describe('translateTerm', () => {
 })
 
 describe('transliterateTranscript', () => {
-  const args = { words: ['猫', 'が', '好き'], lang: 'Japanese' }
+  const args = { sentences: [{ text: '猫が好き', words: ['猫', 'が', '好き'] }], lang: 'Japanese' }
 
   test('returns the readings on success', async () => {
     const data = { readings: ['ねこ', '', 'すき'] }

--- a/tests/unit/api/lessons/db/ai.test.js
+++ b/tests/unit/api/lessons/db/ai.test.js
@@ -14,7 +14,12 @@ vi.mock('@/supabase-client', () => ({
 
 vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
 
-import { transcribeAudio, translateTerm, EdgeFunctionError } from '@/api/lessons/db/ai'
+import {
+  transcribeAudio,
+  translateTerm,
+  transliterateTranscript,
+  EdgeFunctionError
+} from '@/api/lessons/db/ai'
 
 beforeEach(() => {
   invokeMock.mockReset()
@@ -152,6 +157,38 @@ describe('translateTerm', () => {
 
     await expect(translateTerm(args)).rejects.toSatisfy(
       (e) => e instanceof EdgeFunctionError && e.code === 'no_data'
+    )
+  })
+})
+
+describe('transliterateTranscript', () => {
+  const args = { words: ['猫', 'が', '好き'], lang: 'Japanese' }
+
+  test('returns the readings on success', async () => {
+    const data = { readings: ['ねこ', '', 'すき'] }
+    invokeMock.mockResolvedValueOnce({ data, error: null })
+
+    const result = await transliterateTranscript(args)
+    expect(result).toEqual(data)
+  })
+
+  test('invokes the transliterate-transcript edge function with the args as body', async () => {
+    invokeMock.mockResolvedValueOnce({ data: { readings: [] }, error: null })
+    await transliterateTranscript(args)
+
+    const [name, opts] = invokeMock.mock.calls[0]
+    expect(name).toBe('transliterate-transcript')
+    expect(opts.body).toEqual(args)
+  })
+
+  test('throws EdgeFunctionError with parsed code on failure', async () => {
+    invokeMock.mockResolvedValueOnce({
+      data: null,
+      error: makeErrorWithContext({ code: 'transliteration_failed' })
+    })
+
+    await expect(transliterateTranscript(args)).rejects.toSatisfy(
+      (e) => e instanceof EdgeFunctionError && e.code === 'transliteration_failed'
     )
   })
 })

--- a/tests/unit/api/lessons/mutations/create.test.js
+++ b/tests/unit/api/lessons/mutations/create.test.js
@@ -269,7 +269,7 @@ describe('useCreateLessonMutation', () => {
       await mutation({ title: 'My Lesson', file })
 
       expect(transliterateTranscriptMock).toHaveBeenCalledWith({
-        words: ['猫', 'が', '好き'],
+        sentences: [{ text: '猫が好き', words: ['猫', 'が', '好き'] }],
         lang: 'ja'
       })
     })

--- a/tests/unit/api/lessons/mutations/create.test.js
+++ b/tests/unit/api/lessons/mutations/create.test.js
@@ -7,6 +7,7 @@ const {
   deleteLessonAudioMock,
   transcribeAudioMock,
   translateTranscriptMock,
+  transliterateTranscriptMock,
   createLessonMock
 } = vi.hoisted(() => ({
   useMutationSpy: vi.fn((cfg) => cfg),
@@ -15,6 +16,7 @@ const {
   deleteLessonAudioMock: vi.fn().mockResolvedValue(undefined),
   transcribeAudioMock: vi.fn(),
   translateTranscriptMock: vi.fn(),
+  transliterateTranscriptMock: vi.fn(),
   createLessonMock: vi.fn()
 }))
 
@@ -30,7 +32,8 @@ vi.mock('@/api/lessons/db/audio', () => ({
 
 vi.mock('@/api/lessons/db/ai', () => ({
   transcribeAudio: transcribeAudioMock,
-  translateTranscript: translateTranscriptMock
+  translateTranscript: translateTranscriptMock,
+  transliterateTranscript: transliterateTranscriptMock
 }))
 
 vi.mock('@/api/lessons/db/lessons', () => ({
@@ -52,6 +55,7 @@ beforeEach(() => {
   deleteLessonAudioMock.mockClear()
   transcribeAudioMock.mockReset()
   translateTranscriptMock.mockReset()
+  transliterateTranscriptMock.mockReset()
   createLessonMock.mockReset()
 })
 
@@ -240,6 +244,75 @@ describe('useCreateLessonMutation', () => {
 
       const { mutation } = configFrom(useCreateLessonMutation)
       await expect(mutation({ title: 'My Lesson', file })).resolves.not.toThrow()
+    })
+  })
+
+  describe('transliteration', () => {
+    const wordedTranscribe = {
+      text: '猫が好き',
+      segments: [{ start: 0, end: 1, text: '猫が好き' }],
+      words: [
+        { word: '猫', start: 0, end: 0.3 },
+        { word: 'が', start: 0.3, end: 0.6 },
+        { word: '好き', start: 0.6, end: 0.9 }
+      ],
+      lang: 'ja'
+    }
+
+    test('calls transliterateTranscript with the word tokens and lang', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(wordedTranscribe)
+      translateTranscriptMock.mockResolvedValueOnce({ translations: ['I like cats'] })
+      transliterateTranscriptMock.mockResolvedValueOnce({ readings: ['ねこ', '', 'すき'] })
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      expect(transliterateTranscriptMock).toHaveBeenCalledWith({
+        words: ['猫', 'が', '好き'],
+        lang: 'ja'
+      })
+    })
+
+    test('merges readings onto words and drops empty ones before createLesson', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(wordedTranscribe)
+      translateTranscriptMock.mockResolvedValueOnce({ translations: ['I like cats'] })
+      transliterateTranscriptMock.mockResolvedValueOnce({ readings: ['ねこ', '', 'すき'] })
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      const words = createLessonMock.mock.calls[0][0].transcript.words
+      expect(words[0].reading).toBe('ねこ')
+      expect(words[1].reading).toBeUndefined()
+      expect(words[2].reading).toBe('すき')
+    })
+
+    test('skips transliteration when there are no words', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(transcribeResult)
+      translateTranscriptMock.mockResolvedValueOnce(translateResult)
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      await mutation({ title: 'My Lesson', file })
+
+      expect(transliterateTranscriptMock).not.toHaveBeenCalled()
+    })
+
+    test('still creates the lesson with unread words when transliterateTranscript rejects', async () => {
+      transcribeAudioMock.mockResolvedValueOnce(wordedTranscribe)
+      translateTranscriptMock.mockResolvedValueOnce({ translations: ['I like cats'] })
+      transliterateTranscriptMock.mockRejectedValueOnce(new Error('AI unavailable'))
+      createLessonMock.mockResolvedValueOnce(lesson)
+
+      const { mutation } = configFrom(useCreateLessonMutation)
+      const result = await mutation({ title: 'My Lesson', file })
+
+      expect(result).toEqual(lesson)
+      expect(deleteLessonAudioMock).not.toHaveBeenCalled()
+      const words = createLessonMock.mock.calls[0][0].transcript.words
+      expect(words.every((w) => w.reading === undefined)).toBe(true)
     })
   })
 

--- a/tests/unit/utils/transcript.test.js
+++ b/tests/unit/utils/transcript.test.js
@@ -133,6 +133,26 @@ describe('groupWordsBySentence — translation passthrough', () => {
   })
 })
 
+describe('groupWordsBySentence — reading passthrough', () => {
+  test('copies each word reading onto its display word', () => {
+    const words = [
+      { word: '猫', start: 0, end: 0.3, reading: 'ねこ' },
+      { word: 'が', start: 0.3, end: 0.6, reading: '' },
+      { word: '好き', start: 0.6, end: 0.9, reading: 'すき' }
+    ]
+
+    const groups = groupWordsBySentence([seg(0, 2, '猫が好き')], words, '猫が好き')
+
+    expect(groups[0].words.map((d) => d.reading)).toEqual(['ねこ', '', 'すき'])
+  })
+
+  test('leaves reading undefined when the word has none', () => {
+    const groups = groupWordsBySentence([seg(0, 2, 'The cat')], [w('The', 0), w('cat', 0.6)])
+
+    expect(groups[0].words[0].reading).toBeUndefined()
+  })
+})
+
 describe('groupWordsBySentence — inter-sentence spacing invariant', () => {
   test('preserves the space between sentences in the word display slices', () => {
     // "Hello world. How are you?" — ". " between sentences stays on the last

--- a/types/lesson.d.ts
+++ b/types/lesson.d.ts
@@ -14,6 +14,9 @@ type TranscriptWord = {
   word: string
   start: number
   end: number
+  // Phonetic reading shown above the word in the reader (furigana, pinyin, …);
+  // empty/absent when the word needs none or the lesson predates transliteration.
+  reading?: string
 }
 
 type LessonTranscript = {


### PR DESCRIPTION
## Summary

Adds per-word readings (furigana): a `transliterate-transcript` edge function, capture of readings at upload time, and furigana rendering over each word in the transcript. Degrades transliteration per-batch so a single failure doesn't drop all readings.

Stacked on #235. Tip of the stack — equivalent to the original `feat/lesson-word-readings` branch.