### PR TITLE
fix(transcription): durable phase chain so lessons can't get stuck

### DIFF
--- a/.claude/logs/learning-log.md
+++ b/.claude/logs/learning-log.md
@@ -237,3 +237,13 @@ When appending:
 | Function EXECUTE grants: REVOKE FROM public ≠ anon/authenticated    | 4     |
 | Supabase default-privileges (DB-as-API) + why definer fns are risky | 4     |
 | Storage orphan GC: tracked-bucket scan + created_at grace window    | 5     |
+
+### 2026-06-06 — transcription: durable phase chain + stall reaper
+
+| Concept                                                            | Score |
+| ------------------------------------------------------------------ | ----- |
+| Trigger-driven state machine: a phase write fires the next step    | 2     |
+| pg_net.http_post from a SECURITY DEFINER trigger (reuses Vault)    | 2     |
+| IS DISTINCT FROM as null-safe inequality in a trigger guard        | 2     |
+| AFTER trigger fires after commit, so pg_net never reads a stale row | 2     |
+| Reaper/watchdog cron: time-based sweep that settles stuck rows     | 3     |

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -280,6 +280,7 @@
   "audio-reader.lesson-error.invalid-audio": "That audio couldn't be read.",
   "audio-reader.lesson-error.upstream": "Transcription service error. Try again.",
   "audio-reader.lesson-error.audio-unavailable": "Couldn't read the uploaded audio. Try again.",
+  "audio-reader.lesson-error.stalled": "Transcription stalled. Try again.",
   "audio-reader.lesson-error.unknown": "Transcription failed. Try again.",
   "audio-reader.upload.title": "New Lesson",
   "audio-reader.upload.title-placeholder": "Lesson title",

--- a/src/views/audio-reader/lesson-card.vue
+++ b/src/views/audio-reader/lesson-card.vue
@@ -17,7 +17,8 @@ const ERROR_KEYS: Record<string, string> = {
   file_too_large: 'audio-reader.lesson-error.file-too-large',
   invalid_audio: 'audio-reader.lesson-error.invalid-audio',
   upstream_error: 'audio-reader.lesson-error.upstream',
-  audio_unavailable: 'audio-reader.lesson-error.audio-unavailable'
+  audio_unavailable: 'audio-reader.lesson-error.audio-unavailable',
+  stalled: 'audio-reader.lesson-error.stalled'
 }
 
 const { lesson } = defineProps<{ lesson: Lesson }>()

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -267,12 +267,12 @@ enabled = false
 [edge_runtime]
 enabled = true
 # Configure one of the supported request policies: `oneshot`, `per_worker`.
-# `oneshot` gives function hot-reload but TERMINATES the worker the moment it
-# returns a response — which kills `EdgeRuntime.waitUntil` background tasks. The
-# transcribe-lesson worker runs transcription in the background after returning
-# 202, so it needs `per_worker` (also matches hosted Supabase's behavior). The
-# cost is no hot-reload: restart `supabase` to pick up edge-function edits.
-policy = "per_worker"
+# `oneshot` terminates the worker the moment it returns a response (and gives
+# local hot-reload). transcribe-lesson no longer backgrounds work past its
+# response — each invocation runs ONE phase synchronously and returns, with the
+# DB chain trigger driving the next phase — so `oneshot` is correct and we keep
+# hot-reload. (It was `per_worker` while the worker used EdgeRuntime.waitUntil.)
+policy = "oneshot"
 # Port to attach the Chrome inspector for debugging edge functions.
 inspector_port = 8083
 

--- a/supabase/functions/_shared/transcription/anthropic.ts
+++ b/supabase/functions/_shared/transcription/anthropic.ts
@@ -1,0 +1,77 @@
+// Shared Claude (Anthropic) call for the transcription enrichers (translate +
+// transliterate). Both post the same structured-output request shape and both
+// must be best-effort, so the request, the timeout, and the failure handling
+// live here once.
+//
+// The timeout is the important part: unlike the Whisper call, the old enricher
+// requests had no AbortController, so a hung upstream would keep the worker
+// running until the platform force-killed the isolate — stranding the lesson
+// row mid-phase. Bounding the request turns that hang into a clean null the
+// caller already knows how to absorb.
+
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
+
+// A structured Haiku batch is small; a minute is generous headroom over normal
+// latency while still failing fast enough to stay inside one phase's budget.
+const REQUEST_TIMEOUT_MS = 60_000
+
+export type StructuredRequest = {
+  model: string
+  system: string
+  prompt: string
+  // JSON Schema the response is constrained to (guarantees a parseable body).
+  schema: object
+}
+
+// POST a structured-output request and return the model's raw text (the JSON
+// string the schema produced), or null on ANY failure — HTTP error, refusal,
+// truncation, timeout, or a dropped connection. Callers parse their own field
+// from the text and treat null as "this batch didn't come back".
+export async function requestStructured({
+  model,
+  system,
+  prompt,
+  schema
+}: StructuredRequest): Promise<string | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  let res: Response
+  try {
+    res = await fetch(ANTHROPIC_URL, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': Deno.env.get('ANTHROPIC_API_KEY')!,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 4096,
+        system,
+        output_config: { format: { type: 'json_schema', schema } },
+        messages: [{ role: 'user', content: prompt }]
+      })
+    })
+  } catch (error) {
+    console.error(
+      'Anthropic request failed',
+      controller.signal.aborted ? 'timeout' : 'network',
+      error
+    )
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+
+  if (!res.ok) {
+    console.error('Anthropic error', res.status, await res.text())
+    return null
+  }
+
+  const data = await res.json()
+  if (data?.stop_reason === 'max_tokens' || data?.stop_reason === 'refusal') return null
+
+  return data?.content?.[0]?.text ?? ''
+}

