### PR TITLE
feat(audio-reader): mini toolbar control row + live touch selection preview

### DIFF
--- a/src/composables/audio-reader/use-reader-highlights.ts
+++ b/src/composables/audio-reader/use-reader-highlights.ts
@@ -122,6 +122,11 @@ export function useReaderHighlights(
   const anchor_index = ref<number | null>(null)
   const committed = ref<WordRange | null>(null)
 
+  // While an armed touch drag is extending the range, the finger's live viewport
+  // position — drives the preview bubble that trails the finger. Null whenever no
+  // armed touch selection is in flight, so the bubble shows on coarse pointers only.
+  const touch_point = ref<{ x: number; y: number } | null>(null)
+
   // A touch in flight: where it landed and which word, held until release decides
   // tap-vs-scroll. Plain (non-reactive) state — it never drives a pill directly.
   // `touch_selecting` flips true once a long-press arms range-select; from there
@@ -397,6 +402,23 @@ export function useReaderHighlights(
     return null
   })
 
+  // The live preview shown over an armed touch drag: the selected text, the
+  // finger's x (the bubble tracks it horizontally), and the focus word's line rect
+  // (so the bubble rides above that line, fixed vertically rather than bobbing with
+  // the finger). Null whenever no touch selection is dragging, so the host renders
+  // the bubble on touch only.
+  const selection_preview = computed(() => {
+    if (!touch_point.value || anchor_index.value === null || focus_index.value === null) return null
+
+    const text = rangeText(orderedRange(anchor_index.value, focus_index.value))
+    if (!text) return null
+
+    const rect = wordBaseEl(focus_index.value)?.getBoundingClientRect()
+    if (!rect) return null
+
+    return { text, x: touch_point.value.x, top: rect.top, bottom: rect.bottom }
+  })
+
   function onPointerDown(event: PointerEvent) {
     if (event.pointerType === 'touch') {
       beginTap(event)
@@ -434,6 +456,7 @@ export function useReaderHighlights(
     touch_selecting = true
     anchor_index.value = tap.index
     focus_index.value = tap.index
+    touch_point.value = { x: tap.x, y: tap.y }
     navigator.vibrate?.(10)
     emitSfx('ui.tap_05')
   }
@@ -499,6 +522,10 @@ export function useReaderHighlights(
   // (translation gloss, padding) so the range doesn't collapse between words. Each
   // new word ticks `tap_05`, so the range audibly ratchets as words join or leave.
   function extendTouchSelection(event: PointerEvent) {
+    // Update the point every move so the preview bubble tracks the finger smoothly,
+    // even while it travels within the same word.
+    touch_point.value = { x: event.clientX, y: event.clientY }
+
     const index = wordIndexAt(event.clientX, event.clientY)
     if (index === null || index === focus_index.value) return
 
@@ -545,6 +572,7 @@ export function useReaderHighlights(
     anchor_index.value = null
     focus_index.value = null
     touch_selecting = false
+    touch_point.value = null
     tap = null
   }
 
@@ -555,6 +583,7 @@ export function useReaderHighlights(
     anchor_index.value = null
     focus_index.value = null
     touch_selecting = false
+    touch_point.value = null
     tap = null
   }
 
@@ -578,6 +607,7 @@ export function useReaderHighlights(
     hover,
     tap_active,
     interaction_range,
+    selection_preview,
     onPointerDown,
     onPointerMove,
     onPointerUp,

--- a/src/utils/animations/selection-preview.ts
+++ b/src/utils/animations/selection-preview.ts
@@ -1,0 +1,19 @@
+import gsap from 'gsap'
+
+// Short enough to feel instant under the finger, with a slight overshoot so the
+// bubble pops to confirm the long-press armed.
+const DURATION = 0.16
+
+/** Pop the selection-preview bubble in when the touch long-press arms. */
+export function popInPreview(el: Element, onComplete?: () => void) {
+  gsap.fromTo(
+    el,
+    { opacity: 0, scale: 0.8 },
+    { opacity: 1, scale: 1, duration: DURATION, ease: 'back.out(2)', onComplete }
+  )
+}
+
+/** Fade the selection-preview bubble out when the selection commits or cancels. */
+export function popOutPreview(el: Element, onComplete?: () => void) {
+  gsap.to(el, { opacity: 0, scale: 0.8, duration: DURATION, ease: 'power1.in', onComplete })
+}

--- a/src/views/audio-reader/lesson/audio-toolbar.vue
+++ b/src/views/audio-reader/lesson/audio-toolbar.vue
@@ -118,7 +118,7 @@ function setMode(next: 'expanded' | 'mini') {
           data-theme="brown-200"
           data-theme-dark="grey-700"
           :aria-label="t('lesson-view.audio.skip-back-button')"
-          class="flex size-13 cursor-pointer items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
+          class="flex size-13 cursor-pointer touch-manipulation items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
           :class="{ [TAP_BGX]: back_playing }"
           @click.capture="onBackTap"
           @click="skipBack"
@@ -134,7 +134,7 @@ function setMode(next: 'expanded' | 'mini') {
           :aria-label="
             is_playing ? t('lesson-view.audio.pause-button') : t('lesson-view.audio.play-button')
           "
-          class="flex size-18 cursor-pointer items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
+          class="flex size-18 cursor-pointer touch-manipulation items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
           :class="{ [TAP_BGX]: play_playing }"
           @click.capture="onPlayTap"
           @click="toggle"
@@ -148,7 +148,7 @@ function setMode(next: 'expanded' | 'mini') {
           data-theme="brown-200"
           data-theme-dark="grey-700"
           :aria-label="t('lesson-view.audio.skip-forward-button')"
-          class="flex size-13 cursor-pointer items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
+          class="flex size-13 cursor-pointer touch-manipulation items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
           :class="{ [TAP_BGX]: forward_playing }"
           @click.capture="onForwardTap"
           @click="skipForward"
@@ -167,7 +167,7 @@ function setMode(next: 'expanded' | 'mini') {
             variant="ghost"
             icon-only
             play-on-tap
-            :sfx="{ click: 'ui.select' }"
+            :sfx="{ click: 'ui.snappy_button_5' }"
             @click="setMode('mini')"
           />
         </div>
@@ -210,16 +210,36 @@ function setMode(next: 'expanded' | 'mini') {
       </div>
     </div>
 
-    <div v-else data-testid="audio-toolbar__mini" class="flex items-center gap-3">
+    <div
+      v-else
+      data-testid="audio-toolbar__mini"
+      class="grid grid-cols-5 items-center justify-items-center gap-2"
+    >
       <ui-button
         data-testid="audio-toolbar__expand"
-        data-theme="brown-300"
+        data-theme="brown-100"
+        data-theme-dark="stone-700"
         icon-left="maximize"
+        variant="ghost"
         icon-only
         play-on-tap
-        :sfx="{ click: 'ui.select' }"
+        :sfx="{ click: 'ui.snappy_button_5' }"
         @click="setMode('expanded')"
       />
+
+      <button
+        data-testid="audio-toolbar__skip-back"
+        type="button"
+        data-theme="brown-200"
+        data-theme-dark="grey-700"
+        :aria-label="t('lesson-view.audio.skip-back-button')"
+        class="flex size-13 cursor-pointer touch-manipulation items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
+        :class="{ [TAP_BGX]: back_playing }"
+        @click.capture="onBackTap"
+        @click="skipBack"
+      >
+        <ui-icon src="skip-backward-10" class="size-6" />
+      </button>
 
       <button
         data-testid="audio-toolbar__toggle"
@@ -229,15 +249,43 @@ function setMode(next: 'expanded' | 'mini') {
         :aria-label="
           is_playing ? t('lesson-view.audio.pause-button') : t('lesson-view.audio.play-button')
         "
-        class="flex size-11 cursor-pointer items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
+        class="flex size-18 cursor-pointer touch-manipulation items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
         :class="{ [TAP_BGX]: play_playing }"
         @click.capture="onPlayTap"
         @click="toggle"
       >
-        <ui-icon :src="is_playing ? 'pause' : 'play'" class="size-5" />
+        <ui-icon :src="is_playing ? 'pause' : 'play'" class="size-8" />
       </button>
 
-      <scrubber :player="player" layout="inline" />
+      <button
+        data-testid="audio-toolbar__skip-forward"
+        type="button"
+        data-theme="brown-200"
+        data-theme-dark="grey-700"
+        :aria-label="t('lesson-view.audio.skip-forward-button')"
+        class="flex size-13 cursor-pointer touch-manipulation items-center justify-center rounded-full bg-(--theme-primary) text-(--theme-on-primary) transition active:scale-95"
+        :class="{ [TAP_BGX]: forward_playing }"
+        @click.capture="onForwardTap"
+        @click="skipForward"
+      >
+        <ui-icon src="skip-forward-10" class="size-6" />
+      </button>
+
+      <ui-dropdown-button
+        data-testid="audio-toolbar__speed-select"
+        data-theme="brown-100"
+        data-theme-dark="stone-700"
+        icon-left="stopwatch"
+        variant="ghost"
+        open-on-trigger
+        hide-trigger
+        shadow
+        position="top-end"
+        :options="SPEED_OPTIONS"
+        @select="onSpeed"
+      >
+        {{ current_speed_label }}
+      </ui-dropdown-button>
     </div>
   </div>
 </template>

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -7,6 +7,7 @@ import {
   useReaderHighlights
 } from '@/composables/audio-reader/use-reader-highlights'
 import TranscriptSegment from './segment.vue'
+import SelectionPreview from './selection-preview.vue'
 
 const {
   paragraphs,
@@ -26,6 +27,7 @@ const emit = defineEmits<{
 const {
   tap_active,
   interaction_range,
+  selection_preview,
   onPointerDown,
   onPointerMove,
   onPointerUp,
@@ -103,5 +105,7 @@ function commitSelection({
         :index="paragraph.index"
       />
     </div>
+
+    <selection-preview :preview="selection_preview" />
   </div>
 </template>

--- a/src/views/audio-reader/transcript/selection-preview.vue
+++ b/src/views/audio-reader/transcript/selection-preview.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
+import gsap from 'gsap'
+import { popInPreview, popOutPreview } from '@/utils/animations/selection-preview'
+
+type SelectionPreview = { text: string; x: number; top: number; bottom: number }
+
+// Gap between the selected line and the bubble, the line top below which the bubble
+// flips under the line (so selecting the top line doesn't push it off-screen), and
+// the margin it keeps from the viewport edges before it drifts off-centre.
+const LINE_GAP = 22
+const FLIP_BELOW_Y = 112
+const EDGE_MARGIN = 8
+
+const { preview } = defineProps<{
+  preview: SelectionPreview | null
+}>()
+
+const bubble = useTemplateRef<HTMLElement>('bubble')
+
+// What the bubble renders. Tracks `preview` live while a selection is active and is
+// retained through the fade-out (so the bubble keeps its text + position as it
+// animates away), then cleared once hidden. The element itself stays mounted — only
+// its opacity animates — so re-arming always shows it, with no enter/leave race.
+const shown = ref<SelectionPreview | null>(null)
+const bubble_width = ref(0)
+const viewport_width = ref(0)
+let resize_observer: ResizeObserver | null = null
+
+const below = computed(() => !!shown.value && shown.value.top < FLIP_BELOW_Y)
+
+// Centre on the finger, then clamp so the bubble never crosses the edge margins:
+// near an edge it drifts off-centre instead of overflowing.
+const left = computed(() => {
+  if (!shown.value) return 0
+
+  const max_left = Math.max(EDGE_MARGIN, viewport_width.value - bubble_width.value - EDGE_MARGIN)
+  return Math.min(Math.max(shown.value.x - bubble_width.value / 2, EDGE_MARGIN), max_left)
+})
+
+// Move the bubble with the `translate` property so `transform` stays free for the
+// pop-in scale. Above the line, a `calc(... - 100%)` rests its base a gap over the
+// line top without measuring its own height; below, its top sits a gap under the
+// line bottom.
+const bubble_style = computed(() => {
+  if (!shown.value) return undefined
+
+  const y = below.value
+    ? `${shown.value.bottom + LINE_GAP}px`
+    : `calc(${shown.value.top - LINE_GAP}px - 100%)`
+  return { translate: `${left.value}px ${y}` }
+})
+
+function measure() {
+  bubble_width.value = bubble.value?.offsetWidth ?? 0
+  viewport_width.value = window.innerWidth
+}
+
+onMounted(() => {
+  if (!bubble.value) return
+
+  gsap.set(bubble.value, { opacity: 0 })
+  resize_observer = new ResizeObserver(measure)
+  resize_observer.observe(bubble.value)
+})
+
+onBeforeUnmount(() => resize_observer?.disconnect())
+
+// Drive the bubble straight off the prop: appearing pops it in, dragging just keeps
+// `shown` in step, and clearing fades it out before dropping the retained preview.
+watch(
+  () => preview,
+  (next, prev) => {
+    if (next) {
+      shown.value = next
+      if (!prev && bubble.value) {
+        measure()
+        popInPreview(bubble.value)
+      }
+      return
+    }
+
+    if (prev && bubble.value) popOutPreview(bubble.value, () => (shown.value = null))
+  }
+)
+</script>
+
+<template>
+  <teleport to="body">
+    <div
+      ref="bubble"
+      data-testid="selection-preview"
+      :data-below="below"
+      :data-visible="!!shown"
+      aria-hidden="true"
+      class="pointer-events-none fixed left-0 top-0 max-w-[calc(100vw-1rem)] rounded-4 bg-white px-4 py-2 text-center text-2xl text-brown-700"
+      :style="bubble_style"
+    >
+      {{ shown?.text }}
+    </div>
+  </teleport>
+</template>

--- a/tests/integration/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/integration/composables/audio-reader/use-reader-highlights.test.js
@@ -706,4 +706,102 @@ describe('useReaderHighlights', () => {
       expect(emitSfxMock).not.toHaveBeenCalledWith('ui.tap_05')
     })
   })
+
+  describe('selection_preview', () => {
+    test('is non-null the instant a touch long-press arms with NO drag [obligation]', async () => {
+      const wrapper = mountHost(vi.fn())
+
+      vi.useFakeTimers()
+      await touch(wrapper, 'pointerdown', 0)
+
+      // Not armed yet — selection_preview is null
+      expect(wrapper.vm.selection_preview).toBeNull()
+
+      // Advance past LONG_PRESS_MS=400 — no pointermove dispatched
+      vi.advanceTimersByTime(500)
+      await wrapper.vm.$nextTick()
+      vi.useRealTimers()
+
+      // Immediately non-null without any drag [regression guard for the fixed bug]
+      expect(wrapper.vm.selection_preview).not.toBeNull()
+    })
+
+    test('selection_preview x comes from finger clientX at arm time, top/bottom from word rect [obligation]', async () => {
+      const wrapper = mountHost(vi.fn())
+
+      // words[0] is 'Hello ' — give it a measured rect
+      vi.spyOn(words[0], 'getBoundingClientRect').mockReturnValue(new DOMRect(10, 120, 50, 24))
+
+      vi.useFakeTimers()
+      // Press at clientX=0 (maps to words[0] via elementFromPoint stub)
+      words[0].dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          pointerId: 1,
+          pointerType: 'touch',
+          clientX: 0,
+          clientY: 5
+        })
+      )
+      await wrapper.vm.$nextTick()
+
+      vi.advanceTimersByTime(500)
+      await wrapper.vm.$nextTick()
+      vi.useRealTimers()
+
+      const preview = wrapper.vm.selection_preview
+      expect(preview).not.toBeNull()
+      // x is the finger's clientX at arm time
+      expect(preview.x).toBe(0)
+      // top/bottom come from the word's getBoundingClientRect
+      expect(preview.top).toBe(120)
+      expect(preview.bottom).toBe(120 + 24)
+    })
+
+    test('selection_preview stays null for a mouse drag [obligation]', async () => {
+      const wrapper = mountHost(vi.fn())
+
+      await pointer(wrapper, 'pointerdown', 0, 1)
+      await pointer(wrapper, 'pointermove', 1, 1)
+
+      expect(wrapper.vm.selection_preview).toBeNull()
+    })
+
+    test('selection_preview resets to null after commitTouch (pointerup) [obligation]', async () => {
+      const wrapper = mountHost(vi.fn())
+
+      vi.useFakeTimers()
+      await touch(wrapper, 'pointerdown', 0)
+      vi.advanceTimersByTime(500)
+      await wrapper.vm.$nextTick()
+      vi.useRealTimers()
+
+      expect(wrapper.vm.selection_preview).not.toBeNull()
+
+      await touch(wrapper, 'pointerup', 0)
+
+      expect(wrapper.vm.selection_preview).toBeNull()
+    })
+
+    test('selection_preview resets to null after onPointerCancel [obligation]', async () => {
+      const wrapper = mountHost(vi.fn())
+
+      vi.useFakeTimers()
+      await touch(wrapper, 'pointerdown', 0)
+      vi.advanceTimersByTime(500)
+      await wrapper.vm.$nextTick()
+      vi.useRealTimers()
+
+      expect(wrapper.vm.selection_preview).not.toBeNull()
+
+      // The Host component doesn't bind onPointercancel on the content element;
+      // call the handler directly (the composable exposes it on the vm).
+      wrapper.vm.onPointerCancel(
+        new PointerEvent('pointercancel', { bubbles: true, pointerId: 1, pointerType: 'touch' })
+      )
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.vm.selection_preview).toBeNull()
+    })
+  })
 })

--- a/tests/integration/views/audio-reader/lesson/audio-toolbar.test.js
+++ b/tests/integration/views/audio-reader/lesson/audio-toolbar.test.js
@@ -220,6 +220,72 @@ describe('AudioToolbar', () => {
     expect(wrapper.find('[data-testid="audio-toolbar__expanded"]').exists()).toBe(true)
   })
 
+  // ── Mini mode controls [obligation] ───────────────────────────────────────
+
+  test('mini mode renders all five controls via data-testid [obligation]', () => {
+    localRefStore.next = 'mini'
+    const wrapper = mountToolbar()
+
+    expect(wrapper.find('[data-testid="audio-toolbar__expand"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="audio-toolbar__skip-back"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="audio-toolbar__toggle"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="audio-toolbar__skip-forward"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="audio-toolbar__speed-select"]').exists()).toBe(true)
+  })
+
+  test('mini mode audio-toolbar__toggle calls player.play() when paused [obligation]', async () => {
+    localRefStore.next = 'mini'
+    const player = makePlayer({ is_playing: ref(false) })
+    const wrapper = mountToolbar({ player })
+
+    await wrapper.find('[data-testid="audio-toolbar__toggle"]').trigger('click')
+
+    expect(player.play).toHaveBeenCalledOnce()
+  })
+
+  test('mini mode audio-toolbar__toggle calls player.pause() when playing [obligation]', async () => {
+    localRefStore.next = 'mini'
+    const player = makePlayer({ is_playing: ref(true) })
+    const wrapper = mountToolbar({ player })
+
+    await wrapper.find('[data-testid="audio-toolbar__toggle"]').trigger('click')
+
+    expect(player.pause).toHaveBeenCalledOnce()
+  })
+
+  test('mini mode audio-toolbar__skip-back calls player.skip(-10) [obligation]', async () => {
+    localRefStore.next = 'mini'
+    const player = makePlayer()
+    const wrapper = mountToolbar({ player })
+
+    await wrapper.find('[data-testid="audio-toolbar__skip-back"]').trigger('click')
+
+    expect(player.skip).toHaveBeenCalledWith(-10)
+  })
+
+  test('mini mode audio-toolbar__skip-forward calls player.skip(10) [obligation]', async () => {
+    localRefStore.next = 'mini'
+    const player = makePlayer()
+    const wrapper = mountToolbar({ player })
+
+    await wrapper.find('[data-testid="audio-toolbar__skip-forward"]').trigger('click')
+
+    expect(player.skip).toHaveBeenCalledWith(10)
+  })
+
+  test('mini mode audio-toolbar__speed-select calls player.setPlaybackRate [obligation]', async () => {
+    localRefStore.next = 'mini'
+    const player = makePlayer()
+    const wrapper = mountToolbar({ player })
+
+    const speedDropdown = wrapper.find('[data-testid="audio-toolbar__speed-select"]')
+    const options = speedDropdown.findAll('[data-testid="dropdown-button__option"]')
+    // Options: 0.5x, 0.75x, 1x, 1.5x, 2x — click 2x (index 4)
+    await options[4].trigger('click')
+
+    expect(player.setPlaybackRate).toHaveBeenCalledWith(2)
+  })
+
   // ── Transport actions ──────────────────────────────────────────────────────
 
   test('audio-toolbar__toggle calls player.play() when paused [obligation]', async () => {

--- a/tests/integration/views/audio-reader/transcript/index.test.js
+++ b/tests/integration/views/audio-reader/transcript/index.test.js
@@ -204,6 +204,65 @@ describe('TranscriptView', () => {
     })
   })
 
+  describe('pointerleave and pointercancel handlers', () => {
+    test('pointerleave on the content element does not throw', async () => {
+      const wrapper = mountView()
+      const content = wrapper.find('[data-testid="transcript-view__content"]').element
+
+      expect(() => {
+        content.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true, pointerId: 1 }))
+      }).not.toThrow()
+    })
+
+    test('pointercancel on the content element does not throw', async () => {
+      const wrapper = mountView()
+      const content = wrapper.find('[data-testid="transcript-view__content"]').element
+
+      expect(() => {
+        content.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, pointerId: 1 }))
+      }).not.toThrow()
+    })
+
+    test('pointercancel after a touch long-press does not leave selection active', async () => {
+      const wrapper = mountView()
+      const wordEls = wrapper.findAll('[data-testid="transcript-word"]').map((w) => w.element)
+      vi.spyOn(document, 'elementFromPoint').mockImplementation((x) => wordEls[x] ?? null)
+
+      const content = wrapper.find('[data-testid="transcript-view__content"]').element
+
+      vi.useFakeTimers()
+      // Touch press on word 0
+      content.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          pointerId: 1,
+          pointerType: 'touch',
+          clientX: 0,
+          clientY: 0
+        })
+      )
+      await wrapper.vm.$nextTick()
+
+      // Cancel the gesture (browser claims the scroll)
+      content.dispatchEvent(
+        new PointerEvent('pointercancel', {
+          bubbles: true,
+          pointerId: 1,
+          pointerType: 'touch'
+        })
+      )
+      await wrapper.vm.$nextTick()
+
+      // Advance past long-press — should NOT arm after cancel
+      vi.advanceTimersByTime(500)
+      await wrapper.vm.$nextTick()
+      vi.useRealTimers()
+
+      // No selection should have been committed
+      expect(wrapper.emitted('select')).toBeFalsy()
+    })
+  })
+
   describe('readerActiveWordKey provide [obligation]', () => {
     test('provides readerActiveWordKey to child words reflecting active_word prop [obligation]', async () => {
       const wrapper = mountView({ active_word: 3 })

--- a/tests/integration/views/audio-reader/transcript/selection-preview.test.js
+++ b/tests/integration/views/audio-reader/transcript/selection-preview.test.js
@@ -1,0 +1,195 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import SelectionPreview from '@/views/audio-reader/transcript/selection-preview.vue'
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const { mockGsapSet, mockFromTo, mockTo } = vi.hoisted(() => ({
+  mockGsapSet: vi.fn(),
+  mockFromTo: vi.fn((_el, _from, to) => to?.onComplete?.()),
+  mockTo: vi.fn((_el, opts) => opts?.onComplete?.())
+}))
+
+vi.mock('gsap', () => ({
+  default: {
+    set: mockGsapSet,
+    fromTo: mockFromTo,
+    to: mockTo
+  }
+}))
+
+vi.mock('@/utils/animations/selection-preview', () => ({
+  popInPreview: vi.fn((_el, onComplete) => onComplete?.()),
+  popOutPreview: vi.fn((_el, onComplete) => onComplete?.())
+}))
+
+import { popInPreview, popOutPreview } from '@/utils/animations/selection-preview'
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makePreview(overrides = {}) {
+  return {
+    text: 'Hello world',
+    x: 150,
+    top: 200,
+    bottom: 224,
+    ...overrides
+  }
+}
+
+function mountPreview(props = {}) {
+  return mount(SelectionPreview, {
+    props: { preview: null, ...props },
+    attachTo: document.body
+  })
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('SelectionPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    // Clean up any lingering Teleport portals attached to body
+    document.querySelectorAll('[data-testid="selection-preview"]').forEach((el) => el.remove())
+  })
+
+  describe('rendering', () => {
+    test('renders the bubble element in the document (teleported to body)', () => {
+      mountPreview()
+
+      // Teleport to body — must be queryable from document
+      expect(document.querySelector('[data-testid="selection-preview"]')).not.toBeNull()
+    })
+
+    test('bubble is permanently mounted regardless of preview prop', () => {
+      const wrapper = mountPreview({ preview: null })
+
+      expect(document.querySelector('[data-testid="selection-preview"]')).not.toBeNull()
+
+      wrapper.unmount()
+    })
+
+    test('data-visible is false when preview is null', async () => {
+      mountPreview({ preview: null })
+
+      const el = document.querySelector('[data-testid="selection-preview"]')
+      expect(el.getAttribute('data-visible')).toBe('false')
+    })
+
+    test('data-visible is true when preview is non-null', async () => {
+      const wrapper = mountPreview({ preview: null })
+      await wrapper.setProps({ preview: makePreview() })
+
+      const el = document.querySelector('[data-testid="selection-preview"]')
+      expect(el.getAttribute('data-visible')).toBe('true')
+    })
+
+    test('renders the preview text in the bubble when shown', async () => {
+      const wrapper = mountPreview({ preview: null })
+      await wrapper.setProps({ preview: makePreview({ text: '日本語' }) })
+
+      const el = document.querySelector('[data-testid="selection-preview"]')
+      expect(el.textContent.trim()).toBe('日本語')
+    })
+
+    test('bubble is aria-hidden', () => {
+      mountPreview()
+
+      const el = document.querySelector('[data-testid="selection-preview"]')
+      expect(el.getAttribute('aria-hidden')).toBe('true')
+    })
+  })
+
+  describe('data-below positioning flag', () => {
+    test('data-below is false when preview.top is above FLIP_BELOW_Y (112px)', async () => {
+      const wrapper = mountPreview({ preview: makePreview({ top: 200 }) })
+      await wrapper.vm.$nextTick()
+
+      const el = document.querySelector('[data-testid="selection-preview"]')
+      expect(el.getAttribute('data-below')).toBe('false')
+    })
+
+    test('data-below is true when preview.top is below FLIP_BELOW_Y (112px)', async () => {
+      const wrapper = mountPreview({ preview: null })
+      await wrapper.setProps({ preview: makePreview({ top: 50 }) })
+
+      const el = document.querySelector('[data-testid="selection-preview"]')
+      expect(el.getAttribute('data-below')).toBe('true')
+    })
+
+    test('data-below is false when preview is null', () => {
+      mountPreview({ preview: null })
+
+      const el = document.querySelector('[data-testid="selection-preview"]')
+      expect(el.getAttribute('data-below')).toBe('false')
+    })
+  })
+
+  describe('animation: popInPreview called on first appearance', () => {
+    test('popInPreview is called when preview transitions from null to non-null', async () => {
+      const wrapper = mountPreview({ preview: null })
+      await wrapper.vm.$nextTick()
+
+      await wrapper.setProps({ preview: makePreview() })
+
+      expect(popInPreview).toHaveBeenCalledTimes(1)
+    })
+
+    test('popInPreview is NOT called again when dragging updates an already-shown preview', async () => {
+      const wrapper = mountPreview({ preview: makePreview({ x: 100 }) })
+      await wrapper.vm.$nextTick()
+      vi.clearAllMocks()
+
+      // Update x — preview was already non-null, so no re-pop
+      await wrapper.setProps({ preview: makePreview({ x: 120 }) })
+
+      expect(popInPreview).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('animation: popOutPreview called on disappearance', () => {
+    test('popOutPreview is called when preview transitions from non-null to null', async () => {
+      const wrapper = mountPreview({ preview: makePreview() })
+      await wrapper.vm.$nextTick()
+      vi.clearAllMocks()
+
+      await wrapper.setProps({ preview: null })
+
+      expect(popOutPreview).toHaveBeenCalledTimes(1)
+    })
+
+    test('shown text is cleared after popOutPreview onComplete fires', async () => {
+      // popOutPreview mock calls onComplete immediately — so shown.value clears synchronously
+      const wrapper = mountPreview({ preview: makePreview({ text: '選択' }) })
+      await wrapper.vm.$nextTick()
+
+      await wrapper.setProps({ preview: null })
+      await wrapper.vm.$nextTick()
+
+      const el = document.querySelector('[data-testid="selection-preview"]')
+      expect(el.getAttribute('data-visible')).toBe('false')
+    })
+  })
+
+  describe('shown text is retained through fade-out (no flicker)', () => {
+    test('when popOutPreview has not yet called onComplete, shown text is still present', async () => {
+      // Override mock to NOT call onComplete immediately for this test
+      popOutPreview.mockImplementationOnce(vi.fn())
+
+      const wrapper = mountPreview({ preview: null })
+      // Arm: transition null → non-null so the watcher fires and shown is set
+      await wrapper.setProps({ preview: makePreview({ text: '日本語' }) })
+
+      await wrapper.setProps({ preview: null })
+      await wrapper.vm.$nextTick()
+
+      const el = document.querySelector('[data-testid="selection-preview"]')
+      // data-visible stays true until onComplete fires
+      expect(el.getAttribute('data-visible')).toBe('true')
+      expect(el.textContent.trim()).toBe('日本語')
+    })
+  })
+})

--- a/tests/unit/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/unit/composables/audio-reader/use-reader-highlights.test.js
@@ -470,6 +470,141 @@ describe('useReaderHighlights', () => {
     })
   })
 
+  describe('selection_preview', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    test('is null before any pointer activity', () => {
+      const { result } = withHighlights()
+
+      expect(result.selection_preview.value).toBeNull()
+    })
+
+    test('is non-null the instant a touch long-press arms with NO drag [obligation]', async () => {
+      const { result, contentEl } = withHighlights()
+      const wordEl = addWord(contentEl, 1, '語')
+      const base = wordEl.querySelector('[data-word-base]')
+      base.getBoundingClientRect = () => new DOMRect(10, 50, 40, 20)
+
+      stubElementFromPoint(() => wordEl)
+      result.onPointerDown(
+        new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 30, clientY: 55 })
+      )
+      await nextTick()
+
+      // Not armed yet — preview is null before the long-press fires
+      expect(result.selection_preview.value).toBeNull()
+
+      // Advance past LONG_PRESS_MS (400ms) without any pointermove
+      vi.advanceTimersByTime(500)
+      await nextTick()
+
+      // IMMEDIATELY non-null — no drag required [regression guard]
+      expect(result.selection_preview.value).not.toBeNull()
+    })
+
+    test('selection_preview shape has text, x, top, bottom [obligation]', async () => {
+      const { result, contentEl } = withHighlights()
+      const wordEl = addWord(contentEl, 2, '日本語')
+      const base = wordEl.querySelector('[data-word-base]')
+      base.getBoundingClientRect = () => new DOMRect(10, 80, 60, 24)
+
+      stubElementFromPoint(() => wordEl)
+      result.onPointerDown(
+        new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 40, clientY: 90 })
+      )
+
+      vi.advanceTimersByTime(500)
+      await nextTick()
+
+      const preview = result.selection_preview.value
+      expect(preview).not.toBeNull()
+      // text from the word
+      expect(typeof preview.text).toBe('string')
+      // x comes from the finger's clientX at the time of arming (tap.x)
+      expect(preview.x).toBe(40)
+      // top/bottom come from the focus word's base-element rect
+      expect(preview.top).toBe(80)
+      expect(preview.bottom).toBe(80 + 24)
+    })
+
+    test('selection_preview stays null for mouse pointerdown + drag [obligation]', async () => {
+      const { result, contentEl } = withHighlights()
+      const wordEl1 = addWord(contentEl, 0, 'Hello')
+      const wordEl2 = addWord(contentEl, 1, 'World')
+      const base1 = wordEl1.querySelector('[data-word-base]')
+      const base2 = wordEl2.querySelector('[data-word-base]')
+      base1.getBoundingClientRect = () => new DOMRect(0, 50, 40, 20)
+      base2.getBoundingClientRect = () => new DOMRect(50, 50, 40, 20)
+      contentEl.getBoundingClientRect = () => new DOMRect(0, 0, 300, 200)
+
+      stubElementFromPoint(() => wordEl1)
+      result.onPointerDown(
+        new PointerEvent('pointerdown', { pointerType: 'mouse', clientX: 10, clientY: 55 })
+      )
+      await nextTick()
+
+      document.elementFromPoint = () => wordEl2
+      result.onPointerMove(
+        new PointerEvent('pointermove', { pointerType: 'mouse', clientX: 60, clientY: 55 })
+      )
+      await nextTick()
+
+      // Mouse drag must never produce a selection_preview
+      expect(result.selection_preview.value).toBeNull()
+    })
+
+    test('selection_preview resets to null after commitTouch (pointerup) [obligation]', async () => {
+      const { result, contentEl } = withHighlights()
+      const wordEl = addWord(contentEl, 3, '選')
+      const base = wordEl.querySelector('[data-word-base]')
+      base.getBoundingClientRect = () => new DOMRect(10, 50, 30, 20)
+      contentEl.getBoundingClientRect = () => new DOMRect(0, 0, 300, 200)
+
+      stubElementFromPoint(() => wordEl)
+      result.onPointerDown(
+        new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 25, clientY: 55 })
+      )
+      vi.advanceTimersByTime(500)
+      await nextTick()
+
+      expect(result.selection_preview.value).not.toBeNull()
+
+      result.onPointerUp(
+        new PointerEvent('pointerup', { pointerType: 'touch', clientX: 25, clientY: 55 })
+      )
+      await nextTick()
+
+      expect(result.selection_preview.value).toBeNull()
+    })
+
+    test('selection_preview resets to null after onPointerCancel [obligation]', async () => {
+      const { result, contentEl } = withHighlights()
+      const wordEl = addWord(contentEl, 4, '語')
+      const base = wordEl.querySelector('[data-word-base]')
+      base.getBoundingClientRect = () => new DOMRect(10, 50, 30, 20)
+
+      stubElementFromPoint(() => wordEl)
+      result.onPointerDown(
+        new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 25, clientY: 55 })
+      )
+      vi.advanceTimersByTime(500)
+      await nextTick()
+
+      expect(result.selection_preview.value).not.toBeNull()
+
+      result.onPointerCancel(new PointerEvent('pointercancel', { pointerType: 'touch' }))
+      await nextTick()
+
+      expect(result.selection_preview.value).toBeNull()
+    })
+  })
+
   describe('popover_open watcher', () => {
     test('committed range is cleared when popover_open goes false', async () => {
       // Start with popover open (true) so closing it (false) triggers the watcher.

--- a/tests/unit/utils/animations/selection-preview.test.js
+++ b/tests/unit/utils/animations/selection-preview.test.js
@@ -1,0 +1,97 @@
+import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+
+const { mockFromTo, mockTo } = vi.hoisted(() => ({
+  mockFromTo: vi.fn(),
+  mockTo: vi.fn()
+}))
+
+vi.mock('gsap', () => ({
+  default: {
+    fromTo: mockFromTo,
+    to: mockTo
+  }
+}))
+
+import { popInPreview, popOutPreview } from '@/utils/animations/selection-preview'
+
+describe('popInPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('calls gsap.fromTo on the element', () => {
+    const el = document.createElement('div')
+    popInPreview(el)
+
+    expect(mockFromTo).toHaveBeenCalledTimes(1)
+    expect(mockFromTo.mock.calls[0][0]).toBe(el)
+  })
+
+  test('starts from opacity 0, scale 0.8', () => {
+    const el = document.createElement('div')
+    popInPreview(el)
+
+    const fromVars = mockFromTo.mock.calls[0][1]
+    expect(fromVars).toMatchObject({ opacity: 0, scale: 0.8 })
+  })
+
+  test('animates to opacity 1, scale 1', () => {
+    const el = document.createElement('div')
+    popInPreview(el)
+
+    const toVars = mockFromTo.mock.calls[0][2]
+    expect(toVars).toMatchObject({ opacity: 1, scale: 1 })
+  })
+
+  test('calls onComplete callback when provided', () => {
+    const el = document.createElement('div')
+    const onComplete = vi.fn()
+    popInPreview(el, onComplete)
+
+    const toVars = mockFromTo.mock.calls[0][2]
+    toVars.onComplete?.()
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  test('works without an onComplete callback (no crash)', () => {
+    const el = document.createElement('div')
+    expect(() => popInPreview(el)).not.toThrow()
+  })
+})
+
+describe('popOutPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('calls gsap.to on the element', () => {
+    const el = document.createElement('div')
+    popOutPreview(el)
+
+    expect(mockTo).toHaveBeenCalledTimes(1)
+    expect(mockTo.mock.calls[0][0]).toBe(el)
+  })
+
+  test('animates to opacity 0, scale 0.8', () => {
+    const el = document.createElement('div')
+    popOutPreview(el)
+
+    const toVars = mockTo.mock.calls[0][1]
+    expect(toVars).toMatchObject({ opacity: 0, scale: 0.8 })
+  })
+
+  test('calls onComplete callback when provided', () => {
+    const el = document.createElement('div')
+    const onComplete = vi.fn()
+    popOutPreview(el, onComplete)
+
+    const toVars = mockTo.mock.calls[0][1]
+    toVars.onComplete?.()
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  test('works without an onComplete callback (no crash)', () => {
+    const el = document.createElement('div')
+    expect(() => popOutPreview(el)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- Rebuild the mini audio toolbar as a single 5-column control row (expand, rewind, play/pause, jump forward, speed), mirroring the large toolbar's controls and button sizes, dropping the scrub bar and chapter selector. Size-toggle sfx switches to `snappy_button_5`, and the transport buttons get `touch-manipulation` so a double tap fires clicks instead of zooming.
- Add a live text-selection preview bubble for touch: while an armed long-press drag extends a selection, a bubble trails the finger horizontally and rides above the selected line, previewing the current selection text. Coarse-pointer only; mouse selection is unaffected.
- The bubble stays permanently mounted and animates only its opacity (retaining the last preview through its fade-out), so re-arming always shows it with no enter/leave race.