### PR TITLE
Deck view: new-card button + scroll/transition fixes

### DIFF
--- a/src/composables/card-editor/card-list-controller.ts
+++ b/src/composables/card-editor/card-list-controller.ts
@@ -57,6 +57,10 @@ export function useCardListController(opts: Options) {
 
   const saving = ref(false)
 
+  // client_id of the card last staged via `addCardAtTop`, awaiting autofocus.
+  // The matching row claims it on mount (see `claimFocus`) and focuses itself.
+  const pending_focus_client_id = ref<string | null>(null)
+
   const card_attributes = computed<DeckCardAttributes>(() => ({
     front: deck_query.data.value?.card_attributes?.front ?? {},
     back: deck_query.data.value?.card_attributes?.back ?? {}
@@ -71,9 +75,12 @@ export function useCardListController(opts: Options) {
    * @param left_card_id  - If given, the new card is placed `after` this id.
    * @param right_card_id - If given (and `left_card_id` is not), `before` it.
    */
-  async function addCard(left_card_id?: number, right_card_id?: number) {
+  async function addCard(
+    left_card_id?: number,
+    right_card_id?: number
+  ): Promise<string | undefined> {
     if (!(await limit_gate.guardAddCards())) return
-    list.addCard(left_card_id, right_card_id)
+    return list.addCard(left_card_id, right_card_id)
   }
 
   /** Gated stage of a new temp card immediately after the card with `card_id`. */
@@ -84,6 +91,34 @@ export function useCardListController(opts: Options) {
   /** Gated stage of a new temp card immediately before the card with `card_id`. */
   function prependCard(card_id: number) {
     return addCard(undefined, card_id)
+  }
+
+  /**
+   * Stage a new card at the very top of the deck and request autofocus on it,
+   * so the toolbar's "new card" intent drops the user straight into typing.
+   * Anchors before the first persisted card; on an empty deck it appends (the
+   * lone card is still the top). No-op past the plan cap — `addCard` gates it.
+   */
+  async function addCardAtTop() {
+    if (!(await limit_gate.guardAddCards())) return
+
+    // Stage and record the autofocus target in the same synchronous block:
+    // `list.addCardAtTop` pushes the temp and queues Vue's render, which flushes
+    // before any later microtask. Assigning `pending_focus_client_id` after an
+    // `await` here would lose the race — the row mounts and claims focus before
+    // the target is set.
+    pending_focus_client_id.value = list.addCardAtTop()
+  }
+
+  /**
+   * One-shot autofocus claim: returns true exactly once, for the card whose
+   * `client_id` was last staged by `addCardAtTop`. The matching row calls this
+   * on mount and focuses its editor; every other card gets false.
+   */
+  function claimFocus(client_id: string): boolean {
+    if (pending_focus_client_id.value !== client_id) return false
+    pending_focus_client_id.value = null
+    return true
   }
 
   const actions = useCardActions({
@@ -185,6 +220,8 @@ export function useCardListController(opts: Options) {
     addCard,
     appendCard,
     prependCard,
+    addCardAtTop,
+    claimFocus,
     guardAddCards: limit_gate.guardAddCards,
     handleLimitError: limit_gate.handleLimitError,
     saving,

--- a/src/composables/card-editor/deck-view-shell.ts
+++ b/src/composables/card-editor/deck-view-shell.ts
@@ -1,5 +1,6 @@
 import { computed, ref, type InjectionKey } from 'vue'
 import { useLocalRef } from '@/composables/use-local-ref'
+import { emitSfx } from '@/sfx/bus'
 
 export type DeckViewShell = ReturnType<typeof useDeckViewShell>
 
@@ -25,21 +26,48 @@ export function useDeckViewShell() {
   const mode = ref<CardEditorMode>('view')
   const grid_size = useLocalRef<CardGridSize>('deck-grid-size', 'md')
 
+  // Resolvers waiting on the in-flight mode transition; drained by
+  // `notifyModeSettled` when the mode-stack reports an entering pane settled.
+  const settle_waiters = new Set<() => void>()
+
   const is_view = computed(() => mode.value === 'view')
 
-  /** Switch the deck view to `new_mode`. */
-  function setMode(new_mode: CardEditorMode) {
+  /**
+   * Switch the deck view to `new_mode`, resolving once that pane's enter
+   * transition has finished animating — the mode-stack calls `notifyModeSettled`
+   * from the GSAP completion. Resolves immediately when already in `new_mode`.
+   * `mode` still flips synchronously; only the returned promise is deferred, so
+   * callers that ignore it are unaffected. Plays the shared mode-switch chime
+   * (`ui.select`) on every real switch, so call sites don't each wire their own.
+   */
+  function setMode(new_mode: CardEditorMode): Promise<void> {
+    if (mode.value === new_mode) return Promise.resolve()
+
+    emitSfx('ui.select')
+
+    const settled = new Promise<void>((resolve) => settle_waiters.add(resolve))
     mode.value = new_mode
+    return settled
+  }
+
+  /**
+   * Resolve everyone waiting on the current transition. Called by the
+   * mode-stack when an entering pane finishes its GSAP animation.
+   */
+  function notifyModeSettled() {
+    const waiters = [...settle_waiters]
+    settle_waiters.clear()
+    waiters.forEach((resolve) => resolve())
   }
 
   /** Enter `target`, or fall back to the base view when it's already active. */
   function toggleMode(target: CardEditorMode) {
-    setMode(mode.value === target ? 'view' : target)
+    return setMode(mode.value === target ? 'view' : target)
   }
 
   /** Leave the current mode back to the base view. */
   function exitMode() {
-    setMode('view')
+    return setMode('view')
   }
 
   /** Set the card render size for the deck grid (Small / Base / Full). */
@@ -47,5 +75,14 @@ export function useDeckViewShell() {
     grid_size.value = size
   }
 
-  return { mode, is_view, grid_size, setMode, toggleMode, exitMode, setGridSize }
+  return {
+    mode,
+    is_view,
+    grid_size,
+    setMode,
+    notifyModeSettled,
+    toggleMode,
+    exitMode,
+    setGridSize
+  }
 }

--- a/src/composables/card-editor/virtual-card-list.ts
+++ b/src/composables/card-editor/virtual-card-list.ts
@@ -196,27 +196,56 @@ export function useVirtualCardList(
    * @param left_card_id  - If given, the new card is placed `after` this id.
    * @param right_card_id - If given (and `left_card_id` is not), the new card
    *                        is placed `before` this id.
+   * @returns The stable `client_id` of the staged card, so the caller can later
+   *          target it (e.g. to autofocus its editor once it mounts).
    */
-  function addCard(left_card_id?: number, right_card_id?: number) {
+  function addCard(left_card_id?: number, right_card_id?: number): string {
     const { anchor_id, side } = resolveAnchor(left_card_id, right_card_id)
+    const client_id = uid()
 
     temp_entries.value.push({
-      client_id: uid(),
+      client_id,
       card: buildEmptyCard(),
       anchor_id,
       side,
       real_id: null
     })
+
+    return client_id
   }
 
   /** Stage a new temp card immediately after the card with `card_id`. */
   function appendCard(card_id: number) {
-    addCard(card_id)
+    return addCard(card_id)
   }
 
   /** Stage a new temp card immediately before the card with `card_id`. */
   function prependCard(card_id: number) {
-    addCard(undefined, card_id)
+    return addCard(undefined, card_id)
+  }
+
+  /**
+   * Stage a new temp card at the very top of the deck. Anchors `before` the
+   * first *persisted* card — a real id the insert RPC can resolve, where a
+   * still-unsaved temp's placeholder id can't — and `unshift`s the entry so it
+   * renders above any temps already stacked at the top (repeated "add at top"
+   * clicks each land newest-first). Appends with no anchor on an empty deck.
+   *
+   * @returns The stable `client_id` of the staged card.
+   */
+  function addCardAtTop(): string {
+    const first_persisted = persisted_cards.value[0]
+    const client_id = uid()
+
+    temp_entries.value.unshift({
+      client_id,
+      card: buildEmptyCard(),
+      anchor_id: first_persisted?.id ?? null,
+      side: first_persisted?.id !== undefined ? 'before' : null,
+      real_id: null
+    })
+
+    return client_id
   }
 
   /**
@@ -289,6 +318,7 @@ export function useVirtualCardList(
     addCard,
     appendCard,
     prependCard,
+    addCardAtTop,
     findEntryByCardId,
     findCard,
     promoteTemp

--- a/src/utils/animations/deck-view/card-overlay.ts
+++ b/src/utils/animations/deck-view/card-overlay.ts
@@ -101,6 +101,14 @@ export function settleOverlay(el: Element) {
   gsap.set(el, { clearProps: 'position,zIndex,transform' })
 }
 
+// A mode flip can interrupt an in-flight slide. Kill the tween so its late
+// onComplete can't fire and its inline position/transform don't linger on a
+// reused element — the caller has already dropped the pane from its in-flight
+// set, this just stops GSAP from mutating it further.
+export function cancelOverlayAnimation(el: Element) {
+  gsap.killTweensOf(el)
+}
+
 // Leaving overlay drops out of flow (so the entering grid owns the height) and
 // slides one screen down from wherever the user was looking. When the user was
 // scrolled into the pane, one screen of travel can't carry its top edge past

--- a/src/utils/animations/list-item.ts
+++ b/src/utils/animations/list-item.ts
@@ -1,0 +1,22 @@
+import { gsap } from 'gsap'
+
+const ENTER_DURATION = 0.3
+
+/**
+ * Reveal a freshly-added card row, growing it in from a collapsed top edge.
+ * Driven imperatively (not a Vue Transition) because the editor list is
+ * windowed: every row's slot is reserved up front, so a transition would fire
+ * for rows scrolling into view too. The caller gates this to the one card it
+ * just added, animating it within its reserved slot rather than reflowing the
+ * list.
+ */
+export function expandListItemIn(el: HTMLElement) {
+  gsap.from(el, {
+    scaleY: 0,
+    opacity: 0,
+    duration: ENTER_DURATION,
+    ease: 'power2.out',
+    transformOrigin: 'center top',
+    clearProps: 'all'
+  })
+}

--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import CardFaceUploader from './card-face-uploader.vue'
 import { useI18n } from 'vue-i18n'
-import { inject, ref, useTemplateRef } from 'vue'
+import { inject, onMounted, ref, useTemplateRef } from 'vue'
 import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import type { CardWithClientId } from '@/composables/card-editor/virtual-card-list'
 import textEditor from '@/components/card/text-editor.vue'
 import { emitSfx } from '@/sfx/bus'
+import { expandListItemIn } from '@/utils/animations/list-item'
 
 type ListItemCardProps = {
-  card: Card
+  card: CardWithClientId
 }
 
 const { card } = defineProps<ListItemCardProps>()
@@ -25,8 +27,19 @@ const front_text = ref(card.front_text ?? '')
 const back_text = ref(card.back_text ?? '')
 const save_failed = ref(false)
 
-const { selection, updateCard, card_attributes } = inject(cardEditorKey)!
+const { selection, updateCard, card_attributes, claimFocus } = inject(cardEditorKey)!
 const { is_selecting } = selection
+
+// A card staged by the toolbar's "new card" intent claims its one-shot signal
+// the moment its row mounts: land the user in the front editor ready to type,
+// and reveal the new row with a grow-in (gated here so scroll-mounted rows
+// don't animate).
+onMounted(() => {
+  if (!claimFocus(card.client_id)) return
+
+  focusEditor()
+  if (list_item_card.value) expandListItemIn(list_item_card.value)
+})
 
 // Persist both sides from local state, not just the edited one: the merge base
 // in the save path is the cached card, so sending a single side would let it

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -7,10 +7,11 @@ import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 import { inject, computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ListItemCard from './list-item-card.vue'
+import type { CardWithClientId } from '@/composables/card-editor/virtual-card-list'
 
 type ListItemProps = {
   index: number
-  card: Card
+  card: CardWithClientId
 }
 
 const { card, index } = defineProps<ListItemProps>()

--- a/src/views/deck/card-grid/scroll-grid.vue
+++ b/src/views/deck/card-grid/scroll-grid.vue
@@ -35,7 +35,7 @@ observeSentinel(sentinel)
 </script>
 
 <template>
-  <div data-testid="card-grid-container" class="w-full h-full md:min-h-0 overflow-y-auto">
+  <div data-testid="card-grid-container" class="w-full h-full md:min-h-0 overflow-y-auto py-2">
     <div data-testid="card-grid" class="grid justify-center gap-4" :style="grid_style">
       <grid-item
         v-for="card in all_cards"

--- a/src/views/deck/deck-hero/actions.vue
+++ b/src/views/deck/deck-hero/actions.vue
@@ -72,7 +72,6 @@ function onEditOption(option: DropdownOption) {
       :data-theme-dark="is_editing ? 'yellow-700' : 'stone-700'"
       full-width
       size="xl"
-      :sfx="{ click: 'ui.select' }"
       @click="onToggleEditCards"
       @select="onEditOption"
     >

--- a/src/views/deck/mode-stack.vue
+++ b/src/views/deck/mode-stack.vue
@@ -10,6 +10,7 @@ import {
   slideOverlayUp,
   settleOverlay,
   slideOverlayDown,
+  cancelOverlayAnimation,
   type ModeSwitchViewport
 } from '@/utils/animations/deck-view/card-overlay'
 import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
@@ -23,7 +24,10 @@ const { sticky_header = null } = defineProps<ModeStackProps>()
 const shell = inject(deckViewShellKey)!
 
 const stack = useTemplateRef<HTMLElement>('stack')
-const sliding = ref(0)
+// Panes currently mid-slide, keyed by element. A Set (not a counter) so an
+// interrupted transition can't unbalance it: delete is idempotent, and the next
+// add/delete cycle reconciles a missed terminal hook.
+const sliding_panes = ref(new Set<Element>())
 const switch_pending = ref(false)
 const clip_min_height = ref(0)
 
@@ -32,7 +36,7 @@ let viewport: ModeSwitchViewport = { from_y: 0, settle_y: 0, stack_top: 0 }
 const overlay_pane = computed(() =>
   shell.is_view.value ? null : DECK_MODES[shell.mode.value].pane
 )
-const is_transitioning = computed(() => switch_pending.value || sliding.value > 0)
+const is_transitioning = computed(() => switch_pending.value || sliding_panes.value.size > 0)
 const clip_style = computed(() =>
   is_transitioning.value ? { minHeight: `${clip_min_height.value}px` } : undefined
 )
@@ -53,26 +57,36 @@ function onGridLeave(el: Element, done: () => void) {
 // slides — released at rest so card menus can overflow normally.
 function onOverlayBeforeEnter(el: Element) {
   switch_pending.value = false
-  sliding.value++
+  sliding_panes.value.add(el)
   primeOverlayBelow(el, viewport)
 }
 
 function onOverlayAfterEnter(el: Element) {
   settleOverlay(el)
-  sliding.value--
+  sliding_panes.value.delete(el)
   shell.notifyModeSettled()
 }
 
-function onOverlayBeforeLeave() {
-  sliding.value++
+function onOverlayBeforeLeave(el: Element) {
+  sliding_panes.value.add(el)
 }
 
 function onOverlayLeave(el: Element, done: () => void) {
   slideOverlayDown(el, viewport, done)
 }
 
-function onOverlayAfterLeave() {
-  sliding.value--
+function onOverlayAfterLeave(el: Element) {
+  sliding_panes.value.delete(el)
+}
+
+// A rapid mode flip can yank an entering/leaving pane before its slide
+// finishes; Vue fires the *-cancelled hook instead of *-after. Stop the tween
+// and drop the pane from the in-flight set so `is_transitioning` can't latch on
+// forever — which would strand the clip min-height and leave the page scrolled
+// past its content.
+function onOverlayCancelled(el: Element) {
+  cancelOverlayAnimation(el)
+  sliding_panes.value.delete(el)
 }
 
 // Sync flush: the DOM still shows the outgoing mode, so the capture reads the
@@ -112,9 +126,11 @@ watch(
       @before-enter="onOverlayBeforeEnter"
       @enter="slideOverlayUp"
       @after-enter="onOverlayAfterEnter"
+      @enter-cancelled="onOverlayCancelled"
       @before-leave="onOverlayBeforeLeave"
       @leave="onOverlayLeave"
       @after-leave="onOverlayAfterLeave"
+      @leave-cancelled="onOverlayCancelled"
     >
       <component :is="overlay_pane" v-if="overlay_pane" :key="shell.mode.value" class="w-full" />
     </Transition>

--- a/src/views/deck/mode-stack.vue
+++ b/src/views/deck/mode-stack.vue
@@ -39,7 +39,10 @@ const clip_style = computed(() =>
 
 function onGridEnter(el: Element, done: () => void) {
   switch_pending.value = false
-  fadeScaleEnter(el, done)
+  fadeScaleEnter(el, () => {
+    done()
+    shell.notifyModeSettled()
+  })
 }
 
 function onGridLeave(el: Element, done: () => void) {
@@ -57,6 +60,7 @@ function onOverlayBeforeEnter(el: Element) {
 function onOverlayAfterEnter(el: Element) {
   settleOverlay(el)
   sliding.value--
+  shell.notifyModeSettled()
 }
 
 function onOverlayBeforeLeave() {

--- a/src/views/deck/mode-toolbar/mode-view.vue
+++ b/src/views/deck/mode-toolbar/mode-view.vue
@@ -6,10 +6,24 @@ import UiButton from '@/components/ui-kit/button.vue'
 import { useI18n } from 'vue-i18n'
 import { inject } from 'vue'
 import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
+import { emitSfx } from '@/sfx/bus'
 
 const { t } = useI18n()
 
-const { addCard } = inject(cardEditorKey)!
+const { setMode } = inject(deckViewShellKey)!
+const { addCardAtTop } = inject(cardEditorKey)!
+
+// Enter edit mode (no-op if already there; setMode plays the mode-switch chime)
+// and wait for the slide to settle before adding the card, so its focus +
+// scroll-into-view read final positions rather than the mid-animation transform.
+// The add chime is `blocking` so it suppresses the `slide_up` that focusing the
+// new card would otherwise fire.
+async function onNewCard() {
+  await setMode('edit')
+  emitSfx('ui.snappy_button_2', { blocking: true })
+  addCardAtTop()
+}
 </script>
 
 <template>
@@ -34,7 +48,7 @@ const { addCard } = inject(cardEditorKey)!
         data-theme-dark="blue-650"
         size="sm"
         icon-left="add"
-        @click="addCard()"
+        @click="onNewCard"
       >
         {{ t('deck-view.mode-view.new-card') }}
       </ui-button>

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -37,7 +37,8 @@ const TextEditorStub = defineComponent({
 
 const mocks = vi.hoisted(() => ({
   updateCardMock: vi.fn(),
-  emitSfxMock: vi.fn()
+  emitSfxMock: vi.fn(),
+  claimFocusMock: vi.fn()
 }))
 
 vi.mock('@/sfx/bus', () => ({ emitSfx: mocks.emitSfxMock, emitHoverSfx: vi.fn() }))
@@ -49,6 +50,7 @@ import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
 function makeCard(overrides = {}) {
   return {
     id: 1,
+    client_id: 'c1',
     deck_id: 10,
     front_text: 'Q',
     back_text: 'A',
@@ -62,7 +64,8 @@ function makeProvide({ is_selecting = ref(false) } = {}) {
     [cardEditorKey]: {
       selection: { is_selecting },
       updateCard: mocks.updateCardMock,
-      card_attributes: { front: {}, back: {} }
+      card_attributes: { front: {}, back: {} },
+      claimFocus: mocks.claimFocusMock
     }
   }
 }
@@ -101,6 +104,8 @@ beforeEach(() => {
   mocks.updateCardMock.mockReset()
   mocks.updateCardMock.mockResolvedValue(undefined)
   mocks.emitSfxMock.mockReset()
+  mocks.claimFocusMock.mockReset()
+  mocks.claimFocusMock.mockReturnValue(false)
 })
 
 describe('ListItemCard', () => {

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -22,10 +22,13 @@ const CardFaceUploaderStub = defineComponent({
 
 // Stub TextEditor as a real contenteditable div so focusin/focusout
 // tests can dispatch events with e.target.isContentEditable === true.
+// Exposes focus() so useTemplateRef('front-input')?.focus() doesn't throw when
+// the onMounted claimFocus branch runs.
 const TextEditorStub = defineComponent({
   name: 'TextEditor',
   props: ['content', 'attributes', 'placeholder'],
-  setup(_props, { attrs }) {
+  setup(_props, { attrs, expose }) {
+    expose({ focus: vi.fn() })
     return () =>
       h('div', {
         ...attrs,
@@ -38,10 +41,15 @@ const TextEditorStub = defineComponent({
 const mocks = vi.hoisted(() => ({
   updateCardMock: vi.fn(),
   emitSfxMock: vi.fn(),
-  claimFocusMock: vi.fn()
+  claimFocusMock: vi.fn(),
+  gsapFromMock: vi.fn()
 }))
 
 vi.mock('@/sfx/bus', () => ({ emitSfx: mocks.emitSfxMock, emitHoverSfx: vi.fn() }))
+
+vi.mock('@/utils/animations/list-item', () => ({
+  expandListItemIn: mocks.gsapFromMock
+}))
 
 import ListItemCard from '@/views/deck/card-editor/list-item-card.vue'
 import textEditor from '@/components/card/text-editor.vue'
@@ -106,6 +114,7 @@ beforeEach(() => {
   mocks.emitSfxMock.mockReset()
   mocks.claimFocusMock.mockReset()
   mocks.claimFocusMock.mockReturnValue(false)
+  mocks.gsapFromMock.mockReset()
 })
 
 describe('ListItemCard', () => {
@@ -309,6 +318,30 @@ describe('ListItemCard', () => {
     mocks.emitSfxMock.mockReset()
     contenteditable.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }))
     expect(mocks.emitSfxMock).toHaveBeenCalledWith('ui.slide_up')
+    wrapper.unmount()
+  })
+
+  // ── onMounted autofocus — claimFocus true branch ──────────────────────────
+
+  test('does NOT run expandListItemIn when claimFocus returns false (scroll-mounted row) [obligation]', () => {
+    mocks.claimFocusMock.mockReturnValue(false)
+    mount({ card: { id: 99, client_id: 'c99' } })
+    expect(mocks.gsapFromMock).not.toHaveBeenCalled()
+  })
+
+  test('runs expandListItemIn on the root element when claimFocus returns true [obligation]', async () => {
+    mocks.claimFocusMock.mockReturnValue(true)
+    // Use mountWithFocusStubs so the front-input template ref resolves to a real
+    // contenteditable element whose .focus() exists; otherwise focusEditor() throws.
+    const wrapper = shallowMount(ListItemCard, {
+      attachTo: document.body,
+      props: { card: makeCard({ id: 77, client_id: 'c77' }) },
+      global: {
+        stubs: { CardFaceUploader: CardFaceUploaderStub, TextEditor: TextEditorStub },
+        provide: makeProvide()
+      }
+    })
+    expect(mocks.gsapFromMock).toHaveBeenCalledWith(wrapper.element)
     wrapper.unmount()
   })
 

--- a/tests/integration/views/deck/mode-stack.test.js
+++ b/tests/integration/views/deck/mode-stack.test.js
@@ -38,7 +38,7 @@ import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
 function makeShell(mode = 'view') {
   const mode_ref = ref(mode)
   const is_view = ref(mode === 'view')
-  return { mode: mode_ref, is_view }
+  return { mode: mode_ref, is_view, notifyModeSettled: vi.fn() }
 }
 
 function mount(shell = makeShell()) {

--- a/tests/integration/views/deck/mode-stack.test.js
+++ b/tests/integration/views/deck/mode-stack.test.js
@@ -112,6 +112,36 @@ describe('ModeStack', () => {
     expect(wrapper.findComponent({ name: 'CardEditor' }).classes()).toContain('w-full')
   })
 
+  // ── notifyModeSettled — called from overlay enter and grid enter completions
+
+  test('calls shell.notifyModeSettled after the overlay pane finishes entering [obligation]', async () => {
+    const shell = makeShell('view')
+    mount(shell)
+
+    shell.mode.value = 'edit'
+    shell.is_view.value = false
+    await nextTick()
+    await nextTick()
+
+    // The slideOverlayUp mock calls done immediately, triggering after-enter
+    // which calls notifyModeSettled
+    expect(shell.notifyModeSettled).toHaveBeenCalled()
+  })
+
+  test('calls shell.notifyModeSettled after the grid pane finishes entering [obligation]', async () => {
+    const shell = makeShell('edit')
+    mount(shell)
+
+    shell.mode.value = 'view'
+    shell.is_view.value = true
+    await nextTick()
+    await nextTick()
+
+    // The fadeScaleEnter mock calls done immediately, triggering grid enter
+    // completion which calls notifyModeSettled
+    expect(shell.notifyModeSettled).toHaveBeenCalled()
+  })
+
   // Regression: spamming the mode toggle interrupts the slide mid-flight. Vue
   // fires enter-cancelled instead of after-enter, so a counter that only
   // decremented in after-enter latched `is_transitioning` on forever — leaving

--- a/tests/integration/views/deck/mode-stack.test.js
+++ b/tests/integration/views/deck/mode-stack.test.js
@@ -10,7 +10,8 @@ vi.mock('@/utils/animations/deck-view/card-overlay', () => ({
   primeOverlayBelow: vi.fn(),
   slideOverlayUp: vi.fn((_el, done) => done?.()),
   settleOverlay: vi.fn(),
-  slideOverlayDown: vi.fn((_el, _vp, done) => done?.())
+  slideOverlayDown: vi.fn((_el, _vp, done) => done?.()),
+  cancelOverlayAnimation: vi.fn()
 }))
 
 // Panes in DECK_MODES use defineAsyncComponent; mock the whole registry with
@@ -34,6 +35,7 @@ vi.mock('@/views/deck/modes.ts', async () => {
 
 import ModeStack from '@/views/deck/mode-stack.vue'
 import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
+import { slideOverlayUp } from '@/utils/animations/deck-view/card-overlay'
 
 function makeShell(mode = 'view') {
   const mode_ref = ref(mode)
@@ -108,5 +110,35 @@ describe('ModeStack', () => {
   test('forwards w-full to the active pane', () => {
     const wrapper = mount(makeShell('edit'))
     expect(wrapper.findComponent({ name: 'CardEditor' }).classes()).toContain('w-full')
+  })
+
+  // Regression: spamming the mode toggle interrupts the slide mid-flight. Vue
+  // fires enter-cancelled instead of after-enter, so a counter that only
+  // decremented in after-enter latched `is_transitioning` on forever — leaving
+  // the clip (overflow-hidden + min-height) stuck and the page scrolled past
+  // its content. The in-flight Set must release on cancellation.
+  test('releases the clip when a mode flip is interrupted mid-slide', async () => {
+    const shell = makeShell('view')
+    const wrapper = mount(shell)
+
+    // Hold the overlay slide open so its enter stays in flight (done uncalled).
+    slideOverlayUp.mockImplementationOnce(() => {})
+
+    shell.mode.value = 'edit'
+    shell.is_view.value = false
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.classes()).toContain('overflow-hidden')
+
+    // Interrupt before the slide finishes — the entering overlay is yanked,
+    // firing enter-cancelled.
+    shell.mode.value = 'view'
+    shell.is_view.value = true
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.classes()).not.toContain('overflow-hidden')
+    expect(wrapper.attributes('style') ?? '').not.toContain('min-height')
   })
 })

--- a/tests/integration/views/deck/mode-toolbar/mode-view.test.js
+++ b/tests/integration/views/deck/mode-toolbar/mode-view.test.js
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h, useAttrs } from 'vue'
+
+const { emitSfxMock } = vi.hoisted(() => ({ emitSfxMock: vi.fn() }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: emitSfxMock, emitHoverSfx: vi.fn() }))
+
+import ModeView from '@/views/deck/mode-toolbar/mode-view.vue'
+import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import { deckViewShellKey } from '@/composables/card-editor/deck-view-shell'
+
+const UiButtonStub = defineComponent({
+  name: 'UiButton',
+  inheritAttrs: false,
+  setup(_p, { slots, emit }) {
+    const attrs = useAttrs()
+    return () => h('button', { ...attrs, onClick: () => emit('click') }, slots.default?.())
+  }
+})
+
+// toolbar-base must render its named slots so the #left / #right content appears
+const ToolbarBaseStub = defineComponent({
+  name: 'toolbarBase',
+  setup(_p, { slots }) {
+    return () => h('div', null, [slots.left?.(), slots.right?.()])
+  }
+})
+
+function makeShell({ setMode = vi.fn().mockResolvedValue(undefined) } = {}) {
+  return { setMode }
+}
+
+function makeEditor({ addCardAtTop = vi.fn() } = {}) {
+  return { addCardAtTop }
+}
+
+function mount({ shell, editor } = {}) {
+  return shallowMount(ModeView, {
+    global: {
+      stubs: {
+        UiButton: UiButtonStub,
+        toolbarBase: ToolbarBaseStub,
+        CardCount: true,
+        PageSettings: true
+      },
+      provide: {
+        [deckViewShellKey]: shell ?? makeShell(),
+        [cardEditorKey]: editor ?? makeEditor()
+      }
+    }
+  })
+}
+
+describe('mode-toolbar/mode-view', () => {
+  beforeEach(() => {
+    emitSfxMock.mockReset()
+  })
+
+  test('renders the add-card button', () => {
+    const wrapper = mount()
+    expect(wrapper.find('[data-testid="mode-view__add-card-button"]').exists()).toBe(true)
+  })
+
+  // ── onNewCard — obligation: setMode → emitSfx blocking → addCardAtTop ────
+
+  test('clicking new-card calls shell.setMode("edit") [obligation]', async () => {
+    const setMode = vi.fn().mockResolvedValue(undefined)
+    const wrapper = mount({ shell: makeShell({ setMode }) })
+    await wrapper.find('[data-testid="mode-view__add-card-button"]').trigger('click')
+    expect(setMode).toHaveBeenCalledWith('edit')
+  })
+
+  test('addCardAtTop is called after setMode resolves [obligation]', async () => {
+    const addCardAtTop = vi.fn()
+    let resolveSetMode
+    const setMode = vi.fn().mockReturnValue(new Promise((r) => (resolveSetMode = r)))
+    const wrapper = mount({ shell: makeShell({ setMode }), editor: makeEditor({ addCardAtTop }) })
+
+    await wrapper.find('[data-testid="mode-view__add-card-button"]').trigger('click')
+    // setMode hasn't resolved yet — addCardAtTop must not have been called
+    expect(addCardAtTop).not.toHaveBeenCalled()
+
+    resolveSetMode()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(addCardAtTop).toHaveBeenCalledOnce()
+  })
+
+  test('emits ui.snappy_button_2 with blocking=true between setMode and addCardAtTop [obligation]', async () => {
+    const addCardAtTop = vi.fn()
+    const setMode = vi.fn().mockResolvedValue(undefined)
+    const wrapper = mount({ shell: makeShell({ setMode }), editor: makeEditor({ addCardAtTop }) })
+
+    await wrapper.find('[data-testid="mode-view__add-card-button"]').trigger('click')
+    await Promise.resolve()
+
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.snappy_button_2', { blocking: true })
+    expect(addCardAtTop).toHaveBeenCalledOnce()
+    // Chime must be emitted before addCardAtTop
+    const sfx_call_order = emitSfxMock.mock.invocationCallOrder[0]
+    const add_call_order = addCardAtTop.mock.invocationCallOrder[0]
+    expect(sfx_call_order).toBeLessThan(add_call_order)
+  })
+})

--- a/tests/unit/composables/card-editor/card-list-controller.test.js
+++ b/tests/unit/composables/card-editor/card-list-controller.test.js
@@ -108,7 +108,7 @@ function makeDeckQuery(card_count = 0) {
 
 // Returns a minimal shell stub that satisfies the controller's `exitMode` requirement.
 function makeShell(overrides = {}) {
-  return { exitMode: overrides.exitMode ?? vi.fn() }
+  return { exitMode: overrides.exitMode ?? vi.fn(), setMode: overrides.setMode ?? vi.fn() }
 }
 
 // Returns the controller with `deck_query` attached so refetch + reactive
@@ -137,6 +137,9 @@ function makeController(persisted = [], ids = persisted.map((c) => c.id), deck_q
     gated_addCard: controller.addCard,
     gated_appendCard: controller.appendCard,
     gated_prependCard: controller.prependCard,
+    // Expose controller-level addCardAtTop and claimFocus (not spread from list)
+    addCardAtTop: controller.addCardAtTop,
+    claimFocus: controller.claimFocus,
     deck_query: dq,
     shell: sh
   }
@@ -311,6 +314,62 @@ describe('useCardListController', () => {
       guardAddCardsMock.mockResolvedValue(false)
       await gated_prependCard(100)
       expect(all_cards.value).toHaveLength(1)
+    })
+  })
+
+  // ── addCardAtTop ──────────────────────────────────────────────────────────
+
+  describe('addCardAtTop', () => {
+    test('stages a card at the top of all_cards when gate passes [obligation]', async () => {
+      const { addCardAtTop, all_cards } = makeController([makeCard({ id: 100 })])
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      expect(all_cards.value[0].id).toBeLessThan(0)
+      expect(all_cards.value[1].id).toBe(100)
+    })
+
+    test('does not stage a card when guardAddCards resolves false [obligation]', async () => {
+      const { addCardAtTop, all_cards } = makeController([makeCard({ id: 100 })])
+      guardAddCardsMock.mockResolvedValue(false)
+      await addCardAtTop()
+      expect(all_cards.value).toHaveLength(1)
+      expect(all_cards.value[0].id).toBe(100)
+    })
+
+    test('sets pending_focus_client_id in the same synchronous block as staging [obligation]', async () => {
+      // Verify claimFocus returns true for the staged card immediately after addCardAtTop
+      // (no await between staging and target assignment in the source — this test pins that)
+      const { addCardAtTop, claimFocus, all_cards } = makeController([makeCard({ id: 100 })])
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      const staged_client_id = all_cards.value[0].client_id
+      expect(claimFocus(staged_client_id)).toBe(true)
+    })
+  })
+
+  // ── claimFocus ────────────────────────────────────────────────────────────
+
+  describe('claimFocus', () => {
+    test('returns false before any addCardAtTop call [obligation]', () => {
+      const { claimFocus } = makeController()
+      expect(claimFocus('some-id')).toBe(false)
+    })
+
+    test('returns true exactly once for the staged card client_id [obligation]', async () => {
+      const { addCardAtTop, claimFocus, all_cards } = makeController([makeCard({ id: 100 })])
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      const staged_client_id = all_cards.value[0].client_id
+      expect(claimFocus(staged_client_id)).toBe(true)
+      // Second call for the same id must return false (one-shot)
+      expect(claimFocus(staged_client_id)).toBe(false)
+    })
+
+    test('returns false for a different client_id than the one staged [obligation]', async () => {
+      const { addCardAtTop, claimFocus } = makeController([makeCard({ id: 100 })])
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      expect(claimFocus('other-id')).toBe(false)
     })
   })
 

--- a/tests/unit/composables/card-editor/deck-view-shell.test.js
+++ b/tests/unit/composables/card-editor/deck-view-shell.test.js
@@ -1,11 +1,16 @@
-import { describe, test, expect, beforeEach } from 'vite-plus/test'
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 import { nextTick } from 'vue'
+
+const { emitSfxMock } = vi.hoisted(() => ({ emitSfxMock: vi.fn() }))
+vi.mock('@/sfx/bus', () => ({ emitSfx: emitSfxMock }))
+
 import { useDeckViewShell } from '@/composables/card-editor/deck-view-shell'
 
 // useLocalRef reads/writes localStorage — reset between tests so state
 // from one test doesn't bleed into the next.
 beforeEach(() => {
   localStorage.clear()
+  emitSfxMock.mockReset()
 })
 
 describe('useDeckViewShell', () => {
@@ -47,6 +52,63 @@ describe('useDeckViewShell', () => {
     expect(shell.is_view.value).toBe(false)
   })
 
+  test('setMode returns a Promise that resolves immediately when already in new_mode [obligation]', async () => {
+    const shell = useDeckViewShell()
+    // Already in view — should resolve immediately without waiting for notifyModeSettled
+    await expect(shell.setMode('view')).resolves.toBeUndefined()
+  })
+
+  test('setMode flips mode.value synchronously before the returned promise settles [obligation]', () => {
+    const shell = useDeckViewShell()
+    // Do not await — verify the synchronous side-effect
+    shell.setMode('edit')
+    expect(shell.mode.value).toBe('edit')
+  })
+
+  test('setMode returns a Promise that resolves only after notifyModeSettled is called [obligation]', async () => {
+    const shell = useDeckViewShell()
+    let settled = false
+    const p = shell.setMode('edit').then(() => {
+      settled = true
+    })
+    // Promise should not have resolved yet
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    shell.notifyModeSettled()
+    await p
+    expect(settled).toBe(true)
+  })
+
+  test('setMode plays ui.select chime on a real switch [obligation]', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('edit')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.select')
+  })
+
+  test('setMode does NOT play ui.select when already in new_mode [obligation]', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('view') // no-op since already in view
+    expect(emitSfxMock).not.toHaveBeenCalled()
+  })
+
+  test('notifyModeSettled resolves all pending setMode promises [obligation]', async () => {
+    const shell = useDeckViewShell()
+    // Two sequential setMode calls before settling
+    const p1 = shell.setMode('edit')
+    const p2 = shell.setMode('view')
+    shell.notifyModeSettled()
+    // Both should resolve
+    await Promise.all([p1, p2])
+  })
+
+  test('notifyModeSettled is idempotent — second call does nothing when no waiter [obligation]', () => {
+    const shell = useDeckViewShell()
+    expect(() => {
+      shell.notifyModeSettled()
+      shell.notifyModeSettled()
+    }).not.toThrow()
+  })
+
   // ── toggleMode ─────────────────────────────────────────────────────────────
 
   test('toggleMode enters target mode when in view', () => {
@@ -69,6 +131,12 @@ describe('useDeckViewShell', () => {
     expect(shell.mode.value).toBe('import-export')
   })
 
+  test('toggleMode returns a Promise (propagates setMode return value) [obligation]', () => {
+    const shell = useDeckViewShell()
+    const result = shell.toggleMode('edit')
+    expect(result).toBeInstanceOf(Promise)
+  })
+
   // ── exitMode ───────────────────────────────────────────────────────────────
 
   test('exitMode always returns to view mode', () => {
@@ -83,6 +151,13 @@ describe('useDeckViewShell', () => {
     shell.setMode('import-export')
     shell.exitMode()
     expect(shell.is_view.value).toBe(true)
+  })
+
+  test('exitMode returns a Promise (propagates setMode return value) [obligation]', () => {
+    const shell = useDeckViewShell()
+    shell.setMode('edit')
+    const result = shell.exitMode()
+    expect(result).toBeInstanceOf(Promise)
   })
 
   // ── setGridSize ────────────────────────────────────────────────────────────

--- a/tests/unit/composables/card-editor/virtual-card-list.test.js
+++ b/tests/unit/composables/card-editor/virtual-card-list.test.js
@@ -153,6 +153,79 @@ describe('useVirtualCardList', () => {
     })
   })
 
+  describe('addCard / appendCard / prependCard return client_id', () => {
+    test('addCard returns the client_id of the staged entry [obligation]', () => {
+      const list = makeList()
+      const client_id = list.addCard()
+      expect(typeof client_id).toBe('string')
+      expect(client_id).toBe(list.temp_entries.value[0].client_id)
+    })
+
+    test('appendCard propagates the client_id returned by addCard [obligation]', () => {
+      const list = makeList([makeCard({ id: 50 })])
+      const client_id = list.appendCard(50)
+      expect(typeof client_id).toBe('string')
+      expect(client_id).toBe(list.temp_entries.value[0].client_id)
+    })
+
+    test('prependCard propagates the client_id returned by addCard [obligation]', () => {
+      const list = makeList([makeCard({ id: 50 })])
+      const client_id = list.prependCard(50)
+      expect(typeof client_id).toBe('string')
+      expect(client_id).toBe(list.temp_entries.value[0].client_id)
+    })
+  })
+
+  describe('addCardAtTop', () => {
+    test('anchors before the first persisted card (side=before) [obligation]', () => {
+      const list = makeList([makeCard({ id: 100 }), makeCard({ id: 200 })])
+      list.addCardAtTop()
+      const entry = list.temp_entries.value[0]
+      expect(entry.anchor_id).toBe(100)
+      expect(entry.side).toBe('before')
+    })
+
+    test('uses anchor=null and side=null on an empty deck [obligation]', () => {
+      const list = makeList()
+      list.addCardAtTop()
+      const entry = list.temp_entries.value[0]
+      expect(entry.anchor_id).toBeNull()
+      expect(entry.side).toBeNull()
+    })
+
+    test('unshifts so the new card renders at index 0 above any existing temps [obligation]', () => {
+      const list = makeList([makeCard({ id: 100 })])
+      const id1 = list.addCardAtTop()
+      const id2 = list.addCardAtTop()
+      // Newest (id2) should be at position 0, older (id1) at position 1
+      expect(list.temp_entries.value[0].client_id).toBe(id2)
+      expect(list.temp_entries.value[1].client_id).toBe(id1)
+    })
+
+    test('renders the new card at index 0 in all_cards [obligation]', () => {
+      const list = makeList([makeCard({ id: 100 })])
+      list.addCardAtTop()
+      expect(list.all_cards.value[0].id).toBeLessThan(0)
+      expect(list.all_cards.value[1].id).toBe(100)
+    })
+
+    test('returns the stable client_id of the staged card [obligation]', () => {
+      const list = makeList([makeCard({ id: 100 })])
+      const client_id = list.addCardAtTop()
+      expect(typeof client_id).toBe('string')
+      expect(client_id).toBe(list.temp_entries.value[0].client_id)
+    })
+
+    test('anchors before the first persisted card, not a previously-staged temp [obligation]', () => {
+      // A temp id is negative and would raise on the server — the anchor must be real
+      const list = makeList([makeCard({ id: 100 })])
+      list.addCardAtTop() // stages a temp at position 0
+      list.addCardAtTop() // second call — first persisted is still id=100
+      const latest_entry = list.temp_entries.value[0]
+      expect(latest_entry.anchor_id).toBe(100) // real id, not negative temp placeholder
+    })
+  })
+
   describe('all_cards merging', () => {
     test('places a side=after temp immediately after its left anchor', () => {
       const list = makeList([makeCard({ id: 100 }), makeCard({ id: 200 })])

--- a/tests/unit/utils/animations/card-overlay.test.js
+++ b/tests/unit/utils/animations/card-overlay.test.js
@@ -1,15 +1,19 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 
-const { mockSet, mockTo, mockFromTo } = vi.hoisted(() => ({
+const { mockSet, mockTo, mockFromTo, mockKillTweensOf } = vi.hoisted(() => ({
   mockSet: vi.fn(),
   mockTo: vi.fn(),
-  mockFromTo: vi.fn()
+  mockFromTo: vi.fn(),
+  mockKillTweensOf: vi.fn()
 }))
 
-vi.mock('gsap', () => ({ gsap: { set: mockSet, to: mockTo, fromTo: mockFromTo } }))
+vi.mock('gsap', () => ({
+  gsap: { set: mockSet, to: mockTo, fromTo: mockFromTo, killTweensOf: mockKillTweensOf }
+}))
 
 import {
   captureModeSwitch,
+  cancelOverlayAnimation,
   distanceToViewportBottom,
   fadeScaleEnter,
   fadeScaleLeave,
@@ -338,5 +342,20 @@ describe('card-overlay animations', () => {
     slideOverlayDown(el, makeVp(), done)
 
     expect(mockTo.mock.calls[0][1].duration).toBe(mockTo.mock.calls[1][1].duration)
+  })
+
+  // ── cancelOverlayAnimation ────────────────────────────────────────────────
+
+  describe('cancelOverlayAnimation', () => {
+    test('calls gsap.killTweensOf on the element [obligation]', () => {
+      cancelOverlayAnimation(el)
+      expect(mockKillTweensOf).toHaveBeenCalledWith(el)
+    })
+
+    test('does not call gsap.to or gsap.set (kill only, no new animation) [obligation]', () => {
+      cancelOverlayAnimation(el)
+      expect(mockTo).not.toHaveBeenCalled()
+      expect(mockSet).not.toHaveBeenCalled()
+    })
   })
 })

--- a/tests/unit/utils/animations/list-item.test.js
+++ b/tests/unit/utils/animations/list-item.test.js
@@ -1,0 +1,45 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }))
+
+vi.mock('gsap', () => ({ gsap: { from: mockFrom } }))
+
+import { expandListItemIn } from '@/utils/animations/list-item'
+
+const el = document.createElement('div')
+
+describe('expandListItemIn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('calls gsap.from on the provided element [obligation]', () => {
+    expandListItemIn(el)
+    expect(mockFrom).toHaveBeenCalledWith(el, expect.any(Object))
+  })
+
+  test('animates from scaleY=0 and opacity=0 (collapsed top edge grow-in) [obligation]', () => {
+    expandListItemIn(el)
+    const opts = mockFrom.mock.calls[0][1]
+    expect(opts.scaleY).toBe(0)
+    expect(opts.opacity).toBe(0)
+  })
+
+  test('uses transformOrigin=center top so the grow anchors at the row top edge [obligation]', () => {
+    expandListItemIn(el)
+    const opts = mockFrom.mock.calls[0][1]
+    expect(opts.transformOrigin).toBe('center top')
+  })
+
+  test('clears all inline GSAP props on complete (clearProps=all) [obligation]', () => {
+    expandListItemIn(el)
+    const opts = mockFrom.mock.calls[0][1]
+    expect(opts.clearProps).toBe('all')
+  })
+
+  test('uses a positive duration', () => {
+    expandListItemIn(el)
+    const opts = mockFrom.mock.calls[0][1]
+    expect(opts.duration).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

A mixed bag of deck-view fixes and one feature.

- **Grid clipping fix** — the card grid's scroll container (`overflow-y-auto`) clipped on both axes at its edges, cutting off the grid-item "more" button and the card flip animation. Added vertical padding so the overhang sits inside the visible area.
- **New-card button** — the toolbar "new card" button now: enters edit mode (waiting for the slide to settle), adds a card at the very top of the deck (repeated clicks stack newest-first), autofocuses its front editor, plays the shared mode-switch chime (`ui.select`) + a blocking add chime (`ui.snappy_button_2`) that suppresses the focus `slide_up`, and reveals the new row with a GSAP grow-in. `setMode` is now async, resolving on the entering pane's GSAP completion so follow-up work reads settled positions.
- **Interrupted-transition fix** — spamming the edit/view toggle could latch `is_transitioning` on (the old in-flight counter left a cancelled enter's increment orphaned), stranding the clip min-height and leaving the page scrollable past its content. In-flight panes are now tracked in a `Set` keyed by element, plus `*-cancelled` hook handling.
- **Tests** — coverage for the new-card flow (shell async `setMode`, `addCardAtTop`, one-shot `claimFocus`, blocking chime ordering, grow-in gating) and a regression test for the interrupted-transition clip release (verified to fail on the pre-fix code).