### PR TITLE
fix(card-editor): stale view + side-clobber on card edit

### DIFF
--- a/src/api/cards/mutations/save.ts
+++ b/src/api/cards/mutations/save.ts
@@ -1,6 +1,9 @@
-import { useMutation } from '@pinia/colada'
+import { setInfiniteQueryData, useMutation, useQueryCache } from '@pinia/colada'
 import { debounce } from '@/utils/debounce'
 import { saveCard } from '../db'
+import { cardsInDeckQueryKey } from '../queries/cards-page'
+
+type QueryCache = ReturnType<typeof useQueryCache>
 
 type SaveCardVars = {
   card: Card
@@ -8,16 +11,44 @@ type SaveCardVars = {
 }
 
 /**
+ * Optimistically merge `values` into the matching card inside the deck's cached
+ * pages, in place of a refetch. Keeps the read model (view mode + the next
+ * save's merge base) in lockstep with the edit without a network round-trip.
+ * No-op when the deck isn't cached or the card lives on an unloaded page.
+ */
+function patchCardInDeckCache(queryCache: QueryCache, card: Card, values: Partial<Card>) {
+  if (card.deck_id === undefined || card.id === undefined) return
+
+  const key = cardsInDeckQueryKey(card.deck_id)
+  if (!queryCache.getQueryData(key)) return
+
+  // Each page is a `Card[]`, so the page-item type is `Card[]`.
+  setInfiniteQueryData<Card[]>(queryCache, key, (old) => ({
+    pages: (old?.pages ?? []).map((page) =>
+      page.map((c) => (c.id === card.id ? { ...c, ...values } : c))
+    ),
+    pageParams: old?.pageParams ?? []
+  }))
+}
+
+/**
  * Debounce is keyed by card id so concurrent edits to different cards don't
  * supersede each other. Superseded calls resolve with undefined.
  *
- * Intentionally does not invalidate the deck on settle: the calling component
- * owns the authoritative editor state, so a self-triggered refetch would fight
- * it. Bulk ops (delete, move, deck change) still invalidate explicitly.
+ * `onMutate` optimistically patches the cached card synchronously (before the
+ * debounce fires) so view mode and the next save's merge base reflect the edit
+ * immediately. This is a local cache write, not a refetch — it can't fight the
+ * component-owned editor state the way a self-triggered `invalidate` would.
+ * Bulk ops (delete, move, deck change) still invalidate explicitly.
  */
 export function useSaveCardMutation() {
+  const queryCache = useQueryCache()
+
   return useMutation({
     mutation: ({ card, values }: SaveCardVars) =>
-      debounce(() => saveCard(card, values), { key: `card-${card.id}` })
+      debounce(() => saveCard(card, values), { key: `card-${card.id}` }),
+    onMutate: ({ card, values }: SaveCardVars) => {
+      patchCardInDeckCache(queryCache, card, values)
+    }
   })
 }

--- a/src/api/cards/queries/cards-page.ts
+++ b/src/api/cards/queries/cards-page.ts
@@ -4,12 +4,24 @@ import { fetchCardsPageByDeckId } from '../db'
 
 export const CARDS_PAGE_SIZE = 50
 
+/**
+ * Exact cache key for the deck's paginated cards query. Shared with mutations
+ * that optimistically patch the cache (e.g. `useSaveCardMutation`) so the key
+ * shape stays in one place and the two can't drift.
+ */
+export function cardsInDeckQueryKey(
+  deck_id: number | undefined,
+  page_size: number = CARDS_PAGE_SIZE
+) {
+  return ['cards', deck_id ?? 0, 'pages', page_size]
+}
+
 export function useCardsInDeckInfiniteQuery(
   deck_id: MaybeRefOrGetter<number | undefined>,
   page_size: number = CARDS_PAGE_SIZE
 ) {
   return useInfiniteQuery({
-    key: () => ['cards', toValue(deck_id) ?? 0, 'pages', page_size],
+    key: () => cardsInDeckQueryKey(toValue(deck_id), page_size),
     initialPageParam: 0,
     query: ({ pageParam }) =>
       fetchCardsPageByDeckId({

--- a/src/components/text-editor/text-editor.vue
+++ b/src/components/text-editor/text-editor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, ref, useTemplateRef } from 'vue'
 
 type TextEditorProps = {
   disabled?: boolean
@@ -13,12 +13,6 @@ const { disabled, content, attributes } = defineProps<TextEditorProps>()
 const LEVEL_PX = [16, 20, 24, 30, 36, 44, 52, 60, 70, 84]
 const DEFAULT_LEVEL = 4
 
-const font_size_px = computed(() => {
-  const level = attributes?.text_size ?? DEFAULT_LEVEL
-  const clamped = Math.min(LEVEL_PX.length, Math.max(1, Math.round(level)))
-  return LEVEL_PX[clamped - 1]
-})
-
 const emit = defineEmits<{
   (e: 'update', text: string): void
   (e: 'focus'): void
@@ -28,21 +22,27 @@ const emit = defineEmits<{
 const text_editor = useTemplateRef<HTMLDivElement>('text-editor')
 const has_content = ref(Boolean(content?.length))
 
+const font_size_px = computed(() => {
+  const level = attributes?.text_size ?? DEFAULT_LEVEL
+  const clamped = Math.min(LEVEL_PX.length, Math.max(1, Math.round(level)))
+  return LEVEL_PX[clamped - 1]
+})
+
+const editor_style = computed(() => ({ fontSize: `${font_size_px.value}px` }))
+const editor_classes = computed(() => [
+  'text-editor',
+  `text-editor--h-${attributes?.horizontal_alignment ?? 'center'}`,
+  `text-editor--v-${attributes?.vertical_alignment ?? 'center'}`
+])
+
+// The editable surface is uncontrolled: seed it from `content` once, then let
+// the browser own the DOM. We never re-sync from the prop afterwards — `content`
+// in edit mode is only the user's own input echoed back, and re-writing it would
+// snap the caret to the start. Read-only mode renders `content` via Vue instead.
 onMounted(() => {
   if (!text_editor.value) return
   text_editor.value.textContent = content ?? ''
 })
-
-watch(
-  () => content,
-  (next) => {
-    if (!text_editor.value) return
-    const value = next ?? ''
-    if (text_editor.value.textContent === value) return
-    text_editor.value.textContent = value
-    has_content.value = value.length > 0
-  }
-)
 
 function on_input(event: Event) {
   const text = (event.target as HTMLElement).innerText ?? ''
@@ -60,19 +60,27 @@ defineExpose({ focus })
 <template>
   <div data-testid="text-editor-container" class="relative">
     <div
+      v-if="disabled"
+      data-testid="text-editor"
+      contenteditable="false"
+      :style="editor_style"
+      :class="editor_classes"
+    >
+      {{ content }}
+    </div>
+
+    <div
+      v-else
       data-testid="text-editor"
       ref="text-editor"
-      class="text-editor"
-      :contenteditable="disabled ? 'false' : 'plaintext-only'"
-      :style="{ fontSize: `${font_size_px}px` }"
-      :class="[
-        `text-editor--h-${attributes?.horizontal_alignment ?? 'center'}`,
-        `text-editor--v-${attributes?.vertical_alignment ?? 'center'}`
-      ]"
+      contenteditable="plaintext-only"
+      :style="editor_style"
+      :class="editor_classes"
       @input="on_input"
       @focus="emit('focus')"
       @blur="emit('blur')"
     ></div>
+
     <span
       v-if="!has_content && !disabled"
       data-testid="text-editor__placeholder"

--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -28,6 +28,10 @@ const save_failed = ref(false)
 const { selection, updateCard, card_attributes } = inject<CardListController>('card-editor')!
 const { is_selecting } = selection
 
+// Persist both sides from local state, not just the edited one: the merge base
+// in the save path is the cached card, so sending a single side would let it
+// clobber the other side with stale cache data. Local refs are the source of
+// truth while mounted, so they carry the complete, current card.
 async function onUpdate(side: 'front' | 'back', text: string) {
   if (side === 'front') front_text.value = text
   else back_text.value = text
@@ -35,7 +39,7 @@ async function onUpdate(side: 'front' | 'back', text: string) {
   save_failed.value = false
 
   try {
-    await updateCard(card.id, { [`${side}_text`]: text })
+    await updateCard(card.id, { front_text: front_text.value, back_text: back_text.value })
   } catch {
     save_failed.value = true
   }

--- a/tests/integration/components/text-editor/text-editor.test.js
+++ b/tests/integration/components/text-editor/text-editor.test.js
@@ -158,6 +158,33 @@ describe('TextEditor', () => {
     expect(wrapper.emitted('update')).toEqual([['typed']])
   })
 
+  // ── Uncontrolled editable surface ──────────────────────────────────────────
+  // The editable div is seeded once on mount, then owned by the browser. It must
+  // not re-sync from `content` — in edit mode `content` is just the user's own
+  // input echoed back, and rewriting it would snap the caret to the start. This
+  // is what previously broke multi-line backspace (caret jumped to line one).
+
+  test('editable editor ignores content prop changes after mount (caret-safe)', async () => {
+    const wrapper = makeEditor({ content: 'x' })
+    const el = getEditorEl(wrapper).element
+
+    // The browser owns the editable DOM after mount (here standing in for the
+    // user's typing). A later content change must not rewrite it.
+    el.textContent = 'user typed\nline two'
+    await wrapper.setProps({ content: 'something external' })
+
+    expect(el.textContent).toBe('user typed\nline two')
+  })
+
+  test('disabled editor renders content reactively via Vue (no imperative sync)', async () => {
+    const wrapper = makeEditor({ disabled: true, content: 'old' })
+    expect(getEditorEl(wrapper).element.textContent).toBe('old')
+
+    await wrapper.setProps({ content: 'new' })
+
+    expect(getEditorEl(wrapper).element.textContent).toBe('new')
+  })
+
   test('emits focus and blur on native focus events', async () => {
     const wrapper = makeEditor()
     const el = getEditorEl(wrapper)

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -120,14 +120,33 @@ describe('ListItemCard', () => {
 
   // ── Auto-save wiring ──────────────────────────────────────────────────────
 
-  test('forwards text-editor updates to updateCard with the matching side key', async () => {
-    const wrapper = mount({ card: { id: 42 } })
+  test('forwards text-editor updates to updateCard with both sides from local state', async () => {
+    const wrapper = mount({ card: { id: 42, front_text: 'Q', back_text: 'A' } })
     const editors = wrapper.findAllComponents(textEditor)
+
     await editors[0].vm.$emit('update', 'new front')
-    expect(mocks.updateCardMock).toHaveBeenCalledWith(42, { front_text: 'new front' })
+    expect(mocks.updateCardMock).toHaveBeenCalledWith(42, {
+      front_text: 'new front',
+      back_text: 'A'
+    })
 
     await editors[1].vm.$emit('update', 'new back')
-    expect(mocks.updateCardMock).toHaveBeenLastCalledWith(42, { back_text: 'new back' })
+    expect(mocks.updateCardMock).toHaveBeenLastCalledWith(42, {
+      front_text: 'new front',
+      back_text: 'new back'
+    })
+  })
+
+  test('an edit to one side carries the other side, so a save cannot clobber it', async () => {
+    // Regression: editing back then front used to send only the changed side,
+    // and the save path merged it over the stale cached card — wiping the back.
+    const wrapper = mount({ card: { id: 42, front_text: '', back_text: '' } })
+    const editors = wrapper.findAllComponents(textEditor)
+
+    await editors[1].vm.$emit('update', 'B')
+    await editors[0].vm.$emit('update', 'F')
+
+    expect(mocks.updateCardMock).toHaveBeenLastCalledWith(42, { front_text: 'F', back_text: 'B' })
   })
 
   // ── Focus sound effects via native focusin/focusout ───────────────────────

--- a/tests/unit/api/cards/mutations/delete.test.js
+++ b/tests/unit/api/cards/mutations/delete.test.js
@@ -1,0 +1,87 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+const { useMutationSpy, invalidateSpy, deleteCardsMock, deleteCardsInDeckMock } = vi.hoisted(
+  () => ({
+    useMutationSpy: vi.fn((cfg) => cfg),
+    invalidateSpy: vi.fn(),
+    deleteCardsMock: vi.fn().mockResolvedValue(undefined),
+    deleteCardsInDeckMock: vi.fn().mockResolvedValue(undefined)
+  })
+)
+
+vi.mock('@pinia/colada', () => ({
+  useMutation: useMutationSpy,
+  useQueryCache: () => ({ invalidateQueries: invalidateSpy })
+}))
+
+vi.mock('@/api/cards/db', () => ({
+  deleteCards: deleteCardsMock,
+  deleteCardsInDeck: deleteCardsInDeckMock
+}))
+
+import { useDeleteCardsMutation, useDeleteCardsInDeckMutation } from '@/api/cards/mutations/delete'
+
+beforeEach(() => {
+  useMutationSpy.mockClear()
+  invalidateSpy.mockClear()
+  deleteCardsMock.mockClear()
+  deleteCardsInDeckMock.mockClear()
+})
+
+function configFrom(hook) {
+  hook()
+  return useMutationSpy.mock.calls.at(-1)[0]
+}
+
+describe('useDeleteCardsMutation', () => {
+  test('mutation delegates to deleteCards', async () => {
+    const { mutation } = configFrom(useDeleteCardsMutation)
+    const cards = [{ id: 1, deck_id: 10 }]
+    await mutation(cards)
+    expect(deleteCardsMock).toHaveBeenCalledWith(cards)
+  })
+
+  // The active cards query reads the deleted card; invalidating ['cards', deck_id]
+  // is what drops it from the cache so the editor list re-renders without it.
+  test("onSettled invalidates each affected deck's cards + deck queries and all card counts", () => {
+    const { onSettled } = configFrom(useDeleteCardsMutation)
+    onSettled(undefined, undefined, [{ id: 1, deck_id: 10 }])
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['deck', 10] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 10] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 'count'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'] })
+  })
+
+  test('onSettled invalidates each distinct deck once when cards span multiple decks', () => {
+    const { onSettled } = configFrom(useDeleteCardsMutation)
+    onSettled(undefined, undefined, [
+      { id: 1, deck_id: 10 },
+      { id: 2, deck_id: 10 },
+      { id: 3, deck_id: 20 }
+    ])
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 10] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 20] })
+    const cards_invalidations = invalidateSpy.mock.calls.filter(
+      ([f]) => f.key[0] === 'cards' && f.key[1] === 10
+    )
+    expect(cards_invalidations).toHaveLength(1)
+  })
+})
+
+describe('useDeleteCardsInDeckMutation', () => {
+  test('mutation delegates to deleteCardsInDeck', async () => {
+    const { mutation } = configFrom(useDeleteCardsInDeckMutation)
+    const params = { deck_id: 10, except_ids: [7] }
+    await mutation(params)
+    expect(deleteCardsInDeckMock).toHaveBeenCalledWith(params)
+  })
+
+  test("onSettled invalidates the deck's cards + deck queries and all card counts", () => {
+    const { onSettled } = configFrom(useDeleteCardsInDeckMutation)
+    onSettled(undefined, undefined, { deck_id: 10, except_ids: [7] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['deck', 10] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 10] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 'count'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'] })
+  })
+})

--- a/tests/unit/api/cards/mutations/save.test.js
+++ b/tests/unit/api/cards/mutations/save.test.js
@@ -1,15 +1,30 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 
-const { useMutationSpy, saveCardMock, debounceMock } = vi.hoisted(() => ({
-  useMutationSpy: vi.fn((cfg) => cfg),
-  saveCardMock: vi.fn().mockResolvedValue(undefined),
-  // Call the debounced fn immediately so the mutation resolves synchronously
-  // in tests. We still assert on the debounce call shape.
-  debounceMock: vi.fn((fn) => fn())
-}))
+const {
+  useMutationSpy,
+  saveCardMock,
+  debounceMock,
+  setInfiniteQueryDataMock,
+  getQueryDataMock,
+  queryCache
+} = vi.hoisted(() => {
+  const getQueryDataMock = vi.fn()
+  return {
+    useMutationSpy: vi.fn((cfg) => cfg),
+    saveCardMock: vi.fn().mockResolvedValue(undefined),
+    // Call the debounced fn immediately so the mutation resolves synchronously
+    // in tests. We still assert on the debounce call shape.
+    debounceMock: vi.fn((fn) => fn()),
+    setInfiniteQueryDataMock: vi.fn(),
+    getQueryDataMock,
+    queryCache: { getQueryData: getQueryDataMock }
+  }
+})
 
 vi.mock('@pinia/colada', () => ({
-  useMutation: useMutationSpy
+  useMutation: useMutationSpy,
+  useQueryCache: () => queryCache,
+  setInfiniteQueryData: setInfiniteQueryDataMock
 }))
 
 vi.mock('@/api/cards/db', () => ({
@@ -20,6 +35,10 @@ vi.mock('@/utils/debounce', () => ({
   debounce: debounceMock
 }))
 
+vi.mock('@/api/cards/queries/cards-page', () => ({
+  cardsInDeckQueryKey: (deck_id) => ['cards', deck_id, 'pages', 50]
+}))
+
 import { useSaveCardMutation } from '@/api/cards/mutations/save'
 
 beforeEach(() => {
@@ -28,6 +47,9 @@ beforeEach(() => {
   saveCardMock.mockResolvedValue(undefined)
   debounceMock.mockClear()
   debounceMock.mockImplementation((fn) => fn())
+  setInfiniteQueryDataMock.mockClear()
+  getQueryDataMock.mockReset()
+  getQueryDataMock.mockReturnValue({ pages: [], pageParams: [] })
 })
 
 function configFrom() {
@@ -59,5 +81,46 @@ describe('useSaveCardMutation', () => {
     // state that's driving the input. Bulk ops invalidate explicitly.
     const config = configFrom()
     expect(config.onSettled).toBeUndefined()
+  })
+
+  // ── Optimistic cache patch ────────────────────────────────────────────────
+
+  test('onMutate merges values into the matching cached card, leaving siblings and the other side intact', () => {
+    const { onMutate } = configFrom()
+    getQueryDataMock.mockReturnValue({
+      pages: [
+        [
+          { id: 5, deck_id: 10, front_text: 'F0', back_text: 'B0' },
+          { id: 6, deck_id: 10, front_text: 'X', back_text: 'Y' }
+        ]
+      ],
+      pageParams: [0]
+    })
+
+    onMutate({ card: { id: 5, deck_id: 10 }, values: { front_text: 'F1' } })
+
+    const [, key, updater] = setInfiniteQueryDataMock.mock.calls[0]
+    expect(key).toEqual(['cards', 10, 'pages', 50])
+
+    const next = updater(getQueryDataMock.mock.results[0].value)
+    expect(next.pages[0][0]).toEqual({ id: 5, deck_id: 10, front_text: 'F1', back_text: 'B0' })
+    expect(next.pages[0][1]).toEqual({ id: 6, deck_id: 10, front_text: 'X', back_text: 'Y' })
+  })
+
+  test('onMutate is a no-op when the deck is not cached', () => {
+    const { onMutate } = configFrom()
+    getQueryDataMock.mockReturnValue(undefined)
+
+    onMutate({ card: { id: 5, deck_id: 10 }, values: { front_text: 'F1' } })
+
+    expect(setInfiniteQueryDataMock).not.toHaveBeenCalled()
+  })
+
+  test('onMutate is a no-op when the card has no deck_id (unpromoted temp)', () => {
+    const { onMutate } = configFrom()
+
+    onMutate({ card: { id: -1 }, values: { front_text: 'F1' } })
+
+    expect(setInfiniteQueryDataMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Two card-editor bugs, one root cause: the save path persists to the DB but never updates the Pinia Colada cache, and each save merges the edited side over the *stale cached card*.

- **Stale view after "finish editing"** — view mode reads card text from the cache, which was never refreshed after a save. Now `useSaveCardMutation` optimistically patches the edited card into the cached pages in `onMutate` via `setInfiniteQueryData` (a local write, not a refetch, so it doesn't fight the component-owned editor state). Added `cardsInDeckQueryKey` so the query and mutation share one key shape.
- **Only one side persists** — editing the front after the back re-merged over the stale cache and wiped the back. `list-item-card` now sends both sides (its local refs are the source of truth while mounted) on every update, so a save is self-complete and can't clobber the other side regardless of debounce timing.

Regression tests cover the both-sides save, the no-clobber edit sequence, and the optimistic cache patch (merge, no-op when uncached, no-op for unpromoted temps).