### PR TITLE
fix(modal): keep page scroll position when opening a modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@supabase/supabase-js": "^2.103.3",
     "@tanstack/vue-virtual": "^3.13.24",
     "@types/howler": "^2.2.12",
-    "body-scroll-lock": "4.0.0-beta.0",
     "gsap": "^3.15.0",
     "howler": "^2.2.4",
     "lexical": "^0.41.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       '@types/howler':
         specifier: ^2.2.12
         version: 2.2.12
-      body-scroll-lock:
-        specifier: 4.0.0-beta.0
-        version: 4.0.0-beta.0
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
@@ -2143,9 +2140,6 @@ packages:
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
-
-  body-scroll-lock@4.0.0-beta.0:
-    resolution: {integrity: sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -5544,8 +5538,6 @@ snapshots:
   binary-extensions@2.3.0: {}
 
   birpc@2.9.0: {}
-
-  body-scroll-lock@4.0.0-beta.0: {}
 
   boolbase@1.0.0: {}
 

--- a/src/components/ui-kit/modal.vue
+++ b/src/components/ui-kit/modal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { onUnmounted, watchEffect, computed, useTemplateRef } from 'vue'
-import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
 import { useModal, request_close_handlers, type ModalMode } from '@/composables/modal'
 import { useMobileBreakpoint, type BreakpointKey } from '@/composables/use-media-query'
+import { useScrollLock } from '@/composables/use-scroll-lock'
 import { useShortcuts } from '@/composables/use-shortcuts'
 import { MODAL_MODE_CONFIG } from './modal-mode-config'
 import ModalSlot from './modal-slot.vue'
@@ -35,6 +35,7 @@ function isMobileFor(el: Element) {
 }
 
 const modal_container = useTemplateRef<{ $el: HTMLElement }>('modal_container')
+const scroll_lock = useScrollLock(() => modal_container.value?.$el)
 
 function requestClose() {
   const top = modal_stack.value.at(-1)
@@ -50,24 +51,16 @@ function requestClose() {
 
 onUnmounted(() => {
   shortcuts.dispose()
-  if (modal_container.value?.$el) enableBodyScroll(modal_container.value.$el)
-  document.documentElement.style.overflow = ''
 })
 
 watchEffect(() => {
   if (!modal_container.value?.$el) return
 
   if (modal_stack.value.length > 0) {
-    // body-scroll-lock locks the body but iOS Safari still lets the html
-    // element scroll via rubber-banding. Lock html explicitly.
-    document.documentElement.style.overflow = 'hidden'
-    disableBodyScroll(modal_container.value.$el, {
-      allowTouchMove: (el) => modal_container.value!.$el.contains(el as Node)
-    })
+    scroll_lock.lock()
     shortcuts.register({ combo: 'esc', handler: requestClose })
   } else {
-    document.documentElement.style.overflow = ''
-    enableBodyScroll(modal_container.value.$el)
+    scroll_lock.unlock()
     shortcuts.clearScope()
   }
 })

--- a/src/composables/use-scroll-lock.ts
+++ b/src/composables/use-scroll-lock.ts
@@ -1,0 +1,85 @@
+import { onUnmounted, toValue, type MaybeRefOrGetter } from 'vue'
+
+/**
+ * Locks background scrolling **without mutating `<html>`/`<body>` layout**.
+ * Toggling `overflow`/`position` there snaps the page to scroll 0 on iOS Safari,
+ * and any layout shift is visible whenever the overlay above is transparent — so
+ * instead this cancels scroll-producing events (`wheel`, `touchmove`) on
+ * everything outside `container`.
+ *
+ * Scrolls inside `container` pass through so its own content still scrolls, but
+ * are blocked once its scroller reaches the edge the gesture is pushing past, so
+ * the scroll never chains back to the page. The lock releases on unmount.
+ *
+ * @param container - the element whose scrolling stays live (e.g. the open
+ *   modal). Read lazily, so it may resolve after `lock()` is first called.
+ * @example
+ * const { lock, unlock } = useScrollLock(() => modal_container.value?.$el)
+ */
+export function useScrollLock(container: MaybeRefOrGetter<HTMLElement | null | undefined>) {
+  let scroll_locked = false
+  let touch_start_y = 0
+
+  function scrollableAncestor(node: Node, root: HTMLElement): HTMLElement | null {
+    let el = node instanceof HTMLElement ? node : node.parentElement
+    while (el && root.contains(el)) {
+      const overflow_y = getComputedStyle(el).overflowY
+      if ((overflow_y === 'auto' || overflow_y === 'scroll') && el.scrollHeight > el.clientHeight) {
+        return el
+      }
+      el = el.parentElement
+    }
+    return null
+  }
+
+  function wouldScrollBackground(target: EventTarget | null, scrolling_down: boolean): boolean {
+    const root = toValue(container)
+    if (!root || !(target instanceof Node) || !root.contains(target)) return true
+
+    const scroller = scrollableAncestor(target, root)
+    if (!scroller) return true
+
+    const at_top = scroller.scrollTop <= 0
+    const at_bottom = Math.ceil(scroller.scrollTop + scroller.clientHeight) >= scroller.scrollHeight
+    return scrolling_down ? at_bottom : at_top
+  }
+
+  function onTouchStart(e: TouchEvent) {
+    touch_start_y = e.touches[0]?.clientY ?? 0
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    if (e.touches.length > 1) return // let pinch-zoom through
+
+    const scrolling_down = (e.touches[0]?.clientY ?? 0) < touch_start_y
+    if (wouldScrollBackground(e.target, scrolling_down)) e.preventDefault()
+  }
+
+  function onWheel(e: WheelEvent) {
+    if (wouldScrollBackground(e.target, e.deltaY > 0)) e.preventDefault()
+  }
+
+  /** Start swallowing background scroll events. No-op if already locked. */
+  function lock() {
+    if (scroll_locked) return
+    scroll_locked = true
+
+    window.addEventListener('touchstart', onTouchStart, { passive: true })
+    window.addEventListener('touchmove', onTouchMove, { passive: false })
+    window.addEventListener('wheel', onWheel, { passive: false })
+  }
+
+  /** Release the lock and restore normal scrolling. No-op if not locked. */
+  function unlock() {
+    if (!scroll_locked) return
+    scroll_locked = false
+
+    window.removeEventListener('touchstart', onTouchStart)
+    window.removeEventListener('touchmove', onTouchMove)
+    window.removeEventListener('wheel', onWheel)
+  }
+
+  onUnmounted(unlock)
+
+  return { lock, unlock }
+}

--- a/tests/integration/components/ui-kit/modal.test.js
+++ b/tests/integration/components/ui-kit/modal.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
 import { defineComponent, h, nextTick, ref, withAttrs } from 'vue'
 import ModalUiKit from '@/components/ui-kit/modal.vue'
@@ -6,20 +6,10 @@ import { useModal, useModalRequestClose, request_close_handlers } from '@/compos
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { mockDisableBodyScroll, mockEnableBodyScroll } = vi.hoisted(() => ({
-  mockDisableBodyScroll: vi.fn(),
-  mockEnableBodyScroll: vi.fn()
-}))
-
 const { mockRegister, mockDispose, mockClearScope } = vi.hoisted(() => ({
   mockRegister: vi.fn(),
   mockDispose: vi.fn(),
   mockClearScope: vi.fn()
-}))
-
-vi.mock('body-scroll-lock', () => ({
-  disableBodyScroll: mockDisableBodyScroll,
-  enableBodyScroll: mockEnableBodyScroll
 }))
 
 vi.mock('@/composables/use-shortcuts', () => ({
@@ -65,9 +55,28 @@ const ModalStub = defineComponent({
   }
 })
 
+// A modal whose body is a real overflow scroller, for boundary-chaining tests.
+const ScrollableStub = defineComponent({
+  render() {
+    return h('div', { 'data-testid': 'scroll-stub', style: 'overflow-y: auto; height: 50px;' }, [
+      h('div', { style: 'height: 500px;' })
+    ])
+  }
+})
+
+// Modal hosts attach real window listeners while open — unmount every mount so
+// they don't leak into later tests.
+const mounted = []
+
 function mountModal() {
-  return mount(ModalUiKit, { attachTo: document.body })
+  const wrapper = mount(ModalUiKit, { attachTo: document.body })
+  mounted.push(wrapper)
+  return wrapper
 }
+
+afterEach(() => {
+  while (mounted.length > 0) mounted.pop().unmount()
+})
 
 function containerMode(wrapper) {
   return wrapper.find('[data-testid="ui-kit-modal-container"]').attributes('data-modal-mode')
@@ -248,46 +257,83 @@ describe('modal.vue', () => {
     })
   })
 
-  describe('html overflow lock', () => {
-    beforeEach(() => {
-      document.documentElement.style.overflow = ''
-    })
+  describe('background scroll lock', () => {
+    // The lock decides off `wheel`/`touchmove`; wheel is the simplest to forge
+    // and runs through the exact same boundary logic.
+    function fireWheel(target, deltaY = 50) {
+      const event = new WheelEvent('wheel', { deltaY, cancelable: true, bubbles: true })
+      target.dispatchEvent(event)
+      return event
+    }
 
-    test('locks html overflow to hidden while a modal is open', async () => {
+    test('blocks background scroll while a modal is open', async () => {
       const { open } = useModal()
       open(ModalStub)
 
       mountModal()
       await nextTick()
 
-      expect(document.documentElement.style.overflow).toBe('hidden')
+      expect(fireWheel(document.body).defaultPrevented).toBe(true)
     })
 
-    test('restores html overflow when the last modal closes', async () => {
+    test('does not block scroll when no modal is open', async () => {
+      mountModal()
+      await nextTick()
+
+      expect(fireWheel(document.body).defaultPrevented).toBe(false)
+    })
+
+    test('lets a scroll through when the modal scroller has room, so its content scrolls', async () => {
+      const { open } = useModal()
+      open(ScrollableStub)
+
+      const wrapper = mountModal()
+      await nextTick()
+
+      const scroller = wrapper.find('[data-testid="scroll-stub"]').element
+      scroller.scrollTop = 20 // mid-scroll: not at either edge
+
+      expect(fireWheel(scroller, 50).defaultPrevented).toBe(false)
+    })
+
+    test('blocks a scroll at the modal scroller edge so it does not chain to the page', async () => {
+      const { open } = useModal()
+      open(ScrollableStub)
+
+      const wrapper = mountModal()
+      await nextTick()
+
+      const scroller = wrapper.find('[data-testid="scroll-stub"]').element
+      scroller.scrollTop = 0 // at the top, scrolling up
+
+      expect(fireWheel(scroller, -50).defaultPrevented).toBe(true)
+    })
+
+    test('stops blocking background scroll once the last modal closes', async () => {
       const { open, pop } = useModal()
       open(ModalStub)
 
       mountModal()
       await nextTick()
-      expect(document.documentElement.style.overflow).toBe('hidden')
+      expect(fireWheel(document.body).defaultPrevented).toBe(true)
 
       pop()
       await nextTick()
 
-      expect(document.documentElement.style.overflow).toBe('')
+      expect(fireWheel(document.body).defaultPrevented).toBe(false)
     })
 
-    test('restores html overflow on unmount', async () => {
+    test('stops blocking background scroll on unmount', async () => {
       const { open } = useModal()
       open(ModalStub)
 
       const wrapper = mountModal()
       await nextTick()
-      expect(document.documentElement.style.overflow).toBe('hidden')
+      expect(fireWheel(document.body).defaultPrevented).toBe(true)
 
       wrapper.unmount()
 
-      expect(document.documentElement.style.overflow).toBe('')
+      expect(fireWheel(document.body).defaultPrevented).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Summary

Opening any modal snapped the page back to scroll 0 — when scrolled deep in the audio reader, it threw you to the top.

The root cause was `body-scroll-lock@4.0.0-beta.0`: on iOS its `disableBodyScroll` pins `<body>` with `top = -scrollY` as a **unitless number**, which is invalid CSS and gets ignored, so the fixed body lands at `top: 0` and the page jumps. The unmaintained 3.x `position: fixed` approach would instead reflow the `sticky` app nav — visible on mobile because the modal backdrop is transparent there (`pointer-fine:` blur/tint is desktop-only). So no layout-mutating lock works here.

Replaced it with a **layout-free** lock (`src/composables/use-scroll-lock.ts`):

- Cancels `wheel`/`touchmove` on the background instead of touching `<html>`/`<body>` styles — the page never moves, so no jump on open/close and no sticky-nav flash.
- Scrolls inside the open modal pass through so its content still scrolls, but are blocked once the scroller hits the edge the gesture is pushing past, so the scroll never chains back to the page.
- Multi-touch passes through (pinch-zoom preserved); releases on unmount.

Drops the `body-scroll-lock` dependency. Modal integration tests rewritten to assert the event-based behaviour (including boundary chaining) with window-listener cleanup between tests.

Known trade-off: on desktop, keyboard/scrollbar scrolling behind the modal isn't blocked (only wheel/trackpad) — minor, since the desktop backdrop blurs and modals trap focus.