### PR TITLE
refactor(layout): full-page scroll shell + custom lesson audio player

### DIFF
--- a/src/assets/icons/pause.svg
+++ b/src/assets/icons/pause.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24">
+  <path d="M520-200v-560h240v560H520Zm-320 0v-560h240v560H200Z" fill="currentColor" />
+</svg>

--- a/src/composables/audio-reader/use-audio-player.ts
+++ b/src/composables/audio-reader/use-audio-player.ts
@@ -106,3 +106,5 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
 
   return { current_time, duration, is_playing, play, pause, seek }
 }
+
+export type AudioPlayer = ReturnType<typeof useAudioPlayer>

--- a/src/composables/audio-reader/use-lesson-reader.ts
+++ b/src/composables/audio-reader/use-lesson-reader.ts
@@ -35,8 +35,8 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
   const { data: audio_url } = useLessonAudioUrlQuery(audio_path)
 
   const audio_el = useTemplateRef<HTMLAudioElement>('audio')
-  const { current_time } = useAudioPlayer(audio_el)
-  const { active_index: active_word } = useTranscriptSync(words, current_time)
+  const player = useAudioPlayer(audio_el)
+  const { active_index: active_word } = useTranscriptSync(words, player.current_time)
 
   const selection = ref<TermSelection | null>(null)
   const popover_open = ref(false)
@@ -63,6 +63,7 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
     selection,
     popover_open,
     openTerm,
-    closeTerm
+    closeTerm,
+    player
   }
 }

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -266,6 +266,8 @@
   "lesson-view.prev-button": "Previous chapter",
   "lesson-view.next-button": "Next chapter",
   "lesson-view.edit-button": "Edit collection",