--- a/supabase/functions/_shared/transcription/translate.ts
+++ b/supabase/functions/_shared/transcription/translate.ts
@@ -4,7 +4,8 @@
 // Claude Haiku with structured output. Sentences are translated in batches so a
 // long lesson can't blow max_tokens.
 
-const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
+import { requestStructured } from './anthropic.ts'
+
 const MODEL = 'claude-haiku-4-5'
 
 // Few enough that a batch's translations comfortably fit under max_tokens, but
@@ -42,31 +43,13 @@ async function translateBatch(sentences: string[], target_lang: string): Promise
   const numbered = sentences.map((s, i) => `${i + 1}. ${s}`).join('\n')
   const userPrompt = `Target language: ${target_lang}\nSentences (${sentences.length}):\n${numbered}`
 
-  const res = await fetch(ANTHROPIC_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': Deno.env.get('ANTHROPIC_API_KEY')!,
-      'anthropic-version': '2023-06-01'
-    },
-    body: JSON.stringify({
-      model: MODEL,
-      max_tokens: 4096,
-      system: SYSTEM_PROMPT,
-      output_config: { format: { type: 'json_schema', schema: RESULT_SCHEMA } },
-      messages: [{ role: 'user', content: userPrompt }]
-    })
+  const raw = await requestStructured({
+    model: MODEL,
+    system: SYSTEM_PROMPT,
+    prompt: userPrompt,
+    schema: RESULT_SCHEMA
   })
