### PR TITLE
fix(audio-reader): keep audio + cursor stable when returning from background

### DIFF
--- a/src/api/lessons/db/audio.ts
+++ b/src/api/lessons/db/audio.ts
@@ -6,7 +6,7 @@ const BUCKET = 'audio-lessons'
 // The bucket is private, so playback uses a short-lived signed URL rather than a
 // public URL (contrast with member-images). One hour is generous for a single
 // listening session; the reader re-mints if it expires.
-const SIGNED_URL_TTL_SECONDS = 60 * 60
+export const SIGNED_URL_TTL_SECONDS = 60 * 60
 
 export async function uploadLessonAudio(path: string, file: File): Promise<void> {
   const { error } = await supabase.storage.from(BUCKET).upload(path, file, { upsert: true })

--- a/src/api/lessons/queries/audio-url.ts
+++ b/src/api/lessons/queries/audio-url.ts
@@ -1,6 +1,15 @@
 import { useQuery } from '@pinia/colada'
 import { toValue, type MaybeRefOrGetter } from 'vue'
-import { getLessonAudioSignedUrl } from '../db'
+import { getLessonAudioSignedUrl, SIGNED_URL_TTL_SECONDS } from '../db'
+
+// This URL feeds the `<audio>` src directly, and every re-mint returns a *new*
+// signed token — so any refetch swaps the src, which resets playback to 0 and
+// drops the transcript cursor. Pinia Colada's defaults would do exactly that: it
+// refetches stale queries on window focus and network reconnect, so pocketing the
+// phone (tab hidden) and reopening it would restart the audio. Hold the same URL
+// for the whole session instead — the token is valid an hour, well past a single
+// listen — and leave re-minting to a fresh path or an explicit refresh().
+const STALE_TIME_MS = SIGNED_URL_TTL_SECONDS * 1000
 
 // Signed URLs expire (1h TTL), so this is cached server state keyed by path.
 // The reader re-runs it on a fresh path; refresh() re-mints if a URL goes stale
@@ -9,6 +18,9 @@ export function useLessonAudioUrlQuery(path: MaybeRefOrGetter<string | undefined
   return useQuery({
     key: () => ['lesson-audio', toValue(path) ?? ''],
     query: () => getLessonAudioSignedUrl(toValue(path) as string),
-    enabled: () => Boolean(toValue(path))
+    enabled: () => Boolean(toValue(path)),
+    staleTime: STALE_TIME_MS,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false
   })
 }

--- a/src/composables/audio-reader/use-audio-player.ts
+++ b/src/composables/audio-reader/use-audio-player.ts
@@ -68,6 +68,17 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
     if (el && !is_playing.value) current_time.value = el.currentTime
   }
 
+  // Background tabs freeze rAF, so the tick loop stalls and `current_time` drifts
+  // behind the audio (which keeps playing — the point of pocket listening). On the
+  // way back to the foreground, snap to the element's real position so the
+  // transcript cursor lands on the right word at once, and revive the loop if we're
+  // still playing rather than waiting for the next thawed frame.
+  function onVisible() {
+    if (!el || document.hidden) return
+    current_time.value = el.currentTime
+    if (is_playing.value) startTicking()
+  }
+
   function bind(next: HTMLAudioElement) {
     el = next
     el.addEventListener('loadedmetadata', onLoaded)
@@ -75,6 +86,7 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
     el.addEventListener('pause', onPause)
     el.addEventListener('ended', onPause)
     el.addEventListener('timeupdate', onTimeUpdate)
+    document.addEventListener('visibilitychange', onVisible)
     if (el.readyState >= 1) onLoaded()
   }
 
@@ -86,6 +98,7 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
     el.removeEventListener('pause', onPause)
     el.removeEventListener('ended', onPause)
     el.removeEventListener('timeupdate', onTimeUpdate)
+    document.removeEventListener('visibilitychange', onVisible)
     el = null
   }
 

