### PR TITLE
feat(card-editor): image layouts (above / below / behind)

### DIFF
--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -89,13 +89,18 @@ const layout = computed(() => attributes?.image_layout ?? CARD_ATTRIBUTES_DEFAUL
   flex-direction: column-reverse;
 }
 
+/* No overflow:hidden here — the editor's remove button pokes out of the corner
+   and must not be clipped. The image itself rounds via border-radius instead. */
 .card-face__image-region {
   position: relative;
   flex: 1 1 auto;
   min-height: 0;
-  overflow: hidden;
 
   border-radius: var(--inner-radius);
+}
+
+.card-face__image {
+  border-radius: inherit;
 }
 
 .card-face__text-region {
@@ -166,6 +171,12 @@ const layout = computed(() => attributes?.image_layout ?? CARD_ATTRIBUTES_DEFAUL
     border-radius 0.15s ease;
 }
 
+/* above/below: the image stays put; draw the dashed frame just outside it. */
+.card-face[data-mode='edit'][data-image='true'][data-text='true']:not([data-layout='behind'])
+  .card-face__image-region {
+  outline-offset: 4px;
+}
+
 .card-container--edit[data-active]
   .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
   .card-face__image-region {
@@ -185,8 +196,9 @@ const layout = computed(() => attributes?.image_layout ?? CARD_ATTRIBUTES_DEFAUL
   outline-color: var(--color-blue-650);
 }
 
-/* Full-bleed (no text): also inset the image so the dashed frame reads as a
-   border around it rather than sitting flush to the card edge. */
+/* Full-bleed (no text): the image is absolutely positioned and fills the face,
+   so there's no room outside it — inset it on hover and draw the frame in the
+   revealed gap instead. */
 .card-container--edit[data-active]
   .card-face[data-mode='edit'][data-image='true'][data-text='false']:not([data-layout='behind'])
   .card-face__image-region {

--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -152,11 +152,12 @@ const layout = computed(() => attributes?.image_layout ?? CARD_ATTRIBUTES_DEFAUL
   background-color: var(--color-purple-400);
 }
 
-/* ----- Editor: full-bleed image reveals a replaceable dropzone frame ------- */
-/* Hovering a full-bleed image insets it behind a dashed frame, signalling the
-   image is replaceable. Partial (above/below) layouts get their own region-
-   scoped affordance from the uploader. */
-.card-face[data-mode='edit'][data-image='true'][data-text='false'] .card-face__image-region {
+/* ----- Editor: hovering an image reveals a replaceable dropzone frame ------ */
+/* The image region gets a dashed frame on hover/drag for above/below and the
+   full-bleed no-text case. Behind layout uses floating corner controls over the
+   text instead, so it's excluded here. */
+.card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
+  .card-face__image-region {
   outline: 3px dashed transparent;
   outline-offset: -3px;
   transition:
@@ -166,25 +167,32 @@ const layout = computed(() => attributes?.image_layout ?? CARD_ATTRIBUTES_DEFAUL
 }
 
 .card-container--edit[data-active]
-  .card-face[data-mode='edit'][data-image='true'][data-text='false']
+  .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
   .card-face__image-region {
-  inset: var(--face-image-padding);
-
-  border-radius: calc(var(--face-radius) - var(--face-image-padding));
   outline-color: var(--color-brown-500);
 }
 
 .card-container--edit[data-dragging]
-  .card-face[data-mode='edit'][data-image='true'][data-text='false']
+  .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
   .card-face__image-region {
   outline-color: var(--color-blue-500);
 }
 
 [data-theme='dark']
   .card-container--edit[data-dragging]
-  .card-face[data-mode='edit'][data-image='true'][data-text='false']
+  .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
   .card-face__image-region {
   outline-color: var(--color-blue-650);
+}
+
+/* Full-bleed (no text): also inset the image so the dashed frame reads as a
+   border around it rather than sitting flush to the card edge. */
+.card-container--edit[data-active]
+  .card-face[data-mode='edit'][data-image='true'][data-text='false']:not([data-layout='behind'])
+  .card-face__image-region {
+  inset: var(--face-image-padding);
+
+  border-radius: calc(var(--face-radius) - var(--face-image-padding));
 }
 
 .card-face__text-editor {

--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -1,37 +1,58 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import textEditor from '../text-editor/text-editor.vue'
+import { CARD_ATTRIBUTES_DEFAULTS } from '@/utils/deck/defaults'
 
-const { image, text } = defineProps<{
+const { image, text, attributes } = defineProps<{
   image?: string
   text?: string
   mode?: 'view' | 'edit'
   attributes?: CardAttributes
 }>()
+
+const layout = computed(() => attributes?.image_layout ?? CARD_ATTRIBUTES_DEFAULTS.image_layout)
 </script>
 
 <template>
-  <div class="card-face" :data-image="!!image" :data-text="!!text" :data-mode="mode">
-    <img
-      v-if="image"
-      data-testid="card-face__image"
-      :src="image"
-      class="card-face__image h-full w-full object-cover"
-    />
+  <div
+    class="card-face"
+    :data-image="!!image"
+    :data-text="!!text"
+    :data-mode="mode"
+    :data-layout="layout"
+  >
+    <div data-testid="card-face__image-region" class="card-face__image-region">
+      <slot name="image">
+        <img
+          v-if="image"
+          data-testid="card-face__image"
+          :src="image"
+          class="card-face__image h-full w-full object-cover"
+        />
+      </slot>
+    </div>
 
-    <slot name="editor" v-else>
-      <text-editor
-        :content="text"
-        :attributes="attributes"
-        disabled
-        class="card-face__text-editor w-full h-full"
-      />
-    </slot>
+    <div data-testid="card-face__text-region" class="card-face__text-region">
+      <slot name="editor">
+        <text-editor
+          :content="text"
+          :attributes="attributes"
+          disabled
+          class="card-face__text-editor w-full h-full"
+        />
+      </slot>
+    </div>
   </div>
 </template>
 
 <style>
 .card-face {
   --inner-radius: calc(var(--face-radius) - var(--face-border-width) - var(--face-padding));
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--face-image-padding);
 
   width: 100%;
   height: 100%;
@@ -42,6 +63,11 @@ const { image, text } = defineProps<{
 
   aspect-ratio: var(--aspect-card);
 }
+
+.card-face[data-mode='edit'] {
+  --face-border-width: 0px;
+}
+
 .card-face[data-mode='edit']:focus-within {
   outline: 2px solid var(--color-blue-500);
 }
@@ -50,75 +76,115 @@ const { image, text } = defineProps<{
   outline: 2px solid var(--color-red-500);
 }
 
-.card-face[data-mode='edit'][data-image='false'] {
-  grid-template-rows: auto 1fr;
+/* ----- Region placement by image layout ----------------------------------- */
+/* DOM order is image-region then text-region; layout reorders / repositions. */
+
+/* above: image on top, text below */
+.card-face[data-layout='above'] {
+  flex-direction: column;
 }
 
-.card-face[data-mode='view'][data-image='true'][data-text='false'],
-.card-face[data-mode='view'][data-image='false'][data-text='true'] {
-  grid-template-rows: 1fr;
+/* below: image on the bottom, text above */
+.card-face[data-layout='below'] {
+  flex-direction: column-reverse;
 }
 
-.card-face[data-mode='edit'] {
-  --face-border-width: 0px;
+.card-face__image-region {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+
+  border-radius: var(--inner-radius);
 }
 
-.card-face[data-mode='view'][data-text='false'] {
-  --face-padding: 0px;
+.card-face__text-region {
+  flex: 0 0 auto;
+  min-height: 0;
 }
 
-.card-face[data-mode='view'][data-text='false'][data-image='false'],
+/* behind: image fills the face, text floats on top of it */
+.card-face[data-layout='behind'] .card-face__image-region {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+
+  border-radius: var(--face-radius);
+}
+
+.card-face[data-layout='behind'] .card-face__text-region {
+  position: relative;
+  z-index: 1;
+  flex: 1 1 auto;
+}
+
+/* ----- No image: text fills the face -------------------------------------- */
+.card-face[data-image='false'] .card-face__image-region {
+  display: none;
+}
+
+.card-face[data-image='false'] .card-face__text-region {
+  flex: 1 1 auto;
+}
+
+/* ----- Full-bleed: an image with no text fills the face in every layout ---- */
+.card-face[data-image='true'][data-text='false'] {
+  padding: 0;
+  gap: 0;
+}
+
+.card-face[data-image='true'][data-text='false'] .card-face__image-region {
+  position: absolute;
+  inset: 0;
+  flex: none;
+
+  border-radius: var(--face-radius);
+}
+
+.card-face[data-image='true'][data-text='false'] .card-face__text-region {
+  display: none;
+}
+
+/* Empty card (no image, no text) shows the placeholder backdrop edge-to-edge. */
+.card-face[data-mode='view'][data-image='false'][data-text='false'],
 .card-face[data-mode='view'][data-image='false']:has(.ql-blank) {
-  /* background-image: var(--bgx-diagonal-stripes); */
+  padding: 0;
   background-color: var(--color-purple-400);
 }
 
-.card-face[data-image='true'] {
-  overflow: hidden;
-}
-
-/* Images fill the face by default — always in view mode, and in the editor
-   until the card is hovered. */
-.card-face[data-mode='view'][data-image='true'],
-.card-face[data-mode='edit'][data-image='true'] {
-  padding: 0;
-}
-
-/* Card editor: hovering anywhere on the card reveals a dropzone-style frame —
-   the card background and a dashed border show around a padded, inner-rounded
-   image, signalling the image is replaceable. The dashed outline is inset so it
-   reads as a border around the card without shifting layout. */
-.card-face[data-mode='edit'][data-image='true'] {
+/* ----- Editor: full-bleed image reveals a replaceable dropzone frame ------- */
+/* Hovering a full-bleed image insets it behind a dashed frame, signalling the
+   image is replaceable. Partial (above/below) layouts get their own region-
+   scoped affordance from the uploader. */
+.card-face[data-mode='edit'][data-image='true'][data-text='false'] .card-face__image-region {
   outline: 3px dashed transparent;
   outline-offset: -3px;
   transition:
-    padding 0.15s ease,
-    outline-color 0.15s ease;
+    inset 0.15s ease,
+    outline-color 0.15s ease,
+    border-radius 0.15s ease;
 }
 
-.card-face[data-mode='edit'] .card-face__image {
-  border-radius: var(--face-radius);
-  transition: border-radius 0.15s ease;
-}
+.card-container--edit[data-active]
+  .card-face[data-mode='edit'][data-image='true'][data-text='false']
+  .card-face__image-region {
+  inset: var(--face-image-padding);
 
-.card-container--edit[data-active] .card-face[data-mode='edit'][data-image='true'] {
-  padding: var(--face-image-padding);
+  border-radius: calc(var(--face-radius) - var(--face-image-padding));
   outline-color: var(--color-brown-500);
 }
 
-/* While a file is dragged over, the frame turns blue to match the drop affordance. */
-.card-container--edit[data-dragging] .card-face[data-mode='edit'][data-image='true'] {
+.card-container--edit[data-dragging]
+  .card-face[data-mode='edit'][data-image='true'][data-text='false']
+  .card-face__image-region {
   outline-color: var(--color-blue-500);
 }
 
 [data-theme='dark']
   .card-container--edit[data-dragging]
-  .card-face[data-mode='edit'][data-image='true'] {
+  .card-face[data-mode='edit'][data-image='true'][data-text='false']
+  .card-face__image-region {
   outline-color: var(--color-blue-650);
-}
-
-.card-container--edit[data-active] .card-face[data-mode='edit'] .card-face__image {
-  border-radius: calc(var(--face-radius) - var(--face-image-padding));
 }
 
 .card-face__text-editor {

--- a/src/components/card/index.vue
+++ b/src/components/card/index.vue
@@ -96,6 +96,9 @@ function onLeave(el: Element, done: () => void) {
           :mode="mode"
           :attributes="card_attributes?.front"
         >
+          <template #image>
+            <slot name="image"></slot>
+          </template>
           <template #editor>
             <slot name="editor"></slot>
           </template>
@@ -111,6 +114,9 @@ function onLeave(el: Element, done: () => void) {
           :mode="mode"
           :attributes="card_attributes?.back"
         >
+          <template #image>
+            <slot name="image"></slot>
+          </template>
           <template #editor>
             <slot name="editor"></slot>
           </template>

--- a/src/components/modals/deck-settings/tab-design/card-designer/layout-skeleton.vue
+++ b/src/components/modals/deck-settings/tab-design/card-designer/layout-skeleton.vue
@@ -1,33 +1,40 @@
 <script setup lang="ts">
+import CardFace from '@/components/card/card-face.vue'
+
 type LayoutSkeletonProps = {
   layout: CardImageLayout
 }
 
 const { layout } = defineProps<LayoutSkeletonProps>()
+
+// A 1×1 transparent pixel: card-face derives data-image from the `image` prop,
+// so a truthy value flips the image region on. The visible block comes from the
+// #image slot below (themed, unlike a static data-URI), so this is never drawn.
+const IMAGE_FLAG = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
 </script>
 
 <template>
-  <div
+  <card-face
     data-testid="layout-skeleton"
-    :data-layout="layout"
-    class="relative h-full w-full overflow-hidden rounded-(--face-radius) bg-brown-100 p-3"
+    :image="IMAGE_FLAG"
+    text=" "
+    :attributes="{ image_layout: layout }"
   >
-    <div
-      class="flex h-full w-full flex-col justify-center gap-3"
-      :class="{ 'flex-col-reverse': layout === 'above' }"
-    >
+    <template #image>
+      <div
+        data-testid="layout-skeleton__image"
+        class="h-full w-full bg-brown-300 dark:bg-grey-600"
+      ></div>
+    </template>
+
+    <template #editor>
       <div
         data-testid="layout-skeleton__text"
-        class="flex shrink-0 flex-col gap-1 items-center z-1"
+        class="flex flex-col items-center justify-center gap-1"
       >
         <span class="h-1.5 w-3/4 rounded-full bg-brown-500 dark:bg-grey-700"></span>
         <span class="h-1.5 w-1/2 rounded-full bg-brown-500 dark:bg-grey-700"></span>
       </div>
-      <div
-        data-testid="layout-skeleton__image"
-        class="grow rounded-[calc(var(--face-radius)-var(--face-padding))] bg-brown-300 dark:bg-grey-600"
-        :class="{ 'absolute inset-1': layout === 'behind' }"
-      ></div>
-    </div>
-  </div>
+    </template>
+  </card-face>
 </template>

--- a/src/composables/card-editor/use-face-image-upload.ts
+++ b/src/composables/card-editor/use-face-image-upload.ts
@@ -6,7 +6,6 @@ import {
   toValue,
   watch,
   type MaybeRefOrGetter,
-  type Readonly,
   type ShallowRef
 } from 'vue'
 import { useI18n } from 'vue-i18n'

--- a/src/composables/card-editor/use-face-image-upload.ts
+++ b/src/composables/card-editor/use-face-image-upload.ts
@@ -1,0 +1,202 @@
+import {
+  computed,
+  inject,
+  onBeforeUnmount,
+  ref,
+  toValue,
+  watch,
+  type MaybeRefOrGetter,
+  type Readonly,
+  type ShallowRef
+} from 'vue'
+import { useI18n } from 'vue-i18n'
+import { type CardListController } from './card-list-controller'
+import { useCardImageGate } from './use-card-image-gate'
+import { useImageDropzone } from './use-image-dropzone'
+import { useToast } from '@/composables/toast'
+import { emitSfx } from '@/sfx/bus'
+
+// Card images render small but are the app's highest-volume asset, so cap them
+// well below the bucket's 10 MiB backstop. Exported so the uploader can render
+// the size limit in its too-large error copy from the same source.
+export const CARD_IMAGE_MAX_BYTES = 2 * 1024 * 1024
+
+// A fresh drop/pick leaves the pointer over the card; suppress the replace
+// scrim so the new image is visible, until the pointer leaves or this elapses.
+const SUPPRESS_HOVER_MS = 1000
+
+type UseFaceImageUploadOptions = {
+  card: MaybeRefOrGetter<Card>
+  side: 'front' | 'back'
+  fileInput: Readonly<ShallowRef<HTMLInputElement | null>>
+  /** The uploader root element, used to dismiss a lingering error on outside click. */
+  rootEl: () => HTMLElement | undefined
+}
+
+/**
+ * Drives one card face's image-upload interaction: drag/drop + file-picker
+ * plumbing, the hover/drag/error overlay state, and the upload/remove actions.
+ * Layout-agnostic — the consumer decides how to present `active`/`has_image`
+ * per image layout.
+ *
+ * @example
+ * const fileInput = useTemplateRef('fileInput')
+ * const upload = useFaceImageUpload({
+ *   card: () => card,
+ *   side,
+ *   fileInput,
+ *   rootEl: () => cardRef.value?.$el
+ * })
+ */
+export function useFaceImageUpload({ card, side, fileInput, rootEl }: UseFaceImageUploadOptions) {
+  const { t } = useI18n()
+  const toast = useToast()
+  const { guardCardImage } = useCardImageGate()
+  const { setFaceImage } = inject<CardListController>('card-editor')!
+
+  const hovered = ref(false)
+  const hover_suppressed = ref(false)
+  let suppress_timer: ReturnType<typeof setTimeout> | undefined
+
+  const {
+    dragging,
+    error: file_error,
+    clearError,
+    accept,
+    browse,
+    onFileChange,
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDrop
+  } = useImageDropzone({
+    maxBytes: CARD_IMAGE_MAX_BYTES,
+    fileInput,
+    onFile: uploadFile,
+    onError: () => emitSfx('ui.digi_powerdown'),
+    guard: guardCardImage
+  })
+
+  const image_path = computed(() =>
+    side === 'front' ? toValue(card).front_image_path : toValue(card).back_image_path
+  )
+  const has_image = computed(() => !!image_path.value)
+  // Image writes go through insert-backed RPCs that need a persisted row; temp
+  // cards (id <= 0) aren't saved yet, so disable upload until they are.
+  const can_upload = computed(() => (toValue(card).id ?? 0) > 0)
+  // Keep the image in its hover (padded/rounded) state behind a visible error
+  // scrim so it doesn't pop back to full-bleed underneath the overlay.
+  const active = computed(
+    () => ((hovered.value || dragging.value) && !hover_suppressed.value) || !!file_error.value
+  )
+  // While a drag or error overlay covers the editor, make it inert: the user
+  // can't see what's behind the scrim, so they shouldn't be able to focus it
+  // (which would show a stray blue focus ring) or type into it.
+  const covered = computed(() => dragging.value || !!file_error.value)
+
+  onBeforeUnmount(() => {
+    clearTimeout(suppress_timer)
+    document.removeEventListener('pointerdown', onDocumentPointerDown)
+  })
+
+  /** Upload a validated file to this face, suppressing the scrim afterwards. */
+  async function uploadFile(file: File) {
+    if (!can_upload.value) return
+
+    suppressHover()
+
+    try {
+      await setFaceImage(toValue(card).id!, side, file)
+      emitSfx('ui.music_plink_ok', { blocking: true })
+    } catch {
+      toast.error(t('toast.error.card-image-upload-failed'))
+    }
+  }
+
+  /** Remove this face's image. */
+  async function onRemove() {
+    emitSfx('ui.trash_crumple_short')
+    clearError()
+
+    try {
+      await setFaceImage(toValue(card).id!, side, null)
+    } catch {
+      toast.error(t('toast.error.card-image-delete-failed'))
+    }
+  }
+
+  /**
+   * Open the file picker, gated on the paid-images check. A free member gets the
+   * upgrade alert instead; the drop path is gated via the dropzone `guard`.
+   */
+  async function openPicker() {
+    if (!(await guardCardImage())) return
+
+    emitSfx('ui.select')
+    browse()
+  }
+
+  function onDismissError() {
+    emitSfx('ui.snappy_button_5')
+    clearError()
+  }
+
+  // A fresh drop/pick lands with the pointer still over the card, which would
+  // immediately reveal the replace scrim over the new image. Hold the hover
+  // state off until the pointer leaves once, or until the timeout releases it.
+  function suppressHover() {
+    hover_suppressed.value = true
+    clearTimeout(suppress_timer)
+    suppress_timer = setTimeout(() => (hover_suppressed.value = false), SUPPRESS_HOVER_MS)
+  }
+
+  function onPointerEnter() {
+    hovered.value = true
+  }
+
+  function onPointerLeave() {
+    hovered.value = false
+    clearTimeout(suppress_timer)
+    hover_suppressed.value = false
+  }
+
+  // Dismiss a lingering error when the user commits attention to another card.
+  function onDocumentPointerDown(e: PointerEvent) {
+    const root = rootEl()
+    if (root && !root.contains(e.target as Node)) onDismissError()
+  }
+
+  // Chime once when a drag first enters the card (not on every child dragenter).
+  watch(dragging, (now, was) => {
+    if (now && !was && can_upload.value) emitSfx('ui.music_plink_mid')
+  })
+
+  // Only listen for outside clicks while an error is actually showing.
+  watch(file_error, (err) => {
+    if (err) document.addEventListener('pointerdown', onDocumentPointerDown)
+    else document.removeEventListener('pointerdown', onDocumentPointerDown)
+  })
+
+  return {
+    accept,
+    onFileChange,
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDrop,
+    dragging,
+    file_error,
+    clearError,
+    hovered,
+    active,
+    covered,
+    has_image,
+    image_path,
+    can_upload,
+    onRemove,
+    openPicker,
+    onDismissError,
+    onPointerEnter,
+    onPointerLeave
+  }
+}

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -427,6 +427,7 @@
   "deck-view.card-editor.list-item.add-above": "Add Card",
   "deck-view.card-editor.list-item.add-below": "Add Card",
   "deck-view.card-editor.list-item.remove-image-button": "Remove image",
+  "deck-view.card-editor.list-item.replace-image-button": "Replace image",
   "deck-view.card-editor.list-item.upload-image-button": "Add image",
   "deck-view.card-editor.list-item.replace-heading": "Drag an image here, or click to browse",
   "deck-view.card-editor.list-item.invalid-type-error": "Use a PNG, JPEG, WebP, or GIF image.",

--- a/src/views/deck/card-editor/card-face-uploader.vue
+++ b/src/views/deck/card-editor/card-face-uploader.vue
@@ -1,33 +1,20 @@
 <script setup lang="ts">
-import {
-  computed,
-  inject,
-  onBeforeUnmount,
-  ref,
-  useTemplateRef,
-  watch,
-  type ComponentPublicInstance
-} from 'vue'
+import { computed, inject, useTemplateRef, type ComponentPublicInstance } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Card from '@/components/card/index.vue'
-import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
+import FaceImageDropzone from './face-image-dropzone.vue'
+import UiButton from '@/components/ui-kit/button.vue'
 import { type CardListController } from '@/composables/card-editor/card-list-controller'
-import { useCardImageGate } from '@/composables/card-editor/use-card-image-gate'
-import { useImageDropzone } from '@/composables/card-editor/use-image-dropzone'
-import { useToast } from '@/composables/toast'
-import { emitSfx } from '@/sfx/bus'
+import {
+  CARD_IMAGE_MAX_BYTES,
+  useFaceImageUpload
+} from '@/composables/card-editor/use-face-image-upload'
+import { cardImageUrl } from '@/api/media'
+import { CARD_ATTRIBUTES_DEFAULTS } from '@/utils/deck/defaults'
 import { playButtonTap } from '@/utils/animations/button-tap'
 import { bytesToMbLabel } from '@/utils/file-size'
-
-// Card images render small but are the app's highest-volume asset, so cap them
-// well below the bucket's 10 MiB backstop.
-const CARD_IMAGE_MAX_BYTES = 2 * 1024 * 1024
-
-// A fresh drop/pick leaves the pointer over the card; suppress the replace
-// scrim so the new image is visible, until the pointer leaves or this elapses.
-const SUPPRESS_HOVER_MS = 1000
 
 type CardFaceUploaderProps = {
   card: Card
@@ -39,51 +26,47 @@ type CardFaceUploaderProps = {
 const { card, side, disabled = false, error = false } = defineProps<CardFaceUploaderProps>()
 
 const { t } = useI18n()
-const toast = useToast()
-const { guardCardImage } = useCardImageGate()
-const { setFaceImage } = inject<CardListController>('card-editor')!
+const { card_attributes } = inject<CardListController>('card-editor')!
 
 const addIcon = useTemplateRef<HTMLElement>('addIcon')
 const cardRef = useTemplateRef<ComponentPublicInstance>('cardRef')
 const fileInput = useTemplateRef<HTMLInputElement>('fileInput')
 
-const hovered = ref(false)
-const hover_suppressed = ref(false)
-let suppress_timer: ReturnType<typeof setTimeout> | undefined
-
 const {
-  dragging,
-  error: file_error,
-  clearError,
   accept,
-  browse,
   onFileChange,
   onDragEnter,
   onDragLeave,
   onDragOver,
-  onDrop
-} = useImageDropzone({
-  maxBytes: CARD_IMAGE_MAX_BYTES,
+  onDrop,
+  dragging,
+  file_error,
+  hovered,
+  active,
+  covered,
+  has_image,
+  image_path,
+  can_upload,
+  onRemove,
+  openPicker,
+  onDismissError,
+  onPointerEnter,
+  onPointerLeave
+} = useFaceImageUpload({
+  card: () => card,
+  side,
   fileInput,
-  onFile: uploadFile,
-  onError: () => emitSfx('ui.digi_powerdown'),
-  guard: guardCardImage
+  rootEl: () => cardRef.value?.$el as HTMLElement | undefined
 })
 
-const image_path = computed(() => (side === 'front' ? card.front_image_path : card.back_image_path))
-const has_image = computed(() => !!image_path.value)
-// Image writes go through insert-backed RPCs that need a persisted row; temp
-// cards (id <= 0) aren't saved yet, so disable upload until they are.
-const can_upload = computed(() => (card.id ?? 0) > 0)
-// Keep the image in its hover (padded/rounded) state behind a visible error
-// scrim so it doesn't pop back to full-bleed underneath the overlay.
-const active = computed(
-  () => ((hovered.value || dragging.value) && !hover_suppressed.value) || !!file_error.value
+const layout = computed(
+  () => card_attributes.value[side]?.image_layout ?? CARD_ATTRIBUTES_DEFAULTS.image_layout
 )
-// While a drag or error overlay covers the editor, make it inert: the user
-// can't see what's behind the scrim, so they shouldn't be able to focus it
-// (which would show a stray blue focus ring) or type into it.
-const covered = computed(() => dragging.value || !!file_error.value)
+// Behind keeps the image full-bleed under the text, so its controls float in the
+// corners; above/below give the image its own region to scope the dropzone to.
+const dropzone_mode = computed(() => (layout.value === 'behind' ? 'corners' : 'region'))
+const image_url = computed(() => (image_path.value ? cardImageUrl(image_path.value) : undefined))
+
 const error_message = computed(() => {
   if (file_error.value === 'invalid-type') {
     return t('deck-view.card-editor.list-item.invalid-type-error')
@@ -96,85 +79,10 @@ const error_message = computed(() => {
   return ''
 })
 
-onBeforeUnmount(() => {
-  clearTimeout(suppress_timer)
-  document.removeEventListener('pointerdown', onDocumentPointerDown)
-})
-
-async function uploadFile(file: File) {
-  if (!can_upload.value) return
-
-  suppressHover()
-
-  try {
-    await setFaceImage(card.id!, side, file)
-    emitSfx('ui.music_plink_ok', { blocking: true })
-  } catch {
-    toast.error(t('toast.error.card-image-upload-failed'))
-  }
-}
-
-async function onRemove() {
-  emitSfx('ui.trash_crumple_short')
-  clearError()
-
-  try {
-    await setFaceImage(card.id!, side, null)
-  } catch {
-    toast.error(t('toast.error.card-image-delete-failed'))
-  }
-}
-
-async function onBrowse() {
-  // Card images are paid; a free member gets the upgrade alert instead of the
-  // file picker. The drop path is gated via the dropzone `guard`.
-  if (!(await guardCardImage())) return
-
-  emitSfx('ui.select')
+function onAddClick() {
   if (addIcon.value) playButtonTap(addIcon.value, 0.35, { yoyo: true })
-  browse()
+  openPicker()
 }
-
-function onDismissError() {
-  emitSfx('ui.snappy_button_5')
-  clearError()
-}
-
-// A fresh drop/pick lands with the pointer still over the card, which would
-// immediately reveal the replace scrim over the new image. Hold the hover state
-// off until the pointer leaves once, or until the timeout releases it.
-function suppressHover() {
-  hover_suppressed.value = true
-  clearTimeout(suppress_timer)
-  suppress_timer = setTimeout(() => (hover_suppressed.value = false), SUPPRESS_HOVER_MS)
-}
-
-function onPointerEnter() {
-  hovered.value = true
-}
-
-function onPointerLeave() {
-  hovered.value = false
-  clearTimeout(suppress_timer)
-  hover_suppressed.value = false
-}
-
-// Dismiss a lingering error when the user commits attention to another card.
-function onDocumentPointerDown(e: PointerEvent) {
-  const root = cardRef.value?.$el as HTMLElement | undefined
-  if (root && !root.contains(e.target as Node)) onDismissError()
-}
-
-// Chime once when a drag first enters the card (not on every child dragenter).
-watch(dragging, (now, was) => {
-  if (now && !was && can_upload.value) emitSfx('ui.music_plink_mid')
-})
-
-// Only listen for outside clicks while an error is actually showing.
-watch(file_error, (err) => {
-  if (err) document.addEventListener('pointerdown', onDocumentPointerDown)
-  else document.removeEventListener('pointerdown', onDocumentPointerDown)
-})
 </script>
 
 <template>
@@ -184,6 +92,7 @@ watch(file_error, (err) => {
     size="xl"
     :side="side"
     v-bind="card"
+    :card_attributes="card_attributes"
     :error="error"
     :sfx="has_image ? { hover: 'ui.click_07' } : undefined"
     :data-active="active || undefined"
@@ -212,64 +121,33 @@ watch(file_error, (err) => {
       class="absolute! top-(--face-padding) right-(--face-padding) z-20 cursor-pointer text-brown-500 transition-[color,opacity] duration-150 hover:text-blue-500 dark:text-brown-100 dark:hover:text-blue-650"
       :class="hovered ? 'opacity-100' : 'opacity-0'"
       v-sfx="{ hover: 'ui.click_07' }"
-      @click.stop="onBrowse"
+      @click.stop="onAddClick"
     >
       <span ref="addIcon" class="inline-flex">
         <ui-icon src="add-image" class="size-7" />
       </span>
     </ui-tooltip>
 
-    <ui-button
-      v-if="has_image && !disabled"
-      data-testid="card-face-uploader__remove"
-      icon-only
-      icon-left="remove-image"
-      data-theme="red-500"
-      class="absolute! z-20 -translate-y-1/4 translate-x-1/4 transition-[top,right,opacity] duration-150 ease-[ease]"
-      :class="
-        active
-          ? 'top-(--face-image-padding) right-(--face-image-padding) opacity-100 pointer-events-auto'
-          : 'top-0 right-0 opacity-0 pointer-events-none'
-      "
-      @click.stop="onRemove"
-    >
-      {{ t('deck-view.card-editor.list-item.remove-image-button') }}
-    </ui-button>
-
     <button
       v-if="!has_image && can_upload && dragging && !file_error"
       type="button"
       data-testid="card-face-uploader__empty-overlay"
       class="card-face-uploader__overlay card-face-uploader__overlay--full"
-      @click.stop="onBrowse"
+      @click.stop="openPicker"
     >
       <ui-icon src="add-image" class="size-12" />
-    </button>
-
-    <button
-      v-if="has_image && can_upload && !disabled && !file_error"
-      type="button"
-      data-testid="card-face-uploader__scrim"
-      class="card-face-uploader__overlay card-face-uploader__overlay--inset"
-      @click.stop="onBrowse"
-    >
-      <ui-icon src="add-image" class="size-12" />
-      <p class="text-sm">{{ t('deck-view.card-editor.list-item.replace-heading') }}</p>
     </button>
 
     <div
-      v-if="file_error"
+      v-if="!has_image && file_error"
       data-testid="card-face-uploader__error"
       data-error
-      class="card-face-uploader__overlay"
-      :class="
-        has_image ? 'card-face-uploader__overlay--inset' : 'card-face-uploader__overlay--full'
-      "
+      class="card-face-uploader__overlay card-face-uploader__overlay--full"
       @mousedown.stop
-      @click.stop="onBrowse"
+      @click.stop="openPicker"
     >
       <ui-icon src="close" class="size-12" />
-      <p class="text-sm">{{ error_message }}</p>
+      <p class="text-base">{{ error_message }}</p>
       <ui-button
         data-testid="card-face-uploader__dismiss-error"
         size="sm"
@@ -279,6 +157,30 @@ watch(file_error, (err) => {
         {{ t('deck-view.card-editor.list-item.dismiss-error-button') }}
       </ui-button>
     </div>
+
+    <face-image-dropzone
+      v-if="has_image && !disabled && dropzone_mode === 'corners'"
+      mode="corners"
+      :active="active"
+      :disabled="disabled"
+      :error="error_message"
+      @browse="openPicker"
+      @remove="onRemove"
+      @dismiss-error="onDismissError"
+    />
+
+    <template v-if="has_image && !disabled && dropzone_mode === 'region'" #image>
+      <face-image-dropzone
+        mode="region"
+        :image="image_url"
+        :active="active"
+        :disabled="disabled"
+        :error="error_message"
+        @browse="openPicker"
+        @remove="onRemove"
+        @dismiss-error="onDismissError"
+      />
+    </template>
 
     <template #editor>
       <div
@@ -308,10 +210,8 @@ watch(file_error, (err) => {
 
   cursor: pointer;
   transition:
-    inset 0.15s ease,
     opacity 0.15s ease,
-    border-color 0.15s ease,
-    border-radius 0.15s ease;
+    border-color 0.15s ease;
 }
 
 .card-face-uploader__overlay[data-error] {
@@ -338,44 +238,5 @@ watch(file_error, (err) => {
 
 .card-face-uploader__overlay--full[data-error] {
   border-color: var(--color-red-500);
-}
-
-.card-face-uploader__overlay--inset {
-  inset: 0;
-  border-radius: var(--face-radius);
-  background-color: color-mix(in srgb, var(--color-white) 85%, transparent);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-
-  color: var(--color-brown-700);
-  opacity: 0;
-}
-
-[data-theme='dark'] .card-face-uploader__overlay--inset {
-  background-color: color-mix(in srgb, var(--color-stone-700) 85%, transparent);
-}
-
-.card-container--edit[data-active] .card-face-uploader__overlay--inset {
-  inset: var(--face-image-padding);
-  border-radius: calc(var(--face-radius) - var(--face-image-padding));
-
-  opacity: 1;
-}
-
-.card-face-uploader__overlay--inset[data-error] {
-  inset: var(--face-image-padding);
-  border-radius: calc(var(--face-radius) - var(--face-image-padding));
-
-  opacity: 1;
-}
-
-/* Dragging a file over an image card turns the replace scrim blue, matching
-   the empty-card drop affordance. */
-.card-container--edit[data-dragging] .card-face-uploader__overlay--inset {
-  color: var(--color-blue-500);
-}
-
-[data-theme='dark'] .card-container--edit[data-dragging] .card-face-uploader__overlay--inset {
-  color: var(--color-blue-650);
 }
 </style>

--- a/src/views/deck/card-editor/card-face-uploader.vue
+++ b/src/views/deck/card-editor/card-face-uploader.vue
@@ -13,6 +13,8 @@ import {
 } from '@/composables/card-editor/use-face-image-upload'
 import { cardImageUrl } from '@/api/media'
 import { CARD_ATTRIBUTES_DEFAULTS } from '@/utils/deck/defaults'
+import { emitSfx } from '@/sfx/bus'
+import { type SfxOptions } from '@/sfx/directive'
 import { playButtonTap } from '@/utils/animations/button-tap'
 import { bytesToMbLabel } from '@/utils/file-size'
 
@@ -66,6 +68,17 @@ const layout = computed(
 // corners; above/below give the image its own region to scope the dropzone to.
 const dropzone_mode = computed(() => (layout.value === 'behind' ? 'corners' : 'region'))
 const image_url = computed(() => (image_path.value ? cardImageUrl(image_path.value) : undefined))
+// In region mode the image is only part of the card, so hover is scoped to the
+// image region (the dropzone emits enter/leave). Empty cards (add button) and
+// behind layout (full-bleed image) use card-wide hover instead.
+const region_hover = computed(
+  () => has_image.value && !disabled && dropzone_mode.value === 'region'
+)
+// Behind/full-bleed plays the hover chime card-wide; region scopes it to the
+// image region (see onRegionPointerEnter), so the card stays silent there.
+const card_sfx = computed<SfxOptions | undefined>(() =>
+  has_image.value && dropzone_mode.value === 'corners' ? { hover: 'ui.click_07' } : undefined
+)
 
 const error_message = computed(() => {
   if (file_error.value === 'invalid-type') {
@@ -78,6 +91,22 @@ const error_message = computed(() => {
   }
   return ''
 })
+
+// Skip card-wide hover in region mode — the dropzone reports image-region hover.
+function onCardPointerEnter() {
+  if (!region_hover.value) onPointerEnter()
+}
+
+function onCardPointerLeave() {
+  if (!region_hover.value) onPointerLeave()
+}
+
+// Region mode scopes the hover chime to the image region; behind/full-bleed play
+// it card-wide via the card's own sfx prop.
+function onRegionPointerEnter() {
+  emitSfx('ui.click_07')
+  onPointerEnter()
+}
 
 function onAddClick() {
   if (addIcon.value) playButtonTap(addIcon.value, 0.35, { yoyo: true })
@@ -94,12 +123,12 @@ function onAddClick() {
     v-bind="card"
     :card_attributes="card_attributes"
     :error="error"
-    :sfx="has_image ? { hover: 'ui.click_07' } : undefined"
+    :sfx="card_sfx"
     :data-active="active || undefined"
     :data-dragging="dragging || undefined"
     :class="{ 'pointer-events-none': disabled }"
-    @pointerenter="onPointerEnter"
-    @pointerleave="onPointerLeave"
+    @pointerenter="onCardPointerEnter"
+    @pointerleave="onCardPointerLeave"
     @dragenter="onDragEnter"
     @dragleave="onDragLeave"
     @dragover="onDragOver"
@@ -176,6 +205,8 @@ function onAddClick() {
         :active="active"
         :disabled="disabled"
         :error="error_message"
+        @pointerenter="onRegionPointerEnter"
+        @pointerleave="onPointerLeave"
         @browse="openPicker"
         @remove="onRemove"
         @dismiss-error="onDismissError"

--- a/src/views/deck/card-editor/face-image-dropzone.vue
+++ b/src/views/deck/card-editor/face-image-dropzone.vue
@@ -48,7 +48,7 @@ const { t } = useI18n()
       icon-only
       icon-left="remove-image"
       data-theme="red-500"
-      class="face-image-dropzone__corner face-image-dropzone__corner--right"
+      class="absolute! top-(--face-image-padding) right-(--face-image-padding) z-30 transition-opacity duration-150"
       :class="active ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'"
       @click.stop="emit('remove')"
     >
@@ -62,7 +62,7 @@ const { t } = useI18n()
       icon-left="add-image"
       data-theme="blue-500"
       data-theme-dark="blue-650"
-      class="face-image-dropzone__corner face-image-dropzone__corner--left"
+      class="absolute! top-(--face-image-padding) left-(--face-image-padding) z-30 transition-opacity duration-150"
       :class="active ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'"
       @click.stop="emit('browse')"
     >
@@ -116,20 +116,6 @@ const { t } = useI18n()
   inset: 0;
   z-index: 20;
   pointer-events: none;
-}
-
-.face-image-dropzone__corner {
-  position: absolute;
-  top: var(--face-image-padding);
-  z-index: 30;
-
-  transition: opacity 0.15s ease;
-}
-.face-image-dropzone__corner--right {
-  right: var(--face-image-padding);
-}
-.face-image-dropzone__corner--left {
-  left: var(--face-image-padding);
 }
 
 .face-image-dropzone__overlay {

--- a/src/views/deck/card-editor/face-image-dropzone.vue
+++ b/src/views/deck/card-editor/face-image-dropzone.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
@@ -26,6 +27,14 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+
+// Behind/full-bleed images reach the card edges with a large corner radius, so
+// controls sit inset at the face padding to clear the rounded corner (matching
+// the text inset). Region images are inset already, so the remove button pokes
+// out past the image corner.
+const remove_position = computed(() =>
+  mode === 'corners' ? 'top-(--face-padding) right-(--face-padding)' : '-top-2 -right-2'
+)
 </script>
 
 <template>
@@ -48,8 +57,11 @@ const { t } = useI18n()
       icon-only
       icon-left="remove-image"
       data-theme="red-500"
-      class="absolute! top-(--face-image-padding) right-(--face-image-padding) z-30 transition-opacity duration-150"
-      :class="active ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'"
+      class="absolute! z-30 transition-opacity duration-150"
+      :class="[
+        remove_position,
+        active ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+      ]"
       @click.stop="emit('remove')"
     >
       {{ t('deck-view.card-editor.list-item.remove-image-button') }}
@@ -62,7 +74,7 @@ const { t } = useI18n()
       icon-left="add-image"
       data-theme="blue-500"
       data-theme-dark="blue-650"
-      class="absolute! top-(--face-image-padding) left-(--face-image-padding) z-30 transition-opacity duration-150"
+      class="absolute! top-(--face-padding) left-(--face-padding) z-30 transition-opacity duration-150"
       :class="active ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'"
       @click.stop="emit('browse')"
     >
@@ -103,10 +115,18 @@ const { t } = useI18n()
 </template>
 
 <style>
+/* Inherit the image region's radius so the image + scrim stay rounded without an
+   overflow:hidden wrapper (which would clip the poked-out remove button). */
 .face-image-dropzone[data-mode='region'] {
   position: relative;
   width: 100%;
   height: 100%;
+
+  border-radius: inherit;
+}
+
+.face-image-dropzone__image {
+  border-radius: inherit;
 }
 
 /* Corners mode overlays the whole face above the text so its controls sit on
@@ -116,6 +136,8 @@ const { t } = useI18n()
   inset: 0;
   z-index: 20;
   pointer-events: none;
+
+  border-radius: var(--face-radius);
 }
 
 .face-image-dropzone__overlay {
@@ -142,6 +164,7 @@ const { t } = useI18n()
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
 
+  border-radius: inherit;
   color: var(--color-brown-700);
   opacity: 0;
 }

--- a/src/views/deck/card-editor/face-image-dropzone.vue
+++ b/src/views/deck/card-editor/face-image-dropzone.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import UiButton from '@/components/ui-kit/button.vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
+
+type FaceImageDropzoneProps = {
+  mode: 'region' | 'corners'
+  image?: string
+  active?: boolean
+  disabled?: boolean
+  error?: string
+}
+
+const {
+  mode,
+  image,
+  active = false,
+  disabled = false,
+  error
+} = defineProps<FaceImageDropzoneProps>()
+
+const emit = defineEmits<{
+  (e: 'browse'): void
+  (e: 'remove'): void
+  (e: 'dismiss-error'): void
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div
+    data-testid="face-image-dropzone"
+    :data-mode="mode"
+    :data-active="active || undefined"
+    class="face-image-dropzone"
+  >
+    <img
+      v-if="mode === 'region' && image"
+      data-testid="face-image-dropzone__image"
+      :src="image"
+      class="face-image-dropzone__image h-full w-full object-cover"
+    />
+
+    <ui-button
+      v-if="!disabled"
+      data-testid="face-image-dropzone__remove"
+      icon-only
+      icon-left="remove-image"
+      data-theme="red-500"
+      class="face-image-dropzone__corner face-image-dropzone__corner--right"
+      :class="active ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'"
+      @click.stop="emit('remove')"
+    >
+      {{ t('deck-view.card-editor.list-item.remove-image-button') }}
+    </ui-button>
+
+    <ui-button
+      v-if="mode === 'corners' && !disabled"
+      data-testid="face-image-dropzone__replace"
+      icon-only
+      icon-left="add-image"
+      data-theme="blue-500"
+      data-theme-dark="blue-650"
+      class="face-image-dropzone__corner face-image-dropzone__corner--left"
+      :class="active ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'"
+      @click.stop="emit('browse')"
+    >
+      {{ t('deck-view.card-editor.list-item.replace-image-button') }}
+    </ui-button>
+
+    <button
+      v-if="mode === 'region' && !disabled && !error"
+      type="button"
+      data-testid="face-image-dropzone__scrim"
+      class="face-image-dropzone__overlay face-image-dropzone__overlay--inset"
+      @click.stop="emit('browse')"
+    >
+      <ui-icon src="add-image" class="size-12" />
+      <p class="text-base">{{ t('deck-view.card-editor.list-item.replace-heading') }}</p>
+    </button>
+
+    <div
+      v-if="error"
+      data-testid="face-image-dropzone__error"
+      data-error
+      class="face-image-dropzone__overlay face-image-dropzone__overlay--inset"
+      @mousedown.stop
+      @click.stop="emit('browse')"
+    >
+      <ui-icon src="close" class="size-12" />
+      <p class="text-base">{{ error }}</p>
+      <ui-button
+        data-testid="face-image-dropzone__dismiss-error"
+        size="sm"
+        data-theme="red-500"
+        @click.stop="emit('dismiss-error')"
+      >
+        {{ t('deck-view.card-editor.list-item.dismiss-error-button') }}
+      </ui-button>
+    </div>
+  </div>
+</template>
+
+<style>
+.face-image-dropzone[data-mode='region'] {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+/* Corners mode overlays the whole face above the text so its controls sit on
+   top of a behind-layout image; the backdrop itself stays click-through. */
+.face-image-dropzone[data-mode='corners'] {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.face-image-dropzone__corner {
+  position: absolute;
+  top: var(--face-image-padding);
+  z-index: 30;
+
+  transition: opacity 0.15s ease;
+}
+.face-image-dropzone__corner--right {
+  right: var(--face-image-padding);
+}
+.face-image-dropzone__corner--left {
+  left: var(--face-image-padding);
+}
+
+.face-image-dropzone__overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding-inline: 1rem;
+
+  text-align: center;
+
+  cursor: pointer;
+  transition:
+    opacity 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.face-image-dropzone__overlay--inset {
+  background-color: color-mix(in srgb, var(--color-white) 85%, transparent);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+
+  color: var(--color-brown-700);
+  opacity: 0;
+}
+
+[data-theme='dark'] .face-image-dropzone__overlay--inset {
+  background-color: color-mix(in srgb, var(--color-stone-700) 85%, transparent);
+  color: var(--color-brown-100);
+}
+
+.face-image-dropzone[data-active] .face-image-dropzone__overlay--inset {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.face-image-dropzone__overlay[data-error] {
+  pointer-events: auto;
+  color: var(--color-red-500);
+  opacity: 1;
+}
+
+/* Dragging a file over an image turns the replace scrim blue, matching the
+   empty-card drop affordance. */
+.card-container--edit[data-dragging] .face-image-dropzone__overlay:not([data-error]) {
+  color: var(--color-blue-500);
+}
+
+[data-theme='dark']
+  .card-container--edit[data-dragging]
+  .face-image-dropzone__overlay:not([data-error]) {
+  color: var(--color-blue-650);
+}
+</style>

--- a/tests/integration/components/card/card-face.test.js
+++ b/tests/integration/components/card/card-face.test.js
@@ -1,0 +1,144 @@
+import { describe, test, expect, vi } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import CardFace from '@/components/card/card-face.vue'
+
+// TextEditor stub — no real rendering needed; just suppresses warnings
+const TextEditorStub = defineComponent({
+  name: 'TextEditor',
+  props: ['content', 'attributes', 'disabled'],
+  setup: () => () => h('div', { 'data-testid': 'text-editor-stub' })
+})
+
+vi.mock('gsap', () => ({ gsap: { fromTo: vi.fn(), to: vi.fn() } }))
+
+function mountFace(props = {}, slots = {}) {
+  return shallowMount(CardFace, {
+    props,
+    slots,
+    global: {
+      stubs: { TextEditor: TextEditorStub }
+    }
+  })
+}
+
+describe('CardFace', () => {
+  // ── data-layout attribute ────────────────────────────────────────────────────
+
+  test('data-layout defaults to "above" when no attributes provided', () => {
+    const wrapper = mountFace()
+    expect(wrapper.find('.card-face').attributes('data-layout')).toBe('above')
+  })
+
+  test('data-layout defaults to "above" when attributes has no image_layout', () => {
+    const wrapper = mountFace({ attributes: { text_align: 'center' } })
+    expect(wrapper.find('.card-face').attributes('data-layout')).toBe('above')
+  })
+
+  test('data-layout equals attributes.image_layout when set to "below"', () => {
+    const wrapper = mountFace({ attributes: { image_layout: 'below' } })
+    expect(wrapper.find('.card-face').attributes('data-layout')).toBe('below')
+  })
+
+  test('data-layout equals attributes.image_layout when set to "behind"', () => {
+    const wrapper = mountFace({ attributes: { image_layout: 'behind' } })
+    expect(wrapper.find('.card-face').attributes('data-layout')).toBe('behind')
+  })
+
+  test('data-layout equals attributes.image_layout when set to "above"', () => {
+    const wrapper = mountFace({ attributes: { image_layout: 'above' } })
+    expect(wrapper.find('.card-face').attributes('data-layout')).toBe('above')
+  })
+
+  // ── data-image / data-text attributes ───────────────────────────────────────
+
+  test('data-image is false when no image prop', () => {
+    const wrapper = mountFace({ text: 'hello' })
+    expect(wrapper.find('.card-face').attributes('data-image')).toBe('false')
+  })
+
+  test('data-image is true when image prop is provided', () => {
+    const wrapper = mountFace({ image: 'https://example.com/img.jpg' })
+    expect(wrapper.find('.card-face').attributes('data-image')).toBe('true')
+  })
+
+  test('data-text is false when no text prop', () => {
+    const wrapper = mountFace({ image: 'https://example.com/img.jpg' })
+    expect(wrapper.find('.card-face').attributes('data-text')).toBe('false')
+  })
+
+  test('data-text is true when text prop is provided', () => {
+    const wrapper = mountFace({ text: 'hello' })
+    expect(wrapper.find('.card-face').attributes('data-text')).toBe('true')
+  })
+
+  // ── Image region and text region render simultaneously ───────────────────────
+  // Core feature: old XOR behavior gone; both regions always render.
+
+  test('renders both image-region and text-region when only image is present [obligation]', () => {
+    const wrapper = mountFace({ image: 'https://example.com/img.jpg' })
+    expect(wrapper.find('[data-testid="card-face__image-region"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="card-face__text-region"]').exists()).toBe(true)
+  })
+
+  test('renders both image-region and text-region when only text is present [obligation]', () => {
+    const wrapper = mountFace({ text: 'hello' })
+    expect(wrapper.find('[data-testid="card-face__image-region"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="card-face__text-region"]').exists()).toBe(true)
+  })
+
+  test('renders both image-region and text-region when both image and text are present [obligation]', () => {
+    const wrapper = mountFace({ image: 'https://example.com/img.jpg', text: 'hello' })
+    expect(wrapper.find('[data-testid="card-face__image-region"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="card-face__text-region"]').exists()).toBe(true)
+  })
+
+  test('renders both image-region and text-region when neither image nor text is provided', () => {
+    const wrapper = mountFace()
+    expect(wrapper.find('[data-testid="card-face__image-region"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="card-face__text-region"]').exists()).toBe(true)
+  })
+
+  // ── Default image slot: renders <img> when image prop is present ─────────────
+
+  test('renders img element inside image-region when image prop is set', () => {
+    const wrapper = mountFace({ image: 'https://example.com/img.jpg' })
+    const img = wrapper.find('[data-testid="card-face__image"]')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe('https://example.com/img.jpg')
+  })
+
+  test('does not render img element when image prop is absent', () => {
+    const wrapper = mountFace()
+    expect(wrapper.find('[data-testid="card-face__image"]').exists()).toBe(false)
+  })
+
+  // ── Custom #image slot replaces the default img ──────────────────────────────
+
+  test('renders the #image slot content instead of the default img', () => {
+    const wrapper = mountFace(
+      { image: 'https://example.com/img.jpg' },
+      { image: '<div data-testid="custom-image-slot">Custom</div>' }
+    )
+    // The slot replaces the default img
+    expect(wrapper.find('[data-testid="custom-image-slot"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="card-face__image"]').exists()).toBe(false)
+  })
+
+  // ── data-mode attribute ─────────────────────────────────────────────────────
+
+  test('sets data-mode to "view" when mode prop is view', () => {
+    const wrapper = mountFace({ mode: 'view' })
+    expect(wrapper.find('.card-face').attributes('data-mode')).toBe('view')
+  })
+
+  test('sets data-mode to "edit" when mode prop is edit', () => {
+    const wrapper = mountFace({ mode: 'edit' })
+    expect(wrapper.find('.card-face').attributes('data-mode')).toBe('edit')
+  })
+
+  test('data-mode is absent when mode prop is not provided', () => {
+    const wrapper = mountFace()
+    expect(wrapper.find('.card-face').attributes('data-mode')).toBeUndefined()
+  })
+})

--- a/tests/integration/components/card/index.test.js
+++ b/tests/integration/components/card/index.test.js
@@ -1,12 +1,31 @@
 import { describe, test, expect, vi } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
 import Card from '@/components/card/index.vue'
 
 // Stub GSAP so transition hooks don't error in jsdom
 vi.mock('gsap', () => ({ gsap: { fromTo: vi.fn(), to: vi.fn() } }))
 
-function mountCard(props = {}) {
-  return shallowMount(Card, { props: { side: 'front', ...props } })
+// CardFace stub that renders its #image and #editor named slots so slot-
+// forwarding tests can observe what the Card passes through.
+const CardFaceStub = defineComponent({
+  name: 'CardFace',
+  props: ['image', 'text', 'mode', 'attributes'],
+  setup(props, { slots }) {
+    return () =>
+      h('div', { 'data-testid': 'card-face-stub', 'data-image': props.image }, [
+        h('div', { 'data-testid': 'card-face-stub__image-slot' }, slots.image?.()),
+        h('div', { 'data-testid': 'card-face-stub__editor-slot' }, slots.editor?.())
+      ])
+  }
+})
+
+function mountCard(props = {}, slots = {}) {
+  return shallowMount(Card, {
+    props: { side: 'front', ...props },
+    slots,
+    global: { stubs: { CardFace: CardFaceStub }, directives: { sfx: {} } }
+  })
 }
 
 describe('Card (cover side)', () => {
@@ -59,5 +78,57 @@ describe('Card (cover side)', () => {
     // Binding uses `error || undefined` so the attribute is absent when false
     // and present when true; we don't assert a specific value string.
     expect(wrapper.find('[data-testid="card"]').attributes('data-error')).toBeDefined()
+  })
+})
+
+describe('Card slot-forwarding [obligation]', () => {
+  // ── #image slot forwarding ────────────────────────────────────────────────────
+  // The card forwards the caller's #image slot to the active face's #image slot.
+  // When no #image slot is provided the face uses its default <img> from the
+  // `image` prop. This is a regression guard — an unfilled forwarded slot must
+  // not blank out images in study/grid views.
+
+  test('forwards the #image slot to the front face', () => {
+    const wrapper = mountCard(
+      { side: 'front' },
+      { image: '<div data-testid="slot-content">x</div>' }
+    )
+    expect(wrapper.find('[data-testid="slot-content"]').exists()).toBe(true)
+  })
+
+  test('forwards the #image slot to the back face', () => {
+    const wrapper = mountCard(
+      { side: 'back' },
+      { image: '<div data-testid="slot-content">x</div>' }
+    )
+    expect(wrapper.find('[data-testid="slot-content"]').exists()).toBe(true)
+  })
+
+  test('renders default <img> from front_image_path when no #image slot is provided', () => {
+    const wrapper = mountCard({ side: 'front', front_image_path: 'cards/front.jpg' })
+    // The default slot in card-face renders an <img> — card-face-stub exposes
+    // via findComponent since shallowMount stubs the inner CardFace.
+    const face = wrapper.findComponent({ name: 'CardFace' })
+    expect(face.props('image')).toContain('cards/front.jpg')
+  })
+
+  test('renders default <img> from back_image_path when no #image slot is provided', () => {
+    const wrapper = mountCard({ side: 'back', back_image_path: 'cards/back.jpg' })
+    const face = wrapper.findComponent({ name: 'CardFace' })
+    expect(face.props('image')).toContain('cards/back.jpg')
+  })
+
+  test('passes card_attributes.front to the front face', () => {
+    const card_attributes = { front: { image_layout: 'behind' }, back: {} }
+    const wrapper = mountCard({ side: 'front', card_attributes })
+    const face = wrapper.findComponent({ name: 'CardFace' })
+    expect(face.props('attributes')).toEqual({ image_layout: 'behind' })
+  })
+
+  test('passes card_attributes.back to the back face', () => {
+    const card_attributes = { front: {}, back: { image_layout: 'below' } }
+    const wrapper = mountCard({ side: 'back', card_attributes })
+    const face = wrapper.findComponent({ name: 'CardFace' })
+    expect(face.props('attributes')).toEqual({ image_layout: 'below' })
   })
 })

--- a/tests/integration/views/deck/card-editor/card-face-uploader.test.js
+++ b/tests/integration/views/deck/card-editor/card-face-uploader.test.js
@@ -1,18 +1,50 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
 import { shallowMount, flushPromises } from '@vue/test-utils'
-import { defineComponent, h, useAttrs } from 'vue'
+import { defineComponent, h, ref, useAttrs } from 'vue'
 
-// Card stub: render the default + editor slots and forward attrs so the
+// Card stub: render the default + image + editor slots and forward attrs so the
 // data-active, data-dragging flags, drag listeners, and pointer listeners
 // reach a real element.
 const CardStub = defineComponent({
   name: 'Card',
   inheritAttrs: false,
-  props: ['side', 'mode', 'size', 'error', 'sfx'],
+  props: ['side', 'mode', 'size', 'error', 'sfx', 'cardAttributes'],
   setup(_props, { slots }) {
     const attrs = useAttrs()
     return () =>
-      h('div', { ...attrs, 'data-testid': 'card-root' }, [slots.default?.(), slots.editor?.()])
+      h('div', { ...attrs, 'data-testid': 'card-root' }, [
+        slots.default?.(),
+        slots.image?.(),
+        slots.editor?.()
+      ])
+  }
+})
+
+// FaceImageDropzone stub: surfaces the controls it owns as testid'd buttons and
+// re-emits, so the uploader's wiring (remove/browse/dismiss) can be asserted.
+const FaceImageDropzoneStub = defineComponent({
+  name: 'FaceImageDropzone',
+  inheritAttrs: false,
+  props: ['mode', 'image', 'active', 'disabled', 'error'],
+  emits: ['browse', 'remove', 'dismiss-error'],
+  setup(props, { emit }) {
+    return () =>
+      h('div', { 'data-testid': 'face-image-dropzone', 'data-mode': props.mode }, [
+        h('button', {
+          'data-testid': 'face-image-dropzone__remove',
+          onClick: () => emit('remove')
+        }),
+        h('button', {
+          'data-testid': 'face-image-dropzone__scrim',
+          onClick: () => emit('browse')
+        }),
+        props.error
+          ? h('button', {
+              'data-testid': 'face-image-dropzone__error',
+              onClick: () => emit('browse')
+            })
+          : null
+      ])
   }
 })
 
@@ -90,7 +122,7 @@ function dropImage(wrapper, file) {
 let _wrapper
 
 function mount(props = {}) {
-  const { card, ...rest } = props
+  const { card, cardEditor, ...rest } = props
   _wrapper = shallowMount(CardFaceUploader, {
     props: { side: 'front', card: makeCard(card), ...rest },
     global: {
@@ -98,10 +130,17 @@ function mount(props = {}) {
         Card: CardStub,
         UiButton: UiButtonStub,
         UiIcon: UiIconStub,
-        UiTooltip: UiTooltipStub
+        UiTooltip: UiTooltipStub,
+        FaceImageDropzone: FaceImageDropzoneStub
       },
       directives: { sfx: {} },
-      provide: { 'card-editor': { setFaceImage: mocks.setFaceImageMock } }
+      provide: {
+        'card-editor': {
+          setFaceImage: mocks.setFaceImageMock,
+          card_attributes: ref({ front: {}, back: {} }),
+          ...cardEditor
+        }
+      }
     }
   })
   return _wrapper
@@ -143,19 +182,32 @@ describe('CardFaceUploader', () => {
     expect(wrapper.find('[data-testid="card-face-uploader__add"]').exists()).toBe(false)
   })
 
-  test('hides add and remove controls when disabled (selection mode)', () => {
+  test('hides add control and the image dropzone when disabled (selection mode)', () => {
     const wrapper = mount({ card: { id: 5, front_image_path: 'cards/f.png' }, disabled: true })
     expect(wrapper.find('[data-testid="card-face-uploader__add"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="card-face-uploader__remove"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="face-image-dropzone"]').exists()).toBe(false)
   })
 
   // ── Image face ────────────────────────────────────────────────────────────────
 
-  test('shows the remove button and replace scrim on a face that has an image', () => {
+  test('renders the region dropzone on a face that has an image', () => {
     const wrapper = mount({ card: { front_image_path: 'cards/f.png' } })
-    expect(wrapper.find('[data-testid="card-face-uploader__remove"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="card-face-uploader__scrim"]').exists()).toBe(true)
+    const dropzone = wrapper.find('[data-testid="face-image-dropzone"]')
+    expect(dropzone.exists()).toBe(true)
+    expect(dropzone.attributes('data-mode')).toBe('region')
+    expect(wrapper.find('[data-testid="face-image-dropzone__remove"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="face-image-dropzone__scrim"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="card-face-uploader__add"]').exists()).toBe(false)
+  })
+
+  test('renders the corners dropzone for a behind-layout image', () => {
+    const wrapper = mount({
+      card: { front_image_path: 'cards/f.png' },
+      cardEditor: { card_attributes: ref({ front: { image_layout: 'behind' }, back: {} }) }
+    })
+    const dropzone = wrapper.find('[data-testid="face-image-dropzone"]')
+    expect(dropzone.exists()).toBe(true)
+    expect(dropzone.attributes('data-mode')).toBe('corners')
   })
 
   // ── Activation (hover / drag) ─────────────────────────────────────────────────
@@ -338,12 +390,12 @@ describe('CardFaceUploader', () => {
     const wrapper = mount({ card: { id: 5, front_image_path: 'cards/f.png' } })
     await dropImage(wrapper, new File(['x'], 'a.txt', { type: 'text/plain' }))
     await flushPromises()
-    expect(wrapper.find('[data-testid="card-face-uploader__error"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="face-image-dropzone__error"]').exists()).toBe(true)
 
-    await wrapper.find('[data-testid="card-face-uploader__remove"]').trigger('click')
+    await wrapper.find('[data-testid="face-image-dropzone__remove"]').trigger('click')
     await flushPromises()
 
-    expect(wrapper.find('[data-testid="card-face-uploader__error"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="face-image-dropzone__error"]').exists()).toBe(false)
   })
 
   // ── data-active stays truthy while error is showing ───────────────────────
@@ -468,7 +520,7 @@ describe('CardFaceUploader', () => {
 
   test('remove button calls setFaceImage(id, side, null) and plays trash_crumple_short', async () => {
     const wrapper = mount({ card: { id: 5, front_image_path: 'cards/f.png' } })
-    await wrapper.find('[data-testid="card-face-uploader__remove"]').trigger('click')
+    await wrapper.find('[data-testid="face-image-dropzone__remove"]').trigger('click')
     await flushPromises()
 
     expect(mocks.setFaceImageMock).toHaveBeenCalledWith(5, 'front', null)

--- a/tests/integration/views/deck/card-editor/card-face-uploader.test.js
+++ b/tests/integration/views/deck/card-editor/card-face-uploader.test.js
@@ -212,8 +212,33 @@ describe('CardFaceUploader', () => {
 
   // ── Activation (hover / drag) ─────────────────────────────────────────────────
 
-  test('marks the card active on hover and clears it on leave', async () => {
+  test('card-root pointerenter does NOT set data-active in region mode (hover scoped to image region)', async () => {
+    // above/below layout — hover must be scoped to the image region, not the whole card
     const wrapper = mount({ card: { front_image_path: 'cards/f.png' } })
+    const root = wrapper.find('[data-testid="card-root"]')
+    expect(root.attributes('data-active')).toBeUndefined()
+
+    await root.trigger('pointerenter')
+    expect(root.attributes('data-active')).toBeUndefined()
+  })
+
+  test('card-root pointerenter DOES set data-active in behind mode (full-bleed, card-wide hover)', async () => {
+    const wrapper = mount({
+      card: { front_image_path: 'cards/f.png' },
+      cardEditor: { card_attributes: ref({ front: { image_layout: 'behind' }, back: {} }) }
+    })
+    const root = wrapper.find('[data-testid="card-root"]')
+    expect(root.attributes('data-active')).toBeUndefined()
+
+    await root.trigger('pointerenter')
+    expect(root.attributes('data-active')).toBe('true')
+
+    await root.trigger('pointerleave')
+    expect(root.attributes('data-active')).toBeUndefined()
+  })
+
+  test('card-root pointerenter DOES set data-active on an empty card (no image)', async () => {
+    const wrapper = mount({ card: { id: 5 } })
     const root = wrapper.find('[data-testid="card-root"]')
     expect(root.attributes('data-active')).toBeUndefined()
 
@@ -586,10 +611,19 @@ describe('CardFaceUploader', () => {
 
   // ── sfx prop on the Card ──────────────────────────────────────────────────
 
-  test('passes sfx hover prop to Card when the face has an image', () => {
-    const wrapper = mount({ card: { front_image_path: 'cards/f.png' } })
+  test('passes the hover sfx to Card for a behind-layout image (full-bleed, card-wide hover)', () => {
+    const wrapper = mount({
+      card: { front_image_path: 'cards/f.png' },
+      cardEditor: { card_attributes: ref({ front: { image_layout: 'behind' }, back: {} }) }
+    })
     const cardEl = wrapper.findComponent(CardStub)
     expect(cardEl.props('sfx')).toEqual({ hover: 'ui.click_07' })
+  })
+
+  test('does NOT pass card sfx in region mode (hover sfx is scoped to the image region)', () => {
+    const wrapper = mount({ card: { front_image_path: 'cards/f.png' } })
+    const cardEl = wrapper.findComponent(CardStub)
+    expect(cardEl.props('sfx')).toBeUndefined()
   })
 
   test('does NOT pass sfx prop to Card when the face has no image', () => {

--- a/tests/integration/views/deck/card-editor/face-image-dropzone.test.js
+++ b/tests/integration/views/deck/card-editor/face-image-dropzone.test.js
@@ -1,0 +1,203 @@
+import { describe, test, expect, vi } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h, useAttrs } from 'vue'
+import FaceImageDropzone from '@/views/deck/card-editor/face-image-dropzone.vue'
+
+// UiButton stub: forward attrs + native clicks, render default slot
+const UiButtonStub = defineComponent({
+  name: 'UiButton',
+  inheritAttrs: false,
+  props: ['iconOnly', 'iconLeft', 'size'],
+  setup(_p, { slots }) {
+    const attrs = useAttrs()
+    return () => h('button', attrs, slots.default?.())
+  }
+})
+
+// UiIcon stub: no output needed
+const UiIconStub = defineComponent({
+  name: 'UiIcon',
+  props: ['src'],
+  setup: () => () => h('i')
+})
+
+function mountDropzone(props = {}) {
+  return shallowMount(FaceImageDropzone, {
+    props,
+    global: {
+      stubs: { UiButton: UiButtonStub, UiIcon: UiIconStub },
+      directives: { sfx: {} }
+    }
+  })
+}
+
+describe('FaceImageDropzone', () => {
+  // ── data-mode attribute ─────────────────────────────────────────────────────
+
+  test('renders with data-mode="region" in region mode', () => {
+    const wrapper = mountDropzone({ mode: 'region' })
+    expect(wrapper.find('[data-testid="face-image-dropzone"]').attributes('data-mode')).toBe(
+      'region'
+    )
+  })
+
+  test('renders with data-mode="corners" in corners mode', () => {
+    const wrapper = mountDropzone({ mode: 'corners' })
+    expect(wrapper.find('[data-testid="face-image-dropzone"]').attributes('data-mode')).toBe(
+      'corners'
+    )
+  })
+
+  // ── region mode structure [obligation] ──────────────────────────────────────
+
+  test('region mode renders the <img> when image prop is set [obligation]', () => {
+    const wrapper = mountDropzone({ mode: 'region', image: 'https://example.com/img.jpg' })
+    const img = wrapper.find('[data-testid="face-image-dropzone__image"]')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe('https://example.com/img.jpg')
+  })
+
+  test('region mode does NOT render the img when image prop is absent', () => {
+    const wrapper = mountDropzone({ mode: 'region' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__image"]').exists()).toBe(false)
+  })
+
+  test('region mode renders the __scrim when no error [obligation]', () => {
+    const wrapper = mountDropzone({ mode: 'region', image: 'https://example.com/img.jpg' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__scrim"]').exists()).toBe(true)
+  })
+
+  test('region mode renders the __remove button [obligation]', () => {
+    const wrapper = mountDropzone({ mode: 'region', image: 'https://example.com/img.jpg' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__remove"]').exists()).toBe(true)
+  })
+
+  test('region mode does NOT render the __replace button', () => {
+    const wrapper = mountDropzone({ mode: 'region', image: 'https://example.com/img.jpg' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__replace"]').exists()).toBe(false)
+  })
+
+  // ── corners mode structure [obligation] ─────────────────────────────────────
+
+  test('corners mode renders the __remove button [obligation]', () => {
+    const wrapper = mountDropzone({ mode: 'corners' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__remove"]').exists()).toBe(true)
+  })
+
+  test('corners mode renders the __replace button [obligation]', () => {
+    const wrapper = mountDropzone({ mode: 'corners' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__replace"]').exists()).toBe(true)
+  })
+
+  test('corners mode does NOT render the __scrim [obligation]', () => {
+    const wrapper = mountDropzone({ mode: 'corners' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__scrim"]').exists()).toBe(false)
+  })
+
+  test('corners mode does NOT render the <img>', () => {
+    const wrapper = mountDropzone({ mode: 'corners', image: 'https://example.com/img.jpg' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__image"]').exists()).toBe(false)
+  })
+
+  // ── disabled prop hides controls ────────────────────────────────────────────
+
+  test('hides the __remove button when disabled in region mode', () => {
+    const wrapper = mountDropzone({
+      mode: 'region',
+      image: 'https://example.com/img.jpg',
+      disabled: true
+    })
+    expect(wrapper.find('[data-testid="face-image-dropzone__remove"]').exists()).toBe(false)
+  })
+
+  test('hides the __replace button when disabled in corners mode', () => {
+    const wrapper = mountDropzone({ mode: 'corners', disabled: true })
+    expect(wrapper.find('[data-testid="face-image-dropzone__replace"]').exists()).toBe(false)
+  })
+
+  test('hides the __scrim when disabled in region mode', () => {
+    const wrapper = mountDropzone({
+      mode: 'region',
+      image: 'https://example.com/img.jpg',
+      disabled: true
+    })
+    expect(wrapper.find('[data-testid="face-image-dropzone__scrim"]').exists()).toBe(false)
+  })
+
+  // ── error prop [obligation] ─────────────────────────────────────────────────
+
+  test('truthy error renders the __error element [obligation]', () => {
+    const wrapper = mountDropzone({ mode: 'region', error: 'File too large' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__error"]').exists()).toBe(true)
+  })
+
+  test('__error contains the dismiss button [obligation]', () => {
+    const wrapper = mountDropzone({ mode: 'region', error: 'File too large' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__dismiss-error"]').exists()).toBe(true)
+  })
+
+  test('no error: __error element is absent', () => {
+    const wrapper = mountDropzone({ mode: 'region' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__error"]').exists()).toBe(false)
+  })
+
+  test('error hides the __scrim in region mode (both cannot show simultaneously)', () => {
+    const wrapper = mountDropzone({ mode: 'region', error: 'File too large' })
+    expect(wrapper.find('[data-testid="face-image-dropzone__scrim"]').exists()).toBe(false)
+  })
+
+  // ── event contracts [obligation] ────────────────────────────────────────────
+
+  test('__scrim click emits browse [obligation]', async () => {
+    const wrapper = mountDropzone({ mode: 'region', image: 'https://example.com/img.jpg' })
+    await wrapper.find('[data-testid="face-image-dropzone__scrim"]').trigger('click')
+    expect(wrapper.emitted('browse')).toHaveLength(1)
+  })
+
+  test('__replace click emits browse in corners mode [obligation]', async () => {
+    const wrapper = mountDropzone({ mode: 'corners' })
+    await wrapper.find('[data-testid="face-image-dropzone__replace"]').trigger('click')
+    expect(wrapper.emitted('browse')).toHaveLength(1)
+  })
+
+  test('__remove click emits remove [obligation]', async () => {
+    const wrapper = mountDropzone({ mode: 'region', image: 'https://example.com/img.jpg' })
+    await wrapper.find('[data-testid="face-image-dropzone__remove"]').trigger('click')
+    expect(wrapper.emitted('remove')).toHaveLength(1)
+  })
+
+  test('__dismiss-error button emits dismiss-error [obligation]', async () => {
+    const wrapper = mountDropzone({ mode: 'region', error: 'File too large' })
+    await wrapper.find('[data-testid="face-image-dropzone__dismiss-error"]').trigger('click')
+    expect(wrapper.emitted('dismiss-error')).toHaveLength(1)
+  })
+
+  test('__error click emits browse (re-pick after error) [obligation]', async () => {
+    const wrapper = mountDropzone({ mode: 'region', error: 'File too large' })
+    await wrapper.find('[data-testid="face-image-dropzone__error"]').trigger('click')
+    expect(wrapper.emitted('browse')).toHaveLength(1)
+  })
+
+  // ── data-active attribute ───────────────────────────────────────────────────
+
+  test('sets data-active on the root when active is true', () => {
+    const wrapper = mountDropzone({ mode: 'region', active: true })
+    expect(wrapper.find('[data-testid="face-image-dropzone"]').attributes('data-active')).toBe(
+      'true'
+    )
+  })
+
+  test('data-active is absent on the root when active is false', () => {
+    const wrapper = mountDropzone({ mode: 'region', active: false })
+    expect(
+      wrapper.find('[data-testid="face-image-dropzone"]').attributes('data-active')
+    ).toBeUndefined()
+  })
+
+  test('data-active defaults to absent when active prop is omitted', () => {
+    const wrapper = mountDropzone({ mode: 'region' })
+    expect(
+      wrapper.find('[data-testid="face-image-dropzone"]').attributes('data-active')
+    ).toBeUndefined()
+  })
+})

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -40,7 +40,7 @@ const mocks = vi.hoisted(() => ({
   emitSfxMock: vi.fn()
 }))
 
-vi.mock('@/sfx/bus', () => ({ emitSfx: mocks.emitSfxMock }))
+vi.mock('@/sfx/bus', () => ({ emitSfx: mocks.emitSfxMock, emitHoverSfx: vi.fn() }))
 
 import ListItemCard from '@/views/deck/card-editor/list-item-card.vue'
 import textEditor from '@/components/text-editor/text-editor.vue'


### PR DESCRIPTION
## Summary

Implements the per-side card **image layout** setting (`above` / `below` / `behind`) that the deck settings modal already persisted to `decks.card_attributes` but nothing consumed.

- **`card-face` renders image + text as layout regions** instead of image-XOR-text. A card can now show an image *and* text, positioned by `image_layout`. Because `card-face` is the shared render path, this flows to the study view and the settings preview for free (the preview now renders the real `card-face`, so it can't drift).
- **Reworked the editor image interaction per layout:** a region-scoped replace scrim + dashed frame for `above`/`below`, floating corner controls for `behind` (no scrim, so text stays editable over the image). Hover activation and the hover chime are scoped to the image region in `above`/`below`; `behind`/empty cards keep card-wide hover.
- **Extracted for reuse:** `useFaceImageUpload` (the upload state machine) and `face-image-dropzone` (the region/corners overlay), slimming `card-face-uploader`.

No schema or API changes — the column and settings UI already existed.