### PR TITLE
Unify responsive checks into useMatchMedia; fix deck-settings sidebar desync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,10 @@ For any feature work or code changes:
 
 1. **Check current branch.** If on `master`, or current branch's scope doesn't match the requested work, create a new branch before editing.
 2. **Check staleness.** At session start, verify the current branch isn't already merged (e.g. `gh pr view --json state,mergedAt` or `git log master..HEAD`). If merged, create a fresh branch off `master`.
-3. **Commit in logical chunks.** Group related changes into separate commits with clear messages — don't batch unrelated work into one commit.
-4. **Open a PR early.** If the branch has no PR yet, open one (draft is fine) after the first meaningful commit. Push subsequent commits to that PR as you go for incremental review.
-5. **Push as you commit.** Don't accumulate local commits — push after each logical chunk so the PR stays current.
-6. **Squash iterative fixes.** When several attempts go into landing the _same_ logical change (initial fix → didn't work → second fix → third fix), collapse them into a single commit before review. Don't ship `fix attempt 1` / `fix attempt 2` / `fix attempt 3` as separate commits.
+3. **Commit in logical chunks.** Group related changes into separate commits with clear messages — don't batch unrelated work into one commit. Commit freely as work progresses; don't wait for the end of the session.
+4. **Don't open PRs automatically.** Open or push a PR only when explicitly asked. Committing locally is fine; surfacing the work as a PR is the user's call.
+5. **Squash iterative fixes.** When several attempts go into landing the _same_ logical change (initial fix → didn't work → second fix → third fix), collapse them into a single commit before review. Don't ship `fix attempt 1` / `fix attempt 2` / `fix attempt 3` as separate commits.
    - **Not yet pushed:** `git reset --soft HEAD~N` then re-commit, or `git commit --amend --no-edit` for each follow-up before push.
    - **Already pushed to a feature branch:** `git reset --soft HEAD~N && git commit` then `git push --force-with-lease`. Force-push is allowed on a feature branch you own; never on `master`.
    - Logical chunks (e.g. `feat(...)` and the test commit covering it) stay separate. This rule applies only to repeated attempts at the same change.
-7. **No Claude attribution.** Never add `Co-Authored-By: Claude` trailers to commits, and never add the "Generated with Claude Code" footer to PR bodies.
+6. **No Claude attribution.** Never add `Co-Authored-By: Claude` trailers to commits, and never add the "Generated with Claude Code" footer to PR bodies.

--- a/src/components/layout-kit/modal/tab-sheet.vue
+++ b/src/components/layout-kit/modal/tab-sheet.vue
@@ -22,6 +22,7 @@ export type TabSheetParts = {
 export type TabSheetProps = MobileSheetProps & {
   tabs?: Tab[]
   parts?: TabSheetParts
+  sidebar_query?: string
   hover_sfx?: NamespacedAudioKey | ''
   select_sfx?: NamespacedAudioKey | ''
   reselect_sfx?: NamespacedAudioKey | ''
@@ -35,6 +36,7 @@ const {
   show_close_button = true,
   surface = 'standard',
   header_border = 'wave',
+  sidebar_query = 'w>=lg & fine',
   hover_sfx = 'ui.click_07',
   select_sfx = 'ui.select',
   reselect_sfx = 'ui.digi_powerdown'
@@ -62,13 +64,17 @@ provide(activeTabKey, active)
 const sidebar_bg_class = computed(() => SHEET_SIDEBAR_BG[surface])
 
 const has_tabs = computed(() => !!tabs?.length)
-// Mirrors the CSS sidebar condition `lg:pointer-fine:flex` exactly. Hide
-// mobile-sheet's close button whenever the sidebar (which carries its own
-// close) is visible; otherwise the user sees two stacked close buttons.
-const has_sidebar = useMatchMedia('w>=lg & fine')
+// `sidebar_query` defaults to the CSS sidebar condition `lg:pointer-fine:flex`.
+// Exposed below so parents read this one source of truth rather than
+// re-deriving it (and drifting). Also hides mobile-sheet's close button while
+// the sidebar — which carries its own close — is visible, so the user never
+// sees two stacked close buttons.
+const has_sidebar = useMatchMedia(sidebar_query)
 const sheet_close_button = computed(
   () => (!has_tabs.value || !has_sidebar.value) && show_close_button
 )
+
+defineExpose({ has_sidebar })
 
 const tab_panel_id = 'tab-sheet__panel'
 const tab_id_prefix = `tab-sheet__tab--${uid()}--`

--- a/src/components/layout-kit/modal/tab-sheet.vue
+++ b/src/components/layout-kit/modal/tab-sheet.vue
@@ -4,7 +4,7 @@ import mobileSheet, { type MobileSheetProps } from './mobile-sheet.vue'
 import { SHEET_SIDEBAR_BG } from './sheet-surface'
 import { activeTabKey } from './tab-sheet-context'
 import { useShortcuts } from '@/composables/use-shortcuts'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import { emitSfx } from '@/sfx/bus'
 import type { NamespacedAudioKey } from '@/sfx/config'
 import uid from '@/utils/uid'
@@ -62,12 +62,10 @@ provide(activeTabKey, active)
 const sidebar_bg_class = computed(() => SHEET_SIDEBAR_BG[surface])
 
 const has_tabs = computed(() => !!tabs?.length)
-// Sidebar render condition mirrors CSS `lg:pointer-fine:flex`. Hide
+// Mirrors the CSS sidebar condition `lg:pointer-fine:flex` exactly. Hide
 // mobile-sheet's close button whenever the sidebar (which carries its own
 // close) is visible; otherwise the user sees two stacked close buttons.
-const lg_width = useMediaQuery('lg')
-const pointer_fine = useMediaQuery('fine')
-const has_sidebar = computed(() => lg_width.value && pointer_fine.value)
+const has_sidebar = useMatchMedia('w>=lg & fine')
 const sheet_close_button = computed(
   () => (!has_tabs.value || !has_sidebar.value) && show_close_button
 )

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, onMounted, provide, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, onMounted, provide, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DeckAside from './deck-aside.vue'
 import { emitSfx } from '@/sfx/bus'
@@ -51,7 +51,7 @@ provide(deckEditorKey, editor)
 const danger = useDeckDangerActions(editor, deck, close)
 provide(deckDangerActionsKey, danger)
 
-const is_tablet = useMatchMedia('w<lg | h<lg | coarse')
+const tab_sheet = useTemplateRef('tab_sheet')
 const is_mobile = useMatchMedia('w<md | h<sm')
 
 const active_tab = useSessionRef<ActiveTab | null>('deck-settings.active-tab', null)
@@ -64,7 +64,11 @@ const tabs = computed(() => [
   { value: 'danger-zone', icon: 'delete', label: t('deck.settings-modal.tab.danger-zone') }
 ])
 
-const displayed_tab = computed(() => active_tab.value ?? (is_tablet.value ? 'index' : 'general'))
+// Sourced from TabSheet (the one owner of sidebar visibility), so the default
+// tab stays a strict inverse of the sidebar instead of a re-derived condition.
+const has_sidebar = computed(() => tab_sheet.value?.has_sidebar ?? false)
+
+const displayed_tab = computed(() => active_tab.value ?? (has_sidebar.value ? 'general' : 'index'))
 
 const sidebar_active = computed({
   get: () => active_tab.value ?? 'general',
@@ -124,13 +128,14 @@ function onTabEnter(el: Element, done: () => void) {
   tabHeightEnter(tab_outlet.value)(el, done)
 }
 
-watch(is_tablet, (is_below) => {
-  if (is_below && active_tab.value === 'danger-zone') active_tab.value = null
+watch(has_sidebar, (visible) => {
+  if (!visible && active_tab.value === 'danger-zone') active_tab.value = null
 })
 </script>
 
 <template>
   <tab-sheet
+    ref="tab_sheet"
     data-testid="deck-settings-container"
     data-theme="green-500"
     data-theme-dark="green-800"
@@ -180,7 +185,7 @@ watch(is_tablet, (is_below) => {
         @leave="(el, done) => slideFadeRightLeave(el, done)"
       >
         <ui-tag-button
-          v-if="is_tablet && active_tab !== null"
+          v-if="!has_sidebar && active_tab !== null"
           data-testid="deck-settings__back-button"
           :aria-label="t('deck.settings-modal.back-button')"
           data-theme="yellow-500"

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -52,7 +52,9 @@ const danger = useDeckDangerActions(editor, deck, close)
 provide(deckDangerActionsKey, danger)
 
 const tab_sheet = useTemplateRef('tab_sheet')
-const is_mobile = useMatchMedia('w<md | h<sm')
+// Width-only: matches the template's `max-md:` layout switch. The aside +
+// floating preview drop on a narrow viewport, never on a short one.
+const is_mobile = useMatchMedia('w<md')
 
 const active_tab = useSessionRef<ActiveTab | null>('deck-settings.active-tab', null)
 const tab_outlet = ref<HTMLElement>()

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -11,7 +11,7 @@ import {
   deckDangerActionsKey
 } from '@/composables/deck/use-deck-danger-actions'
 import { useSessionRef } from '@/composables/use-session-ref'
-import { useIsTablet, useMobileBreakpoint } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import UiTagButton from '@/components/ui-kit/tag-button.vue'
@@ -51,8 +51,8 @@ provide(deckEditorKey, editor)
 const danger = useDeckDangerActions(editor, deck, close)
 provide(deckDangerActionsKey, danger)
 
-const is_tablet = useIsTablet()
-const is_mobile = useMobileBreakpoint('md')
+const is_tablet = useMatchMedia('w<lg | h<lg | coarse')
+const is_mobile = useMatchMedia('w<md | h<sm')
 
 const active_tab = useSessionRef<ActiveTab | null>('deck-settings.active-tab', null)
 const tab_outlet = ref<HTMLElement>()

--- a/src/components/modals/deck-settings/tab-design/index.vue
+++ b/src/components/modals/deck-settings/tab-design/index.vue
@@ -6,14 +6,14 @@ import CardDesigner from './card-designer/index.vue'
 import TabBar from '@/components/layout-kit/tab-bar.vue'
 import DeckDesignPreview from '@/components/deck/deck-design-preview.vue'
 import { deckEditorKey } from '@/composables/deck-editor'
-import { useMobileBreakpoint } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 
 type SideTab = { value: CardSide; label: string }
 
 const { t } = useI18n()
 const editor = inject(deckEditorKey)!
 
-const is_mobile = useMobileBreakpoint('md')
+const is_mobile = useMatchMedia('w<md | h<sm')
 
 const tabs = computed<SideTab[]>(() => [
   { value: 'cover', label: t('deck.settings-modal.design.designer-tabs.cover') },

--- a/src/components/modals/deck-settings/tab-index/index.vue
+++ b/src/components/modals/deck-settings/tab-index/index.vue
@@ -63,9 +63,9 @@ function onNavigate(value: TabIndexNavValue) {
           v-sfx.hover="'ui.click_07'"
           @click="onNavigate(entry.value)"
         >
-          <ui-icon :src="entry.icon" />
+          <ui-icon :src="entry.icon" class="w-6 h-6" />
           <span class="flex-1">{{ t(`deck.settings-modal.tab.${entry.value}`) }}</span>
-          <ui-icon src="chevron-right" />
+          <ui-icon src="chevron-right" class="w-6 h-6" />
         </button>
       </div>
     </labeled-section>

--- a/src/components/ui-kit/modal-mode-config.ts
+++ b/src/components/ui-kit/modal-mode-config.ts
@@ -28,7 +28,7 @@ export const MODAL_MODE_CONFIG: Record<ModalMode, ModeConfig> = {
   // avoids touch-disrupting setAttribute calls during scroll on iOS Safari.
   'mobile-sheet': {
     containerClass:
-      'items-center mobile-modal:flex-col mobile-modal:overflow-y-auto mobile-modal:overscroll-y-contain mobile-modal:justify-start mobile-modal:pt-4 mobile-modal:pointer-events-auto mobile-modal:items-stretch',
+      'items-center mobile-modal:flex-col mobile-modal:overflow-y-auto mobile-modal:overscroll-y-contain mobile-modal:justify-start mobile-modal:pt-4 mobile-modal:pointer-events-auto',
     enter: (el, is_mobile, done) =>
       is_mobile ? slideUpFromEdge(el, done) : slideUpFadeIn(el, done),
     leave: (el, is_mobile, done) =>

--- a/src/components/ui-kit/modal.vue
+++ b/src/components/ui-kit/modal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onUnmounted, watchEffect, computed, useTemplateRef } from 'vue'
 import { useModal, request_close_handlers, type ModalMode } from '@/composables/modal'
-import { useMobileBreakpoint, type BreakpointKey } from '@/composables/use-media-query'
+import { useMatchMedia, type BreakpointKey } from '@/composables/use-media-query'
 import { useScrollLock } from '@/composables/use-scroll-lock'
 import { useShortcuts } from '@/composables/use-shortcuts'
 import { MODAL_MODE_CONFIG } from './modal-mode-config'
@@ -15,23 +15,11 @@ const shortcuts = useShortcuts('modal')
 const DEFAULT_WIDTH_KEY: BreakpointKey = 'sm'
 const DEFAULT_HEIGHT_KEY: BreakpointKey = 'sm'
 
-const mobile_refs = new Map<string, ReturnType<typeof useMobileBreakpoint>>()
-
-function getMobileRef(width_key: BreakpointKey, height_key: BreakpointKey) {
-  const cache_key = `${width_key}|${height_key}`
-  let r = mobile_refs.get(cache_key)
-  if (!r) {
-    r = useMobileBreakpoint(width_key, height_key)
-    mobile_refs.set(cache_key, r)
-  }
-  return r
-}
-
 function isMobileFor(el: Element) {
   const html = el as HTMLElement
   const width_key = (html.dataset.mobileBelowWidth as BreakpointKey) ?? DEFAULT_WIDTH_KEY
   const height_key = (html.dataset.mobileBelowHeight as BreakpointKey) ?? DEFAULT_HEIGHT_KEY
-  return getMobileRef(width_key, height_key).value
+  return useMatchMedia(`w<${width_key} | h<${height_key}`).value
 }
 
 const modal_container = useTemplateRef<{ $el: HTMLElement }>('modal_container')

--- a/src/components/ui-kit/tooltip.vue
+++ b/src/components/ui-kit/tooltip.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, useTemplateRef, watch, onBeforeUnmount } from 'vue'
 import { useFloating, flip, autoUpdate, offset, type Placement } from '@floating-ui/vue'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 
 // The popover is teleported to <body>, so it can't inherit data-theme through
 // the DOM and reading it off $attrs would wrongly pick up a theme a parent
@@ -34,7 +34,7 @@ const triggerRef = useTemplateRef<HTMLElement>('ui-tooltip-trigger')
 const popoverRef = useTemplateRef<HTMLElement>('ui-tooltip')
 
 const is_active = ref(false)
-const is_coarse_pointer = useMediaQuery('coarse')
+const is_coarse_pointer = useMatchMedia('coarse')
 
 // gates both DOM mount (v-if) and autoUpdate — keeps unused tooltips out of
 // the DOM entirely so switching modes doesn't pay the cost of mounting N

--- a/src/composables/audio-reader/use-lesson-reader.ts
+++ b/src/composables/audio-reader/use-lesson-reader.ts
@@ -2,7 +2,7 @@ import { computed, defineAsyncComponent, ref, toValue, useTemplateRef, watch } f
 import type { MaybeRefOrGetter } from 'vue'
 import { useToast } from '@/composables/toast'
 import { useModal, type ModalCloseFn } from '@/composables/modal'
-import { useMobileBreakpoint } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import { useLessonQuery, useLessonAudioUrlQuery } from '@/api/lessons'
 import { useAudioPlayer } from './use-audio-player'
 import { useTranscriptSync } from './use-transcript-sync'
@@ -29,7 +29,7 @@ const TermSheet = defineAsyncComponent(() => import('@/views/audio-reader/term-p
 export function useLessonReader(id: MaybeRefOrGetter<number>) {
   const toast = useToast()
   const modal = useModal()
-  const is_mobile = useMobileBreakpoint()
+  const is_mobile = useMatchMedia('w<sm | h<sm')
 
   const lesson_id = computed(() => toValue(id))
   const { data: lesson, error } = useLessonQuery(lesson_id)

--- a/src/composables/modals/use-deck-settings-modal.ts
+++ b/src/composables/modals/use-deck-settings-modal.ts
@@ -16,7 +16,7 @@ export function useDeckSettingsModal() {
       backdrop: true,
       mode: 'mobile-sheet',
       mobile_below_width: 'md',
-      mobile_below_height: 'lg',
+      mobile_below_height: 'md',
       props: { deck }
     })
     result.response.then(() => emitSfx('ui.pop_up_close'))

--- a/src/composables/use-media-query.ts
+++ b/src/composables/use-media-query.ts
@@ -1,8 +1,6 @@
-import { ref, computed, type Ref } from 'vue'
+import { ref, type Ref } from 'vue'
 
 export type BreakpointKey = 'sm' | 'md' | 'lg' | 'xl' | '2xl'
-type PointerKey = 'coarse' | 'fine'
-type ColorSchemeKey = 'light' | 'dark'
 
 let styles = getComputedStyle(document.documentElement)
 
@@ -14,78 +12,130 @@ const BREAKPOINTS: Record<BreakpointKey, string> = {
   '2xl': styles.getPropertyValue('--breakpoint-2xl')
 }
 
-const POINTER: Record<PointerKey, string> = {
+const POINTER = {
   coarse: '(pointer: coarse)',
   fine: '(pointer: fine)'
+} as const
+
+const COLOR_SCHEME = {
+  dark: '(prefers-color-scheme: dark)',
+  light: '(prefers-color-scheme: light)'
+} as const
+
+type DimensionAtom = { axis: 'width' | 'height'; below: boolean; length: string }
+type FeatureAtom = { feature: string }
+type Atom = DimensionAtom | FeatureAtom
+
+// `w>=md`, `w<sm`, `h>=lg`, `h<sm` — axis, comparison, breakpoint token.
+const DIMENSION = /^([wh])(>=|<)(sm|md|lg|xl|2xl)$/
+
+function isDimension(atom: Atom): atom is DimensionAtom {
+  return 'axis' in atom
 }
 
-const COLOR_SCHEME: Record<ColorSchemeKey, string> = {
-  light: '(prefers-color-scheme: light)',
-  dark: '(prefers-color-scheme: dark)'
+/** Parse one atom (`w>=lg`, `h<sm`, `fine`, `dark`) into its structured form. */
+function parseAtom(token: string): Atom {
+  const dimension = DIMENSION.exec(token)
+  if (dimension) {
+    const [, axis, comparison, breakpoint] = dimension
+    return {
+      axis: axis === 'w' ? 'width' : 'height',
+      below: comparison === '<',
+      length: BREAKPOINTS[breakpoint as BreakpointKey]
+    }
+  }
+
+  if (token in POINTER) return { feature: POINTER[token as keyof typeof POINTER] }
+  if (token in COLOR_SCHEME) return { feature: COLOR_SCHEME[token as keyof typeof COLOR_SCHEME] }
+
+  throw new Error(`useMatchMedia: unknown atom "${token}"`)
 }
 
-function toMediaQuery(input: string) {
-  const q = input.trim()
-
-  if (q in BREAKPOINTS) {
-    return `(min-width: ${BREAKPOINTS[q as BreakpointKey]})`
-  }
-  if (q in POINTER) {
-    return POINTER[q as PointerKey]
-  }
-  if (q in COLOR_SCHEME) {
-    return COLOR_SCHEME[q as ColorSchemeKey]
-  }
-
-  return q // string query
+// Standalone clause — true exactly when the atom holds. Used for single atoms
+// and for each side of an OR. A `below` atom uses the L3 `not all and
+// (min-…)` form (what Tailwind's `max-*` emits): Safari-safe on every version,
+// no `calc()` and no L4 bare `not (…)`.
+function orClause(atom: Atom): string {
+  if (!isDimension(atom)) return atom.feature
+  const feature = `(min-${atom.axis}: ${atom.length})`
+  return atom.below ? `not all and ${feature}` : feature
 }
 
-// App-lifetime cache. matchMedia listeners are permanent and shared across all
-// callers — no refcount, no component lifecycle. Safe to call from any context
-// (setup, render, transition hooks). One listener per unique query string.
+// AND feature — a positive media feature `and`-joined into one clause. A
+// `below` atom can't appear here: `not` would negate the whole conjunction
+// (De Morgan), flipping every other atom. Width/height bands would need
+// `max-*` support, which no call site wants — throw until one does.
+function andFeature(atom: Atom): string {
+  if (!isDimension(atom)) return atom.feature
+  if (atom.below) {
+    throw new Error('useMatchMedia: "<" atoms are only valid with "|", not "&"')
+  }
+  return `(min-${atom.axis}: ${atom.length})`
+}
+
+/** Compile a token query into a single CSS media-query string. */
+function compile(query: string): string {
+  const trimmed = query.trim()
+  const has_and = trimmed.includes('&')
+  const has_or = trimmed.includes('|')
+
+  if (has_and && has_or) {
+    throw new Error(`useMatchMedia: cannot mix "&" and "|" in one query ("${query}")`)
+  }
+  if (has_or) {
+    return trimmed
+      .split('|')
+      .map((t) => orClause(parseAtom(t.trim())))
+      .join(', ')
+  }
+  if (has_and) {
+    return trimmed
+      .split('&')
+      .map((t) => andFeature(parseAtom(t.trim())))
+      .join(' and ')
+  }
+
+  return orClause(parseAtom(trimmed))
+}
+
+// App-lifetime cache keyed by the compiled CSS query. matchMedia listeners are
+// permanent and shared across all callers — no refcount, no component
+// lifecycle. Safe to call from any context (setup, render, transition hooks).
+// One listener per unique compiled query, so equivalent tokens dedupe.
 const cache = new Map<string, Ref<boolean>>()
 
-export function useMediaQuery(breakpoint: BreakpointKey | PointerKey | ColorSchemeKey) {
-  const query = toMediaQuery(breakpoint)
-
-  let r = cache.get(query)
+function matchCached(media: string): Ref<boolean> {
+  let r = cache.get(media)
   if (r) return r
 
-  const mq = window.matchMedia(query)
+  const mq = window.matchMedia(media)
   r = ref(mq.matches)
   mq.addEventListener('change', () => (r!.value = mq.matches))
-  cache.set(query, r)
+  cache.set(media, r)
 
   return r
 }
 
 /**
- * Reactive boolean — true when viewport width is below `width_key` OR
- * height is below `height_key`. Independent thresholds; either can trigger.
+ * Reactive boolean for a responsive condition, expressed as a token query.
+ *
+ * **Atoms** — `w>=md` / `w<md` (width), `h>=lg` / `h<sm` (height),
+ * `fine` / `coarse` (pointer), `dark` / `light` (color scheme).
+ *
+ * **Combinator** — `&` (all) or `|` (any); one type per query, mixing throws.
+ * `>=` atoms read naturally under `&` ("big enough = every minimum met"),
+ * `<` atoms under `|` ("too small = any maximum exceeded"). A `<` atom under
+ * `&` throws (a width/height band would need `max-*` support — add it then).
+ *
+ * The returned ref is app-lifetime cached and shared across callers; it never
+ * tears down, so it's safe to read from setup, render, or transition hooks.
+ *
+ * @example
+ * useMatchMedia('w>=md')              // ≥ md wide
+ * useMatchMedia('w<md | h<sm')        // compact: narrow OR short
+ * useMatchMedia('w>=lg & fine')       // desktop sidebar (mirrors lg:pointer-fine:)
+ * useMatchMedia('w<lg | h<lg | coarse') // tablet-or-below
  */
-export function useMobileBreakpoint(
-  width_key: BreakpointKey = 'sm',
-  height_key: BreakpointKey = 'sm'
-) {
-  const width_value = BREAKPOINTS[width_key]
-  const height_value = BREAKPOINTS[height_key]
-  // Use the L3 'not all and (min-...)' form. This is exactly what Tailwind's
-  // `max-sm:` variant emits and is supported on every mobile Safari version.
-  // Avoids `calc()` (Safari parser bugs) and bare `not (...)` (L4 syntax).
-  const below_width = useMediaQuery(`not all and (min-width: ${width_value})` as BreakpointKey)
-  const below_height = useMediaQuery(`not all and (min-height: ${height_value})` as BreakpointKey)
-
-  return computed(() => below_width.value || below_height.value)
-}
-
-/**
- * Reactive boolean — true when the viewport sits below the `lg` breakpoint
- * (width or height) OR the primary pointer is coarse (touch). The pointer
- * check lets a large touch screen (e.g. an iPad in landscape) opt into the
- * tablet layout even when its viewport would otherwise read as desktop.
- */
-export function useIsTablet() {
-  const below_lg = useMobileBreakpoint('lg', 'lg')
-  const coarse = useMediaQuery('coarse')
-  return computed(() => below_lg.value || coarse.value)
+export function useMatchMedia(query: string): Ref<boolean> {
+  return matchCached(compile(query))
 }

--- a/src/composables/use-play-on-tap.ts
+++ b/src/composables/use-play-on-tap.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import { BUTTON_TAP_DURATION, playButtonTap } from '@/utils/animations/button-tap'
 
 type Options = {
@@ -39,7 +39,7 @@ export function usePlayOnTap(options: Options = {}) {
   const reset = options.reset ?? true
   const duration = options.duration ?? BUTTON_TAP_DURATION
   const active_on = options.activeOn ?? 'coarse-only'
-  const is_coarse = useMediaQuery('coarse')
+  const is_coarse = useMatchMedia('coarse')
 
   /** Run the tap lifecycle for `e`. `onTap` always fires; the rest fire only when the intercept actually plays. */
   async function interceptClick(e: MouseEvent, hooks: Hooks = {}) {

--- a/src/phone/apps/settings/component/index.vue
+++ b/src/phone/apps/settings/component/index.vue
@@ -17,7 +17,7 @@ import {
   memberDangerActionsKey
 } from '@/composables/member/use-member-danger-actions'
 import { useSessionRef } from '@/composables/use-session-ref'
-import { useMediaQuery, useMobileBreakpoint } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import UiTagButton from '@/components/ui-kit/tag-button.vue'
@@ -45,16 +45,11 @@ const tabs = computed(() => [
 type ActiveTab = 'profile' | 'subscription' | 'app' | 'danger-zone'
 const active_tab = useSessionRef<ActiveTab | null>('settings.active-tab', null)
 
-const is_mobile = useMobileBreakpoint('md')
+const is_mobile = useMatchMedia('w<md | h<sm')
 
-// Sidebar is shown by CSS via `lg:pointer-fine:flex`, which is a viewport-only
-// width check + a pointer-fine media query. `useIsTablet` also folds in a
-// height check, so it can read `true` on a wide-but-short desktop window even
-// while the sidebar is visible — leaving the main column on the mobile index.
-// Match the CSS condition exactly so the displayed tab tracks the sidebar.
-const lg_width = useMediaQuery('lg')
-const pointer_fine = useMediaQuery('fine')
-const has_sidebar = computed(() => lg_width.value && pointer_fine.value)
+// Mirrors the CSS sidebar condition `lg:pointer-fine:flex` exactly, so the
+// displayed tab always tracks whether the sidebar is actually visible.
+const has_sidebar = useMatchMedia('w>=lg & fine')
 
 watch(has_sidebar, (visible) => {
   if (!visible && active_tab.value === 'danger-zone') active_tab.value = null

--- a/src/phone/apps/settings/component/index.vue
+++ b/src/phone/apps/settings/component/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, provide, ref, watch } from 'vue'
+import { computed, provide, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import TabProfile from './tab-profile/index.vue'
 import TabSubscription from './tab-subscription/index.vue'
@@ -46,10 +46,11 @@ type ActiveTab = 'profile' | 'subscription' | 'app' | 'danger-zone'
 const active_tab = useSessionRef<ActiveTab | null>('settings.active-tab', null)
 
 const is_mobile = useMatchMedia('w<md | h<sm')
+const tab_sheet = useTemplateRef('tab_sheet')
 
-// Mirrors the CSS sidebar condition `lg:pointer-fine:flex` exactly, so the
-// displayed tab always tracks whether the sidebar is actually visible.
-const has_sidebar = useMatchMedia('w>=lg & fine')
+// Sourced from TabSheet (the one owner of sidebar visibility), so the displayed
+// tab tracks the actual sidebar instead of a re-derived condition that drifts.
+const has_sidebar = computed(() => tab_sheet.value?.has_sidebar ?? false)
 
 watch(has_sidebar, (visible) => {
   if (!visible && active_tab.value === 'danger-zone') active_tab.value = null
@@ -108,6 +109,7 @@ function onTabEnter(el: Element, done: () => void) {
 
 <template>
   <tab-sheet
+    ref="tab_sheet"
     data-testid="settings-container"
     data-theme="blue-500"
     data-theme-dark="blue-650"

--- a/src/phone/apps/settings/component/tab-profile/index.vue
+++ b/src/phone/apps/settings/component/tab-profile/index.vue
@@ -8,12 +8,12 @@ import SectionList from '@/components/layout-kit/section-list.vue'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
 import MemberCard from '@/components/member/member-card.vue'
 import { memberEditorKey } from '@/composables/member-editor'
-import { useMobileBreakpoint } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import { SUPPORTED_THEMES, SUPPORTED_PATTERNS } from '@/utils/cover'
 
 const { t } = useI18n()
 const editor = inject(memberEditorKey)!
-const is_mobile = useMobileBreakpoint('md')
+const is_mobile = useMatchMedia('w<md | h<sm')
 </script>
 
 <template>

--- a/src/phone/components/app-wrapper.vue
+++ b/src/phone/components/app-wrapper.vue
@@ -2,7 +2,7 @@
 import { ref, useAttrs } from 'vue'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
 import UiBurst, { type BurstSize } from '@/components/ui-kit/burst.vue'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import { usePlayOnTap } from '@/composables/use-play-on-tap'
 
 type AppWrapperProps = {
@@ -24,7 +24,7 @@ const emit = defineEmits<{ (e: 'tapStart'): void }>()
 defineOptions({ inheritAttrs: false })
 
 const attrs = useAttrs()
-const is_coarse = useMediaQuery('coarse')
+const is_coarse = useMatchMedia('coarse')
 const burst_id = ref(0)
 
 const { playing, interceptClick } = usePlayOnTap({

--- a/src/phone/components/phone-base.vue
+++ b/src/phone/components/phone-base.vue
@@ -4,7 +4,7 @@ import UiButton from '@/components/ui-kit/button.vue'
 import { type PhoneApp, type TransitionPreset } from '@/phone/system/types'
 import { type AppSession } from '@/phone/system/runtime'
 import { computed } from 'vue'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 
 const { apps, transition, active_session } = defineProps<{
   apps: PhoneApp[]
@@ -16,7 +16,7 @@ const emit = defineEmits<{
   (e: 'close'): void
 }>()
 
-const is_mobile = useMediaQuery('coarse')
+const is_mobile = useMatchMedia('coarse')
 
 const app = computed(() => {
   return active_session?.app.type === 'view' ? active_session.app : null

--- a/src/phone/phone.vue
+++ b/src/phone/phone.vue
@@ -14,7 +14,7 @@ import { useModal } from '@/composables/modal'
 import phoneSm from '@/phone/components/phone-sm.vue'
 import phoneBase from '@/phone/components/phone-base.vue'
 import { useI18n } from 'vue-i18n'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import {
   slideDownBlurIn,
   slideUpBlurOut,
@@ -24,7 +24,7 @@ import {
 
 const shortcuts = useShortcuts('phone', { priority: 'background' })
 const { open: openModal, pop: popModal, modal_stack } = useModal()
-const is_pointer_coarse = useMediaQuery('coarse')
+const is_pointer_coarse = useMatchMedia('coarse')
 
 const loading = ref(false)
 const open = ref(false)

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import storage from '@/utils/storage'
 
 export type ThemeMode = 'light' | 'dark' | 'system'
@@ -20,7 +20,7 @@ system_mql.addEventListener('change', () => {
 
 export const useThemeStore = defineStore('theme', () => {
   const mode = ref<ThemeMode>('system')
-  const is_system_dark = useMediaQuery('dark')
+  const is_system_dark = useMatchMedia('dark')
 
   const is_dark = computed(() => {
     if (mode.value === 'system') return is_system_dark.value

--- a/src/views/audio-reader/term-popover/add-card-modal.vue
+++ b/src/views/audio-reader/term-popover/add-card-modal.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { useMemberDecksQuery } from '@/api/decks'
 import { useInsertCardAtMutation } from '@/api/cards'
 import { useLastDeck } from '@/composables/use-last-deck'
-import { useMobileBreakpoint } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import { useToast } from '@/composables/toast'
 import MobileSheet from '@/components/layout-kit/modal/mobile-sheet.vue'
 import UiButton from '@/components/ui-kit/button.vue'
@@ -25,7 +25,7 @@ const insert_card = useInsertCardAtMutation()
 const { setLastDeck } = useLastDeck()
 // Match the modal's own `mobile_below_width: 'md'` so the sheet and the
 // single-card flip layout cross over at the same breakpoint.
-const is_mobile = useMobileBreakpoint('md', 'md')
+const is_mobile = useMatchMedia('w<md | h<md')
 
 const { data: decks_data } = useMemberDecksQuery()
 

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -6,7 +6,7 @@ import DeckThumbnail from '@/components/deck/deck-thumbnail.vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import UiButton from '@/components/ui-kit/button.vue'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import ReviewInbox from './review-inbox.vue'
 import AudioReaderSection from './audio-reader-section.vue'
 import { useDeckCreateModal } from '@/composables/modals/use-deck-create-modal'
@@ -16,7 +16,7 @@ import { useCan } from '@/composables/use-can'
 const { t } = useI18n()
 const toast = useToast()
 const router = useRouter()
-const is_md = useMediaQuery('md')
+const is_md = useMatchMedia('w>=md')
 const can = useCan()
 
 const deck_create_modal = useDeckCreateModal()

--- a/src/views/deck/card-grid/index.vue
+++ b/src/views/deck/card-grid/index.vue
@@ -4,7 +4,7 @@ import { type CardListController } from '@/composables/card-editor/card-list-con
 import { computed, inject, ref, useTemplateRef, watch, type CSSProperties } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useGridCapacity } from '@/composables/use-grid-capacity'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 import { slideInFromDirection, slideOutInDirection } from '@/utils/animations/grid-page'
 
 const { t } = useI18n()
@@ -20,7 +20,7 @@ const side = ref<'front' | 'back'>('front')
 const grid_wrapper = useTemplateRef<HTMLElement>('grid_wrapper')
 const sentinel = useTemplateRef<HTMLElement>('sentinel')
 
-const isMd = useMediaQuery('md')
+const isMd = useMatchMedia('w>=md')
 
 observeSentinel(sentinel)
 

--- a/tests/helpers/responsive-mock.js
+++ b/tests/helpers/responsive-mock.js
@@ -1,6 +1,6 @@
 import { ref } from 'vue'
 
-const is_tablet = ref(false)
+const has_sidebar = ref(false)
 const is_mobile = ref(false)
 
 /**
@@ -10,8 +10,11 @@ const is_mobile = ref(false)
  * sees the same instances the test code does. Vitest's per-file module
  * isolation keeps state from leaking between test files.
  *
+ * `'w>=lg & fine'` is the one desktop-sidebar token (toggle with `setSidebar`);
+ * any `w<…` compact token resolves to the mobile ref (toggle with `setBelowMd`).
+ *
  * @example
- *   import { responsiveMockModule, setBelowLg, setBelowMd, resetResponsive }
+ *   import { responsiveMockModule, setSidebar, setBelowMd, resetResponsive }
  *     from '../../helpers/responsive-mock'
  *
  *   vi.mock('@/composables/use-media-query', async () => {
@@ -23,14 +26,14 @@ const is_mobile = ref(false)
  */
 export const responsiveMockModule = {
   useMatchMedia: (query) => {
-    if (query.includes('coarse') && query.includes('lg')) return is_tablet
+    if (query.includes('&')) return has_sidebar
     if (query.startsWith('w<')) return is_mobile
     return ref(false)
   }
 }
 
-export function setBelowLg(v) {
-  is_tablet.value = v
+export function setSidebar(v) {
+  has_sidebar.value = v
 }
 
 export function setBelowMd(v) {
@@ -38,6 +41,6 @@ export function setBelowMd(v) {
 }
 
 export function resetResponsive() {
-  is_tablet.value = false
+  has_sidebar.value = false
   is_mobile.value = false
 }

--- a/tests/helpers/responsive-mock.js
+++ b/tests/helpers/responsive-mock.js
@@ -22,9 +22,11 @@ const is_mobile = ref(false)
  *   beforeEach(() => resetResponsive())
  */
 export const responsiveMockModule = {
-  useMobileBreakpoint: () => is_mobile,
-  useMediaQuery: () => ref(false),
-  useIsTablet: () => is_tablet
+  useMatchMedia: (query) => {
+    if (query.includes('coarse') && query.includes('lg')) return is_tablet
+    if (query.startsWith('w<')) return is_mobile
+    return ref(false)
+  }
 }
 
 export function setBelowLg(v) {

--- a/tests/integration/components/deck/deck-thumbnail.test.js
+++ b/tests/integration/components/deck/deck-thumbnail.test.js
@@ -7,7 +7,7 @@ const { coarseRef, mockEmitSfx } = vi.hoisted(() => ({
 }))
 
 vi.mock('@/composables/use-media-query', () => ({
-  useMediaQuery: () => coarseRef
+  useMatchMedia: () => coarseRef
 }))
 
 vi.mock('@/sfx/bus', () => ({

--- a/tests/integration/components/layout-kit/modal/tab-sheet.test.js
+++ b/tests/integration/components/layout-kit/modal/tab-sheet.test.js
@@ -4,16 +4,11 @@ import { defineComponent, h } from 'vue'
 import { setActivePinia, createPinia } from 'pinia'
 
 vi.mock('@/composables/use-media-query', () => ({
-  useMobileBreakpoint: () => ({ value: false }),
-  useMediaQuery: (key) => ({
+  useMatchMedia: (query) => ({
     get value() {
-      if (key === 'lg' || key === 'fine') return !(globalThis.__isTablet ?? false)
+      // has_sidebar — 'w>=lg & fine'; visible exactly when not in tablet mode.
+      if (query.includes('&')) return !(globalThis.__isTablet ?? false)
       return false
-    }
-  }),
-  useIsTablet: () => ({
-    get value() {
-      return globalThis.__isTablet ?? false
     }
   })
 }))

--- a/tests/integration/components/modals/deck-settings/index.test.js
+++ b/tests/integration/components/modals/deck-settings/index.test.js
@@ -1,9 +1,10 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent, h, ref } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 import DeckSettings from '@/components/modals/deck-settings/index.vue'
+import { useMatchMedia } from '@/composables/use-media-query'
 import { deck as deckFixture } from '../../../../fixtures/deck'
-import { setBelowLg, setBelowMd, resetResponsive } from '../../../../helpers/responsive-mock'
+import { setSidebar, setBelowMd, resetResponsive } from '../../../../helpers/responsive-mock'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
@@ -130,7 +131,9 @@ vi.mock('@/composables/use-session-ref', () => ({
 
 const TabSheetStub = defineComponent({
   emits: ['close', 'update:active'],
-  setup(_props, { slots, emit }) {
+  setup(_props, { slots, emit, expose }) {
+    // Mirror the real TabSheet: own sidebar visibility and expose it upward.
+    expose({ has_sidebar: useMatchMedia('w>=lg & fine') })
     return () =>
       h('div', { 'data-testid': 'tab-sheet' }, [
         h('div', { 'data-testid': 'tab-sheet__header-content' }, slots['header-content']?.()),
@@ -324,42 +327,50 @@ describe('DeckSettings — aside wiring', () => {
   })
 })
 
-describe('DeckSettings — null active_tab + breakpoint redirect', () => {
-  test('null active_tab renders the general header on desktop', () => {
+describe('DeckSettings — null active_tab tracks sidebar visibility', () => {
+  // The default tab must be the strict inverse of whether TabSheet shows its
+  // sidebar ('w>=lg & fine'): sidebar visible -> general, hidden -> index.
+  test('null active_tab renders the general header when the sidebar is visible', async () => {
     initialTab.value = null
-    setBelowLg(false)
+    setSidebar(true)
     const { wrapper } = makeWrapper()
+    // has_sidebar arrives from TabSheet via a template ref — one render late.
+    await nextTick()
     expect(wrapper.find('[data-testid="deck-settings__header-title"]').text()).toBe(
       'Details & Settings'
     )
+    expect(wrapper.find('[data-testid="deck-settings__back-button"]').exists()).toBe(false)
   })
 
-  test('null active_tab renders the index header below lg', () => {
+  test('null active_tab renders the index header when the sidebar is hidden', () => {
     initialTab.value = null
-    setBelowLg(true)
+    setSidebar(false)
     const { wrapper } = makeWrapper()
     expect(wrapper.find('[data-testid="deck-settings__header-title"]').text()).toBe('Deck Settings')
   })
 
-  test('crossing into below-lg with danger-zone selected redirects to the index (null)', async () => {
+  test('hiding the sidebar with danger-zone selected redirects to the index (null)', async () => {
     initialTab.value = 'danger-zone'
-    setBelowLg(false)
+    setSidebar(true)
     const { wrapper } = makeWrapper()
+    // Let the sidebar-visible state settle before hiding it, so the watch sees
+    // the real true -> false transition (not a no-op false -> false).
+    await nextTick()
 
     expect(wrapper.find('[data-testid="deck-settings__header-title"]').text()).toBe('Danger Zone')
 
-    setBelowLg(true)
+    setSidebar(false)
     await flushPromises()
 
     expect(wrapper.find('[data-testid="deck-settings__header-title"]').text()).toBe('Deck Settings')
   })
 
-  test('explicit general tab persists across resize (no auto-collapse to index)', async () => {
+  test('explicit general tab persists when the sidebar hides (no auto-collapse to index)', async () => {
     initialTab.value = 'general'
-    setBelowLg(false)
+    setSidebar(true)
     const { wrapper } = makeWrapper()
 
-    setBelowLg(true)
+    setSidebar(false)
     await flushPromises()
 
     expect(wrapper.find('[data-testid="deck-settings__header-title"]').text()).toBe(
@@ -464,9 +475,9 @@ describe('DeckSettings — overlay actions', () => {
     setActiveSide.mockRestore()
   })
 
-  test('back button clears active_tab when below lg', async () => {
+  test('back button shows and clears active_tab when the sidebar is hidden', async () => {
     initialTab.value = 'design'
-    setBelowLg(true)
+    setSidebar(false)
     const { wrapper } = makeWrapper()
 
     expect(wrapper.find('[data-testid="deck-settings__back-button"]').exists()).toBe(true)

--- a/tests/integration/components/ui-kit/button.test.js
+++ b/tests/integration/components/ui-kit/button.test.js
@@ -7,7 +7,7 @@ const { coarseRef, mockEmitSfx } = vi.hoisted(() => ({
 }))
 
 vi.mock('@/composables/use-media-query', () => ({
-  useMediaQuery: () => coarseRef
+  useMatchMedia: () => coarseRef
 }))
 
 vi.mock('gsap', () => ({

--- a/tests/integration/components/ui-kit/modal.test.js
+++ b/tests/integration/components/ui-kit/modal.test.js
@@ -34,8 +34,7 @@ const mobileBreakpointRef = ref(false)
 const mockUseMobileBreakpoint = vi.fn(() => mobileBreakpointRef)
 
 vi.mock('@/composables/use-media-query', () => ({
-  useMediaQuery: vi.fn(() => ({ value: true })),
-  useMobileBreakpoint: (...args) => mockUseMobileBreakpoint(...args)
+  useMatchMedia: (...args) => mockUseMobileBreakpoint(...args)
 }))
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/tests/integration/components/ui-kit/tooltip.test.js
+++ b/tests/integration/components/ui-kit/tooltip.test.js
@@ -13,7 +13,7 @@ vi.mock('@floating-ui/vue', () => ({
 }))
 
 vi.mock('@/composables/use-media-query', () => ({
-  useMediaQuery: vi.fn(() => ({ value: false }))
+  useMatchMedia: vi.fn(() => ({ value: false }))
 }))
 
 function mountTooltip(props = {}, slots = {}, attrs = {}) {

--- a/tests/integration/phone/apps/settings/component/index.test.js
+++ b/tests/integration/phone/apps/settings/component/index.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent, h, useAttrs } from 'vue'
+import { defineComponent, h, nextTick, useAttrs } from 'vue'
+import { useMatchMedia } from '@/composables/use-media-query'
 
 const { mockEditor, mockDanger, mockEmitSfx, state } = vi.hoisted(() => ({
   state: { hasSidebar: true },
@@ -109,7 +110,9 @@ const TabSheetStub = defineComponent({
   props: ['active', 'tabs', 'surface', 'header_border'],
   emits: ['close', 'update:active'],
   inheritAttrs: false,
-  setup(props, { slots, emit }) {
+  setup(props, { slots, emit, expose }) {
+    // Mirror the real TabSheet: own sidebar visibility and expose it upward.
+    expose({ has_sidebar: useMatchMedia('w>=lg & fine') })
     return () =>
       h(
         'div',
@@ -204,8 +207,10 @@ describe('settings app — tab routing', () => {
 })
 
 describe('settings app — header copy follows displayed tab', () => {
-  test('renders default profile header when no tab has been selected', () => {
+  test('renders default profile header when no tab has been selected', async () => {
     const wrapper = makeWrapper()
+    // has_sidebar arrives from TabSheet via a template ref — one render late.
+    await nextTick()
     expect(wrapper.find('[data-testid="settings__header-title"]').text()).toBe('Profile')
   })
 

--- a/tests/integration/phone/apps/settings/component/index.test.js
+++ b/tests/integration/phone/apps/settings/component/index.test.js
@@ -42,8 +42,7 @@ vi.mock('@/composables/use-session-ref', async () => {
 vi.mock('@/composables/use-media-query', async () => {
   const { ref } = await import('vue')
   return {
-    useMobileBreakpoint: () => ref(false),
-    useMediaQuery: () => ref(state.hasSidebar)
+    useMatchMedia: (query) => ref(query.includes('&') ? state.hasSidebar : false)
   }
 })
 

--- a/tests/integration/views/audio-reader/term-popover/add-card-modal.test.js
+++ b/tests/integration/views/audio-reader/term-popover/add-card-modal.test.js
@@ -38,7 +38,7 @@ vi.mock('@/composables/use-last-deck', () => ({
 vi.mock('@/composables/use-media-query', async (importOriginal) => {
   const actual = await importOriginal()
   const { ref } = await import('vue')
-  return { ...actual, useMobileBreakpoint: () => ref(mediaState.mobile) }
+  return { ...actual, useMatchMedia: () => ref(mediaState.mobile) }
 })
 
 // ── Stubs ──────────────────────────────────────────────────────────────────────

--- a/tests/integration/views/deck/card-grid/index.test.js
+++ b/tests/integration/views/deck/card-grid/index.test.js
@@ -5,15 +5,9 @@ import { ref, computed } from 'vue'
 vi.mock('@/composables/use-media-query', async () => {
   const { ref } = await import('vue')
   const isMd = ref(true)
-  const isSm = ref(true)
   return {
-    useMediaQuery: (key) => {
-      if (key === 'md') return isMd
-      if (key === 'sm') return isSm
-      return ref(false)
-    },
-    __isMd: isMd,
-    __isSm: isSm
+    useMatchMedia: (query) => (query === 'w>=md' ? isMd : ref(false)),
+    __isMd: isMd
   }
 })
 

--- a/tests/unit/composables/audio-reader/use-lesson-reader.test.js
+++ b/tests/unit/composables/audio-reader/use-lesson-reader.test.js
@@ -31,7 +31,7 @@ vi.mock('@/composables/toast', () => ({ useToast: () => ({ error: toastErrorMock
 vi.mock('@/composables/modal', () => ({
   useModal: () => ({ open: openModalMock, pop: vi.fn(), modal_stack: { value: [] } })
 }))
-vi.mock('@/composables/use-media-query', () => ({ useMobileBreakpoint: () => mobileRef }))
+vi.mock('@/composables/use-media-query', () => ({ useMatchMedia: () => mobileRef }))
 vi.mock('@/composables/audio-reader/use-audio-player', () => ({ useAudioPlayer: audioPlayerMock }))
 vi.mock('@/composables/audio-reader/use-transcript-sync', () => ({
   useTranscriptSync: transcriptSyncMock

--- a/tests/unit/composables/use-deck-settings-modal.test.js
+++ b/tests/unit/composables/use-deck-settings-modal.test.js
@@ -45,7 +45,7 @@ describe('useDeckSettingsModal', () => {
       backdrop: true,
       mode: 'mobile-sheet',
       mobile_below_width: 'md',
-      mobile_below_height: 'lg',
+      mobile_below_height: 'md',
       props: { deck }
     })
   })

--- a/tests/unit/composables/use-media-query.test.js
+++ b/tests/unit/composables/use-media-query.test.js
@@ -1,6 +1,4 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
-import { defineComponent, nextTick } from 'vue'
-import { mount } from '@vue/test-utils'
 
 function createMockMql(matches = false) {
   const handlers = new Set()
@@ -14,285 +12,149 @@ function createMockMql(matches = false) {
   }
 }
 
-function withSetup(composable) {
-  let result
-  const Wrapper = defineComponent({
-    setup() {
-      result = composable()
-      return () => null
-    }
-  })
-  const wrapper = mount(Wrapper)
-  return [result, wrapper]
-}
-
-describe('useMediaQuery', () => {
-  let mockMql
-  let useMediaQuery
+describe('useMatchMedia', () => {
+  let useMatchMedia
 
   beforeEach(async () => {
-    // Reset module cache so the internal `cache` Map starts fresh each test
+    // Reset module cache so the internal query cache starts fresh each test.
     vi.resetModules()
-    mockMql = createMockMql(false)
-    window.matchMedia = vi.fn().mockReturnValue(mockMql)
-    ;({ useMediaQuery } = await import('@/composables/use-media-query'))
+    window.matchMedia = vi.fn(() => createMockMql(false))
+    ;({ useMatchMedia } = await import('@/composables/use-media-query'))
   })
 
-  test('returns false initially when matchMedia does not match', async () => {
-    mockMql.matches = false
-    const [result, wrapper] = withSetup(() => useMediaQuery('dark'))
-    await nextTick()
-    expect(result.value).toBe(false)
-    wrapper.unmount()
-  })
+  function compiledFor(token) {
+    useMatchMedia(token)
+    return window.matchMedia.mock.lastCall[0]
+  }
 
-  test('syncs ref to matchMedia.matches on mount', async () => {
-    mockMql.matches = true
-    const [result, wrapper] = withSetup(() => useMediaQuery('dark'))
-    await nextTick()
-    expect(result.value).toBe(true)
-    wrapper.unmount()
-  })
-
-  test('maps coarse pointer key to (pointer: coarse)', () => {
-    const [, w] = withSetup(() => useMediaQuery('coarse'))
-    expect(window.matchMedia).toHaveBeenCalledWith('(pointer: coarse)')
-    w.unmount()
-  })
-
-  test('maps fine pointer key to (pointer: fine)', () => {
-    const [, w] = withSetup(() => useMediaQuery('fine'))
-    expect(window.matchMedia).toHaveBeenCalledWith('(pointer: fine)')
-    w.unmount()
-  })
-
-  test('maps light key to (prefers-color-scheme: light)', () => {
-    const [, w] = withSetup(() => useMediaQuery('light'))
-    expect(window.matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: light)')
-    w.unmount()
-  })
-
-  test('maps dark key to (prefers-color-scheme: dark)', () => {
-    const [, w] = withSetup(() => useMediaQuery('dark'))
-    expect(window.matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)')
-    w.unmount()
-  })
-
-  test('maps breakpoint key to (min-width: ...) query', () => {
-    const [, w] = withSetup(() => useMediaQuery('sm'))
-    expect(window.matchMedia).toHaveBeenCalledWith(expect.stringMatching(/^\(min-width:/))
-    w.unmount()
-  })
-
-  test('caches entry — matchMedia not called again for same query', () => {
-    const [, w1] = withSetup(() => useMediaQuery('dark'))
-    const [, w2] = withSetup(() => useMediaQuery('dark'))
-    expect(window.matchMedia).toHaveBeenCalledTimes(1)
-    w1.unmount()
-    w2.unmount()
-  })
-
-  test('returns the same ref for the same query', () => {
-    const [ref1, w1] = withSetup(() => useMediaQuery('dark'))
-    const [ref2, w2] = withSetup(() => useMediaQuery('dark'))
-    expect(ref1).toBe(ref2)
-    w1.unmount()
-    w2.unmount()
-  })
-
-  test('updates ref value when media query change fires', async () => {
-    const [result, wrapper] = withSetup(() => useMediaQuery('dark'))
-    await nextTick()
-    mockMql.matches = true
-    mockMql._fire()
-    expect(result.value).toBe(true)
-    wrapper.unmount()
-  })
-
-  test('does not remove listener on unmount — cache is app-lifetime', async () => {
-    const [, wrapper] = withSetup(() => useMediaQuery('dark'))
-    await nextTick()
-    wrapper.unmount()
-    expect(mockMql.removeEventListener).not.toHaveBeenCalled()
-  })
-
-  test('different queries create separate cache entries', () => {
-    const mockMql2 = createMockMql(true)
-    window.matchMedia.mockReturnValueOnce(mockMql).mockReturnValueOnce(mockMql2)
-    const [ref1, w1] = withSetup(() => useMediaQuery('dark'))
-    const [ref2, w2] = withSetup(() => useMediaQuery('light'))
-    expect(ref1).not.toBe(ref2)
-    w1.unmount()
-    w2.unmount()
-  })
-})
-
-describe('useMobileBreakpoint', () => {
-  let widthMql
-  let heightMql
-  let useMobileBreakpoint
-
-  beforeEach(async () => {
-    vi.resetModules()
-    widthMql = createMockMql(false)
-    heightMql = createMockMql(false)
-
-    window.matchMedia = vi.fn((query) => {
-      if (query.includes('min-width')) return widthMql
-      if (query.includes('min-height')) return heightMql
-      return createMockMql(false)
+  describe('atom compilation', () => {
+    test('coarse pointer', () => {
+      expect(compiledFor('coarse')).toBe('(pointer: coarse)')
     })
-    ;({ useMobileBreakpoint } = await import('@/composables/use-media-query'))
-  })
 
-  test('queries both width and height against the same breakpoint token', () => {
-    const [, w] = withSetup(() => useMobileBreakpoint('sm'))
-
-    const queries = window.matchMedia.mock.calls.map((c) => c[0])
-    expect(queries.some((q) => q.includes('min-width'))).toBe(true)
-    expect(queries.some((q) => q.includes('min-height'))).toBe(true)
-    w.unmount()
-  })
-
-  test('returns false when both width and height match are false', async () => {
-    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
-    await nextTick()
-    expect(result.value).toBe(false)
-    w.unmount()
-  })
-
-  test('returns true when only width is below threshold', async () => {
-    widthMql.matches = true
-    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
-    await nextTick()
-    expect(result.value).toBe(true)
-    w.unmount()
-  })
-
-  test('returns true when only height is below threshold', async () => {
-    heightMql.matches = true
-    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
-    await nextTick()
-    expect(result.value).toBe(true)
-    w.unmount()
-  })
-
-  test('returns true when both are below threshold', async () => {
-    widthMql.matches = true
-    heightMql.matches = true
-    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
-    await nextTick()
-    expect(result.value).toBe(true)
-    w.unmount()
-  })
-
-  test('reacts when width crosses the threshold', async () => {
-    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
-    await nextTick()
-    expect(result.value).toBe(false)
-
-    widthMql.matches = true
-    widthMql._fire()
-    await nextTick()
-    expect(result.value).toBe(true)
-    w.unmount()
-  })
-
-  test('reacts when height crosses the threshold', async () => {
-    const [result, w] = withSetup(() => useMobileBreakpoint('sm'))
-    await nextTick()
-
-    heightMql.matches = true
-    heightMql._fire()
-    await nextTick()
-    expect(result.value).toBe(true)
-    w.unmount()
-  })
-
-  test('width and height axes are queried separately', () => {
-    const [, w] = withSetup(() => useMobileBreakpoint('md', 'lg'))
-
-    const queries = window.matchMedia.mock.calls.map((c) => c[0])
-    expect(queries.some((q) => q.includes('min-width'))).toBe(true)
-    expect(queries.some((q) => q.includes('min-height'))).toBe(true)
-    w.unmount()
-  })
-
-  test('defaults both width and height to "sm"', () => {
-    const [, w] = withSetup(() => useMobileBreakpoint())
-
-    const queries = window.matchMedia.mock.calls.map((c) => c[0])
-    const widthQuery = queries.find((q) => q.includes('min-width'))
-    const heightQuery = queries.find((q) => q.includes('min-height'))
-
-    const widthValue = widthQuery.match(/min-width:\s*([^)]*)\)/)?.[1]
-    const heightValue = heightQuery.match(/min-height:\s*([^)]*)\)/)?.[1]
-    expect(widthValue).toBe(heightValue)
-    w.unmount()
-  })
-})
-
-describe('useIsTablet', () => {
-  let widthMql
-  let heightMql
-  let coarseMql
-  let useIsTablet
-
-  beforeEach(async () => {
-    vi.resetModules()
-    widthMql = createMockMql(false)
-    heightMql = createMockMql(false)
-    coarseMql = createMockMql(false)
-
-    window.matchMedia = vi.fn((query) => {
-      if (query.includes('min-width')) return widthMql
-      if (query.includes('min-height')) return heightMql
-      if (query.includes('pointer: coarse')) return coarseMql
-      return createMockMql(false)
+    test('fine pointer', () => {
+      expect(compiledFor('fine')).toBe('(pointer: fine)')
     })
-    ;({ useIsTablet } = await import('@/composables/use-media-query'))
+
+    test('dark color scheme', () => {
+      expect(compiledFor('dark')).toBe('(prefers-color-scheme: dark)')
+    })
+
+    test('light color scheme', () => {
+      expect(compiledFor('light')).toBe('(prefers-color-scheme: light)')
+    })
+
+    test('width at-or-above uses a bare min-width', () => {
+      const q = compiledFor('w>=md')
+      expect(q).toContain('(min-width:')
+      expect(q).not.toContain('not all')
+    })
+
+    test('width below uses the Safari-safe `not all and (min-width)` form', () => {
+      expect(compiledFor('w<md')).toMatch(/^not all and \(min-width:/)
+    })
+
+    test('height at-or-above uses a bare min-height', () => {
+      const q = compiledFor('h>=lg')
+      expect(q).toContain('(min-height:')
+      expect(q).not.toContain('not all')
+    })
+
+    test('height below uses the negated min-height form', () => {
+      expect(compiledFor('h<sm')).toMatch(/^not all and \(min-height:/)
+    })
+
+    test('tolerates surrounding whitespace', () => {
+      expect(compiledFor('  coarse  ')).toBe('(pointer: coarse)')
+    })
   })
 
-  test('returns false on a wide fine-pointer viewport', async () => {
-    const [result, w] = withSetup(() => useIsTablet())
-    await nextTick()
-    expect(result.value).toBe(false)
-    w.unmount()
+  describe('combinators', () => {
+    test('`|` comma-joins each atom as a standalone OR clause', () => {
+      const q = compiledFor('w<md | h<sm')
+      expect(q.split(', ')).toHaveLength(2)
+      expect(q).toContain('not all and (min-width:')
+      expect(q).toContain('not all and (min-height:')
+    })
+
+    test('`&` joins atoms into one conjunction clause', () => {
+      const q = compiledFor('w>=lg & fine')
+      expect(q).toContain(' and ')
+      expect(q).toContain('(min-width:')
+      expect(q).toContain('(pointer: fine)')
+      expect(q).not.toContain(',')
+    })
+
+    test('tablet token compiles to three OR clauses including coarse', () => {
+      const q = compiledFor('w<lg | h<lg | coarse')
+      expect(q.split(', ')).toHaveLength(3)
+      expect(q).toContain('(pointer: coarse)')
+    })
+
+    test('whitespace around the combinator is optional', () => {
+      expect(compiledFor('w<md|h<sm')).toBe(compiledFor('w<md | h<sm'))
+    })
   })
 
-  test('returns true when below the lg width breakpoint', async () => {
-    widthMql.matches = true
-    const [result, w] = withSetup(() => useIsTablet())
-    await nextTick()
-    expect(result.value).toBe(true)
-    w.unmount()
+  describe('reactivity', () => {
+    test('seeds the ref from matchMedia.matches', () => {
+      window.matchMedia = vi.fn(() => createMockMql(true))
+      expect(useMatchMedia('dark').value).toBe(true)
+    })
+
+    test('updates when the media query change event fires', () => {
+      const mql = createMockMql(false)
+      window.matchMedia = vi.fn(() => mql)
+      const result = useMatchMedia('dark')
+      expect(result.value).toBe(false)
+
+      mql.matches = true
+      mql._fire()
+      expect(result.value).toBe(true)
+    })
+
+    test('never removes its listener — the cache is app-lifetime', () => {
+      const mql = createMockMql(false)
+      window.matchMedia = vi.fn(() => mql)
+      useMatchMedia('dark')
+      expect(mql.removeEventListener).not.toHaveBeenCalled()
+    })
   })
 
-  test('returns true when below the lg height breakpoint', async () => {
-    heightMql.matches = true
-    const [result, w] = withSetup(() => useIsTablet())
-    await nextTick()
-    expect(result.value).toBe(true)
-    w.unmount()
+  describe('caching', () => {
+    test('same token returns the same ref and queries matchMedia once', () => {
+      const a = useMatchMedia('w<md | h<sm')
+      const b = useMatchMedia('w<md | h<sm')
+      expect(a).toBe(b)
+      expect(window.matchMedia).toHaveBeenCalledTimes(1)
+    })
+
+    test('tokens that compile to the same query dedupe', () => {
+      const a = useMatchMedia('coarse')
+      const b = useMatchMedia(' coarse ')
+      expect(a).toBe(b)
+      expect(window.matchMedia).toHaveBeenCalledTimes(1)
+    })
+
+    test('different queries get separate refs', () => {
+      const a = useMatchMedia('dark')
+      const b = useMatchMedia('light')
+      expect(a).not.toBe(b)
+    })
   })
 
-  test('returns true on a wide viewport when the pointer is coarse', async () => {
-    coarseMql.matches = true
-    const [result, w] = withSetup(() => useIsTablet())
-    await nextTick()
-    expect(result.value).toBe(true)
-    w.unmount()
-  })
+  describe('invalid queries throw', () => {
+    test('mixing `&` and `|`', () => {
+      expect(() => useMatchMedia('w<md & h<sm | coarse')).toThrow(/mix/)
+    })
 
-  test('reacts when the pointer becomes coarse mid-session', async () => {
-    const [result, w] = withSetup(() => useIsTablet())
-    await nextTick()
-    expect(result.value).toBe(false)
+    test('unknown atom', () => {
+      expect(() => useMatchMedia('w<<md')).toThrow(/unknown atom/)
+      expect(() => useMatchMedia('tablet')).toThrow(/unknown atom/)
+    })
 
-    coarseMql.matches = true
-    coarseMql._fire()
-    await nextTick()
-    expect(result.value).toBe(true)
-    w.unmount()
+    test('a `<` atom under `&` (would need max-* support)', () => {
+      expect(() => useMatchMedia('w<md & fine')).toThrow(/"<" atoms/)
+    })
   })
 })

--- a/tests/unit/composables/use-play-on-tap.test.js
+++ b/tests/unit/composables/use-play-on-tap.test.js
@@ -15,7 +15,7 @@ const { coarseRef, mockUseMediaQuery, mockPlayButtonTap } = vi.hoisted(() => {
 })
 
 vi.mock('@/composables/use-media-query', () => ({
-  useMediaQuery: mockUseMediaQuery
+  useMatchMedia: mockUseMediaQuery
 }))
 
 vi.mock('@/utils/animations/button-tap', () => ({

--- a/tests/unit/stores/theme.test.js
+++ b/tests/unit/stores/theme.test.js
@@ -5,7 +5,7 @@ import { setActivePinia, createPinia } from 'pinia'
 vi.mock('@/composables/use-media-query')
 
 import { useThemeStore } from '@/stores/theme'
-import { useMediaQuery } from '@/composables/use-media-query'
+import { useMatchMedia } from '@/composables/use-media-query'
 
 describe('theme store', () => {
   beforeEach(() => {
@@ -16,8 +16,8 @@ describe('theme store', () => {
     // at import time, so the handler would be lost if we reset the array here.
     global.__matchMedia.matches = false
 
-    // Set up useMediaQuery mock before any store call captures the ref.
-    vi.mocked(useMediaQuery).mockReturnValue(ref(false))
+    // Set up useMatchMedia mock before any store call captures the ref.
+    vi.mocked(useMatchMedia).mockReturnValue(ref(false))
     // Reset store mode to 'system' (also writes to localStorage).
     useThemeStore().setMode('system')
     // Clear localStorage so load() tests start clean.
@@ -133,7 +133,7 @@ describe('theme store', () => {
   })
 
   test('is_dark reflects system preference when mode is system and system is dark', () => {
-    vi.mocked(useMediaQuery).mockReturnValue(ref(true))
+    vi.mocked(useMatchMedia).mockReturnValue(ref(true))
     setActivePinia(createPinia())
     expect(useThemeStore().is_dark).toBe(true)
   })
@@ -159,7 +159,7 @@ describe('theme store', () => {
   })
 
   test('cycle advances from system to light when system preference is dark', () => {
-    vi.mocked(useMediaQuery).mockReturnValue(ref(true))
+    vi.mocked(useMatchMedia).mockReturnValue(ref(true))
     setActivePinia(createPinia())
     const store = useThemeStore()
     store.cycle()


### PR DESCRIPTION
## Summary

- Replace `useMediaQuery` / `useMobileBreakpoint` / `useIsTablet` with a single **`useMatchMedia(query)`** token API. Polarity lives in each atom (`w>=md` / `w<md`, `h>=lg` / `h<sm`, `fine`/`coarse`, `dark`/`light`); `&` = all, `|` = any (mixing throws). Returns one app-lifetime-cached ref. All ~21 call sites migrated; `useIsTablet` becomes the self-evident `w<lg | h<lg | coarse`, and the desktop sidebar condition is the literal `w>=lg & fine` shared with CSS.
- Make **TabSheet the single owner of sidebar visibility**: a `sidebar_query` prop (default `w>=lg & fine`) resolved once and surfaced via `defineExpose({ has_sidebar })`. `deck-settings` and `phone-settings` read it through a template ref instead of re-deriving the condition.
- **Fix the deck-settings desync**: the default tab was keyed off `w<lg | h<lg | coarse`, which isn't the inverse of the sidebar condition (extra `h<lg` term) — so on a wide, fine-pointer, but short viewport the sidebar showed while the main column fell back to the mobile `index`. The default tab / back-button / danger-zone reset are now a strict inverse of TabSheet's `has_sidebar`.
- Minor: size the deck-settings tab-index nav icons; drop the mobile-sheet height threshold to `md`.