+  "lesson-view.audio.play-button": "Play",
+  "lesson-view.audio.pause-button": "Pause",
   "audio-reader.lesson-card.delete-button": "Delete lesson",
   "audio-reader.lesson-card.retry-button": "Retry",
   "audio-reader.lesson-card.processing-fallback": "Processing…",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,6 +24,12 @@ async function requireAudioReader() {
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
+  // The app scrolls the page (not inner containers), so reset to the top on each
+  // navigation — including chapter-to-chapter param changes — and restore the
+  // saved position on back/forward.
+  scrollBehavior(_to, _from, savedPosition) {
+    return savedPosition ?? { top: 0 }
+  },
   routes: [
     {
       path: '/welcome',

--- a/src/views/audio-reader/lesson/audio-player.vue
+++ b/src/views/audio-reader/lesson/audio-player.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { computed, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+import UiButton from '@/components/ui-kit/button.vue'
+import type { AudioPlayer } from '@/composables/audio-reader/use-audio-player'
+
+type AudioPlayerProps = {
+  player: AudioPlayer
+}
+
+const { player } = defineProps<AudioPlayerProps>()
+
+const { t } = useI18n()
+
+const track = useTemplateRef<HTMLElement>('track')
+
+const is_playing = computed(() => player.is_playing.value)
+const progress = computed(() => {
+  const total = player.duration.value
+  return total > 0 ? (player.current_time.value / total) * 100 : 0
+})
+const current_label = computed(() => formatTime(player.current_time.value))
+const duration_label = computed(() => formatTime(player.duration.value))
+
+function formatTime(seconds: number) {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00'
+
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+function toggle() {
+  if (player.is_playing.value) player.pause()
+  else player.play()
+}
+
+function seekToClientX(client_x: number) {
+  const el = track.value
+  const total = player.duration.value
+  if (!el || total <= 0) return
+
+  const rect = el.getBoundingClientRect()
+  const ratio = Math.min(Math.max((client_x - rect.left) / rect.width, 0), 1)
+  player.seek(ratio * total)
+}
+
+function onScrubStart(e: PointerEvent) {
+  ;(e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId)
+  seekToClientX(e.clientX)
+}
+
+function onScrubMove(e: PointerEvent) {
+  if (e.buttons === 0) return
+  seekToClientX(e.clientX)
+}
+</script>
+
+<template>
+  <div data-testid="audio-player" class="flex min-w-0 flex-1 items-center gap-3">
+    <ui-button
+      data-testid="audio-player__toggle"
+      data-theme="grey-400"
+      :icon-left="is_playing ? 'pause' : 'play'"
+      icon-only
+      size="lg"
+      @click="toggle"
+    >
+      {{ is_playing ? t('lesson-view.audio.pause-button') : t('lesson-view.audio.play-button') }}
+    </ui-button>
+
+    <span
+      data-testid="audio-player__current"
+      class="hidden shrink-0 text-base text-brown-500 tabular-nums sm:block dark:text-grey-400"
+    >
+      {{ current_label }}
+    </span>
+
+    <div
+      ref="track"
+      data-testid="audio-player__track"
+      class="relative h-2.5 min-w-0 flex-1 cursor-pointer touch-none rounded-full bg-brown-200 dark:bg-grey-700"
+      role="slider"
+      :aria-valuemin="0"
+      :aria-valuemax="100"
+      :aria-valuenow="Math.round(progress)"
+      @pointerdown="onScrubStart"
+      @pointermove="onScrubMove"
+    >
+      <div
+        data-testid="audio-player__fill"
+        class="absolute inset-y-0 left-0 rounded-full bg-blue-500 dark:bg-blue-650"
+        :style="{ width: `${progress}%` }"
+      >
+        <div
+          data-testid="audio-player__thumb"
+          class="absolute top-1/2 right-0 size-4 -translate-y-1/2 translate-x-1/2 rounded-full bg-blue-500 dark:bg-blue-650"
+        ></div>
+      </div>
+    </div>
+
+    <span
+      data-testid="audio-player__duration"
+      class="hidden shrink-0 text-base text-brown-500 tabular-nums sm:block dark:text-grey-400"
+    >
+      {{ duration_label }}
+    </span>
+  </div>
+</template>

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -61,9 +61,12 @@ watch(
 <template>
   <section
     data-testid="lesson-view"
-    class="flex h-[calc(100dvh-var(--nav-height))] flex-col gap-6 xl:flex-row"
+    class="flex min-h-[calc(100dvh-var(--nav-height))] flex-col gap-6 xl:flex-row"
   >
-    <aside data-testid="lesson-view__sidebar" class="flex shrink-0 flex-col gap-4 xl:w-56">
+    <aside
+      data-testid="lesson-view__sidebar"
+      class="flex shrink-0 flex-col gap-4 xl:sticky xl:top-(--nav-height) xl:max-h-[calc(100dvh-var(--nav-height))] xl:w-56 xl:self-start xl:overflow-y-auto"
+    >
       <header data-testid="lesson-view__header" class="flex items-center justify-between gap-4">
         <div data-testid="lesson-view__heading" class="flex flex-col gap-1">
           <h1 class="text-3xl text-brown-700 dark:text-brown-300">{{ lesson?.title }}</h1>
@@ -91,7 +94,7 @@ watch(
 
       <nav
         data-testid="lesson-view__chapters"
-        class="flex gap-2 overflow-x-auto pb-2 xl:min-h-0 xl:flex-1 xl:flex-col xl:overflow-x-visible xl:overflow-y-auto xl:pb-0"
+        class="flex gap-2 overflow-x-auto pb-2 xl:flex-col xl:overflow-x-visible xl:pb-0"
       >
         <button
           v-for="(chapter, index) in chapters"
@@ -107,61 +110,59 @@ watch(
       </nav>
     </aside>
 
-    <div data-testid="lesson-view__reader" class="relative flex min-h-0 flex-1 flex-col xl:min-w-0">
-      <div data-testid="lesson-view__scroll" class="scroll-hidden min-h-0 flex-1 overflow-y-auto">
-        <div
-          data-testid="lesson-view__transcript"
-          class="rounded-7 bg-brown-100 px-0 pt-6 pb-2 sm:px-6 dark:bg-grey-800"
-        >
-          <transcript-view
-            :paragraphs="paragraphs"
-            :active_word="active_word"
-            :popover_open="popover_open"
-            @select="openTerm"
-          />
-        </div>
-
-        <footer
-          data-testid="lesson-view__bar"
-          class="sticky bottom-0 z-30 mt-4 flex flex-col gap-2 border-t border-brown-300 bg-brown-100 pt-3 pb-[env(safe-area-inset-bottom)] pointer-coarse:pr-18 dark:border-grey-700 dark:bg-grey-900"
-        >
-          <audio
-            ref="audio"
-            data-testid="lesson-view__audio"
-            :src="audio_url ?? undefined"
-            controls
-            class="w-full"
-          />
-
-          <div data-testid="lesson-view__nav" class="flex items-center justify-between gap-3">
-            <ui-button
-              data-testid="lesson-view__prev"
-              data-theme="grey-400"
-              icon-left="chevron-left"
-              icon-only
-              size="lg"
-              :disabled="!prev_chapter"
-              @click="prev_chapter && goToChapter(prev_chapter.id)"
-            >
-              {{ t('lesson-view.prev-button') }}
-            </ui-button>
-
-            <ui-button
-              data-testid="lesson-view__next"
-              data-theme="grey-400"
-              icon-left="chevron-right"
-              icon-only
-              size="lg"
-              :disabled="!next_chapter"
-              @click="next_chapter && goToChapter(next_chapter.id)"
-            >
-              {{ t('lesson-view.next-button') }}
-            </ui-button>
-          </div>
-        </footer>
+    <div data-testid="lesson-view__reader" class="relative flex flex-1 flex-col xl:min-w-0">
+      <div
+        data-testid="lesson-view__transcript"
+        class="rounded-7 bg-brown-100 px-0 pt-6 pb-2 sm:px-6 dark:bg-grey-800"
+      >
+        <transcript-view
+          :paragraphs="paragraphs"
+          :active_word="active_word"
+          :popover_open="popover_open"
+          @select="openTerm"
+        />
       </div>
 
-      <scroll-bar class="absolute inset-y-3 right-2" target="[data-testid='lesson-view__scroll']" />
+      <footer
+        data-testid="lesson-view__bar"
+        class="sticky bottom-0 z-30 mt-4 flex flex-col gap-2 border-t border-brown-300 bg-brown-100 pt-3 pb-[env(safe-area-inset-bottom)] pointer-coarse:pr-18 dark:border-grey-700 dark:bg-grey-900"
+      >
+        <audio
+          ref="audio"
+          data-testid="lesson-view__audio"
+          :src="audio_url ?? undefined"
+          controls
+          class="w-full"
+        />
+
+        <div data-testid="lesson-view__nav" class="flex items-center justify-between gap-3">
+          <ui-button
+            data-testid="lesson-view__prev"
+            data-theme="grey-400"
+            icon-left="chevron-left"
+            icon-only
+            size="lg"
+            :disabled="!prev_chapter"
+            @click="prev_chapter && goToChapter(prev_chapter.id)"
+          >
+            {{ t('lesson-view.prev-button') }}
+          </ui-button>
+
+          <ui-button
+            data-testid="lesson-view__next"
+            data-theme="grey-400"
+            icon-left="chevron-right"
+            icon-only
+            size="lg"
+            :disabled="!next_chapter"
+            @click="next_chapter && goToChapter(next_chapter.id)"
+          >
+            {{ t('lesson-view.next-button') }}
+          </ui-button>
+        </div>
+      </footer>
+
+      <scroll-bar class="fixed top-(--nav-height) right-1 bottom-3" target="html" />
 
       <term-popover
         v-if="selection"

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -7,6 +7,7 @@ import { useLessonReader } from '@/composables/audio-reader/use-lesson-reader'
 import { useCollectionEditModal } from '@/composables/modals/use-collection-edit-modal'
 import UiButton from '@/components/ui-kit/button.vue'
 import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
+import AudioPlayer from '@/views/audio-reader/lesson/audio-player.vue'
 import TranscriptView from '@/views/audio-reader/transcript/index.vue'
 import TermPopover from '@/views/audio-reader/term-popover/index.vue'
 
@@ -24,8 +25,17 @@ const set_progress = useSetCollectionProgressMutation()
 const collection_id = computed(() => Number(collectionId))
 const lesson_id = computed(() => Number(lessonId))
 
-const { lesson, paragraphs, audio_url, active_word, selection, popover_open, openTerm, closeTerm } =
-  useLessonReader(lesson_id)
+const {
+  lesson,
+  paragraphs,
+  audio_url,
+  active_word,
+  selection,
+  popover_open,
+  openTerm,
+  closeTerm,
+  player
+} = useLessonReader(lesson_id)
 
 const { data: lessons_data } = useLessonsByCollectionQuery(collection_id)
 
@@ -125,44 +135,43 @@ watch(
 
       <footer
         data-testid="lesson-view__bar"
-        class="sticky bottom-0 z-30 mt-4 flex flex-col gap-2 border-t border-brown-300 bg-brown-100 pt-3 pb-[env(safe-area-inset-bottom)] pointer-coarse:pr-18 dark:border-grey-700 dark:bg-grey-900"
+        class="sticky bottom-0 z-30 mt-4 flex items-center gap-3 border-t border-brown-300 bg-brown-100 pt-3 pb-[env(safe-area-inset-bottom)] pointer-coarse:pr-18 pointer-fine:pb-6 dark:border-grey-700 dark:bg-grey-900"
       >
+        <ui-button
+          data-testid="lesson-view__prev"
+          data-theme="grey-400"
+          icon-left="chevron-left"
+          icon-only
+          size="lg"
+          :disabled="!prev_chapter"
+          @click="prev_chapter && goToChapter(prev_chapter.id)"
+        >
+          {{ t('lesson-view.prev-button') }}
+        </ui-button>
+
+        <audio-player :player="player" />
+
+        <ui-button
+          data-testid="lesson-view__next"
+          data-theme="grey-400"
+          icon-left="chevron-right"
+          icon-only
+          size="lg"
+          :disabled="!next_chapter"
+          @click="next_chapter && goToChapter(next_chapter.id)"
+        >
+          {{ t('lesson-view.next-button') }}
+        </ui-button>
+
         <audio
           ref="audio"
           data-testid="lesson-view__audio"
           :src="audio_url ?? undefined"
-          controls
-          class="w-full"
+          class="hidden"
         />
-
-        <div data-testid="lesson-view__nav" class="flex items-center justify-between gap-3">
-          <ui-button
-            data-testid="lesson-view__prev"
-            data-theme="grey-400"
-            icon-left="chevron-left"
-            icon-only
-            size="lg"
-            :disabled="!prev_chapter"
-            @click="prev_chapter && goToChapter(prev_chapter.id)"
-          >
-            {{ t('lesson-view.prev-button') }}
-          </ui-button>
-
-          <ui-button
-            data-testid="lesson-view__next"
-            data-theme="grey-400"
-            icon-left="chevron-right"
-            icon-only
-            size="lg"
-            :disabled="!next_chapter"
-            @click="next_chapter && goToChapter(next_chapter.id)"
-          >
-            {{ t('lesson-view.next-button') }}
-          </ui-button>
-        </div>
       </footer>
 
-      <scroll-bar class="fixed top-(--nav-height) right-1 bottom-3" target="html" />
+      <scroll-bar class="fixed top-(--nav-height) right-6 bottom-6" target="html" />
 
       <term-popover
         v-if="selection"

--- a/src/views/authenticated.vue
+++ b/src/views/authenticated.vue
@@ -21,11 +21,11 @@ const session = useSessionStore()
     class="absolute inset-0 text-white"
     @finish="clearStaticLoader"
   >
-    <div class="flex flex-col h-full w-full md:items-center">
+    <div class="flex flex-col min-h-dvh w-full shrink-0 md:items-center">
       <nav-bar />
       <phone />
 
-      <main class="md:flex-1 md:min-h-0 w-full max-w-(--page-width) px-4 sm:px-16">
+      <main class="w-full max-w-(--page-width) px-4 sm:px-16">
         <router-view v-slot="{ Component, route }">
           <suspense>
             <component :is="Component" />

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -45,7 +45,7 @@ async function onCreateDeckClicked() {
 <template>
   <div
     data-testid="dashboard"
-    class="grid grid-cols-[1fr] md:grid-cols-[345px_1fr] md:grid-rows-[auto_1fr] gap-x-15.5 gap-y-6 md:gap-y-11.5 h-full pb-12"
+    class="grid grid-cols-[1fr] md:grid-cols-[345px_1fr] md:grid-rows-[auto_auto] gap-x-15.5 gap-y-6 md:gap-y-11.5 pb-12"
   >
     <ui-button
       icon-left="add"

--- a/src/views/deck/index.vue
+++ b/src/views/deck/index.vue
@@ -36,7 +36,7 @@ const { prev_page_number, next_page_number } = editor.carousel
 <template>
   <section
     data-testid="deck-view"
-    class="flex md:h-full flex-col xl:flex-row items-center xl:items-start gap-6 md:gap-15"
+    class="flex md:h-[calc(100dvh-var(--nav-height))] flex-col xl:flex-row items-center xl:items-start gap-6 md:gap-15"
   >
     <deck-hero
       v-if="deck"

--- a/tests/integration/views/audio-reader/lesson/audio-player.test.js
+++ b/tests/integration/views/audio-reader/lesson/audio-player.test.js
@@ -1,0 +1,168 @@
+import { describe, test, expect, vi } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { nextTick, ref } from 'vue'
+
+import AudioPlayer from '@/views/audio-reader/lesson/audio-player.vue'
+import UiButton from '@/components/ui-kit/button.vue'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    current_time: ref(0),
+    duration: ref(120),
+    is_playing: ref(false),
+    play: vi.fn(),
+    pause: vi.fn(),
+    seek: vi.fn(),
+    ...overrides
+  }
+}
+
+function mountPlayer(player) {
+  return shallowMount(AudioPlayer, { props: { player } })
+}
+
+function stubTrackRect(wrapper, { left = 0, width = 200 } = {}) {
+  const track = wrapper.find('[data-testid="audio-player__track"]')
+  track.element.getBoundingClientRect = () => ({
+    left,
+    width,
+    right: left + width,
+    top: 0,
+    bottom: 0,
+    height: 0
+  })
+  // The real browser throws on setPointerCapture without an active pointer.
+  track.element.setPointerCapture = () => {}
+  return track
+}
+
+function scrub(track, clientX) {
+  track.element.dispatchEvent(new PointerEvent('pointerdown', { clientX, bubbles: true }))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('AudioPlayer', () => {
+  describe('play/pause toggle', () => {
+    test('plays when paused', async () => {
+      const player = makePlayer({ is_playing: ref(false) })
+      const wrapper = mountPlayer(player)
+
+      await wrapper.find('[data-testid="audio-player__toggle"]').trigger('click')
+
+      expect(player.play).toHaveBeenCalledOnce()
+      expect(player.pause).not.toHaveBeenCalled()
+    })
+
+    test('pauses when playing', async () => {
+      const player = makePlayer({ is_playing: ref(true) })
+      const wrapper = mountPlayer(player)
+
+      await wrapper.find('[data-testid="audio-player__toggle"]').trigger('click')
+
+      expect(player.pause).toHaveBeenCalledOnce()
+      expect(player.play).not.toHaveBeenCalled()
+    })
+
+    test('shows the play icon when paused and the pause icon when playing', () => {
+      const paused = mountPlayer(makePlayer({ is_playing: ref(false) }))
+      expect(paused.findComponent(UiButton).props('iconLeft')).toBe('play')
+
+      const playing = mountPlayer(makePlayer({ is_playing: ref(true) }))
+      expect(playing.findComponent(UiButton).props('iconLeft')).toBe('pause')
+    })
+  })
+
+  describe('progress fill', () => {
+    test('width reflects current_time over duration', () => {
+      const wrapper = mountPlayer(makePlayer({ current_time: ref(30), duration: ref(120) }))
+
+      expect(wrapper.find('[data-testid="audio-player__fill"]').attributes('style')).toContain(
+        'width: 25%'
+      )
+    })
+
+    test('reacts to current_time changes', async () => {
+      const player = makePlayer({ current_time: ref(30), duration: ref(120) })
+      const wrapper = mountPlayer(player)
+
+      player.current_time.value = 60
+      await nextTick()
+
+      expect(wrapper.find('[data-testid="audio-player__fill"]').attributes('style')).toContain(
+        'width: 50%'
+      )
+    })
+
+    test('stays at 0% when duration is zero (no divide-by-zero)', () => {
+      const wrapper = mountPlayer(makePlayer({ current_time: ref(10), duration: ref(0) }))
+
+      expect(wrapper.find('[data-testid="audio-player__fill"]').attributes('style')).toContain(
+        'width: 0%'
+      )
+    })
+
+    test('exposes rounded progress as aria-valuenow', () => {
+      const wrapper = mountPlayer(makePlayer({ current_time: ref(40), duration: ref(120) }))
+
+      expect(wrapper.find('[data-testid="audio-player__track"]').attributes('aria-valuenow')).toBe(
+        '33'
+      )
+    })
+  })
+
+  describe('time labels', () => {
+    test('formats current time and duration as m:ss', () => {
+      const wrapper = mountPlayer(makePlayer({ current_time: ref(72), duration: ref(5) }))
+
+      expect(wrapper.find('[data-testid="audio-player__current"]').text()).toBe('1:12')
+      expect(wrapper.find('[data-testid="audio-player__duration"]').text()).toBe('0:05')
+    })
+
+    test('falls back to 0:00 for a non-finite duration', () => {
+      const wrapper = mountPlayer(makePlayer({ duration: ref(Number.NaN) }))
+
+      expect(wrapper.find('[data-testid="audio-player__duration"]').text()).toBe('0:00')
+    })
+  })
+
+  describe('seek on scrub', () => {
+    test('seeks to the fraction of duration under the pointer', () => {
+      const player = makePlayer({ duration: ref(120) })
+      const track = stubTrackRect(mountPlayer(player), { left: 0, width: 200 })
+
+      scrub(track, 100)
+
+      expect(player.seek).toHaveBeenCalledWith(60)
+    })
+
+    test('clamps past the right edge to the end', () => {
+      const player = makePlayer({ duration: ref(120) })
+      const track = stubTrackRect(mountPlayer(player), { left: 0, width: 200 })
+
+      scrub(track, 300)
+
+      expect(player.seek).toHaveBeenCalledWith(120)
+    })
+
+    test('clamps before the left edge to the start', () => {
+      const player = makePlayer({ duration: ref(120) })
+      const track = stubTrackRect(mountPlayer(player), { left: 0, width: 200 })
+
+      scrub(track, -50)
+
+      expect(player.seek).toHaveBeenCalledWith(0)
+    })
+
+    test('does not seek when duration is unknown', () => {
+      const player = makePlayer({ duration: ref(0) })
+      const track = stubTrackRect(mountPlayer(player), { left: 0, width: 200 })
+
+      scrub(track, 100)
+
+      expect(player.seek).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Full-page scroll shell.** The app previously clamped each view to one viewport and scrolled an inner container, which let the sticky nav release after one screen and stopped Safari collapsing its URL bar. The shell wrapper now grows with content (`min-h-dvh` + `shrink-0`) and `<main>` flows, so the document scrolls and the sticky nav survives the whole way down.
- **View adaptations.** Dashboard flows; deck keeps its own bounded height via a `dvh` calc so the virtualized card list still has a real scroll container; the lesson reader page-scrolls with a sticky audio bar, an aside that scrolls away on mobile (sticky on desktop), and a page-targeted scroll-bar. A router `scrollBehavior` resets scroll per navigation (incl. chapter switches).
- **Custom inline audio player.** Replaces the native `<audio controls>` with a compact play/pause + seekable progress bar + time labels, so the controls sit inline with the chapter prev/next buttons at every width (the native control hid its seek bar when squeezed on mobile). Backed by the existing `useAudioPlayer`; component tests added.