-
-  if (!res.ok) {
-    console.error('Anthropic error', res.status, await res.text())
-    return null
-  }
-
-  const data = await res.json()
-  if (data?.stop_reason === 'max_tokens' || data?.stop_reason === 'refusal') return null
-
-  const raw = data?.content?.[0]?.text ?? ''
+  if (raw === null) return null
 
   let translations: unknown
   try {

--- a/supabase/functions/_shared/transcription/transliterate.ts
+++ b/supabase/functions/_shared/transcription/transliterate.ts
@@ -13,7 +13,8 @@
 // Words are batched so a long lesson can't blow max_tokens; numbering runs
 // continuously across a batch so the output stays a single flat array.
 
-const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
+import { requestStructured } from './anthropic.ts'
+
 const MODEL = 'claude-haiku-4-5'
 
 // Cap words per request so the readings array stays well under max_tokens.
@@ -92,31 +93,13 @@ async function readBatch(batch: ReadingSentence[], lang: string): Promise<string
     `Source language: ${lang}\n\n${prompt}\n` +
     `Return ${total} readings, one per numbered token, in order.`
 
-  const res = await fetch(ANTHROPIC_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': Deno.env.get('ANTHROPIC_API_KEY')!,
-      'anthropic-version': '2023-06-01'
-    },
-    body: JSON.stringify({
-      model: MODEL,
-      max_tokens: 4096,
-      system: SYSTEM_PROMPT,
-      output_config: { format: { type: 'json_schema', schema: RESULT_SCHEMA } },
-      messages: [{ role: 'user', content: userPrompt }]
-    })
+  const raw = await requestStructured({
+    model: MODEL,
+    system: SYSTEM_PROMPT,
+    prompt: userPrompt,
+    schema: RESULT_SCHEMA
   })
-
-  if (!res.ok) {
-    console.error('Anthropic error', res.status, await res.text())
-    return null
-  }
-
-  const data = await res.json()
-  if (data?.stop_reason === 'max_tokens' || data?.stop_reason === 'refusal') return null
-
-  const raw = data?.content?.[0]?.text ?? ''
+  if (raw === null) return null
 
   let readings: unknown
   try {

--- a/supabase/functions/transcribe-lesson/index.ts
+++ b/supabase/functions/transcribe-lesson/index.ts
@@ -1,16 +1,22 @@
-// transcribe-lesson: kick off (or retry) async transcription of a lesson.
+// transcribe-lesson: kick off (or retry) async transcription, and run one phase
+// of it when the DB chain asks.
 //
-// Request:  { action: 'start',  collection_id, title, audio_path, script?, lang? }
-//           { action: 'retry',  lesson_id }
-// Response: 202 { lesson }  — the row is created/reset to `processing` and a
-//           background worker transcribes it; the FE polls the row for the result.
+// Member-initiated (admin-gated, caller's JWT):
+//   { action: 'start',  collection_id, title, audio_path, script?, lang? }
+//   { action: 'retry',  lesson_id }
+//     → 202 { lesson }. The row is created/reset to `processing`; the DB chain
+//       trigger then drives transcription phase by phase. The FE polls the row.
 //
-// The OpenAI/Anthropic keys never reach the client. Admin-only: requireAdmin()
-// runs before any work.
+// Internal (service-role only, invoked by the chain trigger via pg_net):
+//   { action: 'process', lesson_id }
+//     → 200 { ok }. Runs the single phase the row is on and returns. Advancing
+//       the phase fires the next 'process'; settling ends the chain.
+//
+// The OpenAI/Anthropic keys never reach the client.
 
 import { cors, requireAdmin } from '../_shared/require-admin.ts'
-import { isTargetScript, type TargetScript } from '../_shared/transcription/script.ts'
-import { runTranscription } from './worker.ts'
+import { isTargetScript } from '../_shared/transcription/script.ts'
+import { processLessonPhase, serviceClient } from './worker.ts'
 import { type SupabaseClient } from '@supabase/supabase-js'
 
 function jsonError(code: string, status: number): Response {
@@ -27,16 +33,6 @@ function accepted(lesson: unknown): Response {
   })
 }
 
-// Supabase keeps the worker instance alive until the promise settles, so
-// transcription continues after we've returned 202. Falls back to a detached
-// call when the runtime global is absent (e.g. local `deno test`).
-function runInBackground(promise: Promise<unknown>): void {
-  const runtime = (globalThis as { EdgeRuntime?: { waitUntil(p: Promise<unknown>): void } })
-    .EdgeRuntime
-  if (runtime?.waitUntil) runtime.waitUntil(promise)
-  else void promise
-}
-
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: cors })
@@ -45,19 +41,23 @@ Deno.serve(async (req) => {
     return new Response('Method Not Allowed', { status: 405, headers: cors })
   }
 
+  const body = await req.json().catch(() => ({}))
+
+  // 'process' is the internal step-runner: it authenticates by the service-role
+  // key the chain trigger sends, NOT by a member JWT, so it's handled before the
+  // admin gate that 'start'/'retry' go through.
+  if (body?.action === 'process') return handleProcess(req, body)
+
   const auth = await requireAdmin(req)
   if ('error' in auth) return auth.error
 
-  const body = await req.json().catch(() => ({}))
-
-  if (body?.action === 'start') return handleStart(body, auth.admin, auth.userClient)
+  if (body?.action === 'start') return handleStart(body, auth.userClient)
   if (body?.action === 'retry') return handleRetry(body, auth.admin, auth.userClient)
   return jsonError('bad_request', 400)
 })
 
 async function handleStart(
   body: Record<string, unknown>,
-  admin: SupabaseClient,
   userClient: SupabaseClient
 ): Promise<Response> {
   const { collection_id, title, audio_path } = body
@@ -66,7 +66,9 @@ async function handleStart(
   const script = isTargetScript(body.script) ? body.script : 'original'
 
   // Create the pending row under the caller's JWT so RLS applies and the
-  // set_member_id trigger stamps member_id; the worker then writes via service-role.
+  // set_member_id trigger stamps member_id. The INSERT (status='processing',
+  // phase='transcribing') fires the chain trigger — the first 'process' call —
+  // so there's nothing to background here; we just return the row.
   const { data: lesson, error } = await userClient
     .rpc('create_pending_lesson', {
       p_collection_id: collection_id,
@@ -75,14 +77,13 @@ async function handleStart(
       p_script: script,
       p_lang: body.lang ?? null
     })
-    .single<{ id: number; audio_path: string; script: string }>()
+    .single<{ id: number }>()
 
   if (error || !lesson) {
     console.error('create_pending_lesson failed', error?.message)
     return jsonError('create_failed', 400)
   }
 
-  runInBackground(runTranscription(admin, { ...lesson, script: script }))
   return accepted(lesson)
 }
 
@@ -97,17 +98,46 @@ async function handleRetry(
   // Read under the caller's JWT — RLS guarantees they can only retry their own.
   const { data: lesson, error } = await userClient
     .from('lessons')
-    .select('id, audio_path, script')
+    .select('id')
     .eq('id', lesson_id)
-    .single<{ id: number; audio_path: string; script: TargetScript }>()
+    .single<{ id: number }>()
 
   if (error || !lesson) return jsonError('not_found', 404)
 
-  await admin
+  // Reset to the start of the chain; the UPDATE re-fires the chain trigger. The
+  // audio + script are still on the row, so the worker reloads everything.
+  const reset = { status: 'processing', phase: 'transcribing', error_code: null }
+  const { error: updateError } = await admin
     .from('lessons')
-    .update({ status: 'processing', phase: 'transcribing', error_code: null })
+    .update({ ...reset, updated_at: new Date().toISOString() })
     .eq('id', lesson.id)
 
-  runInBackground(runTranscription(admin, lesson))
-  return accepted({ ...lesson, status: 'processing', phase: 'transcribing', error_code: null })
+  if (updateError) {
+    console.error('retry reset failed', updateError.message)
+    return jsonError('retry_failed', 400)
+  }
+
+  return accepted({ ...lesson, ...reset })
+}
+
+// Internal: run one phase. Authenticated by the service-role key (the chain
+// trigger sends it; verify_jwt at the gateway only proves it's a valid project
+// token, so we also check it IS the service key — a member token must not reach
+// here). Always 200 once authorized: processLessonPhase settles the row itself,
+// so the chain never retries on our response.
+async function handleProcess(req: Request, body: Record<string, unknown>): Promise<Response> {
+  const expected = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  if (!expected || req.headers.get('Authorization') !== `Bearer ${expected}`) {
+    return new Response('Forbidden', { status: 403, headers: cors })
+  }
+
+  const lessonId = Number(body.lesson_id)
+  if (!Number.isFinite(lessonId)) return jsonError('missing_fields', 400)
+
+  await processLessonPhase(serviceClient(), lessonId)
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { ...cors, 'Content-Type': 'application/json' }
+  })
 }

