### PR TITLE
refactor(deck-view): scalable mode system + smoother view/edit transition

### DIFF
--- a/src/composables/card-editor/card-actions.ts
+++ b/src/composables/card-editor/card-actions.ts
@@ -8,6 +8,7 @@ import type { useDeckQuery } from '@/api/decks'
 import type { CardSelection } from './card-selection'
 import type { VirtualCardList } from './virtual-card-list'
 import type { CardMutations } from './card-mutations'
+import type { DeckViewShell } from './deck-view-shell'
 
 export type CardActions = ReturnType<typeof useCardActions>
 
@@ -19,19 +20,20 @@ type Args = {
   mutations: CardMutations
   deck_query: Pick<DeckQuery, 'refetch'>
   deck_id: number
-  setMode: (mode: CardEditorMode) => void
+  shell: Pick<DeckViewShell, 'exitMode'>
 }
 
 /**
  * Intent handlers for the deck-editor: confirm + delete, open + move, enter
  * selection, exit mode. Composes modal / alert / sfx around the underlying
- * mutations so the controller doesn't carry that UI baggage.
+ * mutations so the controller doesn't carry that UI baggage. Flows that end
+ * editing hand control back to the deck-view shell via `shell.exitMode()`.
  *
  * @example
- * const actions = useCardActions({ list, selection, mutations, deck_id, setMode })
+ * const actions = useCardActions({ list, selection, mutations, deck_id, shell })
  * actions.onDeleteCards(card_id)
  */