--- a/tests/unit/api/lessons/queries/audio-url.test.js
+++ b/tests/unit/api/lessons/queries/audio-url.test.js
@@ -1,0 +1,93 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { ref } from 'vue'
+
+// useQuery spy returns the raw config so tests can inspect every option.
+const { useQuerySpy, getLessonAudioSignedUrlMock } = vi.hoisted(() => ({
+  useQuerySpy: vi.fn((cfg) => cfg),
+  getLessonAudioSignedUrlMock: vi.fn().mockResolvedValue('https://example.com/signed')
+}))
+
+vi.mock('@pinia/colada', () => ({
+  useQuery: useQuerySpy
+}))
+
+vi.mock('@/api/lessons/db', () => ({
+  getLessonAudioSignedUrl: getLessonAudioSignedUrlMock,
+  // SIGNED_URL_TTL_SECONDS must be the real constant so the assertion stays in sync
+  SIGNED_URL_TTL_SECONDS: 3600
+}))
+
+import { useLessonAudioUrlQuery } from '@/api/lessons/queries/audio-url'
+
+beforeEach(() => {
+  useQuerySpy.mockClear()
+  getLessonAudioSignedUrlMock.mockClear()
+})
+
+/** Call the hook and return the options object passed to useQuery. */
+function configFrom(path) {
+  useLessonAudioUrlQuery(path)
+  return useQuerySpy.mock.calls.at(-1)[0]
+}
+
+describe('useLessonAudioUrlQuery', () => {
+  describe('query key', () => {
+    test('keys by ["lesson-audio", path] when path is a plain string', () => {
+      const { key } = configFrom('lessons/abc.mp3')
+      expect(key()).toEqual(['lesson-audio', 'lessons/abc.mp3'])
+    })
+
+    test('keys by ["lesson-audio", path] when path is a ref', () => {
+      const { key } = configFrom(ref('lessons/xyz.mp3'))
+      expect(key()).toEqual(['lesson-audio', 'lessons/xyz.mp3'])
+    })
+
+    test('keys with empty string when path ref is undefined', () => {
+      const { key } = configFrom(ref(undefined))
+      expect(key()).toEqual(['lesson-audio', ''])
+    })
+  })
+
+  describe('enabled', () => {
+    test('is true when path is a non-empty string', () => {
+      const { enabled } = configFrom('lessons/abc.mp3')
+      expect(enabled()).toBe(true)
+    })
+
+    test('is false when path ref is undefined', () => {
+      const { enabled } = configFrom(ref(undefined))
+      expect(enabled()).toBe(false)
+    })
+
+    test('is false when path ref is an empty string', () => {
+      const { enabled } = configFrom(ref(''))
+      expect(enabled()).toBe(false)
+    })
+  })
+
+  describe('query function', () => {
+    test('calls getLessonAudioSignedUrl with the resolved path', async () => {
+      const { query } = configFrom('lessons/foo.mp3')
+      await query()
+      expect(getLessonAudioSignedUrlMock).toHaveBeenCalledWith('lessons/foo.mp3')
+    })
+  })
+
+  describe('cache / refetch options [obligation]', () => {
+    test('staleTime equals SIGNED_URL_TTL_SECONDS * 1000 (3_600_000 ms)', () => {
+      const { staleTime } = configFrom('lessons/abc.mp3')
+      // 3600 s × 1000 = 3_600_000 ms — the full token lifetime
+      expect(staleTime).toBe(3_600_000)
+    })
+
+    test('refetchOnWindowFocus is false — focus must not re-mint the signed URL', () => {
+      const { refetchOnWindowFocus } = configFrom('lessons/abc.mp3')
+      expect(refetchOnWindowFocus).toBe(false)
+    })
+
+    test('refetchOnReconnect is false — reconnect must not re-mint the signed URL', () => {
+      const { refetchOnReconnect } = configFrom('lessons/abc.mp3')
+      expect(refetchOnReconnect).toBe(false)
+    })
+  })
+})

--- a/tests/unit/composables/audio-reader/use-audio-player.test.js
+++ b/tests/unit/composables/audio-reader/use-audio-player.test.js
@@ -298,6 +298,102 @@ describe('useAudioPlayer', () => {
     })
   })
 