--- a/supabase/functions/transcribe-lesson/worker.test.ts
+++ b/supabase/functions/transcribe-lesson/worker.test.ts
@@ -1,0 +1,117 @@
+// Tests for the phase state machine in worker.ts — the orchestration the DB
+// chain drives one step at a time. The per-step cores (Whisper, translate,
+// transliterate) have their own tests; here we use phases whose work short-
+// circuits without a network call (empty segments/words, or a download that
+// fails) so we can assert dispatch, idempotency, terminal settling, and that a
+// failed write surfaces as a 'failed' row rather than being swallowed.
+
+import { assertEquals } from '@std/assert'
+import { processLessonPhase } from './worker.ts'
+
+type LoadResult = { data: unknown; error: unknown }
+
+// Minimal fake of the supabase-js client surface worker.ts touches:
+//   from('lessons').select(...).eq(...).single()  -> loadLesson
+//   from('lessons').update(patch).eq(...)          -> update / settleFailed
+//   storage.from(bucket).download(path)            -> downloadAudio
+// Records every update patch, and lets a test force a write to error.
+function makeAdmin(opts: {
+  load: LoadResult
+  download?: { data: unknown; error: unknown }
+  failUpdate?: (patch: Record<string, unknown>) => boolean
+}) {
+  const updates: Record<string, unknown>[] = []
+  // deno-lint-ignore no-explicit-any
+  const admin: any = {
+    from() {
+      return {
+        select: () => ({ eq: () => ({ single: () => Promise.resolve(opts.load) }) }),
+        update: (patch: Record<string, unknown>) => ({
+          eq: () => {
+            updates.push(patch)
+            return Promise.resolve({ error: opts.failUpdate?.(patch) ? { message: 'boom' } : null })
+          }
+        })
+      }
+    },
+    storage: {
+      from: () => ({
+        download: () => Promise.resolve(opts.download ?? { data: null, error: { message: 'gone' } })
+      })
+    }
+  }
+  return { admin, updates }
+}
+
+const row = (over: Record<string, unknown>) => ({
+  data: {
+    id: 1,
+    status: 'processing',
+    phase: null,
+    audio_path: 'm/a.mp3',
+    script: 'original',
+    lang: null,
+    transcript: { text: '', segments: [], words: [] },
+    ...over
+  },
+  error: null
+})
+
+Deno.test('skips a row that is no longer processing (idempotent re-delivery)', async () => {
+  const { admin, updates } = makeAdmin({ load: row({ status: 'ready', phase: null }) })
+  await processLessonPhase(admin, 1)
+  assertEquals(updates.length, 0)
+})
+
+Deno.test('skips when the row is missing', async () => {
+  const { admin, updates } = makeAdmin({ load: { data: null, error: { message: 'no row' } } })
+  await processLessonPhase(admin, 1)
+  assertEquals(updates.length, 0)
+})
+
+Deno.test('transcribe phase: a failed audio download settles failed/audio_unavailable', async () => {
+  const { admin, updates } = makeAdmin({
+    load: row({ phase: 'transcribing' }),
+    download: { data: null, error: { message: 'gone' } }
+  })
+  await processLessonPhase(admin, 1)
+  assertEquals(updates.length, 1)
+  assertEquals(updates[0].status, 'failed')
+  assertEquals(updates[0].error_code, 'audio_unavailable')
+  assertEquals(updates[0].phase, null)
+})
+
+Deno.test('translate phase: empty segments advance to transliterating', async () => {
+  const { admin, updates } = makeAdmin({ load: row({ phase: 'translating' }) })
+  await processLessonPhase(admin, 1)
+  assertEquals(updates.length, 1)
+  assertEquals(updates[0].phase, 'transliterating')
+})
+
+Deno.test('transliterate phase: empty words settle the row to ready', async () => {
+  const { admin, updates } = makeAdmin({ load: row({ phase: 'transliterating' }) })
+  await processLessonPhase(admin, 1)
+  assertEquals(updates.length, 1)
+  assertEquals(updates[0].status, 'ready')
+  assertEquals(updates[0].phase, null)
+  assertEquals(updates[0].error_code, null)
+})
+
+Deno.test('every write stamps updated_at (the reaper heartbeat)', async () => {
+  const { admin, updates } = makeAdmin({ load: row({ phase: 'transliterating' }) })
+  await processLessonPhase(admin, 1)
+  assertEquals(typeof updates[0].updated_at, 'string')
+})
+
+Deno.test('a failed phase write is not swallowed — it settles the row failed', async () => {
+  // Fail only the success write (status: 'ready'); the recovery write succeeds.
+  const { admin, updates } = makeAdmin({
+    load: row({ phase: 'transliterating' }),
+    failUpdate: (patch) => patch.status === 'ready'
+  })
+  await processLessonPhase(admin, 1)
+  assertEquals(updates.length, 2)
+  assertEquals(updates[0].status, 'ready') // attempted, threw
+  assertEquals(updates[1].status, 'failed') // settleFailed caught it
+  assertEquals(updates[1].error_code, 'unknown')
+})

--- a/supabase/functions/transcribe-lesson/worker.ts
+++ b/supabase/functions/transcribe-lesson/worker.ts
@@ -1,10 +1,16 @@
-// Background worker for async lesson transcription. Runs after the HTTP handler
-// has already returned 202 (kept alive by EdgeRuntime.waitUntil), so it never
-// blocks the caller. It always settles the lesson row to a terminal state —
-// 'ready' with the transcript, or 'failed' with a machine-readable error_code —
-// so the FE never sees a row stuck mid-flight from a handled error.
+// One-phase-per-invocation worker for async lesson transcription. The DB chain
+// trigger (see migration 20260606000003) fires this once per phase via pg_net:
+// each call runs EXACTLY ONE step (transcribe | translate | transliterate),
+// persists its result, and advances `phase` — and that write fires the next
+// call. The final step settles the row to 'ready'; any thrown error settles it
+// to 'failed' with a machine-readable code.
+//
+// Because every call returns after a single step, no isolate ever carries the
+// whole pipeline's wall-clock (so we need no EdgeRuntime.waitUntil), and a row
+// can only ever be 'processing' between two short, self-contained invocations —
+// where the stall reaper can still rescue it if one is hard-killed.
 