-export function useCardActions({ list, selection, mutations, deck_query, deck_id, setMode }: Args) {
+export function useCardActions({ list, selection, mutations, deck_query, deck_id, shell }: Args) {
   const { t } = useI18n()
   const modal = useModal()
   const alert = useAlert()
@@ -47,11 +49,10 @@ export function useCardActions({ list, selection, mutations, deck_query, deck_id
     return response
   }
 
-  /** Cleanup applied after any successful delete: drop selection, refetch, exit. */
+  /** Cleanup applied after any successful delete: drop selection, refetch. */
   async function afterDelete() {
     selection.exitSelection()
     await deck_query.refetch()
-    setMode('view')
   }
 
   /** Cleanup applied after any successful move: drop selection, refetch source deck. */
@@ -137,7 +138,7 @@ export function useCardActions({ list, selection, mutations, deck_query, deck_id
   /** Exit the current mode: drop selection, return to view mode. */
   function onCancel() {
     emitSfx('ui.card_drop')
-    setMode('view')
+    shell.exitMode()
     selection.exitSelection()
   }
 

--- a/src/composables/card-editor/card-list-controller.ts
+++ b/src/composables/card-editor/card-list-controller.ts
@@ -1,4 +1,4 @@
-import { computed, ref, type Ref } from 'vue'
+import { computed, ref, type InjectionKey, type Ref } from 'vue'
 import { useInfiniteScroll } from '@/composables/use-infinite-scroll'
 import { useCardsInDeckInfiniteQuery } from '@/api/cards'
 import { useDeckQuery } from '@/api/decks'
@@ -8,29 +8,29 @@ import { useCardMutations } from './card-mutations'
 import { useCardCarousel } from './card-carousel'
 import { useCardActions } from './card-actions'
 import { useCardLimitGate } from '@/composables/use-card-limit-gate'
-import { useLocalRef } from '@/composables/use-local-ref'
+import type { DeckViewShell } from './deck-view-shell'
 
 export type CardListController = ReturnType<typeof useCardListController>
 
-/** Card render size for the deck grid — Small / Base / Full in the toolbar. */
-export type CardGridSize = 'base' | 'md' | 'xl'
+export const cardEditorKey = Symbol('cardEditor') as InjectionKey<CardListController>
 
 type Options = {
   deck_id: number
+  // intent actions hand control back to the shell when a flow ends editing
+  shell: Pick<DeckViewShell, 'exitMode'>
 }
 
 /**
  * Single root composable for the deck-editor card list. Wires the infinite
  * cards query, deck query, virtual list, selection, mutations, carousel, and
  * intent actions together, and exposes the consolidated surface a single
- * `provide('card-editor')` hands to every consumer (list, grid, list-item,
+ * `provide(cardEditorKey)` hands to every consumer (list, grid, list-item,
  * list-item-card, card-importer, mode-toolbar, deck-hero).
  *
- * Owns:
- * - `mode` UI state (view / edit / import-export). Selection is orthogonal:
- *   `is_selecting` flips on the moment any card is selected, regardless of
- *   which mode is active.
- * - the `saving` flag and the INSERT-vs-UPDATE routing in `updateCard`.
+ * Pure card-data concerns: which mode/pane is on screen lives in
+ * `useDeckViewShell`. Selection is orthogonal to mode: `is_selecting` flips on
+ * the moment any card is selected, regardless of which mode is active. Also
+ * owns the `saving` flag and the INSERT-vs-UPDATE routing in `updateCard`.
  *
  * Calls `useDeckQuery` once internally and forwards `deck.card_count` into
  * `useCardSelection` and `useCardCarousel`. Pinia Colada dedupes by key, so
@@ -38,10 +38,13 @@ type Options = {
  * share the cache entry.
  *
  * @param opts.deck_id - Numeric deck id this controller is scoped to.
+ * @param opts.shell - The deck-view shell; intent actions call its `exitMode`
+ *   when a flow ends editing (e.g. deleting the whole selection).
  *
  * @example
- * const editor = useCardListController({ deck_id })
- * provide('card-editor', editor)
+ * const shell = useDeckViewShell()
+ * const editor = useCardListController({ deck_id, shell })
+ * provide(cardEditorKey, editor)
  */
 export function useCardListController(opts: Options) {
   const cards_query = useCardsInDeckInfiniteQuery(() => opts.deck_id)
@@ -54,8 +57,6 @@ export function useCardListController(opts: Options) {
   const mutations = useCardMutations(opts.deck_id)
   const limit_gate = useCardLimitGate(() => deck_query.data.value)
 
-  const mode = ref<CardEditorMode>('view')
-  const grid_size = useLocalRef<CardGridSize>('deck-grid-size', 'md')
   const saving = ref(false)
 
   const card_attributes = computed<DeckCardAttributes>(() => ({
@@ -64,16 +65,6 @@ export function useCardListController(opts: Options) {
   }))
 
   const carousel = useCardCarousel({ list, cards_query, card_count })
-
-  /** Set the editor's UI mode (view / edit / import-export). */
-  function setMode(new_mode: CardEditorMode) {
-    mode.value = new_mode
-  }
-
-  /** Set the card render size for the deck grid (Small / Base / Full). */
-  function setGridSize(size: CardGridSize) {
-    grid_size.value = size
-  }
 
   /**
    * Stage a new temp card, gated on the deck's plan card cap. The single funnel
@@ -105,7 +96,7 @@ export function useCardListController(opts: Options) {
     mutations,
     deck_query,
     deck_id: opts.deck_id,
-    setMode
+    shell: opts.shell
   })
 
   /**
@@ -196,10 +187,6 @@ export function useCardListController(opts: Options) {
     carousel,
     actions,
 
-    mode,
-    setMode,
-    grid_size,
-    setGridSize,
     addCard,
     appendCard,
     prependCard,

--- a/src/composables/card-editor/deck-view-shell.ts
+++ b/src/composables/card-editor/deck-view-shell.ts
@@ -1,0 +1,51 @@
+import { computed, ref, type InjectionKey } from 'vue'
+import { useLocalRef } from '@/composables/use-local-ref'
+
+export type DeckViewShell = ReturnType<typeof useDeckViewShell>
+
+/** Card render size for the deck grid — Small / Base / Full in the toolbar. */
+export type CardGridSize = 'base' | 'md' | 'xl'
+
+export const deckViewShellKey = Symbol('deckViewShell') as InjectionKey<DeckViewShell>
+
+/**
+ * UI shell of the deck view: which mode (pane) is active and how the grid
+ * renders. Deliberately free of card-data concerns so panes that only switch
+ * modes don't have to depend on the whole card-list controller.
+ *
+ * Mode changes all funnel through here — `setMode` / `toggleMode` / `exitMode`
+ * are the single seam for cross-cutting concerns like unsaved-changes guards.
+ * The pane/chrome each mode maps to lives in `views/deck/modes.ts`.
+ *
+ * @example
+ * const shell = useDeckViewShell()
+ * provide(deckViewShellKey, shell)
+ */
+export function useDeckViewShell() {
+  const mode = ref<CardEditorMode>('view')
+  const grid_size = useLocalRef<CardGridSize>('deck-grid-size', 'md')
+
+  const is_view = computed(() => mode.value === 'view')
+
+  /** Switch the deck view to `new_mode`. */
+  function setMode(new_mode: CardEditorMode) {
+    mode.value = new_mode
+  }
+
+  /** Enter `target`, or fall back to the base view when it's already active. */
+  function toggleMode(target: CardEditorMode) {
+    setMode(mode.value === target ? 'view' : target)
+  }
+
+  /** Leave the current mode back to the base view. */
+  function exitMode() {
+    setMode('view')
+  }
+
+  /** Set the card render size for the deck grid (Small / Base / Full). */
+  function setGridSize(size: CardGridSize) {
+    grid_size.value = size
+  }
+
+  return { mode, is_view, grid_size, setMode, toggleMode, exitMode, setGridSize }
+}

--- a/src/composables/card-editor/use-bulk-actions.ts
+++ b/src/composables/card-editor/use-bulk-actions.ts
@@ -1,7 +1,7 @@
 import { computed, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { emitSfx } from '@/sfx/bus'
-import { type CardListController } from './card-list-controller'
+import { cardEditorKey } from './card-list-controller'
 
 /**
  * Reactive labels + handlers shared by the bulk-actions stack and the
@@ -14,7 +14,7 @@ import { type CardListController } from './card-list-controller'
  */
 export function useBulkActions() {
   const { t } = useI18n()
-  const { selection, actions } = inject<CardListController>('card-editor')!
+  const { selection, actions } = inject(cardEditorKey)!
 
   const has_selection = computed(
     () => selection.select_all_mode.value || selection.selected_count.value > 0

--- a/src/composables/card-editor/use-face-image-upload.ts
+++ b/src/composables/card-editor/use-face-image-upload.ts
@@ -9,7 +9,7 @@ import {
   type ShallowRef
 } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { type CardListController } from './card-list-controller'
+import { cardEditorKey } from './card-list-controller'
 import { useCardImageGate } from './use-card-image-gate'
 import { useImageDropzone } from './use-image-dropzone'
 import { useToast } from '@/composables/toast'
@@ -51,7 +51,7 @@ export function useFaceImageUpload({ card, side, fileInput, rootEl }: UseFaceIma
   const { t } = useI18n()
   const toast = useToast()
   const { guardCardImage } = useCardImageGate()
-  const { setFaceImage } = inject<CardListController>('card-editor')!
+  const { setFaceImage } = inject(cardEditorKey)!
 
   const hovered = ref(false)
   const hover_suppressed = ref(false)

--- a/src/utils/animations/deck-view/card-overlay.ts
+++ b/src/utils/animations/deck-view/card-overlay.ts
@@ -3,12 +3,45 @@ import { gsap } from 'gsap'
 const DURATION = 0.5
 const SCALE = 0.95
 
-// One screen of travel. The overlay (editor/importer) is a full page-flow
-// pane far taller than the viewport, so sliding by its own height would push
-// it mostly off-screen for the whole tween; a viewport-relative distance keeps
-// the slide visible regardless of content height.
-function viewportDistance() {
-  return window.innerHeight
+/* ── Viewport context ──────────────────────────────────────────────────────── */
+
+// A mode switch animates in viewport space: the window scroll jumps to
+// `settle_y` (where the incoming pane rests) at the moment of the switch, and
+// every hook offsets its pane so nothing appears to move until the tweens run.
+export type ModeSwitchViewport = {
+  from_y: number
+  settle_y: number
+  stack_top: number
+}
+
+// Must run before the DOM patches — rects and scroll still describe the
+// outgoing mode, i.e. what the user is actually looking at. `settle_y` keeps
+// the user's scroll when they're above the stack, otherwise lands the incoming
+// pane's top just below the sticky header.
+export function captureModeSwitch(
+  stack: HTMLElement,
+  sticky_header?: HTMLElement | null
+): ModeSwitchViewport {
+  const from_y = window.scrollY
+  const stack_top = stack.getBoundingClientRect().top + from_y
+  const header_bottom = sticky_header?.getBoundingClientRect().bottom ?? 0
+
+  const settle_y = Math.min(from_y, Math.max(0, stack_top - header_bottom))
+  return { from_y, settle_y, stack_top }
+}
+
+// The shift that keeps an out-of-flow pane visually still across the
+// settle-scroll jump.
+function scrollCompensation(vp: ModeSwitchViewport) {
+  return vp.settle_y - vp.from_y
+}
+
+// Distance from the stack's top to the viewport's bottom edge once settled.
+// Doubles as the overlay's slide-in offset and as the stack's min-height
+// during the switch — the clip box must reach the screen bottom or a short
+// incoming grid clips the outgoing pane to its own height.
+export function distanceToViewportBottom(vp: ModeSwitchViewport) {
+  return Math.max(0, vp.settle_y + window.innerHeight - vp.stack_top)
 }
 
 /* ── Grid pane: scales down + fades ───────────────────────────────────────── */
@@ -19,10 +52,10 @@ const ORIGIN = 'top center'
 
 // Entering grid stays in flow (it defines the settled height) and fades up
 // from a slightly shrunk state. The grid is kept mounted via v-show, so clear
-// the absolute positioning a prior leave left behind — it must rejoin flow to
-// define the page height again.
+// the absolute positioning and compensation a prior leave left behind — it
+// must rejoin flow to define the page height again.
 export function fadeScaleEnter(el: Element, done: () => void) {
-  gsap.set(el, { clearProps: 'position,top,left,width' })
+  gsap.set(el, { clearProps: 'position,top,left,width,transform' })
   gsap.fromTo(
     el,
     { opacity: 0, scale: SCALE, transformOrigin: ORIGIN },
@@ -31,9 +64,10 @@ export function fadeScaleEnter(el: Element, done: () => void) {
 }
 
 // Leaving grid drops out of flow (so the entering pane owns the height) and
-// shrinks + fades in place.
-export function fadeScaleLeave(el: Element, done: () => void) {
-  gsap.set(el, { position: 'absolute', top: 0, left: 0, width: '100%' })
+// shrinks + fades in place — compensated so the rows under the user's eyes
+// stay put through the scroll jump.
+export function fadeScaleLeave(el: Element, vp: ModeSwitchViewport, done: () => void) {
+  gsap.set(el, { position: 'absolute', top: 0, left: 0, width: '100%', y: scrollCompensation(vp) })
   gsap.to(el, {
     opacity: 0,
     scale: SCALE,
@@ -46,10 +80,10 @@ export function fadeScaleLeave(el: Element, done: () => void) {
 
 /* ── Overlay pane (editor / importer): slides up + down ───────────────────── */
 
-// Entering overlay stays in flow but starts one screen below its slot, layered
-// above the grid, and rises into place.
-export function primeOverlayBelow(el: Element) {
-  gsap.set(el, { position: 'relative', zIndex: 1, y: viewportDistance() })
+// Entering overlay stays in flow but starts with its top at the viewport's
+// bottom edge, layered above the grid, and rises into place.
+export function primeOverlayBelow(el: Element, vp: ModeSwitchViewport) {
+  gsap.set(el, { position: 'relative', zIndex: 1, y: distanceToViewportBottom(vp) })
 }
 
 export function slideOverlayUp(el: Element, done: () => void) {
@@ -68,11 +102,16 @@ export function settleOverlay(el: Element) {
 }
 
 // Leaving overlay drops out of flow (so the entering grid owns the height) and
-// slides one screen down, still layered on top.
-export function slideOverlayDown(el: Element, done: () => void) {
-  gsap.set(el, { position: 'absolute', top: 0, left: 0, width: '100%', zIndex: 1 })
+// slides one screen down from wherever the user was looking. When the user was
+// scrolled into the pane, one screen of travel can't carry its top edge past
+// the viewport bottom — fade it out so it never unmounts mid-screen.
+export function slideOverlayDown(el: Element, vp: ModeSwitchViewport, done: () => void) {
+  const from = scrollCompensation(vp)
+
+  gsap.set(el, { position: 'absolute', top: 0, left: 0, width: '100%', zIndex: 1, y: from })
   gsap.to(el, {
-    y: viewportDistance(),
+    y: from + window.innerHeight,
+    opacity: from < 0 ? 0 : 1,
     duration: DURATION,
     ease: 'expo.out',
     onComplete: done

--- a/src/views/deck/card-editor/card-face-uploader.vue
+++ b/src/views/deck/card-editor/card-face-uploader.vue
@@ -6,7 +6,7 @@ import UiIcon from '@/components/ui-kit/icon.vue'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
 import FaceImageDropzone from './face-image-dropzone.vue'
 import UiButton from '@/components/ui-kit/button.vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 import {
   CARD_IMAGE_MAX_BYTES,
   useFaceImageUpload
@@ -28,7 +28,7 @@ type CardFaceUploaderProps = {
 const { card, side, disabled = false, error = false } = defineProps<CardFaceUploaderProps>()
 
 const { t } = useI18n()
-const { card_attributes } = inject<CardListController>('card-editor')!
+const { card_attributes } = inject(cardEditorKey)!
 
 const addIcon = useTemplateRef<HTMLElement>('addIcon')
 const cardRef = useTemplateRef<ComponentPublicInstance>('cardRef')

--- a/src/views/deck/card-editor/index.vue
+++ b/src/views/deck/card-editor/index.vue
@@ -3,12 +3,12 @@ import List from './list.vue'
 import { useI18n } from 'vue-i18n'
 import UiButton from '@/components/ui-kit/button.vue'
 import { inject } from 'vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 defineOptions({ inheritAttrs: false })
 
 const { t } = useI18n()
-const { list, addCard } = inject<CardListController>('card-editor')!
+const { list, addCard } = inject(cardEditorKey)!
 const { all_cards } = list
 </script>
 

--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -2,7 +2,7 @@
 import CardFaceUploader from './card-face-uploader.vue'
 import { useI18n } from 'vue-i18n'
 import { inject, ref, useTemplateRef } from 'vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 import textEditor from '@/components/card/text-editor.vue'
 import { emitSfx } from '@/sfx/bus'
 
@@ -25,7 +25,7 @@ const front_text = ref(card.front_text ?? '')
 const back_text = ref(card.back_text ?? '')
 const save_failed = ref(false)
 
-const { selection, updateCard, card_attributes } = inject<CardListController>('card-editor')!
+const { selection, updateCard, card_attributes } = inject(cardEditorKey)!
 const { is_selecting } = selection
 
 // Persist both sides from local state, not just the edited one: the merge base

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -3,7 +3,7 @@ import ItemOptions from './list-item-options.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiRadio from '@/components/ui-kit/radio.vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 import { inject, computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ListItemCard from './list-item-card.vue'
@@ -16,7 +16,7 @@ type ListItemProps = {
 const { card, index } = defineProps<ListItemProps>()
 
 const { t } = useI18n()
-const { selection, actions, appendCard, prependCard } = inject<CardListController>('card-editor')!
+const { selection, actions, appendCard, prependCard } = inject(cardEditorKey)!
 const { is_selecting, isCardSelected } = selection
 const { onDeleteCards, onMoveCards, onSelectCard } = actions
 

--- a/src/views/deck/card-editor/list.vue
+++ b/src/views/deck/card-editor/list.vue
@@ -3,7 +3,7 @@ import ListItem from './list-item.vue'
 import { inject, useTemplateRef, computed, ref, watchEffect, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useWindowVirtualizer } from '@tanstack/vue-virtual'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 const { t } = useI18n()
 
@@ -11,7 +11,7 @@ const ROW_PITCH = 407
 const LOAD_MORE_THRESHOLD = 5
 const OVERSCAN = 3
 
-const { list, hasNextPage, isLoading, loadNextPage } = inject<CardListController>('card-editor')!
+const { list, hasNextPage, isLoading, loadNextPage } = inject(cardEditorKey)!
 const { all_cards } = list
 
 const list_el = useTemplateRef<HTMLElement>('list_el')

--- a/src/views/deck/card-grid/grid-item.vue
+++ b/src/views/deck/card-grid/grid-item.vue
@@ -4,9 +4,9 @@ import UiRadio from '@/components/ui-kit/radio.vue'
 import GridItemMenu from './grid-item-menu.vue'
 import { emitSfx } from '@/sfx/bus'
 import { inject, ref } from 'vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
-const { actions, selection } = inject<CardListController>('card-editor')!
+const { actions, selection } = inject(cardEditorKey)!
 const { onDeleteCards, onMoveCards, onSelectCard } = actions
 const { is_selecting } = selection
 

--- a/src/views/deck/card-grid/index.vue
+++ b/src/views/deck/card-grid/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import GridItem from './grid-item.vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 import { computed, inject, ref, useTemplateRef, watch, type CSSProperties } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useGridCapacity } from '@/composables/use-grid-capacity'
@@ -10,7 +10,7 @@ import { slideInFromDirection, slideOutInDirection } from '@/utils/animations/gr
 const { t } = useI18n()
 
 const { list, selection, carousel, card_attributes, hasNextPage, isLoading, observeSentinel } =
-  inject<CardListController>('card-editor')!
+  inject(cardEditorKey)!
 const { all_cards } = list
 const { isCardSelected } = selection
 const { visible_cards, setVisibleCapacity, page, page_size, page_direction, is_page_loading } =

--- a/src/views/deck/card-grid/scroll-grid.vue
+++ b/src/views/deck/card-grid/scroll-grid.vue
@@ -1,16 +1,15 @@
 <script setup lang="ts">
 import GridItem from './grid-item.vue'
-import {
-  type CardGridSize,
-  type CardListController
-} from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey, type CardGridSize } from '@/composables/card-editor/deck-view-shell'
 import { computed, inject, ref, useTemplateRef, type CSSProperties } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 
-const { list, selection, card_attributes, hasNextPage, isLoading, observeSentinel, grid_size } =
-  inject<CardListController>('card-editor')!
+const { list, selection, card_attributes, hasNextPage, isLoading, observeSentinel } =
+  inject(cardEditorKey)!
+const { grid_size } = inject(deckViewShellKey)!
 const { all_cards } = list
 const { isCardSelected } = selection
 

--- a/src/views/deck/card-importer.vue
+++ b/src/views/deck/card-importer.vue
@@ -5,7 +5,7 @@ import UiButton from '@/components/ui-kit/button.vue'
 import Card from '@/components/card/index.vue'
 import { useBulkInsertCardsInDeckMutation } from '@/api/cards'
 import { useToast } from '@/composables/toast'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 const { t } = useI18n()
 const toast = useToast()
@@ -18,7 +18,7 @@ const raw_text = ref<string>('')
 const cards = ref<CardDraft[]>([])
 const bulk_insert_mutation = useBulkInsertCardsInDeckMutation()
 
-const { deck_id, guardAddCards, handleLimitError } = inject<CardListController>('card-editor')!
+const { deck_id, guardAddCards, handleLimitError } = inject(cardEditorKey)!
 
 const has_unsaved_changes = computed(() => cards.value.length > 0)
 

--- a/src/views/deck/deck-hero/actions.vue
+++ b/src/views/deck/deck-hero/actions.vue
@@ -7,7 +7,8 @@ import { computed, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStudyModal } from '@/composables/modals/use-study-modal'
 import { useDeckSettingsModal } from '@/composables/modals/use-deck-settings-modal'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
 
 const { deck } = defineProps<{ deck: Deck }>()
 
@@ -15,10 +16,10 @@ const { t } = useI18n()
 const study_session = useStudyModal()
 const deck_settings = useDeckSettingsModal()
 
-const editor = inject<CardListController | null>('card-editor', null)
-const mode = editor?.mode
+const editor = inject(cardEditorKey, null)
+const shell = inject(deckViewShellKey, null)
 
-const is_editing = computed(() => mode?.value === 'edit')
+const is_editing = computed(() => shell?.mode.value === 'edit')
 const edit_options = computed<DropdownOption[]>(() => [
   { label: t('deck-view.actions.select-cards'), value: 'select', icon: 'data-check' },
   {
@@ -33,8 +34,7 @@ function onStudyClicked() {
 }
 
 function onToggleEditCards() {
-  if (!editor) return
-  editor.setMode(editor.mode.value === 'edit' ? 'view' : 'edit')
+  shell?.toggleMode('edit')
 }
 
 function onEditOption(option: DropdownOption) {

--- a/src/views/deck/deck-hero/index.vue
+++ b/src/views/deck/deck-hero/index.vue
@@ -4,12 +4,12 @@ import DeckDetails from './details.vue'
 import Actions from './actions.vue'
 import BulkActions from './bulk-actions.vue'
 import { inject } from 'vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 import { defaultEnter, defaultLeave, bulkEnter, bulkLeave } from '@/utils/animations/actions-swap'
 
 defineProps<{ deck: Deck; imageUrl?: string }>()
 
-const editor = inject<CardListController | null>('card-editor', null)
+const editor = inject(cardEditorKey, null)
 const is_selecting = editor?.selection.is_selecting
 </script>
 

--- a/src/views/deck/index.vue
+++ b/src/views/deck/index.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
-import { computed, provide, ref, useTemplateRef } from 'vue'
+import { computed, onMounted, provide, ref, useTemplateRef } from 'vue'
 import DeckHero from '@/views/deck/deck-hero/index.vue'
 import ModeToolbar from './mode-toolbar/index.vue'
 import ModeStack from './mode-stack.vue'
+import { preloadDeckModes } from './modes'
 import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
 import { useDeckQuery } from '@/api/decks'
-import { useCardListController } from '@/composables/card-editor/card-list-controller'
+import {
+  cardEditorKey,
+  useCardListController
+} from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey, useDeckViewShell } from '@/composables/card-editor/deck-view-shell'
 
 const { id: deck_id } = defineProps<{
   id: string
@@ -19,11 +24,15 @@ const toolbar = useTemplateRef<HTMLElement>('toolbar')
 const deck_query = useDeckQuery(id)
 const deck = deck_query.data
 
-const editor = useCardListController({ deck_id: id.value })
+const shell = useDeckViewShell()
+provide(deckViewShellKey, shell)
 
-provide('card-editor', editor)
+const editor = useCardListController({ deck_id: id.value, shell })
+provide(cardEditorKey, editor)
 
 const is_empty = computed(() => !editor.isLoading.value && editor.list.all_cards.value.length === 0)
+
+onMounted(preloadDeckModes)
 </script>
 
 <template>
@@ -38,7 +47,7 @@ const is_empty = computed(() => !editor.isLoading.value && editor.list.all_cards
       :image-url="image_url"
     />
 
-    <div data-testid="deck-view__main" :data-mode="editor.mode.value" class="relative w-full pb-4">
+    <div data-testid="deck-view__main" :data-mode="shell.mode.value" class="relative w-full pb-4">
       <div ref="toolbar" data-testid="deck-view__toolbar" class="sticky top-(--nav-height) z-20">
         <div
           data-testid="deck-view__toolbar-backing"

--- a/src/views/deck/index.vue
+++ b/src/views/deck/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, provide, ref } from 'vue'
+import { computed, provide, ref, useTemplateRef } from 'vue'
 import DeckHero from '@/views/deck/deck-hero/index.vue'
 import ModeToolbar from './mode-toolbar/index.vue'
 import ModeStack from './mode-stack.vue'
@@ -14,6 +14,7 @@ const { id: deck_id } = defineProps<{
 const id = computed(() => Number(deck_id))
 
 const image_url = ref<string | undefined>()
+const toolbar = useTemplateRef<HTMLElement>('toolbar')
 
 const deck_query = useDeckQuery(id)
 const deck = deck_query.data
@@ -38,7 +39,7 @@ const is_empty = computed(() => !editor.isLoading.value && editor.list.all_cards
     />
 
     <div data-testid="deck-view__main" :data-mode="editor.mode.value" class="relative w-full pb-4">
-      <div data-testid="deck-view__toolbar" class="sticky top-(--nav-height) z-20">
+      <div ref="toolbar" data-testid="deck-view__toolbar" class="sticky top-(--nav-height) z-20">
         <div
           data-testid="deck-view__toolbar-backing"
           aria-hidden="true"
@@ -48,7 +49,7 @@ const is_empty = computed(() => !editor.isLoading.value && editor.list.all_cards
       </div>
 
       <div v-if="is_empty" data-testid="deck-view__empty" class="mt-6" />
-      <mode-stack v-else class="mt-6" />
+      <mode-stack v-else class="mt-6" :sticky_header="toolbar" />
     </div>
 
     <scroll-bar class="fixed right-4 top-(--nav-height) bottom-10 z-30" target="html" />

--- a/src/views/deck/mode-stack.vue
+++ b/src/views/deck/mode-stack.vue
@@ -1,33 +1,57 @@
 <script setup lang="ts">
-import { computed, inject, ref } from 'vue'
+import { computed, inject, ref, useTemplateRef, watch } from 'vue'
 import CardGrid from './card-grid/scroll-grid.vue'
 import CardEditor from './card-editor/index.vue'
 import CardImporter from './card-importer.vue'
 import {
+  captureModeSwitch,
+  distanceToViewportBottom,
   fadeScaleEnter,
   fadeScaleLeave,
   primeOverlayBelow,
   slideOverlayUp,
   settleOverlay,
-  slideOverlayDown
+  slideOverlayDown,
+  type ModeSwitchViewport
 } from '@/utils/animations/deck-view/card-overlay'
 import type { CardListController } from '@/composables/card-editor/card-list-controller'
 
+type ModeStackProps = {
+  sticky_header?: HTMLElement | null
+}
+
+const { sticky_header = null } = defineProps<ModeStackProps>()
+
 const editor = inject<CardListController>('card-editor')!
 
+const stack = useTemplateRef<HTMLElement>('stack')
 const sliding = ref(0)
+const clip_min_height = ref(0)
+
+let viewport: ModeSwitchViewport = { from_y: 0, settle_y: 0, stack_top: 0 }
 
 const is_view = computed(() => editor.mode.value === 'view')
 const overlay_component = computed(() =>
   editor.mode.value === 'import-export' ? CardImporter : CardEditor
 )
 const is_transitioning = computed(() => sliding.value > 0)
+const clip_style = computed(() =>
+  is_transitioning.value ? { minHeight: `${clip_min_height.value}px` } : undefined
+)
+
+function onGridEnter(el: Element, done: () => void) {
+  fadeScaleEnter(el, done)
+}
+
+function onGridLeave(el: Element, done: () => void) {
+  fadeScaleLeave(el, viewport, done)
+}
 
 // The overlay overhangs the container as it travels, so clip only while it
 // slides — released at rest so card menus can overflow normally.
 function onOverlayBeforeEnter(el: Element) {
   sliding.value++
-  primeOverlayBelow(el)
+  primeOverlayBelow(el, viewport)
 }
 
 function onOverlayAfterEnter(el: Element) {
@@ -39,18 +63,39 @@ function onOverlayBeforeLeave() {
   sliding.value++
 }
 
+function onOverlayLeave(el: Element, done: () => void) {
+  slideOverlayDown(el, viewport, done)
+}
+
 function onOverlayAfterLeave() {
   sliding.value--
 }
+
+// Sync flush: the DOM still shows the outgoing mode, so the capture reads the
+// scroll and rects the user is actually looking at. The scroll jump is never
+// seen — the transition hooks re-offset both panes before the next paint.
+watch(
+  editor.mode,
+  () => {
+    if (!stack.value) return
+
+    viewport = captureModeSwitch(stack.value, sticky_header)
+    clip_min_height.value = distanceToViewportBottom(viewport)
+    window.scrollTo(0, viewport.settle_y)
+  },
+  { flush: 'sync' }
+)
 </script>
 
 <template>
   <div
+    ref="stack"
     data-testid="deck-view__mode-stack"
     class="relative w-full"
     :class="{ 'overflow-hidden': is_transitioning }"
+    :style="clip_style"
   >
-    <Transition :css="false" @enter="fadeScaleEnter" @leave="fadeScaleLeave">
+    <Transition :css="false" @enter="onGridEnter" @leave="onGridLeave">
       <card-grid v-show="is_view" class="w-full" />
     </Transition>
 
@@ -60,7 +105,7 @@ function onOverlayAfterLeave() {
       @enter="slideOverlayUp"
       @after-enter="onOverlayAfterEnter"
       @before-leave="onOverlayBeforeLeave"
-      @leave="slideOverlayDown"
+      @leave="onOverlayLeave"
       @after-leave="onOverlayAfterLeave"
     >
       <component :is="overlay_component" v-if="!is_view" :key="editor.mode.value" class="w-full" />

--- a/src/views/deck/mode-stack.vue
+++ b/src/views/deck/mode-stack.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, ref, useTemplateRef, watch } from 'vue'
-import CardGrid from './card-grid/scroll-grid.vue'
-import CardEditor from './card-editor/index.vue'
-import CardImporter from './card-importer.vue'
+import { DECK_MODES } from './modes'
 import {
   captureModeSwitch,
   distanceToViewportBottom,
@@ -14,7 +12,7 @@ import {
   slideOverlayDown,
   type ModeSwitchViewport
 } from '@/utils/animations/deck-view/card-overlay'
-import type { CardListController } from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
 
 type ModeStackProps = {
   sticky_header?: HTMLElement | null
@@ -22,24 +20,25 @@ type ModeStackProps = {
 
 const { sticky_header = null } = defineProps<ModeStackProps>()
 
-const editor = inject<CardListController>('card-editor')!
+const shell = inject(deckViewShellKey)!
 
 const stack = useTemplateRef<HTMLElement>('stack')
 const sliding = ref(0)
+const switch_pending = ref(false)
 const clip_min_height = ref(0)
 
 let viewport: ModeSwitchViewport = { from_y: 0, settle_y: 0, stack_top: 0 }
 
-const is_view = computed(() => editor.mode.value === 'view')
-const overlay_component = computed(() =>
-  editor.mode.value === 'import-export' ? CardImporter : CardEditor
+const overlay_pane = computed(() =>
+  shell.is_view.value ? null : DECK_MODES[shell.mode.value].pane
 )
-const is_transitioning = computed(() => sliding.value > 0)
+const is_transitioning = computed(() => switch_pending.value || sliding.value > 0)
 const clip_style = computed(() =>
   is_transitioning.value ? { minHeight: `${clip_min_height.value}px` } : undefined
 )
 
 function onGridEnter(el: Element, done: () => void) {
+  switch_pending.value = false
   fadeScaleEnter(el, done)
 }
 
@@ -50,6 +49,7 @@ function onGridLeave(el: Element, done: () => void) {
 // The overlay overhangs the container as it travels, so clip only while it
 // slides — released at rest so card menus can overflow normally.
 function onOverlayBeforeEnter(el: Element) {
+  switch_pending.value = false
   sliding.value++
   primeOverlayBelow(el, viewport)
 }
@@ -74,11 +74,15 @@ function onOverlayAfterLeave() {
 // Sync flush: the DOM still shows the outgoing mode, so the capture reads the
 // scroll and rects the user is actually looking at. The scroll jump is never
 // seen — the transition hooks re-offset both panes before the next paint.
+// `switch_pending` holds the clip from this moment until the entering pane's
+// transition starts: a lazy overlay pane can take a beat to load on first
+// entry, and without the held min-height the stack collapses in that gap.
 watch(
-  editor.mode,
+  shell.mode,
   () => {
     if (!stack.value) return
 
+    switch_pending.value = true
     viewport = captureModeSwitch(stack.value, sticky_header)
     clip_min_height.value = distanceToViewportBottom(viewport)
     window.scrollTo(0, viewport.settle_y)
@@ -96,7 +100,7 @@ watch(
     :style="clip_style"
   >
     <Transition :css="false" @enter="onGridEnter" @leave="onGridLeave">
-      <card-grid v-show="is_view" class="w-full" />
+      <component :is="DECK_MODES.view.pane" v-show="shell.is_view.value" class="w-full" />
     </Transition>
 
     <Transition
@@ -108,7 +112,7 @@ watch(
       @leave="onOverlayLeave"
       @after-leave="onOverlayAfterLeave"
     >
-      <component :is="overlay_component" v-if="!is_view" :key="editor.mode.value" class="w-full" />
+      <component :is="overlay_pane" v-if="overlay_pane" :key="shell.mode.value" class="w-full" />
     </Transition>
   </div>
 </template>

--- a/src/views/deck/mode-toolbar/card-count.vue
+++ b/src/views/deck/mode-toolbar/card-count.vue
@@ -2,11 +2,11 @@
 import UiTag from '@/components/ui-kit/tag.vue'
 import { useI18n } from 'vue-i18n'
 import { inject } from 'vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 const { t } = useI18n()
 
-const { card_count } = inject<CardListController>('card-editor')!
+const { card_count } = inject(cardEditorKey)!
 </script>
 
 <template>

--- a/src/views/deck/mode-toolbar/index.vue
+++ b/src/views/deck/mode-toolbar/index.vue
@@ -2,10 +2,10 @@
 import ModeView from './mode-view.vue'
 import BulkToolbar from './bulk-toolbar.vue'
 import { computed, inject } from 'vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 import { toolbarEnter, toolbarLeave } from '@/utils/animations/toolbar-swap'
 
-const { selection } = inject<CardListController>('card-editor')!
+const { selection } = inject(cardEditorKey)!
 
 const toolbarComponent = computed(() => (selection.is_selecting.value ? BulkToolbar : ModeView))
 </script>

--- a/src/views/deck/mode-toolbar/mode-view.vue
+++ b/src/views/deck/mode-toolbar/mode-view.vue
@@ -5,11 +5,11 @@ import PageSettings from './page-settings.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import { useI18n } from 'vue-i18n'
 import { inject } from 'vue'
-import { type CardListController } from '@/composables/card-editor/card-list-controller'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 const { t } = useI18n()
 
-const { addCard } = inject<CardListController>('card-editor')!
+const { addCard } = inject(cardEditorKey)!
 </script>
 
 <template>

--- a/src/views/deck/mode-toolbar/page-settings.vue
+++ b/src/views/deck/mode-toolbar/page-settings.vue
@@ -3,10 +3,7 @@ import UiButton from '@/components/ui-kit/button.vue'
 import UiPopover from '@/components/ui-kit/popover.vue'
 import SectionList from '@/components/layout-kit/section-list.vue'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
-import {
-  type CardGridSize,
-  type CardListController
-} from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey, type CardGridSize } from '@/composables/card-editor/deck-view-shell'
 import { inject, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { emitSfx } from '@/sfx/bus'
@@ -20,7 +17,7 @@ type SizeOption = {
 
 const { t } = useI18n()
 
-const { grid_size, setGridSize } = inject<CardListController>('card-editor')!
+const { grid_size, setGridSize } = inject(deckViewShellKey)!
 
 const open = ref(false)
 

--- a/src/views/deck/modes.ts
+++ b/src/views/deck/modes.ts
@@ -1,0 +1,51 @@
+import { computed, defineAsyncComponent, inject, type Component } from 'vue'
+import CardGrid from './card-grid/scroll-grid.vue'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
+
+type DeckModeConfig = {
+  pane: Component
+  // page dots + prev/next nav stay interactive while this mode is active
+  pagination: boolean
+}
+
+const loadCardEditor = () => import('./card-editor/index.vue')
+const loadCardImporter = () => import('./card-importer.vue')
+
+// Single source of truth for the deck view's modes. Adding a mode = write the
+// pane component + one entry here; `satisfies` keeps the registry and the
+// `CardEditorMode` union in sync both ways. The base `view` pane stays mounted
+// across switches (it preserves grid scroll/pages), so it's imported eagerly;
+// overlay panes lazy-load out of the deck view's chunk.
+export const DECK_MODES = {
+  view: {
+    pane: CardGrid,
+    pagination: true
+  },
+  edit: {
+    pane: defineAsyncComponent(loadCardEditor),
+    pagination: false
+  },
+  'import-export': {
+    pane: defineAsyncComponent(loadCardImporter),
+    pagination: false
+  }
+} satisfies Record<CardEditorMode, DeckModeConfig>
+
+/**
+ * Warm the lazy overlay chunks so the first mode switch animates immediately
+ * instead of waiting on the network. Call once when the deck view mounts.
+ */
+export function preloadDeckModes() {
+  loadCardEditor()
+  loadCardImporter()
+}
+
+/**
+ * Reactive config of the active mode for components inside the deck view
+ * tree. Chrome reads its flags from here (e.g. `pagination`) instead of
+ * comparing mode names, so new modes never touch existing components.
+ */
+export function useModeConfig() {
+  const shell = inject(deckViewShellKey)!
+  return computed<DeckModeConfig>(() => DECK_MODES[shell.mode.value])
+}

--- a/src/views/deck/page-dots.vue
+++ b/src/views/deck/page-dots.vue
@@ -3,9 +3,11 @@ import { inject, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
 import { emitSfx } from '@/sfx/bus'
-import type { CardListController } from '@/composables/card-editor/card-list-controller'
+import { useModeConfig } from './modes'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
-const editor = inject<CardListController>('card-editor')!
+const editor = inject(cardEditorKey)!
+const mode_config = useModeConfig()
 const { t } = useI18n()
 
 const { total_pages, page, can_paginate, goToPage } = editor.carousel
@@ -46,7 +48,7 @@ function onClick() {
     data-theme-dark="brown-100"
     :data-engaged="hovered_index !== null || undefined"
     class="hidden md:block sm:row-start-3 sm:col-start-2 justify-self-center relative cursor-pointer transition-opacity duration-300 before:content-[''] before:absolute before:-inset-x-10 before:-inset-y-3"
-    :class="{ 'opacity-0 pointer-events-none overflow-hidden': editor.mode.value !== 'view' }"
+    :class="{ 'opacity-0 pointer-events-none overflow-hidden': !mode_config.pagination }"
     @pointermove="onPointerMove"
     @pointerleave="onPointerLeave"
     @click="onClick"

--- a/src/views/deck/page-nav-button.vue
+++ b/src/views/deck/page-nav-button.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, inject } from 'vue'
 import UiButton from '@/components/ui-kit/button.vue'
-import type { CardListController } from '@/composables/card-editor/card-list-controller'
+import { useModeConfig } from './modes'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 type PageNavButtonProps = {
   direction: 'prev' | 'next'
@@ -9,7 +10,8 @@ type PageNavButtonProps = {
 
 const { direction } = defineProps<PageNavButtonProps>()
 
-const editor = inject<CardListController>('card-editor')!
+const editor = inject(cardEditorKey)!
+const mode_config = useModeConfig()
 
 const is_prev = computed(() => direction === 'prev')
 const testid = computed(() => `deck-view__${is_prev.value ? 'previous' : 'next'}-page-button`)
@@ -28,7 +30,7 @@ function onClick() {
     data-theme="brown-300"
     data-theme-dark="stone-700"
     class="sm:row-start-2 self-center max-sm:hidden! transition duration-300"
-    :class="[column, { 'opacity-0 pointer-events-none': editor.mode.value !== 'view' }]"
+    :class="[column, { 'opacity-0 pointer-events-none': !mode_config.pagination }]"
     icon-only
     :icon-left="icon"
     @click="onClick"

--- a/tests/integration/views/deck/card-editor/card-face-uploader.test.js
+++ b/tests/integration/views/deck/card-editor/card-face-uploader.test.js
@@ -99,6 +99,7 @@ vi.mock('@/utils/animations/button-tap', () => ({
 }))
 
 import CardFaceUploader from '@/views/deck/card-editor/card-face-uploader.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 function makeCard(overrides = {}) {
   return { id: 1, deck_id: 10, front_text: 'Q', back_text: 'A', rank: 1000, ...overrides }
@@ -135,7 +136,7 @@ function mount(props = {}) {
       },
       directives: { sfx: {} },
       provide: {
-        'card-editor': {
+        [cardEditorKey]: {
           setFaceImage: mocks.setFaceImageMock,
           card_attributes: ref({ front: {}, back: {} }),
           ...cardEditor

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -44,6 +44,7 @@ vi.mock('@/sfx/bus', () => ({ emitSfx: mocks.emitSfxMock, emitHoverSfx: vi.fn() 
 
 import ListItemCard from '@/views/deck/card-editor/list-item-card.vue'
 import textEditor from '@/components/card/text-editor.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 function makeCard(overrides = {}) {
   return {
@@ -58,7 +59,7 @@ function makeCard(overrides = {}) {
 
 function makeProvide({ is_selecting = ref(false) } = {}) {
   return {
-    'card-editor': {
+    [cardEditorKey]: {
       selection: { is_selecting },
       updateCard: mocks.updateCardMock,
       card_attributes: { front: {}, back: {} }

--- a/tests/integration/views/deck/card-editor/list-item.test.js
+++ b/tests/integration/views/deck/card-editor/list-item.test.js
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
 
 import ListItem from '@/views/deck/card-editor/list-item.vue'
 import ItemOptions from '@/views/deck/card-editor/list-item-options.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 function makeCard(overrides = {}) {
   return {
@@ -38,7 +39,7 @@ function makeCard(overrides = {}) {
 
 function makeProvide({ is_selecting = ref(false) } = {}) {
   return {
-    'card-editor': {
+    [cardEditorKey]: {
       // appendCard/prependCard are injected from the root controller surface
       // (card-list-controller.ts exposes them directly, not nested under list)
       appendCard: mocks.appendCardMock,

--- a/tests/integration/views/deck/card-editor/list.test.js
+++ b/tests/integration/views/deck/card-editor/list.test.js
@@ -6,6 +6,7 @@ const { useWindowVirtualizerMock } = vi.hoisted(() => ({ useWindowVirtualizerMoc
 vi.mock('@tanstack/vue-virtual', () => ({ useWindowVirtualizer: useWindowVirtualizerMock }))
 
 import List from '@/views/deck/card-editor/list.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 const ROW_PITCH = 407
 
@@ -48,7 +49,7 @@ function mount(options = {}) {
   return shallowMount(List, {
     global: {
       provide: {
-        'card-editor': editor
+        [cardEditorKey]: editor
       }
     }
   })

--- a/tests/integration/views/deck/card-grid/grid-item.test.js
+++ b/tests/integration/views/deck/card-grid/grid-item.test.js
@@ -4,7 +4,7 @@ import { defineComponent, h, ref, useAttrs } from 'vue'
 
 const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
 
-vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: vi.fn() }))
 
 const CardStub = defineComponent({
   name: 'Card',
@@ -48,6 +48,7 @@ const GridItemMenuStub = defineComponent({
 })
 
 import GridItem from '@/views/deck/card-grid/grid-item.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 function makeEditor({ is_selecting = false } = {}) {
   return {
@@ -74,7 +75,7 @@ function mountGridItem({ props = {}, editor } = {}) {
       },
       attachTo: document.body,
       global: {
-        provide: { 'card-editor': ed },
+        provide: { [cardEditorKey]: ed },
         stubs: { Card: CardStub, UiRadio: UiRadioStub, GridItemMenu: GridItemMenuStub }
       }
     }),

--- a/tests/integration/views/deck/card-grid/index.test.js
+++ b/tests/integration/views/deck/card-grid/index.test.js
@@ -21,6 +21,7 @@ vi.mock('gsap', () => ({
 
 import * as MediaQueryModule from '@/composables/use-media-query'
 import CardGrid from '@/views/deck/card-grid/index.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 const isMdRef = MediaQueryModule.__isMd
 
@@ -66,7 +67,7 @@ function mount(options = {}) {
   return shallowMount(CardGrid, {
     global: {
       provide: {
-        'card-editor': editor
+        [cardEditorKey]: editor
       }
     }
   })

--- a/tests/integration/views/deck/card-grid/scroll-grid.test.js
+++ b/tests/integration/views/deck/card-grid/scroll-grid.test.js
@@ -18,14 +18,15 @@ const GridItemStub = defineComponent({
 })
 
 import ScrollGrid from '@/views/deck/card-grid/scroll-grid.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
 
 function makeEditor({
   all_cards = [],
   card_attributes = ref({ front: {}, back: {} }),
   hasNextPage = false,
   isLoading = false,
-  observeSentinel = vi.fn(),
-  grid_size = 'md'
+  observeSentinel = vi.fn()
 } = {}) {
   return {
     list: { all_cards: ref(all_cards) },
@@ -33,15 +34,18 @@ function makeEditor({
     card_attributes,
     hasNextPage: ref(hasNextPage),
     isLoading: ref(isLoading),
-    observeSentinel,
-    grid_size: ref(grid_size)
+    observeSentinel
   }
 }
 
-function mountScrollGrid(editor = makeEditor()) {
+function makeShell({ grid_size = 'md' } = {}) {
+  return { grid_size: ref(grid_size) }
+}
+
+function mountScrollGrid(editor = makeEditor(), shell = makeShell()) {
   return shallowMount(ScrollGrid, {
     global: {
-      provide: { 'card-editor': editor },
+      provide: { [cardEditorKey]: editor, [deckViewShellKey]: shell },
       stubs: { GridItem: GridItemStub }
     }
   })
@@ -55,24 +59,21 @@ describe('card-grid/scroll-grid', () => {
   // ── grid_size → gridTemplateColumns track width ───────────────────────────
 
   test('grid style scales the xl track to 0.6 for grid_size="base" [obligation]', () => {
-    const editor = makeEditor({ grid_size: 'base' })
-    const wrapper = mountScrollGrid(editor)
+    const wrapper = mountScrollGrid(makeEditor(), makeShell({ grid_size: 'base' }))
     expect(wrapper.find('[data-testid="card-grid"]').attributes('style')).toContain(
       'grid-template-columns: repeat(auto-fill, 188.4px)'
     )
   })
 
   test('grid style scales the xl track to 0.75 for grid_size="md" [obligation]', () => {
-    const editor = makeEditor({ grid_size: 'md' })
-    const wrapper = mountScrollGrid(editor)
+    const wrapper = mountScrollGrid(makeEditor(), makeShell({ grid_size: 'md' }))
     expect(wrapper.find('[data-testid="card-grid"]').attributes('style')).toContain(
       'grid-template-columns: repeat(auto-fill, 235.5px)'
     )
   })
 
   test('grid style uses the full xl track width for grid_size="xl" [obligation]', () => {
-    const editor = makeEditor({ grid_size: 'xl' })
-    const wrapper = mountScrollGrid(editor)
+    const wrapper = mountScrollGrid(makeEditor(), makeShell({ grid_size: 'xl' }))
     expect(wrapper.find('[data-testid="card-grid"]').attributes('style')).toContain(
       'grid-template-columns: repeat(auto-fill, 314px)'
     )
@@ -138,10 +139,9 @@ describe('card-grid/scroll-grid', () => {
 
   test('passes the computed card_scale to each grid-item as the scale prop', () => {
     const editor = makeEditor({
-      grid_size: 'base',
       all_cards: [{ id: 1, client_id: 'c1', front_text: 'q', back_text: 'a' }]
     })
-    const wrapper = mountScrollGrid(editor)
+    const wrapper = mountScrollGrid(editor, makeShell({ grid_size: 'base' }))
     expect(wrapper.find('[data-testid="grid-item-stub"]').attributes('data-scale')).toBe('0.6')
   })
 

--- a/tests/integration/views/deck/card-importer.test.js
+++ b/tests/integration/views/deck/card-importer.test.js
@@ -15,14 +15,33 @@ vi.mock('@/composables/toast', () => ({
   useToast: () => ({ error: toastErrorMock })
 }))
 
-vi.mock('@/api/cards', () => ({
-  useBulkInsertCardsInDeckMutation: () => ({
-    mutate: bulkInsertMock,
-    mutateAsync: bulkInsertMock
-  })
-}))
+vi.mock('@/api/cards', () => {
+  const noop_mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn() })
+  const noop_query = () => ({ data: { value: null }, refresh: vi.fn() })
+  return {
+    useBulkInsertCardsInDeckMutation: () => ({
+      mutate: bulkInsertMock,
+      mutateAsync: bulkInsertMock
+    }),
+    useCardsInDeckInfiniteQuery: noop_query,
+    useDeleteCardImageMutation: noop_mutation,
+    useDeleteCardsInDeckMutation: noop_mutation,
+    useDeleteCardsMutation: noop_mutation,
+    useInsertCardAtMutation: noop_mutation,
+    useMemberCardCountQuery: noop_query,
+    useMoveCardMutation: noop_mutation,
+    useMoveCardsToDeckMutation: noop_mutation,
+    useSaveCardMutation: noop_mutation,
+    useSearchCardsInDeckQuery: noop_query,
+    useSetCardImageMutation: noop_mutation,
+    useStudySessionCardsQuery: noop_query,
+    useUpsertCardMutation: noop_mutation,
+    useUpsertCardsMutation: noop_mutation
+  }
+})
 
 import CardImporter from '@/views/deck/card-importer.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 const UiButtonStub = defineComponent({
   name: 'UiButton',
@@ -54,7 +73,7 @@ function mount({ deck_id = 10 } = {}) {
     global: {
       stubs: { UiButton: UiButtonStub },
       provide: {
-        'card-editor': {
+        [cardEditorKey]: {
           deck_id,
           guardAddCards: guardAddCardsMock,
           handleLimitError: handleLimitErrorMock

--- a/tests/integration/views/deck/deck-hero/actions.test.js
+++ b/tests/integration/views/deck/deck-hero/actions.test.js
@@ -48,21 +48,28 @@ const UiDropdownButtonStub = defineComponent({
 })
 
 import Actions from '@/views/deck/deck-hero/actions.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
 
-function makeEditor({ mode = 'view', setMode = vi.fn(), onSelectCard = vi.fn() } = {}) {
+function makeEditor({ onSelectCard = vi.fn() } = {}) {
   return {
-    mode: ref(mode),
-    setMode,
     actions: { onSelectCard }
   }
 }
 
-function mount({ deck = {}, editor } = {}) {
+function makeShell({ mode = 'view', toggleMode = vi.fn() } = {}) {
+  return { mode: ref(mode), toggleMode }
+}
+
+function mount({ deck = {}, editor, shell } = {}) {
+  const provide = {}
+  if (editor !== undefined) provide[cardEditorKey] = editor
+  if (shell !== undefined) provide[deckViewShellKey] = shell
   return shallowMount(Actions, {
     props: { deck: { id: 1, title: 'd', card_count: 10, due_count: 3, ...deck } },
     global: {
       stubs: { UiButton: UiButtonStub, UiDropdownButton: UiDropdownButtonStub },
-      provide: editor === undefined ? {} : { 'card-editor': editor }
+      provide
     }
   })
 }
@@ -91,31 +98,24 @@ describe('deck-hero/actions', () => {
     expect(studyBtn(wrapper).text()).toContain('12')
   })
 
-  test('shows "Edit Cards" when mode is view', () => {
-    const wrapper = mount({ editor: makeEditor({ mode: 'view' }) })
+  test('shows "Edit Cards" when shell mode is view', () => {
+    const wrapper = mount({ shell: makeShell({ mode: 'view' }) })
     expect(editBtn(wrapper).text()).toContain('Edit Cards')
   })
 
-  test('shows "Stop Editing" when mode is edit', () => {
-    const wrapper = mount({ editor: makeEditor({ mode: 'edit' }) })
+  test('shows "Stop Editing" when shell mode is edit', () => {
+    const wrapper = mount({ shell: makeShell({ mode: 'edit' }) })
     expect(editBtn(wrapper).text()).toContain('Stop Editing')
   })
 
-  test('clicking edit toggles view → edit', async () => {
-    const setMode = vi.fn()
-    const wrapper = mount({ editor: makeEditor({ mode: 'view', setMode }) })
+  test('clicking edit calls shell.toggleMode("edit")', async () => {
+    const toggleMode = vi.fn()
+    const wrapper = mount({ shell: makeShell({ mode: 'view', toggleMode }) })
     await editBtn(wrapper).trigger('click')
-    expect(setMode).toHaveBeenCalledWith('edit')
+    expect(toggleMode).toHaveBeenCalledWith('edit')
   })
 
-  test('clicking edit toggles edit → view', async () => {
-    const setMode = vi.fn()
-    const wrapper = mount({ editor: makeEditor({ mode: 'edit', setMode }) })
-    await editBtn(wrapper).trigger('click')
-    expect(setMode).toHaveBeenCalledWith('view')
-  })
-
-  test('clicking edit is a no-op when no editor is provided', async () => {
+  test('clicking edit is a no-op when no shell is provided', async () => {
     const wrapper = mount()
     await editBtn(wrapper).trigger('click')
     expect(editBtn(wrapper).exists()).toBe(true)

--- a/tests/integration/views/deck/deck-hero/bulk-actions.test.js
+++ b/tests/integration/views/deck/deck-hero/bulk-actions.test.js
@@ -26,6 +26,7 @@ const UiButtonStub = defineComponent({
 })
 
 import BulkActions from '@/views/deck/deck-hero/bulk-actions.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 function makeEditor({
   selected_count = 0,
@@ -54,7 +55,7 @@ function mount(editor = makeEditor()) {
     wrapper: shallowMount(BulkActions, {
       global: {
         stubs: { UiButton: UiButtonStub },
-        provide: { 'card-editor': editor }
+        provide: { [cardEditorKey]: editor }
       }
     }),
     editor

--- a/tests/integration/views/deck/deck-hero/index.test.js
+++ b/tests/integration/views/deck/deck-hero/index.test.js
@@ -12,6 +12,7 @@ const ChildStub = (name) =>
   })
 
 import DeckHero from '@/views/deck/deck-hero/index.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 function makeEditor({ is_selecting = false } = {}) {
   return { selection: { is_selecting: ref(is_selecting) } }
@@ -21,7 +22,7 @@ function mount({ editor } = {}) {
   return shallowMount(DeckHero, {
     props: { deck: { id: 1, title: 'd', card_count: 10 } },
     global: {
-      provide: editor === undefined ? {} : { 'card-editor': editor },
+      provide: editor === undefined ? {} : { [cardEditorKey]: editor },
       stubs: {
         Thumbnail: ChildStub('Thumbnail'),
         DeckDetails: ChildStub('DeckDetails'),

--- a/tests/integration/views/deck/index.test.js
+++ b/tests/integration/views/deck/index.test.js
@@ -2,9 +2,10 @@ import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
 import { defineComponent, h, ref, computed } from 'vue'
 
-const { useDeckQueryMock, useCardListControllerMock } = vi.hoisted(() => ({
+const { useDeckQueryMock, useCardListControllerMock, useDeckViewShellMock } = vi.hoisted(() => ({
   useDeckQueryMock: vi.fn(),
-  useCardListControllerMock: vi.fn()
+  useCardListControllerMock: vi.fn(),
+  useDeckViewShellMock: vi.fn()
 }))
 
 // card-face-uploader (reached statically via mode-stack → list-item-card) now
@@ -15,7 +16,12 @@ vi.mock('@/api/decks', () => ({
   useMemberDeckCountQuery: () => ({ data: { value: 0 }, refresh: vi.fn() })
 }))
 vi.mock('@/composables/card-editor/card-list-controller', () => ({
+  cardEditorKey: Symbol('cardEditor'),
   useCardListController: useCardListControllerMock
+}))
+vi.mock('@/composables/card-editor/deck-view-shell', () => ({
+  deckViewShellKey: Symbol('deckViewShell'),
+  useDeckViewShell: useDeckViewShellMock
 }))
 
 import DeckView from '@/views/deck/index.vue'
@@ -38,9 +44,13 @@ const ScrollBarStub = defineComponent({
   setup: (props) => () =>
     h('div', { 'data-testid': 'scroll-bar-stub', 'data-target': props.target })
 })
-function makeEditor({ mode = 'view', cards = [], isLoading = false } = {}) {
+
+function makeShell(mode = 'view') {
+  return { mode: ref(mode), is_view: ref(mode === 'view') }
+}
+
+function makeEditor({ cards = [], isLoading = false } = {}) {
   return {
-    mode: ref(mode),
     list: { all_cards: computed(() => cards) },
     isLoading: ref(isLoading)
   }
@@ -50,8 +60,9 @@ function makeDeckQuery(deck) {
   return { data: ref(deck) }
 }
 
-function mount({ deck = { id: 1, name: 'Test' }, editorOpts = {} } = {}) {
+function mount({ deck = { id: 1, name: 'Test' }, mode = 'view', editorOpts = {} } = {}) {
   useDeckQueryMock.mockReturnValue(makeDeckQuery(deck))
+  useDeckViewShellMock.mockReturnValue(makeShell(mode))
   useCardListControllerMock.mockReturnValue(makeEditor(editorOpts))
   return shallowMount(DeckView, {
     props: { id: '1' },
@@ -70,6 +81,7 @@ describe('DeckView (views/deck/index.vue)', () => {
   beforeEach(() => {
     useDeckQueryMock.mockReset()
     useCardListControllerMock.mockReset()
+    useDeckViewShellMock.mockReset()
   })
 
   test('renders the deck-hero when the deck query has data', () => {
@@ -100,14 +112,14 @@ describe('DeckView (views/deck/index.vue)', () => {
     expect(wrapper.find('[data-testid="deck-view__empty"]').exists()).toBe(false)
   })
 
-  test('reflects editor.mode in data-mode on the main grid', () => {
-    const view = mount({ editorOpts: { mode: 'view' } })
+  test('reflects shell.mode in data-mode on the main grid', () => {
+    const view = mount({ mode: 'view' })
     expect(view.find('[data-testid="deck-view__main"]').attributes('data-mode')).toBe('view')
 
-    const edit = mount({ editorOpts: { mode: 'edit' } })
+    const edit = mount({ mode: 'edit' })
     expect(edit.find('[data-testid="deck-view__main"]').attributes('data-mode')).toBe('edit')
 
-    const importExport = mount({ editorOpts: { mode: 'import-export' } })
+    const importExport = mount({ mode: 'import-export' })
     expect(importExport.find('[data-testid="deck-view__main"]').attributes('data-mode')).toBe(
       'import-export'
     )
@@ -119,14 +131,14 @@ describe('DeckView (views/deck/index.vue)', () => {
     expect(idArg.value).toBe(1)
   })
 
-  test('passes the parsed numeric deck id to useCardListController', () => {
+  test('passes the parsed numeric deck id and shell to useCardListController', () => {
     mount()
-    expect(useCardListControllerMock).toHaveBeenCalledWith({ deck_id: 1 })
+    expect(useCardListControllerMock).toHaveBeenCalledWith(expect.objectContaining({ deck_id: 1 }))
   })
 
   test('keeps the main layout stable across modes (no mode-dependent classes)', () => {
-    const view = mount({ editorOpts: { mode: 'view' } })
-    const edit = mount({ editorOpts: { mode: 'edit' } })
+    const view = mount({ mode: 'view' })
+    const edit = mount({ mode: 'edit' })
     const viewClasses = view.find('[data-testid="deck-view__main"]').classes()
     const editClasses = edit.find('[data-testid="deck-view__main"]').classes()
     expect(viewClasses).toEqual(editClasses)
@@ -148,7 +160,7 @@ describe('DeckView (views/deck/index.vue)', () => {
 
   test('renders the page scroll-bar tracking the document in every mode', () => {
     for (const mode of ['view', 'edit', 'import-export']) {
-      const wrapper = mount({ editorOpts: { mode } })
+      const wrapper = mount({ mode })
       const bar = wrapper.find('[data-testid="scroll-bar-stub"]')
       expect(bar.exists()).toBe(true)
       expect(bar.attributes('data-target')).toBe('html')

--- a/tests/integration/views/deck/mode-stack.test.js
+++ b/tests/integration/views/deck/mode-stack.test.js
@@ -3,35 +3,49 @@ import { shallowMount } from '@vue/test-utils'
 import { ref, nextTick } from 'vue'
 
 vi.mock('@/utils/animations/deck-view/card-overlay', () => ({
+  captureModeSwitch: vi.fn(() => ({ from_y: 0, settle_y: 0, stack_top: 0 })),
+  distanceToViewportBottom: vi.fn(() => 0),
   fadeScaleEnter: vi.fn((_el, done) => done?.()),
-  fadeScaleLeave: vi.fn((_el, done) => done?.()),
+  fadeScaleLeave: vi.fn((_el, _vp, done) => done?.()),
   primeOverlayBelow: vi.fn(),
   slideOverlayUp: vi.fn((_el, done) => done?.()),
   settleOverlay: vi.fn(),
-  slideOverlayDown: vi.fn((_el, done) => done?.())
+  slideOverlayDown: vi.fn((_el, _vp, done) => done?.())
 }))
 
-async function stubModule(name, testid) {
+// Panes in DECK_MODES use defineAsyncComponent; mock the whole registry with
+// synchronous stubs so shallowMount can find them by name immediately.
+vi.mock('@/views/deck/modes.ts', async () => {
   const { defineComponent, h } = await import('vue')
+  const makePane = (name, testid) =>
+    defineComponent({ name, setup: () => () => h('div', { 'data-testid': testid }) })
+  const CardGrid = makePane('CardGrid', 'card-grid-stub')
+  const CardEditor = makePane('CardEditor', 'card-editor-stub')
+  const CardImporter = makePane('CardImporter', 'card-importer-stub')
   return {
-    default: defineComponent({ name, setup: () => () => h('div', { 'data-testid': testid }) })
+    DECK_MODES: {
+      view: { pane: CardGrid, pagination: true },
+      edit: { pane: CardEditor, pagination: false },
+      'import-export': { pane: CardImporter, pagination: false }
+    },
+    preloadDeckModes: () => {},
+    useModeConfig: () => {}
   }
-}
-
-vi.mock('@/views/deck/card-grid/scroll-grid.vue', () => stubModule('CardGrid', 'card-grid-stub'))
-vi.mock('@/views/deck/card-editor/index.vue', () => stubModule('CardEditor', 'card-editor-stub'))
-vi.mock('@/views/deck/card-importer.vue', () => stubModule('CardImporter', 'card-importer-stub'))
+})
 
 import ModeStack from '@/views/deck/mode-stack.vue'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
 
-function makeEditor(mode = 'view') {
-  return { mode: ref(mode) }
+function makeShell(mode = 'view') {
+  const mode_ref = ref(mode)
+  const is_view = ref(mode === 'view')
+  return { mode: mode_ref, is_view }
 }
 
-function mount(editor = makeEditor()) {
+function mount(shell = makeShell()) {
   return shallowMount(ModeStack, {
     global: {
-      provide: { 'card-editor': editor },
+      provide: { [deckViewShellKey]: shell },
       // use the real <Transition> so v-show actually toggles display; the
       // card-overlay hooks are mocked to complete synchronously
       stubs: { transition: false }
@@ -56,14 +70,14 @@ describe('ModeStack', () => {
   const gridDisplay = (wrapper) => wrapper.findComponent({ name: 'CardGrid' }).element.style.display
 
   test('shows the card-grid in view mode, with no overlay mounted', () => {
-    const wrapper = mount(makeEditor('view'))
+    const wrapper = mount(makeShell('view'))
     expect(gridDisplay(wrapper)).not.toBe('none')
     expect(wrapper.findComponent({ name: 'CardEditor' }).exists()).toBe(false)
     expect(wrapper.findComponent({ name: 'CardImporter' }).exists()).toBe(false)
   })
 
   test('mounts the card-editor and hides (not unmounts) the grid in edit mode', () => {
-    const wrapper = mount(makeEditor('edit'))
+    const wrapper = mount(makeShell('edit'))
     expect(wrapper.findComponent({ name: 'CardEditor' }).exists()).toBe(true)
     expect(wrapper.findComponent({ name: 'CardGrid' }).exists()).toBe(true)
     expect(gridDisplay(wrapper)).toBe('none')
@@ -71,18 +85,19 @@ describe('ModeStack', () => {
   })
 
   test('mounts the card-importer and hides the grid in import-export mode', () => {
-    const wrapper = mount(makeEditor('import-export'))
+    const wrapper = mount(makeShell('import-export'))
     expect(wrapper.findComponent({ name: 'CardImporter' }).exists()).toBe(true)
     expect(gridDisplay(wrapper)).toBe('none')
     expect(wrapper.findComponent({ name: 'CardEditor' }).exists()).toBe(false)
   })
 
   test('swaps grid for editor when mode flips view → edit (grid stays mounted)', async () => {
-    const editor = makeEditor('view')
-    const wrapper = mount(editor)
+    const shell = makeShell('view')
+    const wrapper = mount(shell)
     expect(gridDisplay(wrapper)).not.toBe('none')
 
-    editor.mode.value = 'edit'
+    shell.mode.value = 'edit'
+    shell.is_view.value = false
     await nextTick()
     await nextTick()
 
@@ -92,7 +107,7 @@ describe('ModeStack', () => {
   })
 
   test('forwards w-full to the active pane', () => {
-    const wrapper = mount(makeEditor('edit'))
+    const wrapper = mount(makeShell('edit'))
     expect(wrapper.findComponent({ name: 'CardEditor' }).classes()).toContain('w-full')
   })
 })

--- a/tests/integration/views/deck/mode-toolbar/bulk-toolbar.test.js
+++ b/tests/integration/views/deck/mode-toolbar/bulk-toolbar.test.js
@@ -45,6 +45,7 @@ const CardCountStub = defineComponent({
 })
 
 import BulkToolbar from '@/views/deck/mode-toolbar/bulk-toolbar.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 function makeEditor({
   selected_count = 0,
@@ -79,7 +80,7 @@ function mount(editor = makeEditor()) {
           toolbarBase: ToolbarBaseStub,
           CardCount: CardCountStub
         },
-        provide: { 'card-editor': editor }
+        provide: { [cardEditorKey]: editor }
       }
     }),
     editor

--- a/tests/integration/views/deck/mode-toolbar/card-count.test.js
+++ b/tests/integration/views/deck/mode-toolbar/card-count.test.js
@@ -10,6 +10,7 @@ const UiTagStub = defineComponent({
 })
 
 import CardCount from '@/views/deck/mode-toolbar/card-count.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 function makeEditor({ card_count = 0 } = {}) {
   return {
@@ -21,7 +22,7 @@ function mount(editor = makeEditor()) {
   return shallowMount(CardCount, {
     global: {
       stubs: { UiTag: UiTagStub },
-      provide: { 'card-editor': editor },
+      provide: { [cardEditorKey]: editor },
       mocks: { $t: (key, n) => (n === 1 ? `${n} Card` : `${n} Cards`) }
     }
   })

--- a/tests/integration/views/deck/mode-toolbar/page-settings.test.js
+++ b/tests/integration/views/deck/mode-toolbar/page-settings.test.js
@@ -68,6 +68,7 @@ const LabeledSectionStub = defineComponent({
 })
 
 import PageSettings from '@/views/deck/mode-toolbar/page-settings.vue'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
 
 function makeEditor({ grid_size_val = 'md' } = {}) {
   const grid_size = ref(grid_size_val)
@@ -81,7 +82,7 @@ function mountPageSettings(editor = makeEditor()) {
   return {
     wrapper: shallowMount(PageSettings, {
       global: {
-        provide: { 'card-editor': editor },
+        provide: { [deckViewShellKey]: editor },
         stubs: {
           UiPopover: UiPopoverStub,
           UiButton: UiButtonStub,

--- a/tests/integration/views/deck/modes.test.js
+++ b/tests/integration/views/deck/modes.test.js
@@ -1,0 +1,97 @@
+import { describe, test, expect, afterEach, vi } from 'vite-plus/test'
+import { createApp, ref } from 'vue'
+import { DECK_MODES, preloadDeckModes, useModeConfig } from '@/views/deck/modes'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
+
+// Lazy pane imports inside DECK_MODES use defineAsyncComponent — mock them so
+// the test environment doesn't need the full component graphs.
+vi.mock('@/views/deck/card-grid/scroll-grid.vue', () => ({
+  default: { name: 'CardGrid' }
+}))
+vi.mock('@/views/deck/card-editor/index.vue', () => ({
+  default: { name: 'CardEditor' }
+}))
+vi.mock('@/views/deck/card-importer.vue', () => ({
+  default: { name: 'CardImporter' }
+}))
+
+function withSetup(composable, provide_pairs = []) {
+  let result
+  const app = createApp({
+    setup() {
+      result = composable()
+      return () => {}
+    }
+  })
+  provide_pairs.forEach(([k, v]) => app.provide(k, v))
+  app.mount(document.createElement('div'))
+  return [result, app]
+}
+
+let app
+
+afterEach(() => {
+  app?.unmount()
+  app = undefined
+})
+
+describe('DECK_MODES registry', () => {
+  test('defines entries for view, edit, and import-export modes', () => {
+    expect(DECK_MODES).toHaveProperty('view')
+    expect(DECK_MODES).toHaveProperty('edit')
+    expect(DECK_MODES).toHaveProperty('import-export')
+  })
+
+  test('only view mode has pagination enabled', () => {
+    expect(DECK_MODES.view.pagination).toBe(true)
+    expect(DECK_MODES.edit.pagination).toBe(false)
+    expect(DECK_MODES['import-export'].pagination).toBe(false)
+  })
+
+  test('each mode has a pane component', () => {
+    for (const config of Object.values(DECK_MODES)) {
+      expect(config.pane).toBeDefined()
+    }
+  })
+})
+
+describe('preloadDeckModes', () => {
+  test('is callable without throwing', () => {
+    expect(() => preloadDeckModes()).not.toThrow()
+  })
+})
+
+describe('useModeConfig', () => {
+  test('returns config for view mode when shell is in view mode', () => {
+    const shell = { mode: ref('view') }
+    let config
+    ;[config, app] = withSetup(() => useModeConfig(), [[deckViewShellKey, shell]])
+    expect(config.value.pagination).toBe(true)
+  })
+
+  test('returns config for edit mode when shell is in edit mode', () => {
+    const shell = { mode: ref('edit') }
+    let config
+    ;[config, app] = withSetup(() => useModeConfig(), [[deckViewShellKey, shell]])
+    expect(config.value.pagination).toBe(false)
+  })
+
+  test('returns config for import-export mode when shell is in import-export mode', () => {
+    const shell = { mode: ref('import-export') }
+    let config
+    ;[config, app] = withSetup(() => useModeConfig(), [[deckViewShellKey, shell]])
+    expect(config.value.pagination).toBe(false)
+  })
+
+  test('config updates reactively when shell mode changes', async () => {
+    const shell = { mode: ref('view') }
+    let config
+    ;[config, app] = withSetup(() => useModeConfig(), [[deckViewShellKey, shell]])
+    expect(config.value.pagination).toBe(true)
+
+    shell.mode.value = 'edit'
+    await Promise.resolve()
+
+    expect(config.value.pagination).toBe(false)
+  })
+})

--- a/tests/integration/views/deck/page-dots.test.js
+++ b/tests/integration/views/deck/page-dots.test.js
@@ -3,9 +3,11 @@ import { shallowMount } from '@vue/test-utils'
 import { defineComponent, h, ref, computed } from 'vue'
 
 const { emitSfxMock } = vi.hoisted(() => ({ emitSfxMock: vi.fn() }))
-vi.mock('@/sfx/bus', () => ({ emitSfx: emitSfxMock }))
+vi.mock('@/sfx/bus', () => ({ emitSfx: emitSfxMock, emitHoverSfx: vi.fn() }))
 
 import PageDots from '@/views/deck/page-dots.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
 
 const UiTooltipStub = defineComponent({
   name: 'UiTooltip',
@@ -21,15 +23,8 @@ const UiTooltipStub = defineComponent({
   }
 })
 
-function makeEditor({
-  mode = 'view',
-  total_pages = 3,
-  page = 0,
-  can_paginate = true,
-  goToPage = vi.fn()
-} = {}) {
+function makeEditor({ total_pages = 3, page = 0, can_paginate = true, goToPage = vi.fn() } = {}) {
   return {
-    mode: ref(mode),
     carousel: {
       total_pages: computed(() => total_pages),
       page: ref(page),
@@ -39,10 +34,14 @@ function makeEditor({
   }
 }
 
-function mount(editor = makeEditor()) {
+function makeShell({ mode = 'view' } = {}) {
+  return { mode: ref(mode) }
+}
+
+function mount(editor = makeEditor(), shell = makeShell()) {
   return shallowMount(PageDots, {
     global: {
-      provide: { 'card-editor': editor },
+      provide: { [cardEditorKey]: editor, [deckViewShellKey]: shell },
       stubs: { UiTooltip: UiTooltipStub }
     }
   })
@@ -221,20 +220,18 @@ describe('PageDots', () => {
     expect(goToPage).not.toHaveBeenCalled()
   })
 
-  // The container is hidden via opacity classes when mode !== 'view'. Class
-  // assertion is unavoidable here — there is no other state signal exposed
-  // on the rendered DOM (mirrors page-nav-button's note).
-  test('applies hidden classes when editor.mode is not view', () => {
-    editor = makeEditor({ mode: 'edit' })
-    const wrapper = mount(editor)
+  // The container is hidden via opacity classes when mode_config.pagination is false.
+  // Class assertion is unavoidable here — there is no other state signal exposed
+  // on the rendered DOM (the component binds opacity classes directly).
+  test('applies hidden classes when shell mode is not view (pagination=false)', () => {
+    const wrapper = mount(makeEditor(), makeShell({ mode: 'edit' }))
     const cls = wrapper.find('[data-testid="deck-view__page-dots"]').classes()
     expect(cls).toContain('opacity-0')
     expect(cls).toContain('pointer-events-none')
   })
 
-  test('does not apply hidden classes in view mode', () => {
-    editor = makeEditor({ mode: 'view' })
-    const wrapper = mount(editor)
+  test('does not apply hidden classes in view mode (pagination=true)', () => {
+    const wrapper = mount(makeEditor(), makeShell({ mode: 'view' }))
     const cls = wrapper.find('[data-testid="deck-view__page-dots"]').classes()
     expect(cls).not.toContain('opacity-0')
   })

--- a/tests/integration/views/deck/page-nav-button.test.js
+++ b/tests/integration/views/deck/page-nav-button.test.js
@@ -4,6 +4,8 @@ import { ref } from 'vue'
 import { defineComponent, h } from 'vue'
 
 import PageNavButton from '@/views/deck/page-nav-button.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
 
 const UiButtonStub = defineComponent({
   name: 'UiButton',
@@ -23,19 +25,27 @@ const UiButtonStub = defineComponent({
   }
 })
 
-function makeEditor({ mode = 'view', prevPage = vi.fn(), nextPage = vi.fn() } = {}) {
+function makeEditor({ prevPage = vi.fn(), nextPage = vi.fn() } = {}) {
   return {
-    mode: ref(mode),
     carousel: { prevPage, nextPage }
   }
 }
 
-function mount({ direction = 'prev', editor = makeEditor(), slot = 'click me' } = {}) {
+function makeShell({ mode = 'view' } = {}) {
+  return { mode: ref(mode) }
+}
+
+function mount({
+  direction = 'prev',
+  editor = makeEditor(),
+  shell = makeShell(),
+  slot = 'click me'
+} = {}) {
   return shallowMount(PageNavButton, {
     props: { direction },
     slots: { default: slot },
     global: {
-      provide: { 'card-editor': editor },
+      provide: { [cardEditorKey]: editor, [deckViewShellKey]: shell },
       stubs: { UiButton: UiButtonStub }
     }
   })
@@ -90,20 +100,18 @@ describe('PageNavButton', () => {
     expect(wrapper.text()).toContain('Page 3')
   })
 
-  // The button is hidden via opacity classes when mode !== 'view'. Class
-  // assertion is unavoidable here — there is no other state signal exposed
+  // The button is hidden via opacity classes when mode_config.pagination is false.
+  // Class assertion is unavoidable here — there is no other state signal exposed
   // on the rendered DOM (called out in quality notes).
-  test('applies hidden classes when editor.mode is not view', () => {
-    editor = makeEditor({ mode: 'edit' })
-    const wrapper = mount({ direction: 'prev', editor })
+  test('applies hidden classes when shell mode is not view (pagination=false)', () => {
+    const wrapper = mount({ direction: 'prev', shell: makeShell({ mode: 'edit' }) })
     const cls = wrapper.find('[data-testid="deck-view__previous-page-button"]').classes()
     expect(cls).toContain('opacity-0')
     expect(cls).toContain('pointer-events-none')
   })
 
-  test('does not apply hidden classes in view mode', () => {
-    editor = makeEditor({ mode: 'view' })
-    const wrapper = mount({ direction: 'prev', editor })
+  test('does not apply hidden classes in view mode (pagination=true)', () => {
+    const wrapper = mount({ direction: 'prev', shell: makeShell({ mode: 'view' }) })
     const cls = wrapper.find('[data-testid="deck-view__previous-page-button"]').classes()
     expect(cls).not.toContain('opacity-0')
   })

--- a/tests/unit/composables/card-editor/card-actions.test.js
+++ b/tests/unit/composables/card-editor/card-actions.test.js
@@ -62,21 +62,25 @@ function makeDeckQuery() {
   return { refetch: vi.fn().mockResolvedValue(undefined) }
 }
 
+function makeShell(opts = {}) {
+  return { exitMode: opts.exitMode ?? vi.fn() }
+}
+
 function makeActions(opts = {}) {
   const list = opts.list ?? makeList()
   const selection = opts.selection ?? makeSelection()
   const mutations = opts.mutations ?? makeMutations()
   const deck_query = opts.deck_query ?? makeDeckQuery()
-  const setMode = opts.setMode ?? vi.fn()
+  const shell = opts.shell ?? makeShell()
   const actions = useCardActions({
     list,
     selection,
     mutations,
     deck_query,
     deck_id: opts.deck_id ?? 10,
-    setMode
+    shell
   })
-  return { actions, list, selection, mutations, deck_query, setMode }
+  return { actions, list, selection, mutations, deck_query, shell }
 }
 
 describe('useCardActions', () => {
@@ -108,10 +112,11 @@ describe('useCardActions', () => {
   // ── onCancel ──────────────────────────────────────────────────────────────
 
   describe('onCancel', () => {
-    test('returns to view mode, exits selection, and emits the cancel sfx', () => {
-      const { actions, selection, setMode } = makeActions()
+    test('calls shell.exitMode, exits selection, and emits the cancel sfx', () => {
+      const exitMode = vi.fn()
+      const { actions, selection } = makeActions({ shell: makeShell({ exitMode }) })
       actions.onCancel()
-      expect(setMode).toHaveBeenCalledWith('view')
+      expect(exitMode).toHaveBeenCalledOnce()
       expect(selection.exitSelection).toHaveBeenCalledOnce()
       expect(emitSfxMock).toHaveBeenCalledWith('ui.card_drop')
     })
@@ -156,17 +161,19 @@ describe('useCardActions', () => {
       expect(args.cards.map((c) => c.id)).toEqual([7])
     })
 
-    test('runs cleanup on confirm: refetch + setMode(view) + exitSelection', async () => {
+    test('runs cleanup on confirm: refetch + exitSelection (mode is NOT reset) [obligation]', async () => {
       alertWarnMock.mockReturnValueOnce({ response: Promise.resolve(true) })
       const persisted = [makeCard({ id: 1 })]
-      const { actions, mutations, selection, deck_query, setMode } = makeActions({
+      const exitMode = vi.fn()
+      const { actions, mutations, selection, deck_query } = makeActions({
         list: makeList({ persisted }),
-        selection: makeSelection({ selected_ids: [1] })
+        selection: makeSelection({ selected_ids: [1] }),
+        shell: makeShell({ exitMode })
       })
       await actions.onDeleteCards()
       expect(mutations.deleteCards).toHaveBeenCalledOnce()
       expect(deck_query.refetch).toHaveBeenCalledOnce()
-      expect(setMode).toHaveBeenCalledWith('view')
+      expect(exitMode).not.toHaveBeenCalled()
       expect(selection.exitSelection).toHaveBeenCalledOnce()
     })
 
@@ -242,17 +249,19 @@ describe('useCardActions', () => {
       expect(emitSfxMock).toHaveBeenCalledWith('ui.double_pop_down')
     })
 
-    test('runs cleanup after a successful move: exitSelection + refetch', async () => {
+    test('runs cleanup after a successful move: exitSelection + refetch (mode unchanged)', async () => {
       modalOpenMock.mockReturnValueOnce({ response: Promise.resolve({ deck_id: 42 }) })
       const persisted = [makeCard({ id: 7 })]
-      const { actions, selection, deck_query, setMode } = makeActions({
+      const exitMode = vi.fn()
+      const { actions, selection, deck_query } = makeActions({
         list: makeList({ persisted }),
-        selection: makeSelection({ selected_ids: [7] })
+        selection: makeSelection({ selected_ids: [7] }),
+        shell: makeShell({ exitMode })
       })
       await actions.onMoveCards()
       expect(selection.exitSelection).toHaveBeenCalledOnce()
       expect(deck_query.refetch).toHaveBeenCalledOnce()
-      expect(setMode).not.toHaveBeenCalled()
+      expect(exitMode).not.toHaveBeenCalled()
     })
 
     test('select-all mode passes { source_deck_id, except_ids } to mutation', async () => {
@@ -291,11 +300,10 @@ describe('useCardActions', () => {
 
   describe('onCancelSelection', () => {
     test('exits selection mode and emits the digi-powerdown sfx', () => {
-      const { actions, selection, setMode } = makeActions()
+      const { actions, selection } = makeActions()
       actions.onCancelSelection()
       expect(selection.exitSelection).toHaveBeenCalledOnce()
       expect(emitSfxMock).toHaveBeenCalledWith('ui.digi_powerdown')
-      expect(setMode).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/composables/card-editor/card-list-controller.test.js
+++ b/tests/unit/composables/card-editor/card-list-controller.test.js
@@ -106,6 +106,11 @@ function makeDeckQuery(card_count = 0) {
   }
 }
 
+// Returns a minimal shell stub that satisfies the controller's `exitMode` requirement.
+function makeShell(overrides = {}) {
+  return { exitMode: overrides.exitMode ?? vi.fn() }
+}
+
 // Returns the controller with `deck_query` attached so refetch + reactive
 // data assertions can target the same handle the controller uses internally.
 // Mocks `useDeckQuery` for the lifetime of the call so both the controller
@@ -114,11 +119,12 @@ function makeDeckQuery(card_count = 0) {
 // Returns the controller flattened — sub-namespaces (list/selection/carousel/
 // actions) are spread onto the root for ergonomic test destructuring. Real
 // consumers reach in via the grouped surface; the flatten happens here only.
-function makeController(persisted = [], ids = persisted.map((c) => c.id), deck_query) {
+function makeController(persisted = [], ids = persisted.map((c) => c.id), deck_query, shell) {
   const dq = deck_query ?? makeDeckQuery(ids.length)
+  const sh = shell ?? makeShell()
   cardsInfiniteQueryMock.mockReturnValueOnce(makeCardsQuery(persisted))
   deckQueryMock.mockReturnValue(dq)
-  const controller = useCardListController({ deck_id: 10 })
+  const controller = useCardListController({ deck_id: 10, shell: sh })
   return {
     ...controller,
     ...controller.list,
@@ -132,7 +138,8 @@ function makeController(persisted = [], ids = persisted.map((c) => c.id), deck_q
     gated_addCard: controller.addCard,
     gated_appendCard: controller.appendCard,
     gated_prependCard: controller.prependCard,
-    deck_query: dq
+    deck_query: dq,
+    shell: sh
   }
 }
 
@@ -171,48 +178,12 @@ describe('useCardListController', () => {
       expect(all_cards.value.map((c) => c.id)).toEqual([1, 2])
     })
 
-    test('starts in view mode with no selection and not in select-all mode', () => {
-      const { mode, selected_card_ids, deselected_ids, select_all_mode, saving } = makeController()
-      expect(mode.value).toBe('view')
+    test('starts with no selection and not in select-all mode', () => {
+      const { selected_card_ids, deselected_ids, select_all_mode, saving } = makeController()
       expect(selected_card_ids.value).toEqual([])
       expect(deselected_ids.value).toEqual([])
       expect(select_all_mode.value).toBe(false)
       expect(saving.value).toBe(false)
-    })
-
-    test('grid_size initializes to "md" when no persisted value exists [obligation]', () => {
-      const { grid_size } = makeController()
-      expect(grid_size.value).toBe('md')
-    })
-
-    test('grid_size rehydrates from localStorage under key deck-grid-size [obligation]', () => {
-      localStorage.setItem('deck-grid-size', JSON.stringify('xl'))
-      const { grid_size } = makeController()
-      expect(grid_size.value).toBe('xl')
-    })
-  })
-
-  // ── setGridSize ────────────────────────────────────────────────────────────
-
-  describe('setGridSize', () => {
-    test('setGridSize("xl") updates grid_size.value to "xl" [obligation]', () => {
-      const { grid_size, setGridSize } = makeController()
-      setGridSize('xl')
-      expect(grid_size.value).toBe('xl')
-    })
-
-    test('setGridSize persists to localStorage under key deck-grid-size [obligation]', async () => {
-      const { setGridSize } = makeController()
-      setGridSize('xl')
-      // watch is { deep: true } with immediate=false; nextTick flushes it
-      await nextTick()
-      expect(JSON.parse(localStorage.getItem('deck-grid-size'))).toBe('xl')
-    })
-
-    test('setGridSize("base") sets grid_size to "base"', () => {
-      const { grid_size, setGridSize } = makeController()
-      setGridSize('base')
-      expect(grid_size.value).toBe('base')
     })
   })
 
@@ -681,7 +652,7 @@ describe('useCardListController', () => {
       const dq = { data: ref(null), refetch: vi.fn() }
       cardsInfiniteQueryMock.mockReturnValueOnce(makeCardsQuery([]))
       deckQueryMock.mockReturnValue(dq)
-      const ctrl = useCardListController({ deck_id: 10 })
+      const ctrl = useCardListController({ deck_id: 10, shell: makeShell() })
       expect(ctrl.card_count.value).toBe(0)
     })
 
@@ -716,13 +687,15 @@ describe('useCardListController', () => {
     })
   })
 
-  // ── setMode ────────────────────────────────────────────────────────────────
+  // ── shell plumbing — mode and grid_size live on the shell, not the controller
 
-  describe('setMode', () => {
-    test('updates the mode ref', () => {
-      const { mode, setMode } = makeController()
-      setMode('edit')
-      expect(mode.value).toBe('edit')
+  describe('shell plumbing', () => {
+    test('controller passes shell.exitMode to card-actions (onCancel calls exitMode)', () => {
+      const exitMode = vi.fn()
+      const sh = makeShell({ exitMode })
+      const ctrl = makeController([], [], undefined, sh)
+      ctrl.onCancel()
+      expect(exitMode).toHaveBeenCalledOnce()
     })
   })
 
@@ -775,26 +748,25 @@ describe('useCardListController', () => {
   // ── intent handlers — onCancel / onSelectCard / onDeleteCards / onMoveCards ─
 
   describe('intent handlers', () => {
-    test('onCancel resets mode to view, exits selection, and clears selection', async () => {
+    test('onCancel calls shell.exitMode, exits selection, and clears selection', async () => {
+      const exitMode = vi.fn()
+      const sh = makeShell({ exitMode })
       const deck_query = makeDeckQuery()
-      const ctrl = makeController([makeCard({ id: 1 })], [1], deck_query)
+      const ctrl = makeController([makeCard({ id: 1 })], [1], deck_query, sh)
       ctrl.selectCard(1)
       ctrl.enterSelection()
-      ctrl.setMode('edit')
       await ctrl.onCancel()
-      expect(ctrl.mode.value).toBe('view')
+      expect(exitMode).toHaveBeenCalledOnce()
       expect(ctrl.is_selecting.value).toBe(false)
       expect(ctrl.selected_card_ids.value).toEqual([])
       expect(deck_query.refetch).not.toHaveBeenCalled()
     })
 
-    test('onSelectCard toggles the id and enters selection mode without changing the editor mode', () => {
+    test('onSelectCard toggles the id and enters selection mode', () => {
       const ctrl = makeController([makeCard({ id: 1 })], [1])
-      ctrl.setMode('edit')
       ctrl.onSelectCard(1)
       expect(ctrl.isCardSelected(1)).toBe(true)
       expect(ctrl.is_selecting.value).toBe(true)
-      expect(ctrl.mode.value).toBe('edit')
     })
 
     test('onSelectCard without id just enters selection mode without mutating selection', () => {
@@ -812,16 +784,18 @@ describe('useCardListController', () => {
       expect(deleteCardsMock).not.toHaveBeenCalled()
     })
 
-    test('onDeleteCards deletes and returns to view mode when confirmed', async () => {
+    test('onDeleteCards deletes and clears selection, mode is unchanged [obligation]', async () => {
       alertWarnMock.mockReturnValueOnce({ response: Promise.resolve(true) })
+      const exitMode = vi.fn()
+      const sh = makeShell({ exitMode })
       const deck_query = makeDeckQuery()
-      const ctrl = makeController([makeCard({ id: 1 })], [1], deck_query)
+      const ctrl = makeController([makeCard({ id: 1 })], [1], deck_query, sh)
       ctrl.selectCard(1)
       ctrl.enterSelection()
       await ctrl.onDeleteCards()
       expect(deleteCardsMock).toHaveBeenCalledOnce()
       expect(deck_query.refetch).toHaveBeenCalledOnce()
-      expect(ctrl.mode.value).toBe('view')
+      expect(exitMode).not.toHaveBeenCalled()
       expect(ctrl.is_selecting.value).toBe(false)
     })
 
@@ -933,7 +907,7 @@ describe('useCardListController', () => {
       cardsInfiniteQueryMock.mockReturnValueOnce(cards_query)
       const dq = makeDeckQuery(card_count ?? ids.length)
       deckQueryMock.mockReturnValue(dq)
-      const root = useCardListController({ deck_id: 10 })
+      const root = useCardListController({ deck_id: 10, shell: makeShell() })
       const controller = { ...root, ...root.list, ...root.selection, ...root.carousel }
       return { controller, cards_query, deck_query: dq }
     }

--- a/tests/unit/composables/card-editor/deck-view-shell.test.js
+++ b/tests/unit/composables/card-editor/deck-view-shell.test.js
@@ -1,0 +1,104 @@
+import { describe, test, expect, beforeEach } from 'vite-plus/test'
+import { nextTick } from 'vue'
+import { useDeckViewShell } from '@/composables/card-editor/deck-view-shell'
+
+// useLocalRef reads/writes localStorage — reset between tests so state
+// from one test doesn't bleed into the next.
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('useDeckViewShell', () => {
+  // ── Initial state ──────────────────────────────────────────────────────────
+
+  test('starts in view mode', () => {
+    const shell = useDeckViewShell()
+    expect(shell.mode.value).toBe('view')
+  })
+
+  test('is_view is true when mode is view', () => {
+    const shell = useDeckViewShell()
+    expect(shell.is_view.value).toBe(true)
+  })
+
+  test('grid_size defaults to md', () => {
+    const shell = useDeckViewShell()
+    expect(shell.grid_size.value).toBe('md')
+  })
+
+  // ── setMode ────────────────────────────────────────────────────────────────
+
+  test('setMode changes the active mode', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('edit')
+    expect(shell.mode.value).toBe('edit')
+  })
+
+  test('is_view becomes false when mode is not view', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('edit')
+    expect(shell.is_view.value).toBe(false)
+  })
+
+  test('setMode to import-export sets mode correctly', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('import-export')
+    expect(shell.mode.value).toBe('import-export')
+    expect(shell.is_view.value).toBe(false)
+  })
+
+  // ── toggleMode ─────────────────────────────────────────────────────────────
+
+  test('toggleMode enters target mode when in view', () => {
+    const shell = useDeckViewShell()
+    shell.toggleMode('edit')
+    expect(shell.mode.value).toBe('edit')
+  })
+
+  test('toggleMode falls back to view when target is already active', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('edit')
+    shell.toggleMode('edit')
+    expect(shell.mode.value).toBe('view')
+  })
+
+  test('toggleMode switches between two non-view modes without going through view first', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('edit')
+    shell.toggleMode('import-export')
+    expect(shell.mode.value).toBe('import-export')
+  })
+
+  // ── exitMode ───────────────────────────────────────────────────────────────
+
+  test('exitMode always returns to view mode', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('edit')
+    shell.exitMode()
+    expect(shell.mode.value).toBe('view')
+  })
+
+  test('exitMode sets is_view back to true', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('import-export')
+    shell.exitMode()
+    expect(shell.is_view.value).toBe(true)
+  })
+
+  // ── setGridSize ────────────────────────────────────────────────────────────
+
+  test('setGridSize changes grid_size', () => {
+    const shell = useDeckViewShell()
+    shell.setGridSize('xl')
+    expect(shell.grid_size.value).toBe('xl')
+  })
+
+  test('setGridSize persists across shell instances via localStorage', async () => {
+    const shell1 = useDeckViewShell()
+    shell1.setGridSize('base')
+    await nextTick()
+
+    const shell2 = useDeckViewShell()
+    expect(shell2.grid_size.value).toBe('base')
+  })
+})

--- a/tests/unit/composables/card-editor/use-bulk-actions.test.js
+++ b/tests/unit/composables/card-editor/use-bulk-actions.test.js
@@ -9,6 +9,7 @@ vi.mock('vue-i18n', () => ({
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
 
 import { useBulkActions } from '@/composables/card-editor/use-bulk-actions'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 
 function makeEditor({
   selected_count = 0,
@@ -39,7 +40,10 @@ function withSetup(composable, { provide } = {}) {
       return () => {}
     }
   })
-  if (provide) Object.entries(provide).forEach(([k, v]) => app.provide(k, v))
+  if (provide) {
+    const entries = Array.isArray(provide) ? provide : Object.entries(provide)
+    entries.forEach(([k, v]) => app.provide(k, v))
+  }
   app.mount(document.createElement('div'))
   return [result, app]
 }
@@ -54,7 +58,7 @@ describe('useBulkActions', () => {
   function setup(opts) {
     const editor = makeEditor(opts)
     const [result, _app] = withSetup(useBulkActions, {
-      provide: { 'card-editor': editor }
+      provide: [[cardEditorKey, editor]]
     })
     app = _app
     return { result, editor }

--- a/tests/unit/utils/animations/card-overlay.test.js
+++ b/tests/unit/utils/animations/card-overlay.test.js
@@ -9,6 +9,8 @@ const { mockSet, mockTo, mockFromTo } = vi.hoisted(() => ({
 vi.mock('gsap', () => ({ gsap: { set: mockSet, to: mockTo, fromTo: mockFromTo } }))
 
 import {
+  captureModeSwitch,
+  distanceToViewportBottom,
   fadeScaleEnter,
   fadeScaleLeave,
   primeOverlayBelow,
@@ -20,10 +22,129 @@ import {
 const el = document.createElement('div')
 const done = vi.fn()
 
+/** Build a ModeSwitchViewport with sensible defaults. */
+function makeVp({ from_y = 0, settle_y = 0, stack_top = 600 } = {}) {
+  return { from_y, settle_y, stack_top }
+}
+
 describe('card-overlay animations', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset scroll/viewport so tests that mock window see consistent values
+    Object.defineProperty(window, 'scrollY', { value: 0, configurable: true, writable: true })
+    Object.defineProperty(window, 'innerHeight', {
+      value: 800,
+      configurable: true,
+      writable: true
+    })
   })
+
+  // ── captureModeSwitch ─────────────────────────────────────────────────────
+
+  describe('captureModeSwitch', () => {
+    function makeStack(rectTop = 200) {
+      const el = document.createElement('div')
+      el.getBoundingClientRect = () => ({
+        top: rectTop,
+        bottom: rectTop + 500,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 500,
+        x: 0,
+        y: rectTop,
+        toJSON: () => ({})
+      })
+      return el
+    }
+
+    function makeHeader(rectBottom = 60) {
+      const el = document.createElement('div')
+      el.getBoundingClientRect = () => ({
+        top: 0,
+        bottom: rectBottom,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: rectBottom,
+        x: 0,
+        y: 0,
+        toJSON: () => ({})
+      })
+      return el
+    }
+
+    test('above-stack regime: settle_y === from_y when user is scrolled above the stack [obligation]', () => {
+      // from_y=50, stack_top=50+200=250, header_bottom=60 → stack_top-header_bottom=190
+      // min(50, max(0,190)) = min(50,190) = 50 → settle_y === from_y
+      window.scrollY = 50
+      const stack = makeStack(200) // rect.top=200, stack_top = 200+50=250
+      const header = makeHeader(60)
+      const vp = captureModeSwitch(stack, header)
+      expect(vp.settle_y).toBe(vp.from_y)
+    })
+
+    test('deep-scroll regime: settle_y === stack_top - header_bottom when scrolled past stack [obligation]', () => {
+      // from_y=600, rect.top at scroll 600 is -200 (stack_top absolute=400), header_bottom=60
+      // max(0, 400-60)=340, min(600,340)=340 → settle_y = stack_top - header_bottom
+      window.scrollY = 600
+      const stack = makeStack(-200) // rect.top=-200 → stack_top = -200+600=400
+      const header = makeHeader(60)
+      const vp = captureModeSwitch(stack, header)
+      expect(vp.settle_y).toBe(400 - 60) // stack_top - header_bottom
+    })
+
+    test('with no header, header_bottom defaults to 0', () => {
+      window.scrollY = 0
+      const stack = makeStack(100) // stack_top=100
+      const vp = captureModeSwitch(stack, null)
+      // min(0, max(0, 100-0)) = min(0, 100) = 0
+      expect(vp.settle_y).toBe(0)
+    })
+
+    test('with no header, settle_y clamps to 0 when stack_top is above viewport', () => {
+      window.scrollY = 0
+      const stack = makeStack(-50) // stack_top = -50
+      const vp = captureModeSwitch(stack, undefined)
+      // max(0, -50) = 0, min(0, 0) = 0
+      expect(vp.settle_y).toBe(0)
+    })
+
+    test('returns from_y and stack_top in the viewport context', () => {
+      window.scrollY = 100
+      const stack = makeStack(50) // stack_top = 50+100=150
+      const vp = captureModeSwitch(stack)
+      expect(vp.from_y).toBe(100)
+      expect(vp.stack_top).toBe(150)
+    })
+  })
+
+  // ── distanceToViewportBottom ──────────────────────────────────────────────
+
+  describe('distanceToViewportBottom', () => {
+    test('returns settle_y + innerHeight - stack_top when positive [obligation]', () => {
+      window.innerHeight = 800
+      // settle_y=0, stack_top=600 → 0+800-600=200
+      const vp = makeVp({ settle_y: 0, stack_top: 600 })
+      expect(distanceToViewportBottom(vp)).toBe(200)
+    })
+
+    test('clamps to 0 when stack_top is below viewport bottom [obligation]', () => {
+      window.innerHeight = 800
+      // settle_y=0, stack_top=900 → 0+800-900=-100 → clamped to 0
+      const vp = makeVp({ settle_y: 0, stack_top: 900 })
+      expect(distanceToViewportBottom(vp)).toBe(0)
+    })
+
+    test('accounts for settle_y offset', () => {
+      window.innerHeight = 800
+      // settle_y=200, stack_top=800 → 200+800-800=200
+      const vp = makeVp({ settle_y: 200, stack_top: 800 })
+      expect(distanceToViewportBottom(vp)).toBe(200)
+    })
+  })
+
+  // ── fadeScaleEnter (grid) ─────────────────────────────────────────────────
 
   describe('fadeScaleEnter (grid)', () => {
     test('fades + scales in from a shrunk, top-anchored state, staying in flow', () => {
@@ -36,27 +157,35 @@ describe('card-overlay animations', () => {
       )
     })
 
-    test('clears leftover positioning so the entering grid rejoins flow', () => {
+    test('clears leftover positioning AND transform so the entering grid rejoins flow', () => {
       fadeScaleEnter(el, done)
 
-      expect(mockSet).toHaveBeenCalledWith(el, { clearProps: 'position,top,left,width' })
+      expect(mockSet).toHaveBeenCalledWith(el, {
+        clearProps: 'position,top,left,width,transform'
+      })
     })
   })
 
+  // ── fadeScaleLeave (grid) ─────────────────────────────────────────────────
+
   describe('fadeScaleLeave (grid)', () => {
-    test('drops the leaving grid out of flow before shrinking it', () => {
-      fadeScaleLeave(el, done)
+    test('drops the leaving grid out of flow with scroll compensation y', () => {
+      // from_y=200, settle_y=100 → scrollCompensation = 100-200 = -100
+      const vp = makeVp({ from_y: 200, settle_y: 100 })
+      fadeScaleLeave(el, vp, done)
 
       expect(mockSet).toHaveBeenCalledWith(el, {
         position: 'absolute',
         top: 0,
         left: 0,
-        width: '100%'
+        width: '100%',
+        y: -100
       })
     })
 
     test('fades to 0 and scales down from the top, calling done on complete', () => {
-      fadeScaleLeave(el, done)
+      const vp = makeVp()
+      fadeScaleLeave(el, vp, done)
 
       expect(mockTo).toHaveBeenCalledWith(
         el,
@@ -68,25 +197,37 @@ describe('card-overlay animations', () => {
         })
       )
     })
+
+    test('scroll compensation is 0 when from_y === settle_y (no scroll jump)', () => {
+      const vp = makeVp({ from_y: 300, settle_y: 300 })
+      fadeScaleLeave(el, vp, done)
+      expect(mockSet).toHaveBeenCalledWith(el, expect.objectContaining({ y: 0 }))
+    })
   })
 
+  // ── primeOverlayBelow ─────────────────────────────────────────────────────
+
   describe('primeOverlayBelow', () => {
-    test('layers the entering pane in flow, one screen below its rest position', () => {
-      primeOverlayBelow(el)
+    test('layers the entering pane in flow, positioned at distanceToViewportBottom', () => {
+      window.innerHeight = 800
+      // settle_y=0, stack_top=600 → distanceToViewportBottom = 200
+      const vp = makeVp({ settle_y: 0, stack_top: 600 })
+      primeOverlayBelow(el, vp)
 
       expect(mockSet).toHaveBeenCalledWith(el, {
         position: 'relative',
         zIndex: 1,
-        y: window.innerHeight
+        y: 200
       })
     })
 
     test('does not call gsap.to (priming only sets initial state)', () => {
-      primeOverlayBelow(el)
-
+      primeOverlayBelow(el, makeVp())
       expect(mockTo).not.toHaveBeenCalled()
     })
   })
+
+  // ── slideOverlayUp ────────────────────────────────────────────────────────
 
   describe('slideOverlayUp', () => {
     test('tweens to y 0', () => {
@@ -116,6 +257,8 @@ describe('card-overlay animations', () => {
     })
   })
 
+  // ── settleOverlay ─────────────────────────────────────────────────────────
+
   describe('settleOverlay', () => {
     test('clears the overlay props so the entered pane rejoins normal flow', () => {
       settleOverlay(el)
@@ -130,43 +273,69 @@ describe('card-overlay animations', () => {
     })
   })
 
+  // ── slideOverlayDown ──────────────────────────────────────────────────────
+
   describe('slideOverlayDown', () => {
-    test('drops the leaving pane out of flow (on top) before sliding it down', () => {
-      slideOverlayDown(el, done)
+    test('drops the leaving pane out of flow with scroll compensation y', () => {
+      // from_y=200, settle_y=100 → scrollCompensation = -100
+      const vp = makeVp({ from_y: 200, settle_y: 100 })
+      slideOverlayDown(el, vp, done)
 
       expect(mockSet).toHaveBeenCalledWith(el, {
         position: 'absolute',
         top: 0,
         left: 0,
         width: '100%',
-        zIndex: 1
+        zIndex: 1,
+        y: -100
       })
     })
 
-    test('tweens down one screen', () => {
-      slideOverlayDown(el, done)
+    test('tweens y down by one innerHeight from the compensation starting point', () => {
+      window.innerHeight = 800
+      // from_y=100, settle_y=100 → scrollCompensation=0 → tween to 0+800=800
+      const vp = makeVp({ from_y: 100, settle_y: 100 })
+      slideOverlayDown(el, vp, done)
 
-      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ y: window.innerHeight }))
+      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ y: 800 }))
+    })
+
+    test('opacity stays 1 when scrollCompensation >= 0 (pane top already off-screen) [obligation]', () => {
+      // from_y=100, settle_y=100 → compensation=0 → opacity=1 (no early fade)
+      const vp = makeVp({ from_y: 100, settle_y: 100 })
+      slideOverlayDown(el, vp, done)
+
+      const opts = mockTo.mock.calls[0][1]
+      expect(opts.opacity).toBe(1)
+    })
+
+    test('opacity is 0 when scrollCompensation < 0 (pane top cannot clear screen in one viewport) [obligation]', () => {
+      // from_y=200, settle_y=100 → compensation=-100 → opacity=0
+      const vp = makeVp({ from_y: 200, settle_y: 100 })
+      slideOverlayDown(el, vp, done)
+
+      const opts = mockTo.mock.calls[0][1]
+      expect(opts.opacity).toBe(0)
+    })
+
+    test('calls done via onComplete', () => {
+      slideOverlayDown(el, makeVp(), done)
+
+      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ onComplete: done }))
     })
 
     test('uses the shared duration and expo.out ease', () => {
-      slideOverlayDown(el, done)
+      slideOverlayDown(el, makeVp(), done)
 
       const opts = mockTo.mock.calls[0][1]
       expect(opts.duration).toBeGreaterThan(0)
       expect(opts.ease).toBe('expo.out')
     })
-
-    test('calls done via onComplete', () => {
-      slideOverlayDown(el, done)
-
-      expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ onComplete: done }))
-    })
   })
 
   test('slideOverlayUp and slideOverlayDown share the same duration', () => {
     slideOverlayUp(el, done)
-    slideOverlayDown(el, done)
+    slideOverlayDown(el, makeVp(), done)
 
     expect(mockTo.mock.calls[0][1].duration).toBe(mockTo.mock.calls[1][1].duration)
   })


### PR DESCRIPTION
## Summary

Reworks the deck view's view/edit mode flow so it scales to new modes (import/export, find & replace) and fixes the jumpy transition.

**Transition fix.** Mode switches now animate in viewport space: the scroll jumps to where the incoming pane rests and both panes are offset so nothing visibly moves. Fixes the clipped edit→view slide on short grids, the strange slide when switching while scrolled, and the overlay unmounting mid-screen.

**Architecture.** A single `DECK_MODES` registry plus a `useDeckViewShell` composable replace the hardcoded pane ternary and scattered `mode !== 'view'` checks. Adding a mode is now one registry entry + a pane component; chrome reads `useModeConfig().pagination` instead of comparing mode names. UI-shell state (mode, grid size) is split out of `useCardListController`, which is now pure card-data, and the stringly-typed `provide('card-editor')` is replaced with typed injection keys.

**First-switch flicker.** Overlay panes lazy-load via `defineAsyncComponent` and are warmed on mount; the stack holds its overflow clip open across the load so the first switch no longer flickers.

Note: deleting the whole selection now keeps the current mode rather than forcing a return to view.
