### PR TITLE
feat(audio-reader): mobile range-select + term-popover playback controls

### DIFF
--- a/src/composables/audio-reader/use-audio-player.ts
+++ b/src/composables/audio-reader/use-audio-player.ts
@@ -22,9 +22,19 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
   let el: HTMLAudioElement | null = null
   let raf = 0
 
+  // When set, playback is bounded to a single clip: the tick loop pauses the
+  // moment it reaches this time. Cleared by any pause, seek, or open-ended play.
+  let clip_end: number | null = null
+
   function tick() {
     if (!el) return
     current_time.value = el.currentTime
+
+    if (clip_end !== null && el.currentTime >= clip_end) {
+      pause()
+      return
+    }
+
     raf = requestAnimationFrame(tick)
   }
 
@@ -50,6 +60,7 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
   function onPause() {
     is_playing.value = false
     stopTicking()
+    clip_end = null
     if (el) current_time.value = el.currentTime
   }
 
@@ -92,11 +103,13 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
   /** Move playback to `seconds` and reflect it immediately (don't wait for timeupdate). */
   function seek(seconds: number) {
     if (!el) return
+    clip_end = null
     el.currentTime = seconds
     current_time.value = seconds
   }
 
   function play() {
+    clip_end = null
     el?.play()
   }
 
@@ -104,7 +117,16 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
     el?.pause()
   }
 
-  return { current_time, duration, is_playing, play, pause, seek }
+  /** Play just the span `[start, end]` — seek to `start`, play, and auto-pause at `end`. */
+  function playClip(start: number, end: number) {
+    if (!el) return
+    clip_end = end
+    el.currentTime = start
+    current_time.value = start
+    el.play()
+  }
+
+  return { current_time, duration, is_playing, play, pause, seek, playClip }
 }
 
 export type AudioPlayer = ReturnType<typeof useAudioPlayer>