-import { type SupabaseClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { transcribeAudioFile, TranscribeError } from './transcribe.ts'
 import { translateSentences } from '../_shared/transcription/translate.ts'
 import { readSentences } from '../_shared/transcription/transliterate.ts'
@@ -15,52 +21,138 @@ import { type TargetScript } from '../_shared/transcription/script.ts'
 const TARGET_LANG = 'English'
 const BUCKET = 'audio-lessons'
 
-export type LessonJob = {
-  id: number
-  audio_path: string
-  script: TargetScript
-}
-
 type Segment = { start: number; end: number; text: string; translation?: string }
 type Word = { word: string; start: number; end: number; reading?: string }
+type Transcript = { text: string; segments: Segment[]; words: Word[] }
 
-export async function runTranscription(admin: SupabaseClient, lesson: LessonJob): Promise<void> {
+// The slice of the lesson row a phase needs. `transcript` accumulates across
+// phases: transcribe writes the skeleton, translate fills segment translations,
+// transliterate fills word readings.
+type LessonRow = {
+  id: number
+  status: string
+  phase: string | null
+  audio_path: string
+  script: TargetScript
+  lang: string | null
+  transcript: Transcript
+}
+
+// Service-role client for the internal `process` step. It bypasses RLS because
+// the worker writes rows on behalf of the owner after the DB trigger (not a
+// signed-in member) invoked it.
+export function serviceClient(): SupabaseClient {
+  return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+}
+
+// Run the one phase the row is currently on, then return. On a handled error,
+// settle the row to 'failed' so the FE shows it (rather than leaving it for the
+// reaper). An unhandled crash leaves the row 'processing' for the reaper.
+export async function processLessonPhase(admin: SupabaseClient, lessonId: number): Promise<void> {
+  const lesson = await loadLesson(admin, lessonId)
+  // Idempotency: a duplicate/late trigger delivery (or a reaper that already
+  // settled the row) must never re-run a phase on a non-processing row.
+  if (!lesson || lesson.status !== 'processing') return
+
   try {
-    await update(admin, lesson.id, { phase: 'transcribing' })
-    const file = await downloadAudio(admin, lesson.audio_path)
-    const transcript = await transcribeAudioFile(file, lesson.script)
-
-    await update(admin, lesson.id, { phase: 'translating' })
-    const segments = await translateSegments(transcript.segments)
-
-    await update(admin, lesson.id, { phase: 'transliterating' })
-    const words = await transliterateWords(
-      transcript.words,
-      transcript.segments,
-      transcript.text,
-      transcript.lang
-    )
-
-    await update(admin, lesson.id, {
-      status: 'ready',
-      phase: null,
-      error_code: null,
-      lang: transcript.lang ?? null,
-      transcript: { text: transcript.text, segments, words }
-    })
+    if (lesson.phase === 'transcribing') return await runTranscribe(admin, lesson)
+    if (lesson.phase === 'translating') return await runTranslate(admin, lesson)
+    if (lesson.phase === 'transliterating') return await runTransliterate(admin, lesson)
   } catch (error) {
     const code = error instanceof TranscribeError ? error.code : 'unknown'
-    console.error(`Lesson ${lesson.id} transcription failed:`, code, error)
-    await update(admin, lesson.id, { status: 'failed', phase: null, error_code: code })
+    console.error(`Lesson ${lessonId} phase ${lesson.phase} failed:`, code, error)
+    await settleFailed(admin, lessonId, code)
   }
 }
 
+async function loadLesson(admin: SupabaseClient, id: number): Promise<LessonRow | null> {
+  const { data, error } = await admin
+    .from('lessons')
+    .select('id, status, phase, audio_path, script, lang, transcript')
+    .eq('id', id)
+    .single<LessonRow>()
+
+  if (error) {
+    console.error(`Lesson ${id} load failed:`, error.message)
+    return null
+  }
+  return data
+}
+
+// Phase 1 — Whisper. Writes the transcript skeleton (no translations/readings
+// yet) and the detected language, then advances to translating.
+async function runTranscribe(admin: SupabaseClient, lesson: LessonRow): Promise<void> {
+  const file = await downloadAudio(admin, lesson.audio_path)
+  const result = await transcribeAudioFile(file, lesson.script)
+
+  await update(admin, lesson.id, {
+    phase: 'translating',
+    lang: result.lang ?? null,
+    transcript: { text: result.text, segments: result.segments, words: result.words }
+  })
+}
+
+// Phase 2 — translate the stored segments in place, then advance to
+// transliterating. Best-effort: failure leaves the segments untranslated.
+async function runTranslate(admin: SupabaseClient, lesson: LessonRow): Promise<void> {
+  const segments = await translateSegments(lesson.transcript.segments ?? [])
+
+  await update(admin, lesson.id, {
+    phase: 'transliterating',
+    transcript: { ...lesson.transcript, segments }
+  })
+}
+
+// Phase 3 — read the stored words in place, then settle the row to 'ready'.
+// Best-effort: failure leaves words unread rather than failing the lesson.
+async function runTransliterate(admin: SupabaseClient, lesson: LessonRow): Promise<void> {
+  const t = lesson.transcript
+  const words = await transliterateWords(
+    t.words ?? [],
+    t.segments ?? [],
+    t.text,
+    lesson.lang ?? undefined
+  )
+
+  await update(admin, lesson.id, {
+    status: 'ready',
+    phase: null,
+    error_code: null,
+    transcript: { ...t, words }
+  })
+}
+
+// Every write stamps updated_at — that's the heartbeat the reaper reads to tell
+// a live phase-in-progress from a dead one. Unlike the old worker, a failed
+// write THROWS (caught by processLessonPhase → settleFailed) rather than being
+// silently swallowed, so a row never advances on a write that didn't land.
 async function update(
   admin: SupabaseClient,
   id: number,
   patch: Record<string, unknown>
 ): Promise<void> {
-  await admin.from('lessons').update(patch).eq('id', id)
+  const { error } = await admin
+    .from('lessons')
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq('id', id)
+
+  if (error) throw new Error(`lesson ${id} update failed: ${error.message}`)
+}
+
+// Best-effort terminal write. If even this fails there's nothing more to do —
+// the row stays 'processing' and the reaper settles it later.
+async function settleFailed(admin: SupabaseClient, id: number, code: string): Promise<void> {
+  const { error } = await admin
+    .from('lessons')
+    .update({
+      status: 'failed',
+      phase: null,
+      error_code: code,
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', id)
+
+  if (error) console.error(`Lesson ${id} settle-failed write failed:`, error.message)
 }
 
 async function downloadAudio(admin: SupabaseClient, path: string): Promise<File> {

--- a/supabase/migrations/20260606000003_lesson-processing-chain.sql
+++ b/supabase/migrations/20260606000003_lesson-processing-chain.sql
@@ -1,0 +1,172 @@
+-- =============================================================================
+-- Audio Reader: durable, DB-driven transcription chain
+-- =============================================================================
+--
+-- Transcription used to run all three steps (transcribe -> translate ->
+-- transliterate) inside ONE edge isolate kept alive by EdgeRuntime.waitUntil.
+-- Their run-times add up, the platform force-kills the isolate at its wall-clock
+-- limit, and the only code that settles the row (the worker's catch block) never
+-- runs -- so the row is stranded in 'processing' forever.
+--
+-- This migration breaks the pipeline into one-step-per-invocation, driven by the
+-- database instead of a long-lived isolate:
+--
+--   * `phase` becomes a STATE-MACHINE POINTER -- it names the step that runs
+--     next ('transcribing' -> 'translating' -> 'transliterating' -> settled).
+--   * The edge function gains a `process` action that runs EXACTLY ONE phase,
+--     persists its result, advances `phase`, and returns normally.
+--   * A trigger on `lessons` notices the row entered a new processing phase and
+--     fires net.http_post back into the function to run that step. Writing the
+--     next phase IS the signal to run it -- so the chain advances itself with no
+--     waitUntil and no single isolate carrying the whole pipeline's wall-clock.
+--
+-- Reuses the pg_net + Vault plumbing already set up for cleanup-media
+-- (20260411000011_cleanup-media-cron.sql): the same 'supabase_url' and
+-- 'service_role_key' Vault secrets are read here.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- 1. create_pending_lesson: seed the state machine in the 'transcribing' phase
+--
+--    The row is born needing step 1. Setting `phase` at insert (rather than
+--    leaving it null and letting the worker set it) means the INSERT itself
+--    carries the "transcribe is pending" signal the trigger below fires on.
+--    CREATE OR REPLACE keeps the same RETURNS, so only the body changes — and
+--    it must keep the server-side `position` (max + 1) stamping that
+--    20260606000000 added, alongside the new `phase`.
+-- -----------------------------------------------------------------------------
+create or replace function "public"."create_pending_lesson"(
+  p_collection_id bigint,
+  p_title text,
+  p_audio_path text,
+  p_script text default 'original',
+  p_lang text default null
+)
+returns "public"."lessons"
+language plpgsql
+as $$
+declare
+  v_lesson public.lessons;
+  v_position numeric;
+begin
+  select coalesce(max("position"), 0) + 1
+  into v_position
+  from public.lessons
+  where collection_id = p_collection_id;
+
+  insert into public.lessons
+    (collection_id, title, audio_path, transcript, lang, status, phase, script, "position")
+  values
+    (p_collection_id, p_title, p_audio_path, '{}'::jsonb, p_lang, 'processing', 'transcribing', p_script, v_position)
+  returning * into v_lesson;
+
+  insert into public.media (bucket, path, lesson_id)
+  values ('audio-lessons', p_audio_path, v_lesson.id);
+
+  return v_lesson;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- 2. invoke_lesson_process(lesson_id): fire the edge function for one step
+--
+--    SECURITY DEFINER so it can read vault.decrypted_secrets (only the postgres
+--    superuser can). Mirrors invoke_cleanup_media, but POSTs an explicit lesson
+--    id + the 'process' action so the function knows which row and which step.
+--
+--    net.http_post is fire-and-forget: it enqueues the request and the pg_net
+--    background worker sends it AFTER this transaction commits -- so the edge
+--    function never reads the row before our phase write is durable.
+-- -----------------------------------------------------------------------------
+create or replace function "public"."invoke_lesson_process"(p_lesson_id bigint)
+  returns void
+  language plpgsql
+  security definer
+as $$
+declare
+  v_url         text;
+  v_service_key text;
+begin
+  select decrypted_secret into v_url
+  from vault.decrypted_secrets where name = 'supabase_url' limit 1;
+
+  if v_url is null then
+    raise exception
+      'Vault secret "supabase_url" not found. '
+      'Run: SELECT vault.create_secret(''<url>'', ''supabase_url'');';
+  end if;
+
+  select decrypted_secret into v_service_key
+  from vault.decrypted_secrets where name = 'service_role_key' limit 1;
+
+  if v_service_key is null then
+    raise exception
+      'Vault secret "service_role_key" not found. '
+      'Run: SELECT vault.create_secret(''<key>'', ''service_role_key'');';
+  end if;
+
+  -- A phase (Whisper especially) runs well past pg_net's 5s default, so raise the
+  -- timeout to the phase budget. We ignore the response either way -- the worker
+  -- settles the row itself -- but this stops pg_net logging spurious timeouts and
+  -- lets net._http_response capture the real result for debugging.
+  perform net.http_post(
+    url     := v_url || '/functions/v1/transcribe-lesson',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || v_service_key,
+      'Content-Type',  'application/json'
+    ),
+    body    := jsonb_build_object('action', 'process', 'lesson_id', p_lesson_id),
+    timeout_milliseconds := 150000
+  );
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- 3. The chain trigger: a phase write drives the next step
+--
+--    Fires for every row, but only ACTS when the row is mid-pipeline AND just
+--    entered a new phase:
+--      * NEW.status = 'processing'        -> still has work to do
+--      * NEW.phase  is not null           -> a step is named
+--      * INSERT, or NEW.phase changed     -> we just ENTERED this phase
+--                                            (IS DISTINCT FROM is the null-safe
+--                                             "not equal" -- never yields null)
+--
+--    So: terminal writes (status -> 'ready'/'failed') don't fire; unrelated
+--    edits (title, progress) on a settled row don't fire; and a same-phase
+--    heartbeat (if we add one later) won't double-fire. Each phase entry fires
+--    exactly one process call -- forward progress only, no loop.
+-- -----------------------------------------------------------------------------
+create or replace function "public"."trigger_lesson_processing"()
+  returns trigger
+  language plpgsql
+  security definer
+as $$
+begin
+  if new.status = 'processing'
+     and new.phase is not null
+     and (tg_op = 'INSERT' or new.phase is distinct from old.phase)
+  then
+    -- Kicking the chain is a SIDE EFFECT — it must never abort the row write
+    -- that triggered it. A raise here (missing Vault secret, pg_net hiccup)
+    -- would roll back the lesson insert/phase advance itself, so swallow it:
+    -- the row is saved, and the reaper settles it later if the kick never lands.
+    begin
+      perform public.invoke_lesson_process(new.id);
+    exception
+      when others then
+        raise warning 'lesson % chain kick failed: %', new.id, sqlerrm;
+    end;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists "lesson_processing_chain" on "public"."lessons";
+create trigger "lesson_processing_chain"
+  after insert or update on "public"."lessons"
+  for each row execute function "public"."trigger_lesson_processing"();
+
+COMMIT;

--- a/supabase/migrations/20260606000004_lesson-stall-reaper.sql
+++ b/supabase/migrations/20260606000004_lesson-stall-reaper.sql
@@ -1,0 +1,77 @@
+-- =============================================================================
+-- Audio Reader: reaper for transcription rows that died mid-flight
+-- =============================================================================
+--
+-- The processing chain (previous migration) advances itself by writing the next
+-- phase. But if an isolate is hard-killed BEFORE it writes that phase -- platform
+-- wall-clock kill, OOM, deploy, crash, or a dropped pg_net delivery -- nothing
+-- advances the row and nothing settles it. It would sit in 'processing' forever.
+--
+-- The reaper is the backstop that removes "forever" from that sentence: a cheap
+-- scheduled sweep that forces any row stuck in 'processing' past a generous
+-- deadline into a terminal 'failed'/'stalled' state, which the FE shows with a
+-- Retry button. It depends on nothing but the clock, so it survives every way an
+-- isolate can die.
+--
+-- The deadline (10 min) must comfortably exceed the longest a single legitimate
+-- phase can take. `updated_at` is stamped on each phase ENTRY (create, retry,
+-- advance), so "updated_at older than 10 min while still processing" means that
+-- one phase has been running for 10 minutes -- which only happens when its
+-- isolate is dead. The worst legitimate phase (Whisper: 3 attempts x 120s +
+-- backoff ~= 6 min) stays well under it.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- reap_stalled_lessons(): settle every over-deadline processing row at once.
+--
+--   SECURITY DEFINER so a manual call (for testing) runs with the same rights as
+--   the cron job, which executes as the postgres owner. Returns the number of
+--   rows reaped so cron logs / a manual call show whether it did anything.
+-- -----------------------------------------------------------------------------
+create or replace function "public"."reap_stalled_lessons"()
+  returns integer
+  language plpgsql
+  security definer
+as $$
+declare
+  v_reaped integer;
+begin
+  update public.lessons
+     set status     = 'failed',
+         phase      = null,
+         error_code = 'stalled',
+         updated_at = now()
+   where status = 'processing'
+     and updated_at < now() - interval '10 minutes';
+
+  get diagnostics v_reaped = row_count;
+  return v_reaped;
+end;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- Schedule it every minute. The sweep is a single indexed UPDATE touching only
+-- over-deadline rows, so running it often is cheap and keeps the worst-case
+-- "stuck" window close to the deadline rather than deadline + cron interval.
+--
+--   View jobs:        SELECT * FROM cron.job;
+--   Run immediately:  SELECT public.reap_stalled_lessons();
+--   Remove:           SELECT cron.unschedule('reap-stalled-lessons');
+-- -----------------------------------------------------------------------------
+do $$
+begin
+  if exists (select 1 from cron.job where jobname = 'reap-stalled-lessons') then
+    perform cron.unschedule('reap-stalled-lessons');
+  end if;
+end;
+$$;
+
+select cron.schedule(
+  'reap-stalled-lessons',
+  '* * * * *',
+  'SELECT public.reap_stalled_lessons()'
+);
+
+COMMIT;

--- a/supabase/tests/00021_lesson_transcription_chain.sql
+++ b/supabase/tests/00021_lesson_transcription_chain.sql
@@ -1,0 +1,88 @@
+-- =============================================================================
+-- Async transcription: durable phase chain + stall reaper
+--
+-- Covers the 20260606000003 + 20260606000004 migrations:
+--   * create_pending_lesson seeds the state machine ('processing'/'transcribing')
+--   * the chain trigger exists and its kick is non-fatal to the row write
+--   * reap_stalled_lessons settles over-deadline processing rows to
+--     failed/'stalled', and leaves fresh processing rows untouched
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(7);
+
+-- ── Setup ─────────────────────────────────────────────────────────────────────
+
+SELECT tests.create_user('33333333-3333-3333-3333-333333333333'::uuid, 'carol_chain');
+SELECT tests.set_claims('33333333-3333-3333-3333-333333333333'::uuid);
+INSERT INTO public.lesson_collections (id, title) VALUES (30, 'Carol Book');
+
+
+-- ── create_pending_lesson seeds the state machine (act as Carol) ────────────────
+SET LOCAL role = 'authenticated';
+
+-- Test 1: a new lesson is born 'processing'
+SELECT is(
+  (public.create_pending_lesson(30, 'Ch1', '33333333-3333-3333-3333-333333333333/c1.mp3')).status,
+  'processing',
+  'create_pending_lesson inserts the row as processing'
+);
+
+-- Test 2: ...pointing at the first phase, so the chain trigger fires step 1
+SELECT is(
+  (public.create_pending_lesson(30, 'Ch2', '33333333-3333-3333-3333-333333333333/c2.mp3')).phase,
+  'transcribing',
+  'create_pending_lesson seeds phase=transcribing'
+);
+
+-- Test 3: the kick is best-effort — even though the AFTER INSERT trigger ran (and
+-- tried to fire the chain), the row itself committed. A raise in the kick would
+-- have rolled this insert back and matched 0 rows.
+SELECT is(
+  (SELECT count(*) FROM public.lessons WHERE collection_id = 30)::int,
+  2,
+  'a failed/no-op chain kick never aborts the lesson insert'
+);
+
+
+-- ── Stall reaper (set up rows that bypass the chain trigger) ────────────────────
+-- phase IS NULL trips the trigger's "phase is not null" guard, so these inserts
+-- don't fire a kick — letting us test the reaper in isolation. updated_at is the
+-- heartbeat the reaper reads.
+INSERT INTO public.lessons (id, collection_id, title, audio_path, "position", status, phase, updated_at)
+VALUES
+  (300, 30, 'Stale', '33333333-3333-3333-3333-333333333333/s.mp3', 10, 'processing', NULL, now() - interval '11 minutes'),
+  (301, 30, 'Fresh', '33333333-3333-3333-3333-333333333333/f.mp3', 11, 'processing', NULL, now());
+
+SET LOCAL role = 'postgres';
+
+-- Test 4: the sweep reports it settled exactly the one over-deadline row
+SELECT is(
+  public.reap_stalled_lessons(),
+  1,
+  'reap_stalled_lessons settles exactly the over-deadline row'
+);
+
+-- Test 5/6: the stale row is now terminal with a retry-able code
+SELECT is(
+  (SELECT status FROM public.lessons WHERE id = 300),
+  'failed',
+  'a stalled row is settled to failed'
+);
+SELECT is(
+  (SELECT error_code FROM public.lessons WHERE id = 300),
+  'stalled',
+  'a stalled row carries error_code=stalled'
+);
+
+-- Test 7: a row still inside the deadline is left running
+SELECT is(
+  (SELECT status FROM public.lessons WHERE id = 301),
+  'processing',
+  'a fresh processing row is not reaped'
+);
+
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

Fixes lessons getting permanently stuck in `processing`/`transliterating` (reported on a ~5-min/10MB file). The old worker ran all three phases (transcribe → translate → transliterate) in one `EdgeRuntime.waitUntil` isolate; their wall-clocks added up, the platform hard-killed the isolate mid-transliterate, and the only code that settles the row (the worker's `catch`) died with it — leaving the row stranded with nothing to recover it.

Reworks transcription into a durable, DB-driven chain (model B), minus audio chunking:

- **One phase per invocation.** New service-role `process` action runs exactly one phase, persists partial progress into `transcript`, advances `phase`, and returns. No isolate carries the whole pipeline.
- **Self-advancing chain.** `lesson_processing_chain` trigger fires `invoke_lesson_process()` (pg_net, reusing the cleanup-media Vault plumbing) on each new processing phase — writing the next phase *is* the signal to run it. The kick is best-effort, so a pg_net/secret failure never aborts the lesson write.
- **Stall reaper.** `reap_stalled_lessons()` pg_cron settles `processing` rows whose `updated_at` heartbeat is >10 min old → `failed`/`stalled`. Backstop that survives any isolate death, so a row can't stay stuck. FE surfaces `stalled` with Retry.
- **Robustness.** `update()` now throws on a failed write (was swallowed) and stamps the heartbeat; AbortController timeouts added to the translate/transliterate Claude calls via a shared `requestStructured()` helper.
- **`edge_runtime.policy` reverted to `oneshot`** (no more waitUntil) → local hot-reload restored.

Verified live on a real 5-min audio (transcribe→translate→transliterate→ready in ~94s, each a separate invocation), plus the failure and reaper paths. Covered by new Deno + pgTAP tests.

**Still punted:** audio chunking/stitching for very long single files (one Whisper call over budget now fails cleanly + retryable, never stranded).

**Deploy:** needs `supabase db push` + `supabase functions deploy transcribe-lesson`. Prod/stage already have the `supabase_url` + `service_role_key` Vault secrets.