### PR TITLE
feat(ui-kit): dropdown-button primitive

### DIFF
--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -51,6 +51,8 @@ const merged_sfx = computed(() => {
 
 const tooltip_active = computed(() => iconOnly && !!slots.default)
 
+const has_trailing = computed(() => !!slots.trailing)
+
 function onCaptureClick(e: MouseEvent) {
   if (!playOnTap) return
   const handler = attrs.onClick as ((ev: MouseEvent) => void) | undefined
@@ -90,16 +92,23 @@ function emitClickSfx() {
       {
         'ui-kit-btn--icon-only': iconOnly,
         'ui-kit-btn--inverted': inverted,
+        'ui-kit-btn--split': has_trailing,
         'rounded-full!': roundedFull,
         'w-full!': fullWidth
       }
     ]"
   >
-    <ui-icon v-if="iconLeft" class="btn-icon btn-icon--left" :src="iconLeft" />
-    <div v-if="!iconOnly" class="btn-label">
-      <slot></slot>
+    <div class="btn-content" data-testid="ui-kit-button__content">
+      <ui-icon v-if="iconLeft" class="btn-icon btn-icon--left" :src="iconLeft" />
+      <div v-if="!iconOnly" class="btn-label">
+        <slot></slot>
+      </div>
+      <ui-icon v-if="iconRight" class="btn-icon btn-icon--right" :src="iconRight" />
     </div>
-    <ui-icon v-if="iconRight" class="btn-icon btn-icon--right" :src="iconRight" />
+
+    <div v-if="has_trailing" class="btn-trailing" data-testid="ui-kit-button__trailing">
+      <slot name="trailing"></slot>
+    </div>
 
     <div
       class="absolute inset-0 bgx-diagonal-stripes animation-safe:bgx-slide rounded-(--btn-border-radius) pointer-events-none"
@@ -132,18 +141,28 @@ function emitClickSfx() {
 
   outline: var(--btn-outline-width, 0) solid var(--btn-outline-color);
   border-radius: var(--btn-border-radius);
-  padding: var(--btn-padding);
   height: var(--btn-height, max-content);
   width: max-content;
 
   flex-grow: 0;
 
   display: flex;
+  align-items: stretch;
+  user-select: none;
+  cursor: pointer;
+}
+
+/* Inner container carries the padding + gap so the trailing slot can sit flush
+   in the raw, unpadded button and style itself freely. */
+.ui-kit-btn .btn-content {
+  flex: 1;
+
+  display: flex;
   gap: var(--btn-gap);
   align-items: center;
   justify-content: center;
-  user-select: none;
-  cursor: pointer;
+
+  padding: var(--btn-padding);
 }
 
 .ui-kit-btn--solid {
@@ -193,20 +212,31 @@ function emitClickSfx() {
   aspect-ratio: 1/1;
 }
 
-/* Button sizes */
-.ui-kit-btn.ui-kit-btn--xl {
+.ui-kit-btn .btn-trailing {
+  display: flex;
+}
+.ui-kit-btn--split .btn-content {
+  justify-content: flex-start;
+}
+
+/* Button sizes — the `-tokens-` alias exposes the same custom properties to
+   non-button elements (e.g. the dropdown-button menu) without the base layout. */
+.ui-kit-btn.ui-kit-btn--xl,
+.ui-kit-btn-tokens--xl {
   --btn-font-size: var(--text-xl);
   --btn-font-size--line-height: var(--text-xl--line-height);
   --btn-border-radius: 22.5px;
   --btn-gap: 10px;
   --btn-padding: 14px 24px;
   --btn-height: 50px;
+  --icon-size: 18px;
 
   &.ui-kit-btn--icon-only {
     --btn-padding: 14px;
   }
 }
-.ui-kit-btn.ui-kit-btn--lg {
+.ui-kit-btn.ui-kit-btn--lg,
+.ui-kit-btn-tokens--lg {
   --btn-font-size: var(--text-xl);
   --btn-font-size--line-height: var(--text-xl--line-height);
   --btn-border-radius: 19px;
@@ -219,7 +249,8 @@ function emitClickSfx() {
     --btn-padding: 10px;
   }
 }
-.ui-kit-btn.ui-kit-btn--base {
+.ui-kit-btn.ui-kit-btn--base,
+.ui-kit-btn-tokens--base {
   --btn-font-size: var(--text-lg);
   --btn-font-size--line-height: var(--text-lg--line-height);
   --btn-border-radius: 18px;
@@ -233,7 +264,8 @@ function emitClickSfx() {
     --btn-padding: 8px;
   }
 }
-.ui-kit-btn.ui-kit-btn--sm {
+.ui-kit-btn.ui-kit-btn--sm,
+.ui-kit-btn-tokens--sm {
   --btn-font-size: var(--text-base);
   --btn-font-size--line-height: var(--text-base--line-height);
   --btn-border-radius: 13px;

--- a/src/components/ui-kit/dropdown-button/index.vue
+++ b/src/components/ui-kit/dropdown-button/index.vue
@@ -1,0 +1,279 @@
+<script setup lang="ts">
+import { computed, ref, useAttrs } from 'vue'
+import type { Placement } from '@floating-ui/vue'
+import UiButton, { type ButtonProps } from '../button.vue'
+import UiPopover from '@/components/ui-kit/popover.vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
+import { emitSfx } from '@/sfx/bus'
+import { flipEnter, flipLeave } from '@/utils/animations/flip'
+import { useDropdownSizing } from './use-dropdown-sizing'
+
+type DropdownOption = {
+  label: string
+  value: string | number
+  icon?: string
+}
+
+type DropdownButtonProps = Pick<
+  ButtonProps,
+  'size' | 'variant' | 'inverted' | 'fullWidth' | 'iconLeft' | 'sfx'
+> & {
+  options: DropdownOption[]
+  position?: Placement
+  triggerIcon?: string
+  gap?: number
+}
+
+defineOptions({ inheritAttrs: false })
+
+const {
+  options,
+  size = 'base',
+  variant = 'solid',
+  inverted,
+  fullWidth,
+  iconLeft,
+  sfx,
+  position = 'bottom-start',
+  triggerIcon = 'arrow-drop-down',
+  gap = 4
+} = defineProps<DropdownButtonProps>()
+
+const emit = defineEmits<{
+  (e: 'select', option: DropdownOption): void
+}>()
+
+const slots = defineSlots<{
+  default(): unknown
+}>()
+
+const attrs = useAttrs()
+const { triggerRef, sizerRef, min_width, trigger_width } = useDropdownSizing(() => options)
+
+const popover_open = ref(false)
+
+// Theme/class/layout attrs ride the popover container (its non-teleported
+// content inherits the theme), while event handlers — the consumer's primary
+// @click — land on the inner button so they fire only from the label region.
+const popover_attrs = computed(() => filter_attrs((key) => !key.startsWith('on')))
+const button_attrs = computed(() => filter_attrs((key) => key.startsWith('on')))
+
+const min_width_style = computed(() =>
+  min_width.value ? { minWidth: `${min_width.value}px` } : undefined
+)
+
+const menu_style = computed(() =>
+  trigger_width.value ? { width: `${trigger_width.value}px` } : undefined
+)
+
+function filter_attrs(keep: (key: string) => boolean) {
+  const result: Record<string, unknown> = {}
+  for (const key in attrs) {
+    if (keep(key)) result[key] = attrs[key]
+  }
+  return result
+}
+
+function toggle() {
+  emitSfx('ui.select', { blocking: true })
+  popover_open.value = !popover_open.value
+}
+
+function onCaretEnter(el: Element, done: () => void) {
+  flipEnter(el, 'x', done)
+}
+
+function onCaretLeave(el: Element, done: () => void) {
+  flipLeave(el, 'x', done)
+}
+
+function close() {
+  popover_open.value = false
+}
+
+function onSelect(option: DropdownOption) {
+  emit('select', option)
+  close()
+}
+</script>
+
+<template>
+  <ui-popover
+    :open="popover_open"
+    :position="position"
+    :gap="gap"
+    :use_arrow="false"
+    data-testid="dropdown-button"
+    v-bind="popover_attrs"
+    :class="{ 'z-100': popover_open }"
+    @close="close"
+  >
+    <template #trigger>
+      <ui-button
+        ref="triggerRef"
+        v-bind="button_attrs"
+        :size="size"
+        :variant="variant"
+        :inverted="inverted"
+        :full-width="fullWidth"
+        :icon-left="iconLeft"
+        :sfx="sfx"
+        :style="min_width_style"
+        data-testid="dropdown-button__button"
+      >
+        <slot></slot>
+        <template #trailing>
+          <div
+            class="ui-kit-dropdown-button__trigger-wrap"
+            data-testid="dropdown-button__trigger-wrap"
+          >
+            <transition mode="out-in" @enter="onCaretEnter" @leave="onCaretLeave">
+              <span
+                :key="String(popover_open)"
+                role="button"
+                tabindex="0"
+                aria-haspopup="menu"
+                :aria-expanded="popover_open"
+                :data-active="popover_open"
+                class="ui-kit-dropdown-button__trigger"
+                data-testid="dropdown-button__trigger"
+                v-sfx.hover="'ui.click_07'"
+                @click.stop="toggle"
+                @keydown.enter.space.stop.prevent="toggle"
+              >
+                <ui-icon
+                  :src="triggerIcon"
+                  class="ui-kit-dropdown-button__trigger-icon"
+                  :class="{ 'ui-kit-dropdown-button__trigger-icon--open': popover_open }"
+                />
+              </span>
+            </transition>
+          </div>
+        </template>
+      </ui-button>
+
+      <span
+        ref="sizerRef"
+        aria-hidden="true"
+        data-testid="dropdown-button__sizer"
+        :class="['ui-kit-dropdown-button__sizer', `ui-kit-btn-tokens--${size}`]"
+      >
+        <span v-for="option in options" :key="option.value" class="ui-kit-dropdown-button__row">
+          <ui-icon v-if="option.icon" :src="option.icon" class="ui-kit-dropdown-button__row-icon" />
+          <span>{{ option.label }}</span>
+        </span>
+      </span>
+    </template>
+
+    <div
+      :class="['ui-kit-dropdown-button__menu', `ui-kit-btn-tokens--${size}`]"
+      :style="menu_style"
+      data-testid="dropdown-button__menu"
+    >
+      <button
+        v-for="option in options"
+        :key="option.value"
+        type="button"
+        class="ui-kit-dropdown-button__row ui-kit-dropdown-button__option"
+        data-testid="dropdown-button__option"
+        @click="onSelect(option)"
+      >
+        <ui-icon v-if="option.icon" :src="option.icon" class="ui-kit-dropdown-button__row-icon" />
+        <span>{{ option.label }}</span>
+      </button>
+    </div>
+  </ui-popover>
+</template>
+
+<style>
+.ui-kit-dropdown-button__trigger-wrap {
+  display: flex;
+  height: 100%;
+  padding: 8px;
+}
+
+.ui-kit-dropdown-button__trigger {
+  position: relative;
+  z-index: 1;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  height: 100%;
+  aspect-ratio: 1;
+
+  background-color: var(--theme-secondary);
+  color: var(--theme-on-secondary);
+  border-radius: calc(var(--btn-border-radius) - 8px);
+  cursor: pointer;
+
+  transition: scale 120ms ease;
+}
+
+@media (hover: hover) {
+  .ui-kit-dropdown-button__trigger:hover {
+    scale: 1.1;
+  }
+}
+
+.ui-kit-dropdown-button__trigger-icon {
+  width: calc(var(--icon-size, 20px) - 6px);
+  height: calc(var(--icon-size, 20px) - 6px);
+}
+
+.ui-kit-dropdown-button__trigger-icon--open {
+  rotate: 180deg;
+}
+
+.ui-kit-dropdown-button__menu {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  border-radius: var(--btn-border-radius);
+
+  background-color: var(--theme-primary);
+  color: var(--theme-on-primary);
+  font-size: var(--btn-font-size);
+  line-height: var(--btn-font-size--line-height);
+}
+
+.ui-kit-dropdown-button__row {
+  display: flex;
+  align-items: center;
+  gap: var(--btn-gap);
+
+  padding: var(--btn-padding);
+  white-space: nowrap;
+}
+
+.ui-kit-dropdown-button__row-icon {
+  width: var(--icon-size, 20px);
+  height: var(--icon-size, 20px);
+}
+
+.ui-kit-dropdown-button__option {
+  width: 100%;
+  text-align: start;
+  cursor: pointer;
+}
+
+@media (hover: hover) {
+  .ui-kit-dropdown-button__option:hover {
+    background-color: color-mix(in srgb, var(--theme-on-primary) 14%, transparent);
+  }
+}
+
+.ui-kit-dropdown-button__sizer {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+
+  display: flex;
+  flex-direction: column;
+
+  visibility: hidden;
+  pointer-events: none;
+}
+</style>

--- a/src/components/ui-kit/dropdown-button/use-dropdown-sizing.ts
+++ b/src/components/ui-kit/dropdown-button/use-dropdown-sizing.ts
@@ -1,0 +1,50 @@
+import { onBeforeUnmount, onMounted, ref, watch, type ComponentPublicInstance } from 'vue'
+
+// Measures two widths so the dropdown can mirror the button:
+//  - `min_width`: the widest option row (drives the button's min-width so it is
+//    never narrower than its own menu items).
+//  - `trigger_width`: the button's actual rendered width (drives the menu width
+//    so the menu always matches the button).
+// `deps` is a reactive getter watched only to re-measure when options change —
+// its value is never read.
+export function useDropdownSizing(deps: () => unknown) {
+  const triggerRef = ref<ComponentPublicInstance | null>(null)
+  const sizerRef = ref<HTMLElement | null>(null)
+  const min_width = ref(0)
+  const trigger_width = ref(0)
+
+  let observer: ResizeObserver | null = null
+
+  function trigger_el() {
+    return (triggerRef.value?.$el ?? null) as HTMLElement | null
+  }
+
+  function measure() {
+    const sizer = sizerRef.value
+    if (sizer) min_width.value = Math.ceil(sizer.getBoundingClientRect().width)
+
+    const el = trigger_el()
+    if (el) trigger_width.value = Math.ceil(el.getBoundingClientRect().width)
+  }
+
+  onMounted(() => {
+    observer = new ResizeObserver(measure)
+    const sizer = sizerRef.value
+    const el = trigger_el()
+
+    if (sizer) observer.observe(sizer)
+    if (el) observer.observe(el)
+
+    measure()
+    document.fonts?.ready.then(measure)
+  })
+
+  onBeforeUnmount(() => {
+    observer?.disconnect()
+    observer = null
+  })
+
+  watch(deps, measure, { flush: 'post' })
+
+  return { triggerRef, sizerRef, min_width, trigger_width }
+}

--- a/src/utils/animations/flip.ts
+++ b/src/utils/animations/flip.ts
@@ -1,0 +1,36 @@
+import { gsap } from 'gsap'
+
+// The card's flip (src/components/card/index.vue), generalised so the rotation
+// axis can be chosen: 'y' flips horizontally (like the card), 'x' vertically.
+type FlipAxis = 'x' | 'y'
+
+const ROTATE = { x: 'rotateX', y: 'rotateY' } as const
+
+export function flipEnter(el: Element, axis: FlipAxis, done: () => void) {
+  gsap.fromTo(
+    el,
+    { [ROTATE[axis]]: -60, translateY: '-12px', scale: 0.95 },
+    {
+      [ROTATE[axis]]: 0,
+      translateY: 0,
+      scale: 1,
+      duration: 0.2,
+      ease: 'back.out(2)',
+      // The resting state is identity, so drop GSAP's inline transform on
+      // completion — otherwise it shadows CSS hover transforms (e.g. scale).
+      clearProps: 'transform',
+      onComplete: done
+    }
+  )
+}
+
+export function flipLeave(el: Element, axis: FlipAxis, done: () => void) {
+  gsap.to(el, {
+    [ROTATE[axis]]: 60,
+    translateY: '8px',
+    scale: 0.95,
+    duration: 0.12,
+    ease: 'expo.in',
+    onComplete: done
+  })
+}

--- a/tests/integration/components/ui-kit/button.test.js
+++ b/tests/integration/components/ui-kit/button.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h, useAttrs } from 'vue'
 
 const { coarseRef, mockEmitSfx } = vi.hoisted(() => ({
   coarseRef: { value: true },
@@ -22,8 +23,30 @@ vi.mock('@/sfx/bus', () => ({
 import UiButton from '@/components/ui-kit/button.vue'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
 
+// A UiTooltip stub that forwards attrs and renders slot content so inner
+// data-testid elements (ui-kit-button__content, ui-kit-button__trailing) are
+// accessible in tests that assert on button structure.
+const UiTooltipSlotStub = defineComponent({
+  name: 'UiTooltip',
+  inheritAttrs: false,
+  props: ['element', 'gap', 'suppress', 'static_on_mobile', 'text'],
+  setup(_props, { slots, attrs }) {
+    return () => h('button', { ...attrs, 'data-testid': 'ui-kit-button' }, slots.default?.())
+  }
+})
+
 function mountButton(props = {}, slots = {}) {
   return shallowMount(UiButton, { props, slots })
+}
+
+// Variant used for trailing-slot structure tests — uses a slot-rendering stub
+// so inner data-testid elements are reachable.
+function mountButtonWithSlots(props = {}, slots = {}) {
+  return shallowMount(UiButton, {
+    props,
+    slots,
+    global: { stubs: { UiTooltip: UiTooltipSlotStub }, directives: { sfx: {} } }
+  })
 }
 
 function findTooltip(wrapper) {
@@ -182,6 +205,46 @@ describe('UiButton', () => {
       await wrapper.find('[data-testid="ui-kit-button"]').trigger('click')
 
       expect(mockEmitSfx).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── trailing slot / split layout [obligation] ──────────────────────────────
+  // Uses mountButtonWithSlots — a UiTooltip stub that renders slot content so
+  // inner data-testid elements (ui-kit-button__content, ui-kit-button__trailing)
+  // are reachable in the wrapper tree.
+
+  describe('trailing slot', () => {
+    test('renders ui-kit-button__content when no #trailing slot is provided', () => {
+      const wrapper = mountButtonWithSlots({}, { default: 'Label' })
+      expect(wrapper.find('[data-testid="ui-kit-button__content"]').exists()).toBe(true)
+    })
+
+    test('does NOT render ui-kit-button__trailing when no #trailing slot is provided [obligation]', () => {
+      const wrapper = mountButtonWithSlots({}, { default: 'Label' })
+      expect(wrapper.find('[data-testid="ui-kit-button__trailing"]').exists()).toBe(false)
+    })
+
+    test('renders ui-kit-button__trailing when a #trailing slot is provided [obligation]', () => {
+      const wrapper = mountButtonWithSlots({}, { trailing: () => h('span', 'caret') })
+      expect(wrapper.find('[data-testid="ui-kit-button__trailing"]').exists()).toBe(true)
+    })
+
+    test('renders ui-kit-button__content alongside the trailing slot [obligation]', () => {
+      const wrapper = mountButtonWithSlots(
+        {},
+        { default: 'Label', trailing: () => h('span', 'caret') }
+      )
+      expect(wrapper.find('[data-testid="ui-kit-button__content"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="ui-kit-button__trailing"]').exists()).toBe(true)
+    })
+
+    test('trailing slot content is rendered inside ui-kit-button__trailing', () => {
+      const wrapper = mountButtonWithSlots(
+        {},
+        { trailing: () => h('span', { 'data-testid': 'caret' }, '▼') }
+      )
+      const trailing = wrapper.find('[data-testid="ui-kit-button__trailing"]')
+      expect(trailing.find('[data-testid="caret"]').exists()).toBe(true)
     })
   })
 })

--- a/tests/integration/components/ui-kit/dropdown-button.test.js
+++ b/tests/integration/components/ui-kit/dropdown-button.test.js
@@ -1,0 +1,382 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, ref } from 'vue'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+
+vi.mock('@/sfx/bus', () => ({
+  emitSfx: mockEmitSfx,
+  emitHoverSfx: vi.fn()
+}))
+
+vi.mock('gsap', () => ({
+  gsap: {
+    fromTo: vi.fn((_el, _from, to) => to?.onComplete?.()),
+    to: vi.fn((_el, opts) => opts?.onComplete?.())
+  }
+}))
+
+// Mock useDropdownSizing so tests don't need ResizeObserver or real DOM layout.
+// Plain { value } objects satisfy the component's `.value` reads at mount time.
+// Set sizing.min_width.value / sizing.trigger_width.value BEFORE mounting in
+// each test — the computed initialises once at setup with the current value.
+const { sizing } = vi.hoisted(() => ({
+  sizing: {
+    triggerRef: { value: null },
+    sizerRef: { value: null },
+    min_width: { value: 0 },
+    trigger_width: { value: 0 }
+  }
+}))
+
+vi.mock('@/components/ui-kit/dropdown-button/use-dropdown-sizing', () => ({
+  useDropdownSizing: vi.fn(() => sizing)
+}))
+
+// Stub floating-ui used transitively by UiPopover
+vi.mock('@floating-ui/vue', () => ({
+  useFloating: vi.fn(() => ({
+    placement: { value: 'bottom-start' },
+    middlewareData: { value: {} },
+    floatingStyles: { value: {} }
+  })),
+  shift: vi.fn(() => ({})),
+  flip: vi.fn(() => ({})),
+  autoUpdate: vi.fn(),
+  arrow: vi.fn(() => ({})),
+  offset: vi.fn(() => ({})),
+  hide: vi.fn(() => ({}))
+}))
+
+// ── Stub UiButton so we can isolate dropdown-button logic ─────────────────────
+// The stub renders a split-button structure:
+//   - a main button area (default slot → label)
+//   - renders the #trailing slot so the trigger span appears
+// It forwards attrs to the root so consumer @click / data-* land on the right
+// element (as UiButton with inheritAttrs:false normally handles).
+
+const UiButtonStub = defineComponent({
+  name: 'UiButton',
+  inheritAttrs: false,
+  props: ['size', 'variant', 'inverted', 'fullWidth', 'iconLeft', 'sfx', 'style'],
+  setup(props, { slots, attrs }) {
+    return () =>
+      h('button', { ...attrs, style: props.style, 'data-testid': 'dropdown-button__button' }, [
+        slots.default?.(),
+        slots.trailing?.()
+      ])
+  }
+})
+
+// Stub UiPopover — renders trigger + default slot (menu content) inline so
+// jsdom/shallowMount can find them without Teleport gymnastics.
+const UiPopoverStub = defineComponent({
+  name: 'UiPopover',
+  inheritAttrs: false,
+  props: ['open', 'position', 'gap', 'use_arrow'],
+  emits: ['close'],
+  setup(props, { slots, attrs, emit }) {
+    return () =>
+      h('div', { ...attrs }, [
+        slots.trigger?.(),
+        props.open
+          ? h(
+              'div',
+              {
+                'data-testid': 'ui-popover-backdrop',
+                onClick: (e) => {
+                  // Simulate backdrop outside click → close
+                  if (e.target === e.currentTarget) emit('close')
+                }
+              },
+              slots.default?.()
+            )
+          : null
+      ])
+  }
+})
+
+// Stub UiIcon — trivial placeholder
+const UiIconStub = defineComponent({
+  name: 'UiIcon',
+  props: ['src'],
+  setup(props) {
+    return () => h('span', { 'data-testid': 'ui-icon', 'data-src': props.src })
+  }
+})
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_OPTIONS = [
+  { label: 'Select Cards', value: 'select', icon: 'data-check' },
+  { label: 'Delete All', value: 'delete' }
+]
+
+// ── Mount helper ──────────────────────────────────────────────────────────────
+
+import UiDropdownButton from '@/components/ui-kit/dropdown-button/index.vue'
+
+function mountDropdown(props = {}, { attrs = {}, slots = {} } = {}) {
+  return shallowMount(UiDropdownButton, {
+    props: { options: DEFAULT_OPTIONS, ...props },
+    attrs,
+    slots: { default: slots.default ?? (() => 'Edit Cards') },
+    global: {
+      stubs: {
+        UiButton: UiButtonStub,
+        UiPopover: UiPopoverStub,
+        UiIcon: UiIconStub
+      },
+      directives: { sfx: {} }
+    }
+  })
+}
+
+// ── Shorthand element finders ─────────────────────────────────────────────────
+
+const popoverRoot = (w) => w.find('[data-testid="dropdown-button"]')
+const mainButton = (w) => w.find('[data-testid="dropdown-button__button"]')
+const trigger = (w) => w.find('[data-testid="dropdown-button__trigger"]')
+const options = (w) => w.findAll('[data-testid="dropdown-button__option"]')
+const menu = (w) => w.find('[data-testid="dropdown-button__menu"]')
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('UiDropdownButton', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+    sizing.min_width.value = 0
+    sizing.trigger_width.value = 0
+  })
+
+  // ── Structure ──────────────────────────────────────────────────────────────
+
+  test('renders the popover container with data-testid="dropdown-button"', () => {
+    const wrapper = mountDropdown()
+    expect(popoverRoot(wrapper).exists()).toBe(true)
+  })
+
+  test('renders the inner button with data-testid="dropdown-button__button"', () => {
+    const wrapper = mountDropdown()
+    expect(mainButton(wrapper).exists()).toBe(true)
+  })
+
+  test('renders the caret trigger with data-testid="dropdown-button__trigger"', () => {
+    const wrapper = mountDropdown()
+    expect(trigger(wrapper).exists()).toBe(true)
+  })
+
+  test('menu is not rendered when closed', () => {
+    const wrapper = mountDropdown()
+    expect(menu(wrapper).exists()).toBe(false)
+  })
+
+  test('menu is rendered when open', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    expect(menu(wrapper).exists()).toBe(true)
+  })
+
+  test('renders an option row for each option', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    expect(options(wrapper)).toHaveLength(2)
+  })
+
+  // ── Open / close state ─────────────────────────────────────────────────────
+
+  test('clicking the trigger opens the menu', async () => {
+    const wrapper = mountDropdown()
+    expect(menu(wrapper).exists()).toBe(false)
+    await trigger(wrapper).trigger('click')
+    expect(menu(wrapper).exists()).toBe(true)
+  })
+
+  test('clicking the trigger twice closes the menu', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    await trigger(wrapper).trigger('click')
+    expect(menu(wrapper).exists()).toBe(false)
+  })
+
+  // ── Open-state reflection on trigger element [obligation] ─────────────────
+
+  test('trigger has aria-expanded=false when menu is closed [obligation]', () => {
+    const wrapper = mountDropdown()
+    expect(trigger(wrapper).attributes('aria-expanded')).toBe('false')
+  })
+
+  test('trigger has aria-expanded=true when menu is open [obligation]', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    expect(trigger(wrapper).attributes('aria-expanded')).toBe('true')
+  })
+
+  test('trigger has data-active=false when menu is closed [obligation]', () => {
+    const wrapper = mountDropdown()
+    expect(trigger(wrapper).attributes('data-active')).toBe('false')
+  })
+
+  test('trigger has data-active=true when menu is open [obligation]', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    expect(trigger(wrapper).attributes('data-active')).toBe('true')
+  })
+
+  // ── Split-button click contract [obligation] ──────────────────────────────
+
+  test('clicking the trigger does NOT fire consumer @click handler [obligation]', async () => {
+    const onClick = vi.fn()
+    const wrapper = mountDropdown({}, { attrs: { onClick } })
+    await trigger(wrapper).trigger('click')
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  test('clicking the trigger DOES toggle the menu open [obligation]', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    expect(menu(wrapper).exists()).toBe(true)
+  })
+
+  test('clicking the label button (default slot) DOES fire consumer @click [obligation]', async () => {
+    const onClick = vi.fn()
+    const wrapper = mountDropdown({}, { attrs: { onClick } })
+    await mainButton(wrapper).trigger('click')
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  // ── Attr routing split [obligation] ──────────────────────────────────────
+
+  test('data-theme attr lands on the popover container (non-on attr) [obligation]', () => {
+    const wrapper = mountDropdown({}, { attrs: { 'data-theme': 'blue-500' } })
+    expect(popoverRoot(wrapper).attributes('data-theme')).toBe('blue-500')
+  })
+
+  test('data-theme attr does NOT appear on the inner button [obligation]', () => {
+    const wrapper = mountDropdown({}, { attrs: { 'data-theme': 'blue-500' } })
+    // UiButtonStub forwards button_attrs which should be empty of non-on keys
+    expect(mainButton(wrapper).attributes('data-theme')).toBeUndefined()
+  })
+
+  test('consumer @click (on* handler) is routed to the inner button [obligation]', async () => {
+    // The main button stub forwards all attrs including onClick to the button element.
+    // Confirm clicking the label area fires the consumer handler.
+    const onClick = vi.fn()
+    const wrapper = mountDropdown({}, { attrs: { onClick } })
+    await mainButton(wrapper).trigger('click')
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  // ── Select + close contract [obligation] ──────────────────────────────────
+
+  test('clicking an option emits "select" with the option object [obligation]', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    await options(wrapper)[0].trigger('click')
+    expect(wrapper.emitted('select')).toHaveLength(1)
+    expect(wrapper.emitted('select')[0][0]).toEqual(DEFAULT_OPTIONS[0])
+  })
+
+  test('clicking an option closes the menu [obligation]', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    await options(wrapper)[0].trigger('click')
+    expect(menu(wrapper).exists()).toBe(false)
+  })
+
+  test('clicking a second option emits "select" with the correct option object', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    await options(wrapper)[1].trigger('click')
+    expect(wrapper.emitted('select')[0][0]).toEqual(DEFAULT_OPTIONS[1])
+  })
+
+  test('default-slot label content is unchanged after selecting an option [obligation]', async () => {
+    const wrapper = mountDropdown()
+    const originalText = mainButton(wrapper).text()
+    await trigger(wrapper).trigger('click')
+    await options(wrapper)[0].trigger('click')
+    // label should not change — it's fixed, not bound to selection
+    expect(mainButton(wrapper).text()).toContain('Edit Cards')
+    expect(mainButton(wrapper).text()).toBe(originalText)
+  })
+
+  // ── Close from popover @close event ──────────────────────────────────────
+
+  test('@close from the popover closes the menu', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    expect(menu(wrapper).exists()).toBe(true)
+
+    // Find the UiPopover stub and emit close
+    const popover = wrapper.findComponent(UiPopoverStub)
+    popover.vm.$emit('close')
+    await nextTick()
+    expect(menu(wrapper).exists()).toBe(false)
+  })
+
+  // ── Keyboard a11y [obligation] ────────────────────────────────────────────
+
+  test('Enter keydown on trigger opens the menu [obligation]', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('keydown', { key: 'Enter' })
+    expect(menu(wrapper).exists()).toBe(true)
+  })
+
+  test('Space keydown on trigger opens the menu [obligation]', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('keydown', { key: ' ' })
+    expect(menu(wrapper).exists()).toBe(true)
+  })
+
+  test('Enter keydown on trigger when open closes the menu [obligation]', async () => {
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    await trigger(wrapper).trigger('keydown', { key: 'Enter' })
+    expect(menu(wrapper).exists()).toBe(false)
+  })
+
+  test('trigger has aria-haspopup="menu"', () => {
+    const wrapper = mountDropdown()
+    expect(trigger(wrapper).attributes('aria-haspopup')).toBe('menu')
+  })
+
+  // ── Min-width style ────────────────────────────────────────────────────────
+
+  test('applies min-width style to inner button when min_width is set', () => {
+    sizing.min_width.value = 150
+    const wrapper = mountDropdown()
+    expect(mainButton(wrapper).attributes('style')).toContain('min-width: 150px')
+  })
+
+  test('no min-width style when min_width is 0', () => {
+    sizing.min_width.value = 0
+    const wrapper = mountDropdown()
+    expect(mainButton(wrapper).attributes('style') ?? '').not.toContain('min-width')
+  })
+
+  // ── menu width style (trigger_width) ──────────────────────────────────────
+
+  test('applies width style to menu when trigger_width is set', async () => {
+    sizing.trigger_width.value = 200
+    const wrapper = mountDropdown()
+    await trigger(wrapper).trigger('click')
+    expect(menu(wrapper).attributes('style')).toContain('width: 200px')
+  })
+
+  // ── Sizer element ─────────────────────────────────────────────────────────
+
+  test('renders the hidden sizer element', () => {
+    const wrapper = mountDropdown()
+    expect(wrapper.find('[data-testid="dropdown-button__sizer"]').exists()).toBe(true)
+  })
+
+  test('sizer has a row per option', () => {
+    const wrapper = mountDropdown()
+    const sizer = wrapper.find('[data-testid="dropdown-button__sizer"]')
+    // Each option renders a span row inside the sizer
+    expect(sizer.findAll('.ui-kit-dropdown-button__row')).toHaveLength(DEFAULT_OPTIONS.length)
+  })
+})

--- a/tests/unit/composables/use-dropdown-sizing.test.js
+++ b/tests/unit/composables/use-dropdown-sizing.test.js
@@ -1,0 +1,215 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { ref, nextTick, createApp } from 'vue'
+
+// ── ResizeObserver stub ───────────────────────────────────────────────────────
+// jsdom does not implement ResizeObserver. We need a stub that:
+//  - records observed elements
+//  - exposes a way to trigger callbacks from tests
+//  - records disconnect() calls
+
+let resizeCallback = null
+let observedElements = []
+let disconnectCalled = false
+
+class ResizeObserverStub {
+  constructor(cb) {
+    resizeCallback = cb
+  }
+  observe(el) {
+    observedElements.push(el)
+  }
+  disconnect() {
+    disconnectCalled = true
+  }
+}
+
+// Stub document.fonts?.ready.then(...) — jsdom has no FontFaceSet.
+// The source reads `document.fonts?.ready.then(measure)`, so the stub must
+// expose a `.ready` object with a `.then` method.
+const mockFontsReady = { ready: { then: vi.fn((cb) => cb()) } }
+
+// ── Host-app helper (composable needs onMounted / onBeforeUnmount) ─────────────
+
+function withSetup(composable) {
+  let result
+  let app
+  const el = document.createElement('div')
+
+  app = createApp({
+    setup() {
+      result = composable()
+      return () => {}
+    }
+  })
+  app.mount(el)
+
+  return { result, unmount: () => app.unmount() }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+import { useDropdownSizing } from '@/components/ui-kit/dropdown-button/use-dropdown-sizing'
+
+describe('useDropdownSizing', () => {
+  beforeEach(() => {
+    resizeCallback = null
+    observedElements = []
+    disconnectCalled = false
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+    Object.defineProperty(document, 'fonts', {
+      value: mockFontsReady,
+      writable: true,
+      configurable: true
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // ── Return shape ───────────────────────────────────────────────────────────
+
+  test('returns triggerRef, sizerRef, min_width, trigger_width', () => {
+    const { result, unmount } = withSetup(() => useDropdownSizing(() => []))
+    expect(result).toHaveProperty('triggerRef')
+    expect(result).toHaveProperty('sizerRef')
+    expect(result).toHaveProperty('min_width')
+    expect(result).toHaveProperty('trigger_width')
+    unmount()
+  })
+
+  test('min_width and trigger_width start at 0', () => {
+    const { result, unmount } = withSetup(() => useDropdownSizing(() => []))
+    expect(result.min_width.value).toBe(0)
+    expect(result.trigger_width.value).toBe(0)
+    unmount()
+  })
+
+  // ── measure() reads sizerRef and triggerRef.$el widths ────────────────────
+
+  test('measure() reads sizerRef getBoundingClientRect().width into min_width [obligation]', () => {
+    const { result, unmount } = withSetup(() => useDropdownSizing(() => []))
+
+    const sizerEl = document.createElement('div')
+    sizerEl.getBoundingClientRect = () => ({ width: 123.4 })
+    result.sizerRef.value = sizerEl
+
+    // Trigger measure via ResizeObserver callback
+    resizeCallback([])
+
+    expect(result.min_width.value).toBe(124) // Math.ceil(123.4)
+    unmount()
+  })
+
+  test('measure() reads triggerRef.$el getBoundingClientRect().width into trigger_width [obligation]', () => {
+    const { result, unmount } = withSetup(() => useDropdownSizing(() => []))
+
+    const triggerEl = document.createElement('button')
+    triggerEl.getBoundingClientRect = () => ({ width: 200.7 })
+    result.triggerRef.value = { $el: triggerEl }
+
+    resizeCallback([])
+
+    expect(result.trigger_width.value).toBe(201) // Math.ceil(200.7)
+    unmount()
+  })
+
+  test('measure() skips min_width update when sizerRef is null', () => {
+    const { result, unmount } = withSetup(() => useDropdownSizing(() => []))
+    result.sizerRef.value = null
+
+    resizeCallback([])
+
+    expect(result.min_width.value).toBe(0)
+    unmount()
+  })
+
+  test('measure() skips trigger_width update when triggerRef.$el is null', () => {
+    const { result, unmount } = withSetup(() => useDropdownSizing(() => []))
+    result.triggerRef.value = null
+
+    resizeCallback([])
+
+    expect(result.trigger_width.value).toBe(0)
+    unmount()
+  })
+
+  // ── ResizeObserver wiring ──────────────────────────────────────────────────
+
+  test('observes sizerRef element on mount [obligation]', () => {
+    const { result, unmount } = withSetup(() => useDropdownSizing(() => []))
+
+    const sizerEl = document.createElement('div')
+    sizerEl.getBoundingClientRect = () => ({ width: 0 })
+    result.sizerRef.value = sizerEl
+
+    // The observer is created on mount — we verify it was set up by checking
+    // that resizeCallback was assigned (meaning new ResizeObserver was called).
+    expect(resizeCallback).not.toBeNull()
+    unmount()
+  })
+
+  test('disconnects the ResizeObserver on unmount [obligation]', () => {
+    const { unmount } = withSetup(() => useDropdownSizing(() => []))
+    expect(disconnectCalled).toBe(false)
+    unmount()
+    expect(disconnectCalled).toBe(true)
+  })
+
+  // ── Deps watcher re-measures ───────────────────────────────────────────────
+
+  test('re-measures when the deps getter changes [obligation]', async () => {
+    const options = ref([{ label: 'A', value: 'a' }])
+
+    const { result, unmount } = withSetup(() => useDropdownSizing(() => options.value))
+
+    const sizerEl = document.createElement('div')
+    sizerEl.getBoundingClientRect = () => ({ width: 50 })
+    result.sizerRef.value = sizerEl
+
+    // Trigger initial read
+    resizeCallback([])
+    expect(result.min_width.value).toBe(50)
+
+    // Change options — width increases
+    sizerEl.getBoundingClientRect = () => ({ width: 100 })
+    options.value = [{ label: 'Longer Option', value: 'b' }]
+    await nextTick()
+    await nextTick() // flush: 'post' watcher needs an extra tick
+
+    expect(result.min_width.value).toBe(100)
+    unmount()
+  })
+
+  // ── document.fonts.ready ───────────────────────────────────────────────────
+
+  test('calls measure after document.fonts.ready resolves [obligation]', () => {
+    let fontsReadyCb = null
+    const readyMock = {
+      then: vi.fn((cb) => {
+        fontsReadyCb = cb
+      })
+    }
+    const fontsMock = { ready: readyMock }
+    Object.defineProperty(document, 'fonts', {
+      value: fontsMock,
+      writable: true,
+      configurable: true
+    })
+
+    const { result, unmount } = withSetup(() => useDropdownSizing(() => []))
+
+    const sizerEl = document.createElement('div')
+    sizerEl.getBoundingClientRect = () => ({ width: 77 })
+    result.sizerRef.value = sizerEl
+
+    expect(readyMock.then).toHaveBeenCalled()
+
+    // Simulate fonts ready resolving
+    fontsReadyCb()
+
+    expect(result.min_width.value).toBe(77)
+    unmount()
+  })
+})

--- a/tests/unit/utils/animations/flip.test.js
+++ b/tests/unit/utils/animations/flip.test.js
@@ -1,0 +1,97 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+// ── gsap mock ─────────────────────────────────────────────────────────────────
+
+vi.mock('gsap', () => ({
+  gsap: {
+    fromTo: vi.fn((_el, _from, to) => to?.onComplete?.()),
+    to: vi.fn((_el, opts) => opts?.onComplete?.())
+  }
+}))
+
+import { flipEnter, flipLeave } from '@/utils/animations/flip'
+
+describe('flip', () => {
+  let fromTo
+  let to
+  let el
+  let done
+
+  beforeEach(async () => {
+    const { gsap } = await import('gsap')
+    fromTo = gsap.fromTo
+    to = gsap.to
+    fromTo.mockClear()
+    to.mockClear()
+    el = document.createElement('div')
+    done = vi.fn()
+  })
+
+  // ── flipEnter ─────────────────────────────────────────────────────────────
+
+  describe('flipEnter', () => {
+    test("axis 'x' maps to rotateX in fromTo [obligation]", () => {
+      flipEnter(el, 'x', done)
+      expect(fromTo).toHaveBeenCalledTimes(1)
+      const [, fromVars, toVars] = fromTo.mock.calls[0]
+      expect(fromVars).toHaveProperty('rotateX')
+      expect(toVars).toHaveProperty('rotateX', 0)
+    })
+
+    test("axis 'y' maps to rotateY in fromTo [obligation]", () => {
+      flipEnter(el, 'y', done)
+      const [, fromVars, toVars] = fromTo.mock.calls[0]
+      expect(fromVars).toHaveProperty('rotateY')
+      expect(toVars).toHaveProperty('rotateY', 0)
+    })
+
+    test("axis 'x' does NOT produce rotateY", () => {
+      flipEnter(el, 'x', done)
+      const [, fromVars] = fromTo.mock.calls[0]
+      expect(fromVars).not.toHaveProperty('rotateY')
+    })
+
+    test('calls done via onComplete', () => {
+      flipEnter(el, 'x', done)
+      expect(done).toHaveBeenCalledTimes(1)
+    })
+
+    test('passes the element as the first argument', () => {
+      flipEnter(el, 'x', done)
+      expect(fromTo.mock.calls[0][0]).toBe(el)
+    })
+  })
+
+  // ── flipLeave ─────────────────────────────────────────────────────────────
+
+  describe('flipLeave', () => {
+    test("axis 'x' maps to rotateX in to [obligation]", () => {
+      flipLeave(el, 'x', done)
+      expect(to).toHaveBeenCalledTimes(1)
+      const [, opts] = to.mock.calls[0]
+      expect(opts).toHaveProperty('rotateX', 60)
+    })
+
+    test("axis 'y' maps to rotateY in to [obligation]", () => {
+      flipLeave(el, 'y', done)
+      const [, opts] = to.mock.calls[0]
+      expect(opts).toHaveProperty('rotateY', 60)
+    })
+
+    test("axis 'x' does NOT produce rotateY", () => {
+      flipLeave(el, 'x', done)
+      const [, opts] = to.mock.calls[0]
+      expect(opts).not.toHaveProperty('rotateY')
+    })
+
+    test('calls done via onComplete', () => {
+      flipLeave(el, 'x', done)
+      expect(done).toHaveBeenCalledTimes(1)
+    })
+
+    test('passes the element as the first argument', () => {
+      flipLeave(el, 'x', done)
+      expect(to.mock.calls[0][0]).toBe(el)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `dropdown-button` ui-kit primitive: a themed split-button whose label region fires the consumer's primary `@click`, while a trailing trigger opens a popover-rendered menu of options.

- Options come from a structured `options` prop; selecting one emits `select` and closes the menu (the label stays fixed — menu semantics).
- The menu mirrors the button: its width tracks the button's rendered width, and its border-radius + option padding/gap/font/icon come from shared `--btn-*` tokens. The button's min-width tracks the widest option via a `ResizeObserver`-measured hidden sizer (`use-dropdown-sizing`).
- Theme inherits through the non-teleported popover container; the consumer's `@click` is routed to the inner button via an attr split. The caret flips vertically on toggle.

Supporting changes:
- `ui-kit/button`: padding/gap move to an inner `.btn-content` wrapper so the new `trailing` slot can sit flush in the raw button; per-size `--btn-*` tokens exposed via `.ui-kit-btn-tokens--<size>`. Existing button usages are unaffected.
- `utils/animations/flip`: the card's GSAP flip generalised to a selectable rotation axis.

Covered by unit + integration tests (split-button click contract, attr routing, select/close, open-state attrs, keyboard a11y, sizing composable, flip axis mapping).