### PR TITLE
Improve mobile audio-reader reading UX

### DIFF
--- a/src/composables/audio-reader/use-lesson-reader.ts
+++ b/src/composables/audio-reader/use-lesson-reader.ts
@@ -6,7 +6,7 @@ import { useMobileBreakpoint } from '@/composables/use-media-query'
 import { useLessonQuery, useLessonAudioUrlQuery } from '@/api/lessons'
 import { useAudioPlayer } from './use-audio-player'
 import { useTranscriptSync } from './use-transcript-sync'
-import { groupWordsBySentence, groupSentencesIntoParagraphs } from '@/utils/transcript'
+import { groupWordsBySentence } from '@/utils/transcript'
 
 // Translate into the app language. A per-member target language can replace this
 // later; admin-only v1 is English.
@@ -35,10 +35,11 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
   const { data: lesson, error } = useLessonQuery(lesson_id)
 
   const words = computed(() => lesson.value?.transcript.words ?? [])
+  // Each sentence renders as its own block (one interlinear gloss apiece), evenly
+  // spaced — see the reader's transcript view.
   const paragraphs = computed(() => {
     const segments = lesson.value?.transcript.segments ?? []
-    const groups = groupWordsBySentence(segments, words.value, lesson.value?.transcript.text)
-    return groupSentencesIntoParagraphs(groups)
+    return groupWordsBySentence(segments, words.value, lesson.value?.transcript.text)
   })
 
   const audio_path = computed(() => lesson.value?.audio_path)

--- a/src/composables/audio-reader/use-lesson-reader.ts
+++ b/src/composables/audio-reader/use-lesson-reader.ts
@@ -1,10 +1,18 @@
-import { computed, ref, toValue, useTemplateRef, watch } from 'vue'
+import { computed, defineAsyncComponent, ref, toValue, useTemplateRef, watch } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 import { useToast } from '@/composables/toast'
+import { useModal, type ModalCloseFn } from '@/composables/modal'
+import { useMobileBreakpoint } from '@/composables/use-media-query'
 import { useLessonQuery, useLessonAudioUrlQuery } from '@/api/lessons'
 import { useAudioPlayer } from './use-audio-player'
 import { useTranscriptSync } from './use-transcript-sync'
 import { groupWordsBySentence, groupSentencesIntoParagraphs } from '@/utils/transcript'