+  describe('rAF tick loop', () => {
+    test('tick() copies el.currentTime into current_time', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      el._emit('play') // starts ticking
+      el.currentTime = 7.5
+
+      // Manually fire the stored rAF callback (tick())
+      rafCallback()
+
+      expect(result.current_time.value).toBe(7.5)
+    })
+
+    test('tick() re-schedules itself while playing and clip_end not reached', async () => {
+      const target = ref(null)
+      const [, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      el._emit('play')
+      requestAnimationFrame.mockClear()
+
+      rafCallback() // simulate one rAF frame
+
+      expect(requestAnimationFrame).toHaveBeenCalled()
+    })
+
+    test('tick() pauses and stops rAF when clip_end is reached', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      result.playClip(1, 5) // sets clip_end = 5
+      // playClip calls el.play() (mocked) but doesn't fire the play event;
+      // fire it manually so startTicking() runs and rafCallback is set.
+      el._emit('play')
+      el.currentTime = 5 // advance to the clip boundary
+      requestAnimationFrame.mockClear()
+
+      rafCallback() // tick fires; clip_end reached → pause
+
+      expect(el.pause).toHaveBeenCalled()
+    })
+  })
+
+  describe('playClip()', () => {
+    test('seeks the element to start and calls el.play()', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      result.playClip(3, 10)
+
+      expect(el.currentTime).toBe(3)
+      expect(el.play).toHaveBeenCalled()
+    })
+
+    test('sets current_time immediately to start without waiting for timeupdate', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      result.playClip(3, 10)
+
+      expect(result.current_time.value).toBe(3)
+    })
+
+    test('is a no-op when no element is bound', () => {
+      const [result, a] = withSetup(() => useAudioPlayer(ref(null)))
+      app = a
+      // Must not throw
+      result.playClip(0, 5)
+    })
+  })
+
   describe('timeupdate event', () => {
     test('updates current_time from el.currentTime while paused', async () => {
       const target = ref(null)
@@ -328,6 +424,136 @@ describe('useAudioPlayer', () => {
       el._emit('timeupdate')
       // timeupdate is ignored while playing; current_time stays 0
       expect(result.current_time.value).toBe(0)
+    })
+  })
+
+  describe('visibilitychange — background tab / foreground return', () => {
+    // We need a spy on document.addEventListener so we can capture the
+    // visibilitychange handler and fire it directly.
+    let docAddSpy
+    let docRemoveSpy
+    let registeredVisibilityHandler
+
+    beforeEach(() => {
+      registeredVisibilityHandler = null
+      docAddSpy = vi.spyOn(document, 'addEventListener').mockImplementation((event, cb) => {
+        if (event === 'visibilitychange') registeredVisibilityHandler = cb
+      })
+      docRemoveSpy = vi.spyOn(document, 'removeEventListener')
+    })
+
+    afterEach(() => {
+      docAddSpy.mockRestore()
+      docRemoveSpy.mockRestore()
+      // Reset document.hidden to its jsdom default (false) so it doesn't bleed
+      // into subsequent tests — each test that needs a specific value sets it explicitly.
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+    })
+
+    async function setupWithEl() {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+      return { result, a, el }
+    }
+
+    test('registers visibilitychange listener on document when element is bound', async () => {
+      await setupWithEl()
+      expect(docAddSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    })
+
+    test('snaps current_time to el.currentTime immediately when page returns to foreground [obligation]', async () => {
+      const { result, el } = await setupWithEl()
+
+      // Simulate audio advancing while the tab was hidden
+      el.currentTime = 42
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+
+      registeredVisibilityHandler()
+
+      expect(result.current_time.value).toBe(42)
+
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+    })
+
+    test('does not touch current_time when visibilitychange fires while document.hidden is true [obligation]', async () => {
+      const { result, el } = await setupWithEl()
+
+      // current_time starts at 0 — confirm it stays there
+      el.currentTime = 99
+      Object.defineProperty(document, 'hidden', { value: true, configurable: true })
+
+      registeredVisibilityHandler()
+
+      expect(result.current_time.value).toBe(0)
+
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+    })
+
+    test('revives the rAF tick loop on foreground return when still playing [obligation]', async () => {
+      const { result, el } = await setupWithEl()
+
+      // Start playing so is_playing = true
+      el._emit('play')
+      // Clear the rAF calls from the initial play
+      requestAnimationFrame.mockClear()
+
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+
+      registeredVisibilityHandler()
+
+      // A fresh requestAnimationFrame must have been scheduled
+      expect(requestAnimationFrame).toHaveBeenCalled()
+
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+    })
+
+    test('does not revive rAF loop on foreground return when paused [obligation]', async () => {
+      const { result, el } = await setupWithEl()
+
+      // Stay paused (is_playing = false by default)
+      requestAnimationFrame.mockClear()
+
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+
+      registeredVisibilityHandler()
+
+      expect(requestAnimationFrame).not.toHaveBeenCalled()
+
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+    })
+
+    test('removes visibilitychange listener from document when target ref becomes null [obligation]', async () => {
+      const target = ref(null)
+      const [, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      target.value = null
+      await nextTick()
+
+      expect(docRemoveSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    })
+
+    test('removes visibilitychange listener from document on unmount [obligation]', async () => {
+      const target = ref(null)
+      const [, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      a.unmount()
+      app = null
+
+      expect(docRemoveSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
     })
   })
 })


### PR DESCRIPTION
## Summary

Cleans up the audio reader's behaviour when a mobile browser tab is backgrounded (phone in pocket) and reopened.

The lesson audio `<audio>` src is bound to a Supabase **signed URL** from `useLessonAudioUrlQuery`. Pinia Colada's defaults refetch stale queries on window focus and network reconnect, and each `createSignedUrl` call mints a *new* token — so returning to the tab swapped the src, which reset playback to 0, paused it, and dropped the transcript cursor (`active_word` → -1).

- **Hold the signed URL stable for the session** — pin `staleTime` to the 1h token TTL and disable `refetchOnWindowFocus` / `refetchOnReconnect`, so focus/reconnect no longer re-mints the URL and resets the audio.
- **Resync the cursor on return** — background tabs freeze `requestAnimationFrame`, so the tick loop stalls while the audio keeps playing. On `visibilitychange` back to foreground, snap `current_time` to the element's real position and revive the loop if still playing, so the playhead lands on the right word immediately.
- Regression-lock tests on the query options + visibilitychange behaviour; `audio-url.ts` at 100% coverage, `use-audio-player.ts` up to 100% lines.