### PR TITLE
feat(card-grid): scale a single xl card instead of per-size rendering

### DIFF
--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -80,7 +80,7 @@ const font_size = computed(() => {
 
 <style>
 .card-face {
-  --inner-radius: calc(var(--face-radius) - var(--face-border-width) - var(--face-padding));
+  --inner-radius: calc(var(--face-radius) - var(--face-padding));
 
   position: relative;
   display: flex;

--- a/src/components/card/index.vue
+++ b/src/components/card/index.vue
@@ -157,7 +157,7 @@ function onLeave(el: Element, done: () => void) {
   --card-width: 314px;
   --face-border-width: 6px;
   --face-radius: 58px;
-  --face-padding: 30px;
+  --face-padding: 20px;
   --min-element-height: 80px;
 }
 .card-container--lg {

--- a/src/views/deck/card-grid/grid-item.vue
+++ b/src/views/deck/card-grid/grid-item.vue
@@ -14,16 +14,16 @@ const {
   card,
   side,
   fill = true,
-  size = 'base'
+  scale = 1
 } = defineProps<{
   card: Card
   side: 'front' | 'back'
   selected: boolean
   card_attributes?: DeckCardAttributes
   // fill: scale an xl card to fill a computed carousel cell;
-  // false: render the card at its natural `size` in normal flow
+  // false: render an xl card uniformly scaled by `scale` into a fixed grid cell
   fill?: boolean
-  size?: CardSize
+  scale?: number
 }>()
 
 const active_side = ref(side)
@@ -42,9 +42,9 @@ function onCardClick() {
 <template>
   <div
     data-testid="grid-item"
-    class="grid-item group relative touch-manipulation"
+    class="grid-item group relative aspect-card w-full touch-manipulation"
     :class="[
-      fill ? 'aspect-card w-full pointer-fine:transition-transform duration-75' : 'w-fit',
+      { 'pointer-fine:transition-transform duration-75': fill },
       { 'card-outline pointer-fine:hover:scale-101': is_selecting }
     ]"
     v-sfx.hover="is_selecting ? 'ui.click_07' : undefined"
@@ -52,8 +52,9 @@ function onCardClick() {
     <card
       v-bind="card"
       class="cursor-pointer"
-      :class="{ 'grid-item__card': fill }"
-      :size="fill ? 'xl' : size"
+      :class="fill ? 'grid-item__card' : 'grid-item__card--scaled'"
+      :style="fill ? undefined : { '--card-scale': scale }"
+      size="xl"
       :side="active_side"
       :card_attributes="card_attributes"
       @click="onCardClick"
@@ -84,6 +85,18 @@ function onCardClick() {
 
   transform-origin: top left;
   transform: scale(var(--scale));
+}
+
+/* Uniform scale: an xl card rendered at its natural width, scaled by --card-scale
+   to fill the fixed grid cell (cell width = xl width × --card-scale). */
+.grid-item :deep(.grid-item__card--scaled) {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  transform-origin: top left;
+  transform: scale(var(--card-scale));
+  transition: transform 0.05s ease-in-out;
 }
 
 .grid-item.card-outline {

--- a/src/views/deck/card-grid/scroll-grid.vue
+++ b/src/views/deck/card-grid/scroll-grid.vue
@@ -14,17 +14,22 @@ const { list, selection, card_attributes, hasNextPage, isLoading, observeSentine
 const { all_cards } = list
 const { isCardSelected } = selection
 
-const COLUMN_WIDTH: Record<CardGridSize, string> = {
-  base: '192px',
-  md: '240px',
-  xl: '314px'
+// Cards always render at xl and scale uniformly, so one factor drives both the
+// rendered card and its grid column — no per-size visual tuning to keep in sync.
+const XL_CARD_WIDTH = 314
+const CARD_SCALE: Record<CardGridSize, number> = {
+  base: 0.6,
+  md: 0.75,
+  xl: 1
 }
 
 const side = ref<'front' | 'back'>('front')
 const sentinel = useTemplateRef<HTMLElement>('sentinel')
 
+const card_scale = computed(() => CARD_SCALE[grid_size.value])
+
 const grid_style = computed<CSSProperties>(() => ({
-  gridTemplateColumns: `repeat(auto-fill, ${COLUMN_WIDTH[grid_size.value]})`
+  gridTemplateColumns: `repeat(auto-fill, ${XL_CARD_WIDTH * card_scale.value}px)`
 }))
 
 observeSentinel(sentinel)
@@ -39,7 +44,7 @@ observeSentinel(sentinel)
         :card="card"
         :side="side"
         :fill="false"
-        :size="grid_size"
+        :scale="card_scale"
         :card_attributes="card_attributes"
         :selected="card.id !== undefined ? isCardSelected(card.id) : false"
       ></grid-item>

--- a/tests/integration/views/deck/card-grid/grid-item.test.js
+++ b/tests/integration/views/deck/card-grid/grid-item.test.js
@@ -19,6 +19,8 @@ const CardStub = defineComponent({
           'data-testid': 'card-stub',
           'data-side': props.side,
           'data-size': props.size,
+          'data-card-class': attrs.class,
+          'data-card-scale': attrs.style?.['--card-scale'],
           onClick: attrs.onClick
         },
         slots.default?.()
@@ -170,26 +172,28 @@ describe('GridItem (card-grid/grid-item.vue)', () => {
     expect(editor.actions.onDeleteCards).toHaveBeenCalledWith(1)
   })
 
-  // ── fill prop ─────────────────────────────────────────────────────────────
+  // ── fill / scale props ──────────────────────────────────────────────────────
 
-  test('fill=true (default) renders Card at size="xl" [obligation]', () => {
-    const { wrapper } = mountGridItem({ props: { fill: true } })
-    expect(wrapper.find('[data-testid="card-stub"]').attributes('data-size')).toBe('xl')
+  test('renders Card at size="xl" regardless of fill [obligation]', () => {
+    const filled = mountGridItem({ props: { fill: true } })
+    const scaled = mountGridItem({ props: { fill: false } })
+    expect(filled.wrapper.find('[data-testid="card-stub"]').attributes('data-size')).toBe('xl')
+    expect(scaled.wrapper.find('[data-testid="card-stub"]').attributes('data-size')).toBe('xl')
   })
 
-  test('fill=false renders Card at size="base" [obligation]', () => {
-    const { wrapper } = mountGridItem({ props: { fill: false } })
-    expect(wrapper.find('[data-testid="card-stub"]').attributes('data-size')).toBe('base')
+  test('fill=false applies the scale prop as --card-scale on Card [obligation]', () => {
+    const { wrapper } = mountGridItem({ props: { fill: false, scale: 0.6 } })
+    const card = wrapper.find('[data-testid="card-stub"]')
+    expect(card.attributes('data-card-class')).toContain('grid-item__card--scaled')
+    expect(card.attributes('data-card-scale')).toBe('0.6')
   })
 
-  test('fill=false forwards the explicit size prop to Card [obligation]', () => {
-    const { wrapper } = mountGridItem({ props: { fill: false, size: 'md' } })
-    expect(wrapper.find('[data-testid="card-stub"]').attributes('data-size')).toBe('md')
-  })
-
-  test('fill=true overrides any size prop and always passes "xl" to Card [obligation]', () => {
-    const { wrapper } = mountGridItem({ props: { fill: true, size: 'base' } })
-    expect(wrapper.find('[data-testid="card-stub"]').attributes('data-size')).toBe('xl')
+  test('fill=true uses the fill class and no --card-scale [obligation]', () => {
+    const { wrapper } = mountGridItem({ props: { fill: true, scale: 0.6 } })
+    const card = wrapper.find('[data-testid="card-stub"]')
+    expect(card.attributes('data-card-class')).toContain('grid-item__card')
+    expect(card.attributes('data-card-class')).not.toContain('grid-item__card--scaled')
+    expect(card.attributes('data-card-scale')).toBeUndefined()
   })
 
   test('fill defaults to true when prop is omitted', () => {

--- a/tests/integration/views/deck/card-grid/scroll-grid.test.js
+++ b/tests/integration/views/deck/card-grid/scroll-grid.test.js
@@ -4,13 +4,15 @@ import { defineComponent, h, ref } from 'vue'
 
 const GridItemStub = defineComponent({
   name: 'GridItem',
-  props: ['card', 'side', 'fill', 'card_attributes', 'selected'],
+  props: ['card', 'side', 'fill', 'scale', 'card_attributes', 'selected'],
   setup(props) {
     return () =>
       h('div', {
         'data-testid': 'grid-item-stub',
         'data-card-id': props.card?.id,
-        'data-fill': String(props.fill)
+        'data-fill': String(props.fill),
+        'data-scale': String(props.scale),
+        'data-selected': String(props.selected)
       })
   }
 })
@@ -132,5 +134,22 @@ describe('card-grid/scroll-grid', () => {
     const wrapper = mountScrollGrid(editor)
     expect(wrapper.findAll('[data-testid="grid-item-stub"]')).toHaveLength(0)
     expect(wrapper.find('[data-testid="card-grid"]').exists()).toBe(true)
+  })
+
+  test('passes the computed card_scale to each grid-item as the scale prop', () => {
+    const editor = makeEditor({
+      grid_size: 'base',
+      all_cards: [{ id: 1, client_id: 'c1', front_text: 'q', back_text: 'a' }]
+    })
+    const wrapper = mountScrollGrid(editor)
+    expect(wrapper.find('[data-testid="grid-item-stub"]').attributes('data-scale')).toBe('0.6')
+  })
+
+  test('grid-item selected is false when card.id is undefined', () => {
+    const editor = makeEditor({
+      all_cards: [{ client_id: 'c1', front_text: 'q', back_text: 'a' }]
+    })
+    const wrapper = mountScrollGrid(editor)
+    expect(wrapper.find('[data-testid="grid-item-stub"]').attributes('data-selected')).toBe('false')
   })
 })

--- a/tests/integration/views/deck/card-grid/scroll-grid.test.js
+++ b/tests/integration/views/deck/card-grid/scroll-grid.test.js
@@ -52,23 +52,23 @@ describe('card-grid/scroll-grid', () => {
 
   // ── grid_size → gridTemplateColumns track width ───────────────────────────
 
-  test('grid style uses 192px track width for grid_size="base" [obligation]', () => {
+  test('grid style scales the xl track to 0.6 for grid_size="base" [obligation]', () => {
     const editor = makeEditor({ grid_size: 'base' })
     const wrapper = mountScrollGrid(editor)
     expect(wrapper.find('[data-testid="card-grid"]').attributes('style')).toContain(
-      'grid-template-columns: repeat(auto-fill, 192px)'
+      'grid-template-columns: repeat(auto-fill, 188.4px)'
     )
   })
 
-  test('grid style uses 240px track width for grid_size="md" [obligation]', () => {
+  test('grid style scales the xl track to 0.75 for grid_size="md" [obligation]', () => {
     const editor = makeEditor({ grid_size: 'md' })
     const wrapper = mountScrollGrid(editor)
     expect(wrapper.find('[data-testid="card-grid"]').attributes('style')).toContain(
-      'grid-template-columns: repeat(auto-fill, 240px)'
+      'grid-template-columns: repeat(auto-fill, 235.5px)'
     )
   })
 
-  test('grid style uses 314px track width for grid_size="xl" [obligation]', () => {
+  test('grid style uses the full xl track width for grid_size="xl" [obligation]', () => {
     const editor = makeEditor({ grid_size: 'xl' })
     const wrapper = mountScrollGrid(editor)
     expect(wrapper.find('[data-testid="card-grid"]').attributes('style')).toContain(


### PR DESCRIPTION
## Summary

Grid cards previously rendered at three distinct sizes (`base`/`md`/`xl`), which forced each size's font, padding, radius, and border rows to be hand-tuned to look right against the others. This renders **every grid card at `xl`** and applies a **uniform CSS `transform: scale()`** driven by the selected display-size option, so one factor scales the whole card faithfully and there is nothing per-size to keep in visual sync.

- `scroll-grid.vue` — `COLUMN_WIDTH` map replaced by a single `CARD_SCALE` map; the grid track width and the card scale now derive from one shared factor (`314 × scale`), so they can't drift.
- `grid-item.vue` — `size` prop replaced by `scale`; non-fill path renders `size="xl"` with `--card-scale` and a new `grid-item__card--scaled` rule. The carousel's `fill=true` path is unchanged.
- Tuned the canonical xl card's face padding and inner-radius.

Tests updated to the new contract (track width = `314 × scale`, cards always `xl`, non-fill carries `--card-scale`); carousel tests unaffected.