+
+// Translate into the app language. A per-member target language can replace this
+// later; admin-only v1 is English.
+const TARGET_LANG = 'English'
+
+const TermSheet = defineAsyncComponent(() => import('@/views/audio-reader/term-popover/sheet.vue'))
 
 /**
  * Orchestrate a lesson for reading: fetch it, shape its transcript into
@@ -20,6 +28,8 @@ import { groupWordsBySentence, groupSentencesIntoParagraphs } from '@/utils/tran
  */
 export function useLessonReader(id: MaybeRefOrGetter<number>) {
   const toast = useToast()
+  const modal = useModal()
+  const is_mobile = useMobileBreakpoint()
 
   const lesson_id = computed(() => toValue(id))
   const { data: lesson, error } = useLessonQuery(lesson_id)
@@ -41,14 +51,44 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
   const selection = ref<TermSelection | null>(null)
   const popover_open = ref(false)
 
+  // The bottom sheet's own close fn while it's open on mobile, so a fresh term
+  // selection can dismiss the previous sheet before opening its own.
+  let sheet_close: ModalCloseFn<void> | null = null
+
   watch(error, (err) => {
     if (err) toast.error(err.message)
   })
 
-  /** Open the translation popover anchored to a tapped/selected term. */
+  /**
+   * Show the translation for a tapped/selected term. On a coarse/narrow screen
+   * it opens as a bottom sheet (the anchored popover crowds a phone); on desktop
+   * it's the rect-anchored popover.
+   */
   function openTerm(next: TermSelection) {
+    if (is_mobile.value) {
+      openTermSheet(next)
+      return
+    }
+
     selection.value = next
     popover_open.value = true
+  }
+
+  // Route the term through the global modal stack as a mobile sheet, reusing its
+  // backdrop, scroll-lock, and slide animation. Resolving (backdrop/esc/close)
+  // drops our handle.
+  function openTermSheet(next: TermSelection) {
+    sheet_close?.()
+
+    const { response, close } = modal.open<void>(TermSheet, {
+      mode: 'mobile-sheet',
+      backdrop: true,
+      props: { term: next.term, sentence: next.sentence, target_lang: TARGET_LANG }
+    })
+    sheet_close = close
+    response.then(() => {
+      sheet_close = null
+    })
   }
 
   function closeTerm() {
@@ -62,6 +102,7 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
     active_word,
     selection,
     popover_open,
+    target_lang: TARGET_LANG,
     openTerm,
     closeTerm,
     player

--- a/src/composables/audio-reader/use-reader-highlights.ts
+++ b/src/composables/audio-reader/use-reader-highlights.ts
@@ -23,6 +23,11 @@ const SENTENCE_DURATION = 0.3
 // audio-driven playhead (which keeps the slower, stretchy default).
 const HOVER_DURATION = 0.12
 
+// How far a touch may drift between press and release and still count as a tap
+// rather than a scroll. Past this the finger is panning the column, not picking
+// a word.
+const TAP_SLOP = 10
+
 // What a committed selection hands back: the bare term, the rect to anchor the
 // popover against, and the first word's element so the caller can resolve which
 // sentence it sits in (translator context).
@@ -36,12 +41,15 @@ type WordRange = { lo: number; hi: number }
  * **interaction** pill — which doubles as the hover indicator, the drag-to-select
  * highlight, and the standing selection while its popover is open.
  *
- * The pill is the selection: press a word and the pill anchors there; drag and
- * it stretches word by word to cover the range; release commits the term via
- * `onSelect` (a plain click is a zero-width range, so it selects one word). The
- * committed range stays lit — hover is held off — until `popover_open` flips
- * false. The translation gloss carries no `data-word-index`, so it can never join
- * a range; native text selection is left disabled by the host.
+ * The pill is the selection: with a mouse, press a word and the pill anchors
+ * there; drag and it stretches word by word to cover the range; release commits
+ * the term via `onSelect` (a plain click is a zero-width range, so it selects one
+ * word). A touch instead claims nothing on the way down — the column scrolls
+ * freely under the finger — and selects the word on release, but only if the
+ * finger stayed put; a touch that drifts past `TAP_SLOP` is a scroll and commits
+ * nothing. The committed range stays lit — hover is held off — until
+ * `popover_open` flips false. The translation gloss carries no `data-word-index`,
+ * so it can never join a range; native text selection is left disabled by the host.
  *
  * "Which word" is JS state; the DOM is read only to measure "where is word N",
  * located by its stable `data-word-index`. Pills live inside `content` and are
@@ -74,6 +82,10 @@ export function useReaderHighlights(
   const focus_index = ref<number | null>(null)
   const anchor_index = ref<number | null>(null)
   const committed = ref<WordRange | null>(null)
+
+  // A touch in flight: where it landed and which word, held until release decides
+  // tap-vs-scroll. Plain (non-reactive) state — it never drives a pill directly.
+  let tap: { x: number; y: number; index: number } | null = null
 
   let resize_observer: ResizeObserver | null = null
 
@@ -302,6 +314,22 @@ export function useReaderHighlights(
   function onPointerDown(event: PointerEvent) {
     committed.value = null
 
+    if (event.pointerType === 'touch') {
+      beginTap(event)
+      return
+    }
+
+    beginDrag(event)
+  }
+
+  // A touch defers everything to release: just remember where it landed and which
+  // word, leaving the gesture to the browser so the column still scrolls.
+  function beginTap(event: PointerEvent) {
+    const index = wordIndexAt(event.clientX, event.clientY)
+    tap = index === null ? null : { x: event.clientX, y: event.clientY, index }
+  }
+
+  function beginDrag(event: PointerEvent) {
     const index = wordIndexAt(event.clientX, event.clientY)
     if (index === null) return
 
@@ -320,6 +348,11 @@ export function useReaderHighlights(
   }
 
   function onPointerMove(event: PointerEvent) {
+    if (event.pointerType === 'touch') {
+      trackTap(event)
+      return
+    }
+
     const index = wordIndexAt(event.clientX, event.clientY)
 
     // Mid-drag, ignore gaps (translation gloss, padding) so the range holds its
@@ -336,11 +369,38 @@ export function useReaderHighlights(
     if (index !== focus_index.value) focus_index.value = index
   }
 
-  function onPointerUp() {
+  // A touch that travels past the slop is a scroll, not a tap — forget it so
+  // release selects nothing.
+  function trackTap(event: PointerEvent) {
+    if (!tap) return
+    if (Math.hypot(event.clientX - tap.x, event.clientY - tap.y) > TAP_SLOP) tap = null
+  }
+
+  function onPointerUp(event: PointerEvent) {
+    if (event.pointerType === 'touch') {
+      commitTap()
+      return
+    }
+
     if (anchor_index.value === null) return
 
     commitSelection()
     anchor_index.value = null
+  }
+
+  // Release of a stationary touch selects its word; a scroll (tap already cleared)
+  // commits nothing. The range collapses to the one tapped word, then clears so
+  // the committed pill — not a lingering hover — is what stays lit.
+  function commitTap() {
+    if (!tap) return
+
+    anchor_index.value = tap.index
+    focus_index.value = tap.index
+    tap = null
+
+    commitSelection()
+    anchor_index.value = null
+    focus_index.value = null
   }
 
   function onPointerLeave() {

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -295,6 +295,7 @@
   "audio-reader.upload.cancel-button": "Cancel",
   "audio-reader.upload.submit-button": "Create",
   "audio-reader.popover.close-button": "Close",
+  "audio-reader.popover.definition-label": "Definition",
   "audio-reader.popover.loading": "Translating…",
   "audio-reader.popover.error": "Couldn't translate that. Try again.",
   "audio-reader.popover.too-long-error": "That selection is too long. Try a shorter phrase.",

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -11,10 +11,6 @@ import AudioPlayer from '@/views/audio-reader/lesson/audio-player.vue'
 import TranscriptView from '@/views/audio-reader/transcript/index.vue'
 import TermPopover from '@/views/audio-reader/term-popover/index.vue'
 
-// Translate into the app language. A per-member target language can replace this
-// later; admin-only v1 is English.
-const TARGET_LANG = 'English'
-
 const { collectionId, lessonId } = defineProps<{ collectionId: string; lessonId: string }>()
 
 const { t } = useI18n()
@@ -32,6 +28,7 @@ const {
   active_word,
   selection,
   popover_open,
+  target_lang,
   openTerm,
   closeTerm,
   player
@@ -179,7 +176,7 @@ watch(
         :rect="selection.rect"
         :term="selection.term"
         :sentence="selection.sentence"
-        :target_lang="TARGET_LANG"
+        :target_lang="target_lang"
         @close="closeTerm"
       />
     </div>

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -72,7 +72,7 @@ watch(
   >
     <aside
       data-testid="lesson-view__sidebar"
-      class="flex shrink-0 flex-col gap-4 xl:sticky xl:top-(--nav-height) xl:max-h-[calc(100dvh-var(--nav-height))] xl:w-56 xl:self-start xl:overflow-y-auto"
+      class="hidden shrink-0 flex-col gap-4 xl:flex xl:sticky xl:top-(--nav-height) xl:max-h-[calc(100dvh-var(--nav-height))] xl:w-56 xl:self-start xl:overflow-y-auto"
     >
       <header data-testid="lesson-view__header" class="flex items-center justify-between gap-4">
         <div data-testid="lesson-view__heading" class="flex flex-col gap-1">
@@ -118,6 +118,18 @@ watch(
     </aside>
 
     <div data-testid="lesson-view__reader" class="relative flex flex-1 flex-col xl:min-w-0">
+      <header
+        data-testid="lesson-view__title"
+        class="flex flex-col items-center px-4 pb-6 text-center xl:hidden"
+      >
+        <h1
+          data-testid="lesson-view__title-text"
+          class="text-3xl text-brown-700 dark:text-brown-300"
+        >
+          {{ lesson?.title }}
+        </h1>
+      </header>
+
       <div
         data-testid="lesson-view__transcript"
         class="rounded-7 bg-brown-100 px-0 pt-6 pb-2 sm:px-6 dark:bg-grey-800"

--- a/src/views/audio-reader/term-popover/index.vue
+++ b/src/views/audio-reader/term-popover/index.vue
@@ -1,12 +1,6 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { useTranslateTermMutation, EdgeFunctionError, type TranslationResult } from '@/api/lessons'
 import UiPopover from '@/components/ui-kit/popover.vue'
-import UiButton from '@/components/ui-kit/button.vue'
-import UiDivider from '@/components/ui-kit/divider.vue'
-import UiTag from '@/components/ui-kit/tag.vue'
-import AddCardForm from './add-card-form.vue'
+import TermCard from './term-card.vue'
 
 const { open, rect, term, sentence, target_lang } = defineProps<{
   open: boolean
@@ -19,39 +13,6 @@ const { open, rect, term, sentence, target_lang } = defineProps<{
 const emit = defineEmits<{
   (e: 'close'): void
 }>()
-
-const { t } = useI18n()
-const translate = useTranslateTermMutation()
-
-const result = ref<TranslationResult | null>(null)
-const is_loading = ref(false)
-const error_key = ref<string | null>(null)
-const adding = ref(false)
-
-async function fetchTranslation() {
-  result.value = null
-  error_key.value = null
-  adding.value = false
-  is_loading.value = true
-  try {
-    result.value = await translate.mutateAsync({ term, sentence, target_lang })
-  } catch (error) {
-    error_key.value =
-      error instanceof EdgeFunctionError && error.code === 'output_truncated'
-        ? 'audio-reader.popover.too-long-error'
-        : 'audio-reader.popover.error'
-  } finally {
-    is_loading.value = false
-  }
-}
-
-watch(
-  () => [open, term] as const,
-  ([is_open, current]) => {
-    if (is_open && current) fetchTranslation()
-  },
-  { immediate: true }
-)
 </script>
 
 <template>
@@ -66,129 +27,12 @@ watch(
     @close="emit('close')"
   >
     <div data-testid="term-popover" class="w-84 rounded-7 bg-brown-300 p-8 dark:bg-grey-700">
-      <header data-testid="term-popover__header" class="flex items-start justify-between gap-3">
-        <span
-          data-testid="term-popover__term"
-          class="text-6xl leading-tight wrap-break-word text-brown-700 dark:text-brown-200"
-        >
-          {{ term }}
-        </span>
-        <ui-button
-          data-theme="grey-400"
-          icon-left="close"
-          icon-only
-          size="sm"
-          @click="emit('close')"
-        >
-          {{ t('audio-reader.popover.close-button') }}
-        </ui-button>
-      </header>
-
-      <div
-        v-if="result && (result.reading || result.pos)"
-        data-testid="term-popover__reading"
-        class="mt-1 flex flex-wrap items-center gap-2"
-      >
-        <span v-if="result.reading" class="text-base text-brown-700 dark:text-grey-400">
-          {{ result.reading }}
-        </span>
-        <ui-tag v-if="result.pos" data-theme="green-400" class="bgx-diagonal-stripes">{{
-          result.pos
-        }}</ui-tag>
-      </div>
-
-      <ui-divider class="my-3" label="Definition" />
-
-      <div
-        v-if="is_loading"
-        data-testid="term-popover__loading"
-        class="flex flex-col gap-2 [--skeleton-sheen:var(--color-brown-200)] dark:[--skeleton-sheen:var(--color-grey-400)]"
-        aria-busy="true"
-        :aria-label="t('audio-reader.popover.loading')"
-      >
-        <span class="term-popover__skeleton h-6 w-3/5 rounded-2 bg-brown-500 dark:bg-grey-500" />
-        <span class="term-popover__skeleton h-4 w-full rounded-2 bg-brown-500 dark:bg-grey-500" />
-        <span class="term-popover__skeleton h-4 w-4/5 rounded-2 bg-brown-500 dark:bg-grey-500" />
-      </div>
-
-      <p
-        v-else-if="error_key"
-        data-testid="term-popover__error"
-        class="text-red-500 dark:text-red-400"
-      >
-        {{ t(error_key) }}
-      </p>
-
-      <template v-else-if="result">
-        <div data-testid="term-popover__result" class="flex flex-col gap-1">
-          <p
-            data-testid="term-popover__translation"
-            class="text-3xl text-brown-700 dark:text-brown-200 capitalize"
-          >
-            {{ result.translation }}
-          </p>
-          <p
-            v-if="result.description"
-            data-testid="term-popover__description"
-            class="text-base text-brown-700 dark:text-grey-300"
-          >
-            {{ result.description }}
-          </p>
-        </div>
-
-        <add-card-form
-          v-if="adding"
-          :front="term"
-          :back="result.translation"
-          @saved="emit('close')"
-          @cancel="adding = false"
-        />
-        <ui-button
-          v-else
-          data-testid="term-popover__add"
-          data-theme="blue-500"
-          data-theme-dark="blue-650"
-          icon-left="add"
-          size="sm"
-          full-width
-          class="mt-3"
-          @click="adding = true"
-        >
-          {{ t('audio-reader.popover.add-card-button') }}
-        </ui-button>
-      </template>
+      <term-card
+        :term="term"
+        :sentence="sentence"
+        :target_lang="target_lang"
+        @close="emit('close')"
+      />
     </div>
   </ui-popover>
 </template>
-
-<style>
-.term-popover__skeleton {
-  position: relative;
-  overflow: hidden;
-}
-
-/* A light gradient sweeps L→R across each bar; staggered so the lines cascade.
-   Gated behind the reduce-animations toggle — bars sit static when it's on. */
-body:not(.animation-safe) .term-popover__skeleton::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  transform: translateX(-100%);
-  background: linear-gradient(90deg, transparent, var(--skeleton-sheen), transparent);
-  animation: term-popover-skeleton-sweep 1.4s ease-in-out infinite;
-}
-
-body:not(.animation-safe) .term-popover__skeleton:nth-child(2)::after {
-  animation-delay: 0.1s;
-}
-
-body:not(.animation-safe) .term-popover__skeleton:nth-child(3)::after {
-  animation-delay: 0.2s;
-}
-
-@keyframes term-popover-skeleton-sweep {
-  to {
-    transform: translateX(100%);
-  }
-}
-</style>

--- a/src/views/audio-reader/term-popover/sheet.vue
+++ b/src/views/audio-reader/term-popover/sheet.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import MobileSheet from '@/components/layout-kit/modal/mobile-sheet.vue'
+import TermCard from './term-card.vue'
+
+const { term, sentence, target_lang, close } = defineProps<{
+  term: string
+  sentence: string
+  target_lang: string
+  close: () => void
+}>()
+</script>
+
+<template>
+  <mobile-sheet :show_close_button="false">
+    <div data-testid="term-sheet" class="px-6 pt-6 pb-10">
+      <term-card :term="term" :sentence="sentence" :target_lang="target_lang" @close="close()" />
+    </div>
+  </mobile-sheet>
+</template>

--- a/src/views/audio-reader/term-popover/term-card.vue
+++ b/src/views/audio-reader/term-popover/term-card.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useTranslateTermMutation, EdgeFunctionError, type TranslationResult } from '@/api/lessons'
+import UiButton from '@/components/ui-kit/button.vue'
+import UiDivider from '@/components/ui-kit/divider.vue'
+import UiTag from '@/components/ui-kit/tag.vue'
+import AddCardForm from './add-card-form.vue'
+
+const { term, sentence, target_lang } = defineProps<{
+  term: string
+  sentence: string
+  target_lang: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const { t } = useI18n()
+const translate = useTranslateTermMutation()
+
+const result = ref<TranslationResult | null>(null)
+const is_loading = ref(false)
+const error_key = ref<string | null>(null)
+const adding = ref(false)
+
+async function fetchTranslation() {
+  result.value = null
+  error_key.value = null
+  adding.value = false
+  is_loading.value = true
+  try {
+    result.value = await translate.mutateAsync({ term, sentence, target_lang })
+  } catch (error) {
+    error_key.value =
+      error instanceof EdgeFunctionError && error.code === 'output_truncated'
+        ? 'audio-reader.popover.too-long-error'
+        : 'audio-reader.popover.error'
+  } finally {
+    is_loading.value = false
+  }
+}
+
+// The card only mounts while a term is showing, so fetch on mount and whenever
+// the term changes underneath it — an empty term (punctuation-only) never fetches.
+watch(
+  () => term,
+  (current) => {
+    if (current) fetchTranslation()
+  },
+  { immediate: true }
+)
+</script>
+
+<template>
+  <div data-testid="term-card" class="flex flex-col">
+    <header data-testid="term-card__header" class="flex items-start justify-between gap-3">
+      <span
+        data-testid="term-card__term"
+        class="text-6xl leading-tight wrap-break-word text-brown-700 dark:text-brown-200"
+      >
+        {{ term }}
+      </span>
+      <ui-button
+        data-testid="term-card__close"
+        data-theme="grey-400"
+        icon-left="close"
+        icon-only
+        size="sm"
+        @click="emit('close')"
+      >
+        {{ t('audio-reader.popover.close-button') }}
+      </ui-button>
+    </header>
+
+    <div
+      v-if="result && (result.reading || result.pos)"
+      data-testid="term-card__reading"
+      class="mt-1 flex flex-wrap items-center gap-2"
+    >
+      <span v-if="result.reading" class="text-base text-brown-700 dark:text-grey-400">
+        {{ result.reading }}
+      </span>
+      <ui-tag v-if="result.pos" data-theme="green-400" class="bgx-diagonal-stripes">{{
+        result.pos
+      }}</ui-tag>
+    </div>
+
+    <ui-divider class="my-3" :label="t('audio-reader.popover.definition-label')" />
+
+    <div
+      v-if="is_loading"
+      data-testid="term-card__loading"
+      class="flex flex-col gap-2 [--skeleton-sheen:var(--color-brown-200)] dark:[--skeleton-sheen:var(--color-grey-400)]"
+      aria-busy="true"
+      :aria-label="t('audio-reader.popover.loading')"
+    >
+      <span class="term-card__skeleton h-6 w-3/5 rounded-2 bg-brown-500 dark:bg-grey-500" />
+      <span class="term-card__skeleton h-4 w-full rounded-2 bg-brown-500 dark:bg-grey-500" />
+      <span class="term-card__skeleton h-4 w-4/5 rounded-2 bg-brown-500 dark:bg-grey-500" />
+    </div>
+
+    <p v-else-if="error_key" data-testid="term-card__error" class="text-red-500 dark:text-red-400">
+      {{ t(error_key) }}
+    </p>
+
+    <template v-else-if="result">
+      <div data-testid="term-card__result" class="flex flex-col gap-1">
+        <p
+          data-testid="term-card__translation"
+          class="text-3xl text-brown-700 capitalize dark:text-brown-200"
+        >
+          {{ result.translation }}
+        </p>
+        <p
+          v-if="result.description"
+          data-testid="term-card__description"
+          class="text-base text-brown-700 dark:text-grey-300"
+        >
+          {{ result.description }}
+        </p>
+      </div>
+
+      <add-card-form
+        v-if="adding"
+        :front="term"
+        :back="result.translation"
+        @saved="emit('close')"
+        @cancel="adding = false"
+      />
+      <ui-button
+        v-else
+        data-testid="term-card__add"
+        data-theme="blue-500"
+        data-theme-dark="blue-650"
+        icon-left="add"
+        size="sm"
+        full-width
+        class="mt-3"
+        @click="adding = true"
+      >
+        {{ t('audio-reader.popover.add-card-button') }}
+      </ui-button>
+    </template>
+  </div>
+</template>
+
+<style>
+.term-card__skeleton {
+  position: relative;
+  overflow: hidden;
+}
+
+/* A light gradient sweeps L→R across each bar; staggered so the lines cascade.
+   Gated behind the reduce-animations toggle — bars sit static when it's on. */
+body:not(.animation-safe) .term-card__skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, var(--skeleton-sheen), transparent);
+  animation: term-card-skeleton-sweep 1.4s ease-in-out infinite;
+}
+
+body:not(.animation-safe) .term-card__skeleton:nth-child(2)::after {
+  animation-delay: 0.1s;
+}
+
+body:not(.animation-safe) .term-card__skeleton:nth-child(3)::after {
+  animation-delay: 0.2s;
+}
+
+@keyframes term-card-skeleton-sweep {
+  to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { SentenceWords } from '@/utils/transcript'
 import { useReaderHighlights } from '@/composables/audio-reader/use-reader-highlights'
 import TranscriptSegment from './segment.vue'
@@ -9,7 +8,7 @@ const {
   active_word,
   popover_open = false
 } = defineProps<{
-  paragraphs: SentenceWords[][]
+  paragraphs: SentenceWords[]
   active_word: number
   popover_open?: boolean
 }>()
@@ -24,19 +23,17 @@ const { onPointerDown, onPointerMove, onPointerUp, onPointerLeave } = useReaderH
   () => popover_open
 )
 
-const sentences = computed(() => paragraphs.flat())
-
-function sentenceIndexOf(node: Element): number | null {
+function paragraphIndexOf(node: Element): number | null {
   const segment = node.closest('[data-testid="transcript-segment"]')
   const index = segment?.getAttribute('data-index')
   return index === null || index === undefined ? null : Number(index)
 }
 
-// A committed word-range carries its own term + rect; the sentence it starts in
-// (translator context) comes from the anchor word's segment.
+// A committed word-range carries its own term + rect; the surrounding text
+// (translator context) is the whole paragraph the anchor word sits in.
 function commitSelection({ term, rect, anchor }: { term: string; rect: DOMRect; anchor: Element }) {
-  const index = sentenceIndexOf(anchor)
-  const sentence = (index !== null && sentences.value[index]?.sentence) || term
+  const index = paragraphIndexOf(anchor)
+  const sentence = (index !== null && paragraphs[index]?.sentence) || term
   emit('select', { term, sentence, rect })
 }
 </script>
@@ -70,19 +67,12 @@ function commitSelection({ term, rect, anchor }: { term: string; rect: DOMRect; 
         aria-hidden="true"
         class="pointer-events-none absolute left-0 top-0 -z-10 rounded-2 bg-(--theme-primary) opacity-0"
       />
-      <div
-        v-for="(paragraph, p) in paragraphs"
-        :key="p"
-        data-testid="transcript-view__paragraph"
-        class="flex flex-col gap-3"
-      >
-        <transcript-segment
-          v-for="sentence in paragraph"
-          :key="sentence.index"
-          :group="sentence"
-          :index="sentence.index"
-        />
-      </div>
+      <transcript-segment
+        v-for="paragraph in paragraphs"
+        :key="paragraph.index"
+        :group="paragraph"
+        :index="paragraph.index"
+      />
     </div>
   </div>
 </template>

--- a/tests/integration/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/integration/composables/audio-reader/use-reader-highlights.test.js
@@ -88,6 +88,22 @@ describe('useReaderHighlights', () => {
     return wrapper.vm.$nextTick()
   }
 
+  // A touch over word `index`, optionally drifted `y` px down (the hit-test keys
+  // off clientX = index, so vertical drift moves the finger without leaving the
+  // word). Carries pointerType 'touch' so the composable takes its tap path.
+  function touch(wrapper, type, index, y = 0) {
+    words[index].dispatchEvent(
+      new PointerEvent(type, {
+        bubbles: true,
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX: index,
+        clientY: y
+      })
+    )
+    return wrapper.vm.$nextTick()
+  }
+
   beforeEach(() => {
     moveMock.mockClear()
     hideMock.mockClear()
@@ -156,6 +172,62 @@ describe('useReaderHighlights', () => {
 
       expect(onSelect.mock.calls[0][0].term).toBe('Hello world')
       expect(onSelect.mock.calls[0][0].anchor).toBe(words[0])
+    })
+  })
+
+  describe('touch selects on release, not on press', () => {
+    test('a stationary tap commits the word on release', async () => {
+      const onSelect = vi.fn()
+      const wrapper = mountHost(onSelect)
+
+      await touch(wrapper, 'pointerdown', 1)
+      expect(onSelect).not.toHaveBeenCalled()
+
+      await touch(wrapper, 'pointerup', 1)
+
+      expect(onSelect).toHaveBeenCalledTimes(1)
+      expect(onSelect.mock.calls[0][0].term).toBe('world')
+    })
+
+    test('press does not claim the gesture, so the column can still scroll', async () => {
+      const wrapper = mountHost(vi.fn())
+      const prevent = vi.fn()
+
+      const event = new PointerEvent('pointerdown', {
+        bubbles: true,
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX: 1,
+        clientY: 0
+      })
+      event.preventDefault = prevent
+      words[1].dispatchEvent(event)
+      await wrapper.vm.$nextTick()
+
+      expect(prevent).not.toHaveBeenCalled()
+    })
+
+    test('a touch that drifts past the slop is a scroll and commits nothing', async () => {
+      const onSelect = vi.fn()
+      const wrapper = mountHost(onSelect)
+
+      await touch(wrapper, 'pointerdown', 1)
+      await touch(wrapper, 'pointermove', 1, 40)
+      await touch(wrapper, 'pointerup', 1, 40)
+
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    test('a touch that drifts within the slop still commits', async () => {
+      const onSelect = vi.fn()
+      const wrapper = mountHost(onSelect)
+
+      await touch(wrapper, 'pointerdown', 1)
+      await touch(wrapper, 'pointermove', 1, 5)
+      await touch(wrapper, 'pointerup', 1, 5)
+
+      expect(onSelect).toHaveBeenCalledTimes(1)
+      expect(onSelect.mock.calls[0][0].term).toBe('world')
     })
   })
 

--- a/tests/integration/views/audio-reader/lesson/index.test.js
+++ b/tests/integration/views/audio-reader/lesson/index.test.js
@@ -248,6 +248,13 @@ describe('LessonView', () => {
     })
   })
 
+  describe('mobile title', () => {
+    test('renders a centered lesson-title heading above the transcript', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('[data-testid="lesson-view__title-text"]').exists()).toBe(true)
+    })
+  })
+
   describe('edit button', () => {
     test('clicking lesson-view__edit opens the collection edit modal', async () => {
       const wrapper = mountView()

--- a/tests/integration/views/audio-reader/lesson/index.test.js
+++ b/tests/integration/views/audio-reader/lesson/index.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount, flushPromises } from '@vue/test-utils'
-import { defineComponent, h, ref } from 'vue'
+import { defineComponent, h } from 'vue'
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────────
 
@@ -11,6 +11,7 @@ const {
   activeWordRef,
   selectionRef,
   popoverOpenRef,
+  targetLang,
   openTermMock,
   closeTermMock,
   chaptersRef,
@@ -24,6 +25,7 @@ const {
   activeWordRef: { value: null },
   selectionRef: { value: null },
   popoverOpenRef: { value: false },
+  targetLang: 'English',
   openTermMock: vi.fn(),
   closeTermMock: vi.fn(),
   chaptersRef: { value: [] },
@@ -40,6 +42,7 @@ vi.mock('@/composables/audio-reader/use-lesson-reader', () => ({
     active_word: activeWordRef,
     selection: selectionRef,
     popover_open: popoverOpenRef,
+    target_lang: targetLang,
     openTerm: openTermMock,
     closeTerm: closeTermMock
   })

--- a/tests/integration/views/audio-reader/term-popover/index.test.js
+++ b/tests/integration/views/audio-reader/term-popover/index.test.js
@@ -1,37 +1,10 @@
-import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
-import { shallowMount, flushPromises } from '@vue/test-utils'
-import { h } from 'vue'
+import { describe, test, expect } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
 
-// ── Hoisted mocks ──────────────────────────────────────────────────────────────
-
-const { mutateAsyncMock } = vi.hoisted(() => ({
-  mutateAsyncMock: vi.fn()
-}))
-
-vi.mock('@/api/lessons', () => ({
-  useTranslateTermMutation: () => ({ mutateAsync: mutateAsyncMock }),
-  EdgeFunctionError: class EdgeFunctionError extends Error {
-    constructor(code) {
-      super(code)
-      this.name = 'EdgeFunctionError'
-      this.code = code
-    }
-  }
-}))
-
-// ── Helpers ────────────────────────────────────────────────────────────────────
-
-const TRANSLATION_RESULT = {
-  translation: 'cat',
-  reading: 'ねこ',
-  pos: 'noun',
-  description: 'A small domesticated carnivorous mammal.'
-}
-
-// Stub UiPopover so the term-popover test stays focused on translation
-// behaviour. The stub mirrors the real popover's open-gated rendering so the
-// visibility assertions still exercise the `open` prop. A render function is
-// used because the browser-mode build has no runtime template compiler.
+// Stub UiPopover so the test stays focused on the wrapper's open-gating + prop
+// forwarding. The stub mirrors the real popover's open-gated rendering. A render
+// function is used because the browser-mode build has no runtime template compiler.
 const UiPopoverStub = {
   name: 'UiPopover',
   props: ['open'],
@@ -40,13 +13,15 @@ const UiPopoverStub = {
   }
 }
 
-// Slot-rendering stub so the pos tag's text is observable (auto-stubs drop slots).
-const UiTagStub = {
-  name: 'UiTag',
-  setup(_props, { slots }) {
-    return () => h('span', slots.default?.())
+// Capture the props handed to TermCard so we can assert they're forwarded.
+const TermCardStub = defineComponent({
+  name: 'TermCard',
+  props: ['term', 'sentence', 'target_lang'],
+  emits: ['close'],
+  setup() {
+    return () => h('div', { 'data-testid': 'term-card-stub' })
   }
-}
+})
 
 function mountPopover(props = {}) {
   return shallowMount(TermPopover, {
@@ -59,176 +34,42 @@ function mountPopover(props = {}) {
       ...props
     },
     global: {
-      stubs: { UiPopover: UiPopoverStub, UiTag: UiTagStub },
+      stubs: { UiPopover: UiPopoverStub, TermCard: TermCardStub },
       mocks: { $t: (key) => key }
     }
   })
 }
 
 import TermPopover from '@/views/audio-reader/term-popover/index.vue'
-import { EdgeFunctionError } from '@/api/lessons'
-
-beforeEach(() => {
-  mutateAsyncMock.mockReset()
-})
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('TermPopover', () => {
-  describe('visibility', () => {
-    test('does not render the popover when open is false', () => {
-      const wrapper = mountPopover({ open: false, term: '猫' })
-      expect(wrapper.find('[data-testid="term-popover"]').exists()).toBe(false)
-    })
-
-    test('renders the popover when open is true', async () => {
-      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: '猫がいる' })
-      await flushPromises()
-      expect(wrapper.find('[data-testid="term-popover"]').exists()).toBe(true)
-    })
+  test('does not render the card surface when open is false', () => {
+    const wrapper = mountPopover({ open: false, term: '猫' })
+    expect(wrapper.find('[data-testid="term-popover"]').exists()).toBe(false)
   })
 
-  describe('translation fetch on open', () => {
-    test('calls translate mutation with term + sentence + target_lang when opened with a term', async () => {
-      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
-      mountPopover({ open: true, term: '猫', sentence: '猫がいる', target_lang: 'en' })
-      await flushPromises()
-
-      expect(mutateAsyncMock).toHaveBeenCalledWith({
-        term: '猫',
-        sentence: '猫がいる',
-        target_lang: 'en'
-      })
-    })
-
-    test('does not call translate mutation when opened with an empty term', async () => {
-      mountPopover({ open: true, term: '', sentence: '' })
-      await flushPromises()
-      expect(mutateAsyncMock).not.toHaveBeenCalled()
-    })
+  test('renders the card surface when open is true', () => {
+    const wrapper = mountPopover({ open: true, term: '猫' })
+    expect(wrapper.find('[data-testid="term-popover"]').exists()).toBe(true)
   })
 
-  describe('loading state', () => {
-    test('shows term-popover__loading while the mutation is pending', async () => {
-      // Never resolve — mutation stays pending
-      mutateAsyncMock.mockReturnValueOnce(new Promise(() => {}))
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      // Don't await flushPromises — we want the pending state
-      expect(wrapper.find('[data-testid="term-popover__loading"]').exists()).toBe(true)
+  test('forwards term + sentence + target_lang to the card', () => {
+    const wrapper = mountPopover({
+      open: true,
+      term: '猫',
+      sentence: '猫がいる',
+      target_lang: 'en'
     })
 
-    test('hides term-popover__loading after the mutation resolves', async () => {
-      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-      expect(wrapper.find('[data-testid="term-popover__loading"]').exists()).toBe(false)
-    })
+    const card = wrapper.findComponent(TermCardStub)
+    expect(card.props()).toMatchObject({ term: '猫', sentence: '猫がいる', target_lang: 'en' })
   })
 
-  describe('success state', () => {
-    test('renders term-popover__translation with the translated text', async () => {
-      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
+  test('re-emits close when the card requests it', () => {
+    const wrapper = mountPopover({ open: true, term: '猫' })
 
-      expect(wrapper.find('[data-testid="term-popover__translation"]').text()).toContain('cat')
-    })
+    wrapper.findComponent(TermCardStub).vm.$emit('close')
 
-    test('renders term-popover__reading with the reading and a pos tag', async () => {
-      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      const reading = wrapper.find('[data-testid="term-popover__reading"]')
-      expect(reading.exists()).toBe(true)
-      expect(reading.text()).toContain('ねこ')
-      expect(reading.text()).toContain('noun')
-    })
-
-    test('renders term-popover__description with the description text', async () => {
-      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      const desc = wrapper.find('[data-testid="term-popover__description"]')
-      expect(desc.exists()).toBe(true)
-      expect(desc.text()).toContain('A small domesticated carnivorous mammal.')
-    })
-
-    test('hides term-popover__error on success', async () => {
-      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      expect(wrapper.find('[data-testid="term-popover__error"]').exists()).toBe(false)
-    })
-  })
-
-  describe('error state', () => {
-    test('shows term-popover__error when the mutation rejects with a generic error', async () => {
-      mutateAsyncMock.mockRejectedValueOnce(new Error('network error'))
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      expect(wrapper.find('[data-testid="term-popover__error"]').exists()).toBe(true)
-    })
-
-    test('shows the generic error message for a non-EdgeFunctionError', async () => {
-      mutateAsyncMock.mockRejectedValueOnce(new Error('network error'))
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      // Component renders the translated string, not the key
-      expect(wrapper.find('[data-testid="term-popover__error"]').text()).toBe(
-        "Couldn't translate that. Try again."
-      )
-    })
-
-    test('shows the too-long message for EdgeFunctionError code "output_truncated"', async () => {
-      mutateAsyncMock.mockRejectedValueOnce(new EdgeFunctionError('output_truncated'))
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      expect(wrapper.find('[data-testid="term-popover__error"]').text()).toBe(
-        'That selection is too long. Try a shorter phrase.'
-      )
-    })
-
-    test('shows the generic error message for other EdgeFunctionError codes', async () => {
-      mutateAsyncMock.mockRejectedValueOnce(new EdgeFunctionError('file_too_large'))
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      expect(wrapper.find('[data-testid="term-popover__error"]').text()).toBe(
-        "Couldn't translate that. Try again."
-      )
-    })
-
-    test('does not render translation result on error', async () => {
-      mutateAsyncMock.mockRejectedValueOnce(new Error('fail'))
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      expect(wrapper.find('[data-testid="term-popover__translation"]').exists()).toBe(false)
-    })
-
-    test('does not show term-popover__loading on error', async () => {
-      mutateAsyncMock.mockRejectedValueOnce(new Error('fail'))
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      expect(wrapper.find('[data-testid="term-popover__loading"]').exists()).toBe(false)
-    })
-  })
-
-  describe('header', () => {
-    test('renders the header with the term text', async () => {
-      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
-      const wrapper = mountPopover({ open: true, term: '猫', sentence: 'test' })
-      await flushPromises()
-
-      expect(wrapper.find('[data-testid="term-popover__header"]').text()).toContain('猫')
-    })
+    expect(wrapper.emitted('close')).toBeTruthy()
   })
 })

--- a/tests/integration/views/audio-reader/term-popover/term-card.test.js
+++ b/tests/integration/views/audio-reader/term-popover/term-card.test.js
@@ -1,0 +1,215 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { h } from 'vue'
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const { mutateAsyncMock } = vi.hoisted(() => ({
+  mutateAsyncMock: vi.fn()
+}))
+
+vi.mock('@/api/lessons', () => ({
+  useTranslateTermMutation: () => ({ mutateAsync: mutateAsyncMock }),
+  EdgeFunctionError: class EdgeFunctionError extends Error {
+    constructor(code) {
+      super(code)
+      this.name = 'EdgeFunctionError'
+      this.code = code
+    }
+  }
+}))
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const TRANSLATION_RESULT = {
+  translation: 'cat',
+  reading: 'ねこ',
+  pos: 'noun',
+  description: 'A small domesticated carnivorous mammal.'
+}
+
+// Slot-rendering stub so the pos tag's text is observable (auto-stubs drop slots).
+const UiTagStub = {
+  name: 'UiTag',
+  setup(_props, { slots }) {
+    return () => h('span', slots.default?.())
+  }
+}
+
+function mountCard(props = {}) {
+  return shallowMount(TermCard, {
+    props: {
+      term: '',
+      sentence: '',
+      target_lang: 'en',
+      ...props
+    },
+    global: {
+      stubs: { UiTag: UiTagStub },
+      mocks: { $t: (key) => key }
+    }
+  })
+}
+
+import TermCard from '@/views/audio-reader/term-popover/term-card.vue'
+import { EdgeFunctionError } from '@/api/lessons'
+
+beforeEach(() => {
+  mutateAsyncMock.mockReset()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('TermCard', () => {
+  describe('translation fetch on mount', () => {
+    test('calls translate mutation with term + sentence + target_lang', async () => {
+      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
+      mountCard({ term: '猫', sentence: '猫がいる', target_lang: 'en' })
+      await flushPromises()
+
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        term: '猫',
+        sentence: '猫がいる',
+        target_lang: 'en'
+      })
+    })
+
+    test('does not call translate mutation with an empty term', async () => {
+      mountCard({ term: '', sentence: '' })
+      await flushPromises()
+      expect(mutateAsyncMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('loading state', () => {
+    test('shows term-card__loading while the mutation is pending', () => {
+      // Never resolve — mutation stays pending
+      mutateAsyncMock.mockReturnValueOnce(new Promise(() => {}))
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      expect(wrapper.find('[data-testid="term-card__loading"]').exists()).toBe(true)
+    })
+
+    test('hides term-card__loading after the mutation resolves', async () => {
+      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+      expect(wrapper.find('[data-testid="term-card__loading"]').exists()).toBe(false)
+    })
+  })
+
+  describe('success state', () => {
+    test('renders term-card__translation with the translated text', async () => {
+      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="term-card__translation"]').text()).toContain('cat')
+    })
+
+    test('renders term-card__reading with the reading and a pos tag', async () => {
+      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      const reading = wrapper.find('[data-testid="term-card__reading"]')
+      expect(reading.exists()).toBe(true)
+      expect(reading.text()).toContain('ねこ')
+      expect(reading.text()).toContain('noun')
+    })
+
+    test('renders term-card__description with the description text', async () => {
+      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      const desc = wrapper.find('[data-testid="term-card__description"]')
+      expect(desc.exists()).toBe(true)
+      expect(desc.text()).toContain('A small domesticated carnivorous mammal.')
+    })
+
+    test('hides term-card__error on success', async () => {
+      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="term-card__error"]').exists()).toBe(false)
+    })
+  })
+
+  describe('error state', () => {
+    test('shows term-card__error when the mutation rejects with a generic error', async () => {
+      mutateAsyncMock.mockRejectedValueOnce(new Error('network error'))
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="term-card__error"]').exists()).toBe(true)
+    })
+
+    test('shows the generic error message for a non-EdgeFunctionError', async () => {
+      mutateAsyncMock.mockRejectedValueOnce(new Error('network error'))
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      // Component renders the translated string, not the key
+      expect(wrapper.find('[data-testid="term-card__error"]').text()).toBe(
+        "Couldn't translate that. Try again."
+      )
+    })
+
+    test('shows the too-long message for EdgeFunctionError code "output_truncated"', async () => {
+      mutateAsyncMock.mockRejectedValueOnce(new EdgeFunctionError('output_truncated'))
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="term-card__error"]').text()).toBe(
+        'That selection is too long. Try a shorter phrase.'
+      )
+    })
+
+    test('shows the generic error message for other EdgeFunctionError codes', async () => {
+      mutateAsyncMock.mockRejectedValueOnce(new EdgeFunctionError('file_too_large'))
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="term-card__error"]').text()).toBe(
+        "Couldn't translate that. Try again."
+      )
+    })
+
+    test('does not render translation result on error', async () => {
+      mutateAsyncMock.mockRejectedValueOnce(new Error('fail'))
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="term-card__translation"]').exists()).toBe(false)
+    })
+
+    test('does not show term-card__loading on error', async () => {
+      mutateAsyncMock.mockRejectedValueOnce(new Error('fail'))
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="term-card__loading"]').exists()).toBe(false)
+    })
+  })
+
+  describe('header', () => {
+    test('renders the header with the term text', async () => {
+      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="term-card__header"]').text()).toContain('猫')
+    })
+
+    test('emits close when the header close button is clicked', async () => {
+      mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
+      const wrapper = mountCard({ term: '猫', sentence: 'test' })
+      await flushPromises()
+
+      await wrapper.find('[data-testid="term-card__close"]').trigger('click')
+
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+  })
+})

--- a/tests/integration/views/audio-reader/transcript/index.test.js
+++ b/tests/integration/views/audio-reader/transcript/index.test.js
@@ -15,21 +15,19 @@ const sentence = (index, sentenceText, words, extra = {}) => ({
   ...extra
 })
 
-// Two paragraphs: [[s0], [s1, s2]]
-function makeParagraphs() {
+// Each sentence renders as its own block (one segment apiece).
+function makeSentences() {
   return [
-    [sentence(0, 'Hello world.', [word('Hello ', 0), word('world.', 1)])],
-    [
-      sentence(1, 'How are you?', [word('How ', 2), word('are ', 3), word('you?', 4)]),
-      sentence(2, 'Fine thanks.', [word('Fine ', 5), word('thanks.', 6)])
-    ]
+    sentence(0, 'Hello world.', [word('Hello ', 0), word('world.', 1)]),
+    sentence(1, 'How are you?', [word('How ', 2), word('are ', 3), word('you?', 4)]),
+    sentence(2, 'Fine thanks.', [word('Fine ', 5), word('thanks.', 6)])
   ]
 }
 
 function mountView(props = {}) {
   return mount(TranscriptView, {
     props: {
-      paragraphs: makeParagraphs(),
+      paragraphs: makeSentences(),
       active_word: -1,
       ...props
     }
@@ -43,13 +41,8 @@ describe('TranscriptView', () => {
     vi.restoreAllMocks()
   })
 
-  describe('paragraph rendering', () => {
-    test('renders one paragraph element per paragraph', () => {
-      const wrapper = mountView()
-      expect(wrapper.findAll('[data-testid="transcript-view__paragraph"]')).toHaveLength(2)
-    })
-
-    test('renders one transcript-segment per sentence across all paragraphs', () => {
+  describe('segment rendering', () => {
+    test('renders one transcript-segment per sentence block', () => {
       const wrapper = mountView()
       expect(wrapper.findAll('[data-testid="transcript-segment"]')).toHaveLength(3)
     })

--- a/tests/unit/composables/audio-reader/use-lesson-reader.test.js
+++ b/tests/unit/composables/audio-reader/use-lesson-reader.test.js
@@ -97,15 +97,14 @@ describe('useLessonReader', () => {
   })
 
   describe('transcript shaping', () => {
-    test('shapes the lesson transcript into paragraphs of sentences', () => {
+    test('shapes the lesson transcript into one block per sentence', () => {
       let reader
       ;[reader, app] = withReader()
 
-      const paragraphs = reader.paragraphs.value
-      const sentences = paragraphs.flat()
-      expect(sentences).toHaveLength(2)
-      expect(sentences[0].sentence).toBe('Hello world.')
-      expect(sentences.flatMap((s) => s.words)).toHaveLength(5)
+      const blocks = reader.paragraphs.value
+      expect(blocks).toHaveLength(2)
+      expect(blocks[0].sentence).toBe('Hello world.')
+      expect(blocks.flatMap((s) => s.words)).toHaveLength(5)
     })
 
     test('is empty before the lesson resolves', () => {

--- a/tests/unit/composables/audio-reader/use-lesson-reader.test.js
+++ b/tests/unit/composables/audio-reader/use-lesson-reader.test.js
@@ -1,20 +1,37 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
 import { createApp, ref, nextTick } from 'vue'
 
-const { lessonQueryMock, audioUrlQueryMock, audioPlayerMock, transcriptSyncMock, toastErrorMock } =
-  vi.hoisted(() => ({
-    lessonQueryMock: vi.fn(),
-    audioUrlQueryMock: vi.fn(),
-    audioPlayerMock: vi.fn(),
-    transcriptSyncMock: vi.fn(),
-    toastErrorMock: vi.fn()
-  }))
+const {
+  lessonQueryMock,
+  audioUrlQueryMock,
+  audioPlayerMock,
+  transcriptSyncMock,
+  toastErrorMock,
+  openModalMock,
+  modalCloseMock,
+  mobileRef
+} = vi.hoisted(() => ({
+  lessonQueryMock: vi.fn(),
+  audioUrlQueryMock: vi.fn(),
+  audioPlayerMock: vi.fn(),
+  transcriptSyncMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  openModalMock: vi.fn(),
+  modalCloseMock: vi.fn(),
+  // Plain holder the composable reads at call time; flip .value per test to pick
+  // the mobile (sheet) vs desktop (anchored popover) branch.
+  mobileRef: { value: false }
+}))
 
 vi.mock('@/api/lessons', () => ({
   useLessonQuery: lessonQueryMock,
   useLessonAudioUrlQuery: audioUrlQueryMock
 }))
 vi.mock('@/composables/toast', () => ({ useToast: () => ({ error: toastErrorMock }) }))
+vi.mock('@/composables/modal', () => ({
+  useModal: () => ({ open: openModalMock, pop: vi.fn(), modal_stack: { value: [] } })
+}))
+vi.mock('@/composables/use-media-query', () => ({ useMobileBreakpoint: () => mobileRef }))
 vi.mock('@/composables/audio-reader/use-audio-player', () => ({ useAudioPlayer: audioPlayerMock }))
 vi.mock('@/composables/audio-reader/use-transcript-sync', () => ({
   useTranscriptSync: transcriptSyncMock
@@ -69,6 +86,10 @@ describe('useLessonReader', () => {
     audioPlayerMock.mockReturnValue({ current_time: ref(0) })
     transcriptSyncMock.mockReturnValue({ active_index: ref(-1) })
     toastErrorMock.mockReset()
+    openModalMock.mockReset()
+    openModalMock.mockReturnValue({ response: Promise.resolve(), close: modalCloseMock })
+    modalCloseMock.mockReset()
+    mobileRef.value = false
   })
 
   afterEach(() => {
@@ -110,7 +131,7 @@ describe('useLessonReader', () => {
   })
 
   describe('term popover', () => {
-    test('openTerm stores the selection and opens; closeTerm closes', () => {
+    test('on desktop, openTerm stores the selection and opens; closeTerm closes', () => {
       let reader
       ;[reader, app] = withReader()
       const term = { term: 'world', sentence: 'Hello world.', rect: new DOMRect() }
@@ -118,9 +139,42 @@ describe('useLessonReader', () => {
       reader.openTerm(term)
       expect(reader.selection.value).toEqual(term)
       expect(reader.popover_open.value).toBe(true)
+      expect(openModalMock).not.toHaveBeenCalled()
 
       reader.closeTerm()
       expect(reader.popover_open.value).toBe(false)
+    })
+
+    test('on mobile, openTerm opens the term as a mobile sheet, not the anchored popover', () => {
+      mobileRef.value = true
+      let reader
+      ;[reader, app] = withReader()
+
+      reader.openTerm({ term: 'world', sentence: 'Hello world.', rect: new DOMRect() })
+
+      expect(openModalMock).toHaveBeenCalledTimes(1)
+      const [, opts] = openModalMock.mock.calls[0]
+      expect(opts.mode).toBe('mobile-sheet')
+      expect(opts.backdrop).toBe(true)
+      expect(opts.props).toMatchObject({
+        term: 'world',
+        sentence: 'Hello world.',
+        target_lang: 'English'
+      })
+      expect(reader.popover_open.value).toBe(false)
+      expect(reader.selection.value).toBe(null)
+    })
+
+    test('on mobile, selecting another term dismisses the previous sheet first', () => {
+      mobileRef.value = true
+      let reader
+      ;[reader, app] = withReader()
+
+      reader.openTerm({ term: 'a', sentence: 's', rect: new DOMRect() })
+      reader.openTerm({ term: 'b', sentence: 's', rect: new DOMRect() })
+
+      expect(modalCloseMock).toHaveBeenCalledTimes(1)
+      expect(openModalMock).toHaveBeenCalledTimes(2)
     })
   })
 


### PR DESCRIPTION
## Summary

A pass over the audio-reader's mobile reading experience.

### 1. Select words on touch release, not touch-down
`onPointerDown` used to claim the gesture immediately (`preventDefault` + pointer capture), killing native scroll and selecting a word the instant a finger landed. Touch now defers to release: it claims nothing on the way down (the column scrolls freely) and selects the tapped word on `pointerup`, only if the finger stayed within `TAP_SLOP` (10px) — a larger drift is a scroll and commits nothing. Mouse press-drag-release is unchanged (gated on `pointerType === 'touch'`).

### 2. Term popover opens as a bottom sheet on mobile
The rect-anchored popover crowds a phone. On a coarse/narrow viewport, `openTerm` routes the term through the global modal stack as a `mobile-sheet` (reusing its backdrop, scroll-lock, slide animation); desktop keeps the anchored popover. The fetch + card body were extracted into a presentation-agnostic `term-card.vue` shared by the popover and the new `sheet.vue`.

### 3. One sentence per block in the reader
Each sentence carries its own interlinear gloss, so sentences can't flow as continuous prose. Stacking several per paragraph read as ambiguous mini-paragraphs and squished the next sentence's pinyin against the previous gloss. The reader now renders one evenly-spaced block per sentence. (Proper block-shaping belongs in the generation pipeline — this is the honest FE rendering of the current per-sentence shape; `groupSentencesIntoParagraphs` is left in place, currently unused.)

### 4. Book-style title on mobile
Below the `xl` sidebar breakpoint the lesson aside (chapter nav + edit) is hidden and the lesson title shows centered above the transcript, like a chapter heading. Desktop keeps the sticky sidebar.

## Tests
- `use-reader-highlights`: tap-to-select, no-claim-on-press, scroll-drift discard, within-slop drift.
- `term-card`: translation fetch + content states + close emit.
- `use-lesson-reader`: popover-vs-sheet branch, re-select dismisses prior sheet, one-block-per-sentence shaping.
- `transcript` view: one segment per sentence block, data-index, selection emit.
- All audio-reader suites green; `vp check` + `vue-tsc` clean.

## Follow-up (not in this PR)
Reshaping the transcript into coherent display blocks (and translating per block for coherent glosses) belongs in the transcription/translation pipeline — discussed and deferred; the BE keeps returning the pure per-sentence shape.