--- a/src/composables/audio-reader/use-lesson-reader.ts
+++ b/src/composables/audio-reader/use-lesson-reader.ts
@@ -61,11 +61,14 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
   })
 
   /**
-   * Show the translation for a tapped/selected term. On a coarse/narrow screen
-   * it opens as a bottom sheet (the anchored popover crowds a phone); on desktop
-   * it's the rect-anchored popover.
+   * Show the translation for a tapped/selected term. Pauses playback so the term
+   * holds still under the popover. On a coarse/narrow screen it opens as a bottom
+   * sheet (the anchored popover crowds a phone); on desktop it's the rect-anchored
+   * popover.
    */
   function openTerm(next: TermSelection) {
+    player.pause()
+
     if (is_mobile.value) {
       openTermSheet(next)
       return
@@ -84,7 +87,13 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
     const { response, close } = modal.open<void>(TermSheet, {
       mode: 'mobile-sheet',
       backdrop: true,
-      props: { term: next.term, sentence: next.sentence, target_lang: TARGET_LANG }
+      props: {
+        term: next.term,
+        sentence: next.sentence,
+        target_lang: TARGET_LANG,
+        play_from_here: () => playFromWord(next.word_index),
+        play_word: () => playWordRange(next.word_index, next.word_end_index)
+      }
     })
     sheet_close = close
     response.then(() => {
@@ -94,6 +103,38 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
 
   function closeTerm() {
     popover_open.value = false
+  }
+
+  /** Seek to the desktop popover's term and resume — its standing selection. */
+  function playFromHere() {
+    if (selection.value) playFromWord(selection.value.word_index)
+  }
+
+  /** Play just the desktop popover's term — its standing selection. */
+  function playClip() {
+    if (selection.value) playWordRange(selection.value.word_index, selection.value.word_end_index)
+  }
+
+  // Seek to a word's start time, resume playback, and dismiss the open term
+  // surface (popover on desktop, sheet on mobile — one is always a no-op).
+  function playFromWord(word_index: number) {
+    const start = words.value[word_index]?.start
+    if (start === undefined) return
+
+    player.seek(start)
+    player.play()
+    closeTerm()
+    sheet_close?.()
+  }
+
+  // Play only the selected phrase — its first word's start to its last word's end
+  // — then stop. Leaves the term surface open so its translation stays readable.
+  function playWordRange(first_index: number, last_index: number) {
+    const start = words.value[first_index]?.start
+    const end = words.value[last_index]?.end
+    if (start === undefined || end === undefined) return
+
+    player.playClip(start, end)
   }
 
   return {
@@ -106,6 +147,8 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
     target_lang: TARGET_LANG,
     openTerm,
     closeTerm,
+    playFromHere,
+    playClip,
     player
   }
 }

--- a/src/composables/audio-reader/use-reader-highlights.ts
+++ b/src/composables/audio-reader/use-reader-highlights.ts
@@ -28,6 +28,12 @@ const HOVER_DURATION = 0.12
 // a word.
 const TAP_SLOP = 10
 
+// A still press this long arms range-select: the column stops scrolling and the
+// drag extends the selection word by word instead of panning. A touch shorter
+// than this (or one that drifts first) stays a tap-or-scroll. Kept just under the
+// ~500ms native long-press so it feels responsive without firing on a quick tap.
+const LONG_PRESS_MS = 400
+
 // What a committed selection hands back: the bare term, the rect to anchor the
 // popover against, and the first word's element so the caller can resolve which
 // sentence it sits in (translator context).
@@ -47,7 +53,9 @@ type WordRange = { lo: number; hi: number }
  * word). A touch instead claims nothing on the way down — the column scrolls
  * freely under the finger — and selects the word on release, but only if the
  * finger stayed put; a touch that drifts past `TAP_SLOP` is a scroll and commits
- * nothing. The committed range stays lit — hover is held off — until
+ * nothing. Holding a word still for `LONG_PRESS_MS` arms range-select instead: the
+ * column stops scrolling, the drag extends the range word by word, and release
+ * commits it. The committed range stays lit — hover is held off — until
  * `popover_open` flips false. The translation gloss carries no `data-word-index`,
  * so it can never join a range; native text selection is left disabled by the host.
  *
@@ -63,7 +71,7 @@ type WordRange = { lo: number; hi: number }
  * @param popover_open - whether the term popover is showing; the selection holds
  *   while true and clears when it goes false.
  * @example
- * const { onPointerDown, onPointerMove, onPointerUp, onPointerLeave } =
+ * const { onPointerDown, onPointerMove, onPointerUp, onPointerLeave, onPointerCancel } =
  *   useReaderHighlights(() => active_word, commitSelection, () => popover_open)
  */
 export function useReaderHighlights(
@@ -85,20 +93,36 @@ export function useReaderHighlights(
 
   // A touch in flight: where it landed and which word, held until release decides
   // tap-vs-scroll. Plain (non-reactive) state — it never drives a pill directly.
+  // `touch_selecting` flips true once a long-press arms range-select; from there
+  // the drag extends the range and the column no longer scrolls. The timer is the
+  // pending arm, cleared the moment the finger drifts or lifts.
   let tap: { x: number; y: number; index: number } | null = null
+  let touch_selecting = false
+  let long_press_timer: ReturnType<typeof setTimeout> | null = null
 
   let resize_observer: ResizeObserver | null = null
 
   onMounted(() => {
     resize_observer = new ResizeObserver(reposition)
     if (content.value) resize_observer.observe(content.value)
+    content.value?.addEventListener('touchmove', blockScrollWhileSelecting, { passive: false })
     window.addEventListener('click', swallowGestureClick, true)
   })
 
   onBeforeUnmount(() => {
     resize_observer?.disconnect()
+    content.value?.removeEventListener('touchmove', blockScrollWhileSelecting)
     window.removeEventListener('click', swallowGestureClick, true)
+    cancelLongPress()
   })
+
+  // Once a long-press has armed range-select the finger is extending the range,
+  // not panning — so swallow the native scroll. Touch scrolling can only be killed
+  // from a non-passive `touchmove`; a pointer-event `preventDefault` won't do it,
+  // which is why this is a native listener rather than the Vue `@pointermove`.
+  function blockScrollWhileSelecting(event: TouchEvent) {
+    if (touch_selecting) event.preventDefault()
+  }
 
   // A pointer tap inside the reader is a word selection, not a click — yet the
   // browser still fires a compatibility `click` after `pointerup`. Swallow it in
@@ -322,11 +346,32 @@ export function useReaderHighlights(
     beginDrag(event)
   }
 
-  // A touch defers everything to release: just remember where it landed and which
-  // word, leaving the gesture to the browser so the column still scrolls.
+  // A touch defers to release or to a long-press: remember where it landed and
+  // which word, and start the arm timer. Until it fires the gesture stays the
+  // browser's, so the column scrolls; a drift past the slop cancels it (trackTap).
   function beginTap(event: PointerEvent) {
     const index = wordIndexAt(event.clientX, event.clientY)
     tap = index === null ? null : { x: event.clientX, y: event.clientY, index }
+    if (tap) long_press_timer = setTimeout(armTouchSelection, LONG_PRESS_MS)
+  }
+
+  function cancelLongPress() {
+    if (long_press_timer === null) return
+    clearTimeout(long_press_timer)
+    long_press_timer = null
+  }
+
+  // The long-press fired with the finger still on its word: arm range-select. The
+  // pill lights on the anchor word and the drag now extends it; a brief haptic tick
+  // confirms (no-op where the Vibration API is absent, e.g. iOS Safari).
+  function armTouchSelection() {
+    long_press_timer = null
+    if (!tap) return
+
+    touch_selecting = true
+    anchor_index.value = tap.index
+    focus_index.value = tap.index
+    navigator.vibrate?.(10)
   }
 
   function beginDrag(event: PointerEvent) {
@@ -369,16 +414,31 @@ export function useReaderHighlights(
     if (index !== focus_index.value) focus_index.value = index
   }
 
-  // A touch that travels past the slop is a scroll, not a tap — forget it so
-  // release selects nothing.
+  // Pre-arm, a touch that travels past the slop is a scroll, not a tap — forget it
+  // (and the pending arm) so release selects nothing. Once armed, the same travel
+  // extends the range instead.
   function trackTap(event: PointerEvent) {
+    if (touch_selecting) {
+      extendTouchSelection(event)
+      return
+    }
     if (!tap) return
-    if (Math.hypot(event.clientX - tap.x, event.clientY - tap.y) > TAP_SLOP) tap = null
+    if (Math.hypot(event.clientX - tap.x, event.clientY - tap.y) > TAP_SLOP) {
+      cancelLongPress()
+      tap = null
+    }
+  }
+
+  // While armed, follow the finger word by word, holding the last extent over gaps
+  // (translation gloss, padding) so the range doesn't collapse between words.
+  function extendTouchSelection(event: PointerEvent) {
+    const index = wordIndexAt(event.clientX, event.clientY)
+    if (index !== null && index !== focus_index.value) focus_index.value = index
   }
 
   function onPointerUp(event: PointerEvent) {
     if (event.pointerType === 'touch') {
-      commitTap()
+      commitTouch()
       return
     }
 
@@ -388,19 +448,33 @@ export function useReaderHighlights(
     anchor_index.value = null
   }
 
-  // Release of a stationary touch selects its word; a scroll (tap already cleared)
-  // commits nothing. The range collapses to the one tapped word, then clears so
-  // the committed pill — not a lingering hover — is what stays lit.
-  function commitTap() {
-    if (!tap) return
+  // Release ends the touch gesture. An armed range commits its current extent; an
+  // un-armed stationary tap commits its single word; a drift (tap cleared, never
+  // armed) commits nothing. The range refs then clear so the committed pill — not
+  // a lingering hover — is what stays lit.
+  function commitTouch() {
+    cancelLongPress()
 
-    anchor_index.value = tap.index
-    focus_index.value = tap.index
-    tap = null
+    if (!touch_selecting && tap) {
+      anchor_index.value = tap.index
+      focus_index.value = tap.index
+    }
 
     commitSelection()
     anchor_index.value = null
     focus_index.value = null
+    touch_selecting = false
+    tap = null
+  }
+
+  // A scroll the browser claims (or any aborted touch) fires pointercancel: drop
+  // the pending tap and disarm so nothing commits on the absent release.
+  function onPointerCancel() {
+    cancelLongPress()
+    anchor_index.value = null
+    focus_index.value = null
+    touch_selecting = false
+    tap = null
   }
 
   function onPointerLeave() {
@@ -434,6 +508,7 @@ export function useReaderHighlights(
     onPointerDown,
     onPointerMove,
     onPointerUp,
-    onPointerLeave
+    onPointerLeave,
+    onPointerCancel
   }
 }

--- a/src/composables/audio-reader/use-reader-highlights.ts
+++ b/src/composables/audio-reader/use-reader-highlights.ts
@@ -35,9 +35,16 @@ const TAP_SLOP = 10
 const LONG_PRESS_MS = 400
 
 // What a committed selection hands back: the bare term, the rect to anchor the
-// popover against, and the first word's element so the caller can resolve which
-// sentence it sits in (translator context).
-type ReaderSelection = { term: string; rect: DOMRect; anchor: HTMLElement }
+// popover against, the first word's element so the caller can resolve which
+// sentence it sits in (translator context), and the range's first/last word
+// indices so playback can seek there or play just the phrase.
+type ReaderSelection = {
+  term: string
+  rect: DOMRect
+  anchor: HTMLElement
+  index: number
+  end_index: number
+}
 
 type WordRange = { lo: number; hi: number }
 
@@ -332,7 +339,7 @@ export function useReaderHighlights(
     if (!term) return
 
     committed.value = range
-    onSelect({ term, rect, anchor })
+    onSelect({ term, rect, anchor, index: range.lo, end_index: range.hi })
   }
 
   function onPointerDown(event: PointerEvent) {

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -299,6 +299,8 @@
   "audio-reader.popover.loading": "Translating…",
   "audio-reader.popover.error": "Couldn't translate that. Try again.",
   "audio-reader.popover.too-long-error": "That selection is too long. Try a shorter phrase.",
+  "audio-reader.popover.play-word-button": "Play word",
+  "audio-reader.popover.play-from-here-button": "Play from here",
   "audio-reader.popover.add-card-button": "Add flashcard",
   "audio-reader.popover.add-to-deck-button": "Add to {deck}",
   "audio-reader.popover.choose-deck-button": "Choose a deck",

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -31,6 +31,8 @@ const {
   target_lang,
   openTerm,
   closeTerm,
+  playFromHere,
+  playClip,
   player
 } = useLessonReader(lesson_id)
 
@@ -190,6 +192,8 @@ watch(
         :sentence="selection.sentence"
         :target_lang="target_lang"
         @close="closeTerm"
+        @play-from-here="playFromHere"
+        @play-word="playClip"
       />
     </div>
   </section>

--- a/src/views/audio-reader/term-popover/index.vue
+++ b/src/views/audio-reader/term-popover/index.vue
@@ -12,6 +12,8 @@ const { open, rect, term, sentence, target_lang } = defineProps<{
 
 const emit = defineEmits<{
   (e: 'close'): void
+  (e: 'play-from-here'): void
+  (e: 'play-word'): void
 }>()
 </script>
 
@@ -32,6 +34,8 @@ const emit = defineEmits<{
         :sentence="sentence"
         :target_lang="target_lang"
         @close="emit('close')"
+        @play-from-here="emit('play-from-here')"
+        @play-word="emit('play-word')"
       />
     </div>
   </ui-popover>

--- a/src/views/audio-reader/term-popover/sheet.vue
+++ b/src/views/audio-reader/term-popover/sheet.vue
@@ -2,18 +2,27 @@
 import MobileSheet from '@/components/layout-kit/modal/mobile-sheet.vue'
 import TermCard from './term-card.vue'
 
-const { term, sentence, target_lang, close } = defineProps<{
+const { term, sentence, target_lang, close, play_from_here, play_word } = defineProps<{
   term: string
   sentence: string
   target_lang: string
   close: () => void
+  play_from_here: () => void
+  play_word: () => void
 }>()
 </script>
 
 <template>
   <mobile-sheet :show_close_button="false">
     <div data-testid="term-sheet" class="px-6 pt-6 pb-10">
-      <term-card :term="term" :sentence="sentence" :target_lang="target_lang" @close="close()" />
+      <term-card
+        :term="term"
+        :sentence="sentence"
+        :target_lang="target_lang"
+        @close="close()"
+        @play-from-here="play_from_here()"
+        @play-word="play_word()"
+      />
     </div>
   </mobile-sheet>
 </template>

--- a/src/views/audio-reader/term-popover/term-card.vue
+++ b/src/views/audio-reader/term-popover/term-card.vue
@@ -16,6 +16,8 @@ const { term, sentence, target_lang } = defineProps<{
 
 const emit = defineEmits<{
   (e: 'close'): void
+  (e: 'play-from-here'): void
+  (e: 'play-word'): void
 }>()
 
 const { t } = useI18n()
@@ -65,12 +67,26 @@ watch(
 <template>
   <div data-testid="term-card" class="flex flex-col">
     <header data-testid="term-card__header" class="flex items-start justify-between gap-3">
-      <span
-        data-testid="term-card__term"
-        class="text-6xl leading-tight wrap-break-word text-brown-700 dark:text-brown-200"
-      >
-        {{ term }}
-      </span>
+      <div data-testid="term-card__term-group" class="flex min-w-0 items-center gap-2">
+        <span
+          data-testid="term-card__term"
+          class="text-6xl leading-tight wrap-break-word text-brown-700 dark:text-brown-200"
+        >
+          {{ term }}
+        </span>
+
+        <ui-button
+          data-testid="term-card__play-word"
+          data-theme="grey-400"
+          class="shrink-0"
+          icon-left="play"
+          icon-only
+          size="sm"
+          @click="emit('play-word')"
+        >
+          {{ t('audio-reader.popover.play-word-button') }}
+        </ui-button>
+      </div>
 
       <add-card-control v-if="result" @add="onAddCard" />
 
@@ -133,6 +149,18 @@ watch(
         {{ result.description }}
       </p>
     </div>
+
+    <footer data-testid="term-card__footer" class="mt-4 flex">
+      <ui-button
+        data-testid="term-card__play-from-here"
+        data-theme="grey-400"
+        icon-left="play"
+        size="sm"
+        @click="emit('play-from-here')"
+      >
+        {{ t('audio-reader.popover.play-from-here-button') }}
+      </ui-button>
+    </footer>
   </div>
 </template>
 

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -17,11 +17,12 @@ const emit = defineEmits<{
   (e: 'select', selection: TermSelection): void
 }>()
 
-const { onPointerDown, onPointerMove, onPointerUp, onPointerLeave } = useReaderHighlights(
-  () => active_word,
-  commitSelection,
-  () => popover_open
-)
+const { onPointerDown, onPointerMove, onPointerUp, onPointerLeave, onPointerCancel } =
+  useReaderHighlights(
+    () => active_word,
+    commitSelection,
+    () => popover_open
+  )
 
 function paragraphIndexOf(node: Element): number | null {
   const segment = node.closest('[data-testid="transcript-segment"]')
@@ -48,6 +49,7 @@ function commitSelection({ term, rect, anchor }: { term: string; rect: DOMRect; 
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"
       @pointerleave="onPointerLeave"
+      @pointercancel="onPointerCancel"
     >
       <div
         ref="sentence"

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -30,12 +30,25 @@ function paragraphIndexOf(node: Element): number | null {
   return index === null || index === undefined ? null : Number(index)
 }
 
-// A committed word-range carries its own term + rect; the surrounding text
-// (translator context) is the whole paragraph the anchor word sits in.
-function commitSelection({ term, rect, anchor }: { term: string; rect: DOMRect; anchor: Element }) {
+// A committed word-range carries its own term + rect + first/last word indices;
+// the surrounding text (translator context) is the whole paragraph the anchor
+// word sits in.
+function commitSelection({
+  term,
+  rect,
+  anchor,
+  index: word_index,
+  end_index: word_end_index
+}: {
+  term: string
+  rect: DOMRect
+  anchor: Element
+  index: number
+  end_index: number
+}) {
   const index = paragraphIndexOf(anchor)
   const sentence = (index !== null && paragraphs[index]?.sentence) || term
-  emit('select', { term, sentence, rect })
+  emit('select', { term, sentence, rect, word_index, word_end_index })
 }
 </script>
 

--- a/tests/unit/composables/audio-reader/use-lesson-reader.test.js
+++ b/tests/unit/composables/audio-reader/use-lesson-reader.test.js
@@ -83,7 +83,13 @@ describe('useLessonReader', () => {
   beforeEach(() => {
     lessonQueryMock.mockReturnValue({ data: ref(makeLesson()), error: ref(null) })
     audioUrlQueryMock.mockReturnValue({ data: ref('https://cdn/1.mp3') })
-    audioPlayerMock.mockReturnValue({ current_time: ref(0) })
+    audioPlayerMock.mockReturnValue({
+      current_time: ref(0),
+      play: vi.fn(),
+      pause: vi.fn(),
+      seek: vi.fn(),
+      playClip: vi.fn()
+    })
     transcriptSyncMock.mockReturnValue({ active_index: ref(-1) })
     toastErrorMock.mockReset()
     openModalMock.mockReset()

--- a/types/lesson.d.ts
+++ b/types/lesson.d.ts
@@ -73,9 +73,13 @@ type LessonCollectionWithCount = LessonCollection & {
 }
 
 // A term the reader tapped or selected, with the sentence it sits in (translator
-// context) and the rect to anchor the details popover against.
+// context), the rect to anchor the details popover against, and its first/last
+// word indices so playback can seek there ("play from here") or play just the
+// phrase ("play word").
 type TermSelection = {
   term: string
   sentence: string
   rect: DOMRect
+  word_index: number
+  word_end_index: number
 }


### PR DESCRIPTION
## Summary

Two improvements to the audio-reader, both aimed at building flashcards from the transcript:

**Mobile range-select.** Touch previously reserved every drag for scrolling, so you could only ever select one word per tap. Holding a word still for ~400ms now arms range-select: a haptic confirms, the column stops scrolling, and the drag extends the selection word by word until release commits it. A quick tap still selects one word; an immediate drag still scrolls; a browser-claimed scroll disarms via `pointercancel`.

**Term-popover playback controls.** Opening a term popover/sheet pauses playback so the term holds still under it. Two actions ride along with the selection:
- **Play word** (header, beside the term) plays just the selected phrase — first word's start to last word's end — then auto-pauses, leaving the popover open so its translation stays readable. Backed by a new bounded `playClip(start, end)` on the audio player.
- **Play from here** (footer) seeks to the term and resumes open-ended playback, dismissing the popover.

The committed selection now carries its first and last word indices so both actions resolve start/end times from the transcript.