### PR TITLE
feat(audio-reader): resume playback at saved position within a chapter

### DIFF
--- a/src/api/lessons/db/collections.ts
+++ b/src/api/lessons/db/collections.ts
@@ -51,13 +51,15 @@ export async function createLessonCollection(title: string): Promise<LessonColle
 
 export async function setCollectionProgress(
   collection_id: number,
-  lesson_id: number
+  lesson_id: number,
+  position_seconds = 0
 ): Promise<void> {
-  // Bookmark the chapter the member is on. The owner-update RLS policy already
-  // scopes this to the caller's own collection, so no RPC is needed.
+  // Bookmark the chapter the member is on plus the audio offset within it. The
+  // owner-update RLS policy already scopes this to the caller's own collection,
+  // so no RPC is needed.
   const { error } = await supabase
     .from('lesson_collections')
-    .update({ last_lesson_id: lesson_id })
+    .update({ last_lesson_id: lesson_id, last_position_seconds: position_seconds })
     .eq('id', collection_id)
 
   if (error) {

--- a/src/api/lessons/mutations/update-progress.ts
+++ b/src/api/lessons/mutations/update-progress.ts
@@ -3,24 +3,41 @@ import { setCollectionProgress } from '../db'
 
 export type SetCollectionProgressVars = {
   collection_id: number
-  // The chapter the member just opened — becomes the collection's bookmark.
+  // The chapter the member is on — becomes the collection's bookmark.
   lesson_id: number
+  // Audio offset (seconds) within that chapter; defaults to the chapter start.
+  position_seconds?: number
 }
 
 /**
- * Bookmark the chapter the member is currently reading, so the dashboard reopens
- * the collection there next time. Fire-and-forget from the reader page on open;
- * onSettled refreshes the collection caches the dashboard resolves against.
+ * Persist the member's resume point — which chapter they're on plus the audio
+ * offset within it. Fires on reader open (offset 0) and then throttled during
+ * playback, so onSettled patches the collection caches in place rather than
+ * invalidating: a refetch on every playback tick would be wasteful and could
+ * re-trigger the reader's restore.
  */
 export function useSetCollectionProgressMutation() {
   const queryCache = useQueryCache()
 
   return useMutation({
-    mutation: ({ collection_id, lesson_id }: SetCollectionProgressVars) =>
-      setCollectionProgress(collection_id, lesson_id),
-    onSettled: (_data, _error, { collection_id }) => {
-      queryCache.invalidateQueries({ key: ['lesson-collections'] })
-      queryCache.invalidateQueries({ key: ['lesson-collection', collection_id] })
+    mutation: ({ collection_id, lesson_id, position_seconds = 0 }: SetCollectionProgressVars) =>
+      setCollectionProgress(collection_id, lesson_id, position_seconds),
+    onSettled: (_data, _error, { collection_id, lesson_id, position_seconds = 0 }) => {
+      const bookmark = { last_lesson_id: lesson_id, last_position_seconds: position_seconds }
+
+      const single = queryCache.getQueryData<LessonCollection>(['lesson-collection', collection_id])
+      if (single)
+        queryCache.setQueryData(['lesson-collection', collection_id], { ...single, ...bookmark })
+
+      const list = queryCache.getQueryData<LessonCollectionWithCount[]>(['lesson-collections'])
+      if (list) {
+        queryCache.setQueryData(
+          ['lesson-collections'],
+          list.map((collection) =>
+            collection.id === collection_id ? { ...collection, ...bookmark } : collection
+          )
+        )
+      }
     }
   })
 }

--- a/src/composables/audio-reader/use-audio-player.ts
+++ b/src/composables/audio-reader/use-audio-player.ts
@@ -19,6 +19,9 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
   const duration = ref(0)
   const is_playing = ref(false)
   const playback_rate = ref(1)
+  // True once the bound source's metadata is in (so seeking sticks); flips back to
+  // false on `emptied` when the src swaps to another chapter, awaiting its load.
+  const loaded = ref(false)
 
   let el: HTMLAudioElement | null = null
   let raf = 0
@@ -51,6 +54,12 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
 
   function onLoaded() {
     if (el) duration.value = el.duration || 0
+    loaded.value = true
+  }
+
+  function onEmptied() {
+    loaded.value = false
+    duration.value = 0
   }
 
   function onPlay() {
@@ -84,6 +93,7 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
     el = next
     el.playbackRate = playback_rate.value
     el.addEventListener('loadedmetadata', onLoaded)
+    el.addEventListener('emptied', onEmptied)
     el.addEventListener('play', onPlay)
     el.addEventListener('pause', onPause)
     el.addEventListener('ended', onPause)
@@ -94,8 +104,10 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
 
   function unbind() {
     stopTicking()
+    loaded.value = false
     if (!el) return
     el.removeEventListener('loadedmetadata', onLoaded)
+    el.removeEventListener('emptied', onEmptied)
     el.removeEventListener('play', onPlay)
     el.removeEventListener('pause', onPause)
     el.removeEventListener('ended', onPause)
@@ -157,6 +169,7 @@ export function useAudioPlayer(target: MaybeRefOrGetter<HTMLAudioElement | null>
     duration,
     is_playing,
     playback_rate,
+    loaded,
     play,
     pause,
     seek,

--- a/src/composables/audio-reader/use-reader-progress.ts
+++ b/src/composables/audio-reader/use-reader-progress.ts
@@ -1,0 +1,90 @@
+import { onUnmounted, toValue, watch, type MaybeRefOrGetter } from 'vue'
+import { useLessonCollectionQuery, useSetCollectionProgressMutation } from '@/api/lessons'
+import type { AudioPlayer } from './use-audio-player'
+
+// Save at most once per this many seconds of playback progress.
+const SAVE_INTERVAL_SECONDS = 5
+// A stored offset within this much of the end counts as "finished" — restart the
+// chapter rather than resuming on its last word.
+const END_EPSILON_SECONDS = 2
+
+/**
+ * Persist and restore the member's resume point within a book. On opening a
+ * chapter it seeks to the stored offset (only when that chapter is the book's
+ * bookmark) and re-bookmarks the chapter; while listening it saves the position
+ * — throttled by playback progress, plus on pause, tab-hide, and unmount — so a
+ * refresh resumes where they left off. Stays paused after the restoring seek.
+ *
+ * One resume point per book: opening a different chapter than the bookmark
+ * starts at 0 and makes that chapter the new bookmark.
+ *
+ * @param collectionId - the book whose resume point is tracked, reactive.
+ * @param lessonId - the chapter currently open, reactive.
+ * @param player - the audio player driving (and driven by) the position.
+ * @example
+ * useReaderProgress(() => collection_id.value, lesson_id, player)
+ */
+export function useReaderProgress(
+  collectionId: MaybeRefOrGetter<number>,
+  lessonId: MaybeRefOrGetter<number>,
+  player: AudioPlayer
+) {
+  const { data: collection } = useLessonCollectionQuery(collectionId)
+  const set_progress = useSetCollectionProgressMutation()
+
+  // The chapter whose stored offset we've already applied — guards against
+  // re-seeking when the collection cache is patched under the same chapter.
+  let restored_for: number | null = null
+  // Playback position (seconds) at the last save; the throttle measures from here.
+  let saved_at = 0
+
+  function save(position: number) {
+    saved_at = position
+    set_progress.mutate({
+      collection_id: toValue(collectionId),
+      lesson_id: toValue(lessonId),
+      position_seconds: position
+    })
+  }
+
+  // Seek to the stored offset (if this chapter is the bookmark) and re-bookmark
+  // the chapter at that offset. Waits for the collection data and the current
+  // chapter's audio so the seek sticks; runs once per chapter open.
+  function restore() {
+    const data = collection.value
+    const lesson_id = toValue(lessonId)
+    if (!data || !player.loaded.value || restored_for === lesson_id) return
+
+    restored_for = lesson_id
+    const stored = data.last_lesson_id === lesson_id ? (data.last_position_seconds ?? 0) : 0
+    const target = stored < player.duration.value - END_EPSILON_SECONDS ? stored : 0
+
+    if (target > 0) player.seek(target)
+    save(target)
+  }
+
+  function onHidden() {
+    if (document.hidden) save(player.current_time.value)
+  }
+
+  document.addEventListener('visibilitychange', onHidden)
+  onUnmounted(() => {
+    document.removeEventListener('visibilitychange', onHidden)
+    if (player.loaded.value) save(player.current_time.value)
+  })
+
+  watch([() => collection.value, player.loaded, () => toValue(lessonId)], restore, {
+    immediate: true
+  })
+
+  // Throttle by playback progress: write once the position has advanced a step
+  // since the last save, never on every animation frame.
+  watch(player.current_time, (now) => {
+    if (player.is_playing.value && Math.abs(now - saved_at) >= SAVE_INTERVAL_SECONDS) save(now)
+  })
+
+  // Flush the exact spot whenever playback settles.
+  watch(player.is_playing, (playing) => {
+    if (!playing && player.loaded.value) save(player.current_time.value)
+  })
+}

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed, useTemplateRef, watch } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { emitSfx } from '@/sfx/bus'
-import { useLessonsByCollectionQuery, useSetCollectionProgressMutation } from '@/api/lessons'
+import { useLessonsByCollectionQuery } from '@/api/lessons'
 import { useLessonReader } from '@/composables/audio-reader/use-lesson-reader'
+import { useReaderProgress } from '@/composables/audio-reader/use-reader-progress'
 import { useCollectionEditModal } from '@/composables/modals/use-collection-edit-modal'
 import { useMatchMedia } from '@/composables/use-media-query'
 import { useAnimatedHeight } from '@/composables/use-animated-height'
@@ -26,7 +27,6 @@ const { collectionId, lessonId } = defineProps<{ collectionId: string; lessonId:
 const { t } = useI18n()
 const router = useRouter()
 const edit_modal = useCollectionEditModal()
-const set_progress = useSetCollectionProgressMutation()
 const is_mobile = useMatchMedia('w<sm | h<sm')
 
 const collection_id = computed(() => Number(collectionId))
@@ -48,6 +48,8 @@ const {
   playClip,
   player
 } = useLessonReader(lesson_id)
+
+useReaderProgress(collection_id, lesson_id, player)
 
 const { data: lessons_data } = useLessonsByCollectionQuery(collection_id)
 
@@ -125,17 +127,6 @@ function reclearSelection() {
 // crossfade between the two panes owns the height while `swapping`.
 useAnimatedHeight(footer_swap, footer_term, () => !swapping, reclearSelection)
 useAnimatedHeight(footer_swap, footer_toolbar, () => !swapping)
-
-// Bookmark the chapter once it's confirmed loaded, so the dashboard reopens the
-// book here next time. Reacting to the loaded lesson id (not the raw route param)
-// avoids writing a bookmark for a lesson that doesn't exist.
-watch(
-  () => lesson.value?.id,
-  (id) => {
-    if (id) set_progress.mutate({ collection_id: collection_id.value, lesson_id: id })
-  },
-  { immediate: true }
-)
 </script>
 
 <template>

--- a/supabase/migrations/20260612000001_lesson-collection-position.sql
+++ b/supabase/migrations/20260612000001_lesson-collection-position.sql
@@ -1,0 +1,46 @@
+-- =============================================================================
+-- Audio Reader: within-chapter resume position (one per book)
+-- =============================================================================
+--
+-- The collection already bookmarks WHICH chapter the member left off on
+-- (last_lesson_id). This adds WHERE in that chapter they were — the audio
+-- timestamp in seconds — so a refresh resumes mid-chapter instead of at 0:00.
+--
+-- One position per book: the pair (last_lesson_id, last_position_seconds) is the
+-- single resume point. Opening a different chapter overwrites both.
+--
+-- The existing lesson_collections_owner_update RLS policy already scopes writes
+-- to the caller's own collection, so no new policy or RPC is needed.
+-- =============================================================================
+
+BEGIN;
+
+-- double precision: Whisper timestamps are fractional seconds. NOT NULL DEFAULT 0
+-- so existing collections (and never-played chapters) read as "start at 0:00".
+alter table "public"."lesson_collections"
+  add column "last_position_seconds" double precision not null default 0;
+
+-- The view lists its columns explicitly, so the new column won't surface until
+-- the view is rebuilt -- DROP + CREATE rather than rely on column expansion.
+drop view "public"."lesson_collections_with_counts";
+
+create view "public"."lesson_collections_with_counts"
+  with (security_invoker = true) as
+select
+  lc.id,
+  lc.member_id,
+  lc.title,
+  lc.last_lesson_id,
+  lc.last_position_seconds,
+  lc.created_at,
+  lc.updated_at,
+  (
+    select count(*)::int
+    from "public"."lessons" l
+    where l.collection_id = lc.id
+  ) as lesson_count
+from "public"."lesson_collections" lc;
+
+grant select on "public"."lesson_collections_with_counts" to "authenticated";
+
+COMMIT;

--- a/tests/contract/api/lessons.test.js
+++ b/tests/contract/api/lessons.test.js
@@ -1,0 +1,165 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vite-plus/test'
+import { signInAsTestUser, adminClient } from '../setup.js'
+import {
+  fetchMemberLessonCollections,
+  fetchLessonCollection,
+  createLessonCollection,
+  setCollectionProgress,
+  deleteLessonCollection
+} from '@/api/lessons/db/collections'
+
+let session
+
+beforeEach(async () => {
+  session = await signInAsTestUser()
+})
+
+afterEach(async () => {
+  await session?.cleanup()
+  session = null
+})
+
+// Helper: create a lesson collection using the authenticated user client so the
+// set_member_id trigger picks up auth.uid() correctly.
+async function createCollectionDirect(client, overrides = {}) {
+  const { data, error } = await client
+    .from('lesson_collections')
+    .insert({ title: 'Contract Test Collection', ...overrides })
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+// Helper: create a lesson via the authenticated user client. The set_member_id trigger
+// stamps member_id from auth.uid(). audio_path and position are required by the schema.
+async function createLessonDirect(client, collectionId, overrides = {}) {
+  const { data, error } = await client
+    .from('lessons')
+    .insert({
+      collection_id: collectionId,
+      title: 'Contract Lesson',
+      audio_path: 'contract-test/placeholder.mp3',
+      position: 1,
+      ...overrides
+    })
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+describe('fetchMemberLessonCollections (contract)', () => {
+  test('returns an array for a member with no collections', async () => {
+    const result = await fetchMemberLessonCollections()
+    expect(Array.isArray(result)).toBe(true)
+  })
+
+  test('includes collections owned by the member', async () => {
+    await createCollectionDirect(session.client, { title: 'My Book' })
+    const result = await fetchMemberLessonCollections()
+    expect(result.some((c) => c.title === 'My Book')).toBe(true)
+  })
+
+  test("returns only the current member's own collections (not other members)", async () => {
+    // Create two collections for this member to confirm the filter works correctly.
+    await createCollectionDirect(session.client, { title: 'My First Book' })
+    await createCollectionDirect(session.client, { title: 'My Second Book' })
+
+    const result = await fetchMemberLessonCollections()
+
+    // All returned rows must belong to the session user.
+    expect(result.every((c) => c.member_id === session.userId)).toBe(true)
+  })
+
+  test('returned rows include id, title, and lesson_count fields', async () => {
+    await createCollectionDirect(session.client, { title: 'Shape Check' })
+    const result = await fetchMemberLessonCollections()
+    const row = result.find((c) => c.title === 'Shape Check')
+    expect(row).toBeDefined()
+    expect(typeof row.id).toBe('number')
+    expect(typeof row.title).toBe('string')
+    expect(typeof row.lesson_count).toBe('number')
+  })
+})
+
+describe('fetchLessonCollection (contract)', () => {
+  test('returns the collection by id', async () => {
+    const created = await createCollectionDirect(session.client, { title: 'Fetch Me' })
+    const result = await fetchLessonCollection(created.id)
+    expect(result.id).toBe(created.id)
+    expect(result.title).toBe('Fetch Me')
+  })
+
+  test('throws on a non-existent id', async () => {
+    await expect(fetchLessonCollection(999999999)).rejects.toBeDefined()
+  })
+})
+
+describe('createLessonCollection (contract)', () => {
+  test('creates a collection owned by the caller and returns it', async () => {
+    const result = await createLessonCollection('New Collection')
+    expect(typeof result.id).toBe('number')
+    expect(result.title).toBe('New Collection')
+  })
+})
+
+describe('setCollectionProgress (contract)', () => {
+  test('writes last_lesson_id and last_position_seconds to the collection row [obligation]', async () => {
+    const collection = await createCollectionDirect(session.client)
+    const lesson = await createLessonDirect(session.client, collection.id)
+
+    await setCollectionProgress(collection.id, lesson.id, 37)
+
+    const { data, error } = await adminClient
+      .from('lesson_collections')
+      .select('last_lesson_id, last_position_seconds')
+      .eq('id', collection.id)
+      .single()
+    if (error) throw error
+
+    expect(data.last_lesson_id).toBe(lesson.id)
+    expect(data.last_position_seconds).toBe(37)
+  })
+
+  test('defaults position_seconds to 0 when caller omits it [obligation]', async () => {
+    // First set a non-zero position, then call without position_seconds to confirm it resets to 0.
+    const collection = await createCollectionDirect(session.client)
+    const lesson = await createLessonDirect(session.client, collection.id)
+
+    // Set a non-zero value first so we can confirm the default resets it.
+    await setCollectionProgress(collection.id, lesson.id, 99)
+    await setCollectionProgress(collection.id, lesson.id)
+
+    const { data, error } = await adminClient
+      .from('lesson_collections')
+      .select('last_position_seconds')
+      .eq('id', collection.id)
+      .single()
+    if (error) throw error
+
+    expect(data.last_position_seconds).toBe(0)
+  })
+
+  test('updating a non-existent collection id silently affects 0 rows (RLS boundary)', async () => {
+    // A non-existent collection id either belongs to another member (blocked by RLS)
+    // or does not exist — either way setCollectionProgress must not throw.
+    await expect(setCollectionProgress(999999999, 999999999, 50)).resolves.toBeUndefined()
+  })
+})
+
+describe('deleteLessonCollection (contract)', () => {
+  test('removes the collection row', async () => {
+    const collection = await createCollectionDirect(session.client)
+
+    await deleteLessonCollection(collection.id)
+
+    const { data } = await adminClient
+      .from('lesson_collections')
+      .select('id')
+      .eq('id', collection.id)
+      .single()
+
+    expect(data).toBeNull()
+  })
+})

--- a/tests/integration/views/audio-reader/lesson/index.test.js
+++ b/tests/integration/views/audio-reader/lesson/index.test.js
@@ -21,6 +21,7 @@ const {
   playerRef,
   chaptersRef,
   progressMutate,
+  useReaderProgressMock,
   editModalOpenMock,
   routerPushMock,
   emitSfxMock
@@ -37,6 +38,7 @@ const {
   playerRef: { value: {} },
   chaptersRef: { value: [] },
   progressMutate: vi.fn(),
+  useReaderProgressMock: vi.fn(),
   editModalOpenMock: vi.fn(),
   routerPushMock: vi.fn(),
   emitSfxMock: vi.fn()
@@ -63,6 +65,10 @@ vi.mock('@/composables/audio-reader/use-lesson-reader', () => ({
     playClip: playClipMock,
     player: playerRef
   })
+}))
+
+vi.mock('@/composables/audio-reader/use-reader-progress', () => ({
+  useReaderProgress: useReaderProgressMock
 }))
 
 vi.mock('@/composables/use-media-query', () => ({
@@ -203,6 +209,7 @@ beforeEach(() => {
   progressMutate.mockClear()
   editModalOpenMock.mockClear()
   routerPushMock.mockClear()
+  useReaderProgressMock.mockClear()
   openTermMock.mockClear()
   closeTermMock.mockClear()
   playFromHereMock.mockClear()
@@ -211,22 +218,16 @@ beforeEach(() => {
 })
 
 describe('LessonView', () => {
-  describe('progress bookmark', () => {
-    test('calls progress mutate with collection_id and lesson_id on mount when lesson is loaded', async () => {
-      lessonRef.value = { id: 2, title: 'Hiragana Basics' }
+  describe('progress tracking', () => {
+    test('hands the collection id, lesson id, and player to useReaderProgress', async () => {
       mountView()
       await flushPromises()
 
-      expect(progressMutate).toHaveBeenCalledOnce()
-      expect(progressMutate).toHaveBeenCalledWith({ collection_id: 5, lesson_id: 2 })
-    })
-
-    test('does not call mutate when lesson is null on mount', async () => {
-      lessonRef.value = null
-      mountView()
-      await flushPromises()
-
-      expect(progressMutate).not.toHaveBeenCalled()
+      expect(useReaderProgressMock).toHaveBeenCalledOnce()
+      const [collectionArg, lessonArg, playerArg] = useReaderProgressMock.mock.calls[0]
+      expect(collectionArg.value).toBe(5)
+      expect(lessonArg.value).toBe(2)
+      expect(playerArg).toBe(playerRef)
     })
   })
 

--- a/tests/unit/api/lessons/mutations/update-progress.test.js
+++ b/tests/unit/api/lessons/mutations/update-progress.test.js
@@ -1,14 +1,17 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 
-const { useMutationSpy, invalidateSpy, setCollectionProgressMock } = vi.hoisted(() => ({
-  useMutationSpy: vi.fn((cfg) => cfg),
-  invalidateSpy: vi.fn(),
-  setCollectionProgressMock: vi.fn().mockResolvedValue(undefined)
-}))
+const { useMutationSpy, getQueryDataSpy, setQueryDataSpy, setCollectionProgressMock } = vi.hoisted(
+  () => ({
+    useMutationSpy: vi.fn((cfg) => cfg),
+    getQueryDataSpy: vi.fn(),
+    setQueryDataSpy: vi.fn(),
+    setCollectionProgressMock: vi.fn().mockResolvedValue(undefined)
+  })
+)
 
 vi.mock('@pinia/colada', () => ({
   useMutation: useMutationSpy,
-  useQueryCache: () => ({ invalidateQueries: invalidateSpy })
+  useQueryCache: () => ({ getQueryData: getQueryDataSpy, setQueryData: setQueryDataSpy })
 }))
 
 vi.mock('@/api/lessons/db', () => ({
@@ -19,7 +22,8 @@ import { useSetCollectionProgressMutation } from '@/api/lessons/mutations/update
 
 beforeEach(() => {
   useMutationSpy.mockClear()
-  invalidateSpy.mockClear()
+  getQueryDataSpy.mockReset()
+  setQueryDataSpy.mockClear()
   setCollectionProgressMock.mockClear()
 })
 
@@ -30,24 +34,65 @@ function configFrom(hook) {
 
 describe('useSetCollectionProgressMutation', () => {
   describe('mutation', () => {
-    test('delegates to setCollectionProgress with collection_id and lesson_id', async () => {
+    test('delegates to setCollectionProgress with collection_id, lesson_id, and position', async () => {
+      const { mutation } = configFrom(useSetCollectionProgressMutation)
+      await mutation({ collection_id: 3, lesson_id: 17, position_seconds: 42 })
+      expect(setCollectionProgressMock).toHaveBeenCalledWith(3, 17, 42)
+    })
+
+    test('defaults the position to the chapter start when omitted', async () => {
       const { mutation } = configFrom(useSetCollectionProgressMutation)
       await mutation({ collection_id: 3, lesson_id: 17 })
-      expect(setCollectionProgressMock).toHaveBeenCalledWith(3, 17)
+      expect(setCollectionProgressMock).toHaveBeenCalledWith(3, 17, 0)
     })
   })
 
   describe('onSettled', () => {
-    test('invalidates ["lesson-collections"] so the dashboard list refreshes', () => {
+    test('patches the detail cache with the new bookmark + position in place', () => {
+      getQueryDataSpy.mockImplementation((key) =>
+        key[0] === 'lesson-collection' ? { id: 3, title: 'Book', last_lesson_id: 1 } : undefined
+      )
       const { onSettled } = configFrom(useSetCollectionProgressMutation)
-      onSettled(undefined, undefined, { collection_id: 3, lesson_id: 17 })
-      expect(invalidateSpy).toHaveBeenCalledWith({ key: ['lesson-collections'] })
+
+      onSettled(undefined, undefined, { collection_id: 3, lesson_id: 17, position_seconds: 42 })
+
+      expect(setQueryDataSpy).toHaveBeenCalledWith(['lesson-collection', 3], {
+        id: 3,
+        title: 'Book',
+        last_lesson_id: 17,
+        last_position_seconds: 42
+      })
     })
 
-    test('invalidates ["lesson-collection", collection_id] so the detail cache refreshes', () => {
+    test('patches the matching entry in the dashboard list, leaving others untouched', () => {
+      getQueryDataSpy.mockImplementation((key) =>
+        key[0] === 'lesson-collections'
+          ? [
+              { id: 3, last_lesson_id: 1, last_position_seconds: 0, lesson_count: 4 },
+              { id: 9, last_lesson_id: 2, last_position_seconds: 5, lesson_count: 2 }
+            ]
+          : undefined
+      )
       const { onSettled } = configFrom(useSetCollectionProgressMutation)
-      onSettled(undefined, undefined, { collection_id: 3, lesson_id: 17 })
-      expect(invalidateSpy).toHaveBeenCalledWith({ key: ['lesson-collection', 3] })
+
+      onSettled(undefined, undefined, { collection_id: 3, lesson_id: 17, position_seconds: 42 })
+
+      expect(setQueryDataSpy).toHaveBeenCalledWith(
+        ['lesson-collections'],
+        [
+          { id: 3, last_lesson_id: 17, last_position_seconds: 42, lesson_count: 4 },
+          { id: 9, last_lesson_id: 2, last_position_seconds: 5, lesson_count: 2 }
+        ]
+      )
+    })
+
+    test('writes nothing when the caches are cold', () => {
+      getQueryDataSpy.mockReturnValue(undefined)
+      const { onSettled } = configFrom(useSetCollectionProgressMutation)
+
+      onSettled(undefined, undefined, { collection_id: 3, lesson_id: 17, position_seconds: 42 })
+
+      expect(setQueryDataSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/api/lessons/mutations/update-progress.test.js
+++ b/tests/unit/api/lessons/mutations/update-progress.test.js
@@ -1,17 +1,26 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 
-const { useMutationSpy, getQueryDataSpy, setQueryDataSpy, setCollectionProgressMock } = vi.hoisted(
-  () => ({
-    useMutationSpy: vi.fn((cfg) => cfg),
-    getQueryDataSpy: vi.fn(),
-    setQueryDataSpy: vi.fn(),
-    setCollectionProgressMock: vi.fn().mockResolvedValue(undefined)
-  })
-)
+const {
+  useMutationSpy,
+  getQueryDataSpy,
+  setQueryDataSpy,
+  invalidateQueriesSpy,
+  setCollectionProgressMock
+} = vi.hoisted(() => ({
+  useMutationSpy: vi.fn((cfg) => cfg),
+  getQueryDataSpy: vi.fn(),
+  setQueryDataSpy: vi.fn(),
+  invalidateQueriesSpy: vi.fn(),
+  setCollectionProgressMock: vi.fn().mockResolvedValue(undefined)
+}))
 
 vi.mock('@pinia/colada', () => ({
   useMutation: useMutationSpy,
-  useQueryCache: () => ({ getQueryData: getQueryDataSpy, setQueryData: setQueryDataSpy })
+  useQueryCache: () => ({
+    getQueryData: getQueryDataSpy,
+    setQueryData: setQueryDataSpy,
+    invalidateQueries: invalidateQueriesSpy
+  })
 }))
 
 vi.mock('@/api/lessons/db', () => ({
@@ -24,6 +33,7 @@ beforeEach(() => {
   useMutationSpy.mockClear()
   getQueryDataSpy.mockReset()
   setQueryDataSpy.mockClear()
+  invalidateQueriesSpy.mockClear()
   setCollectionProgressMock.mockClear()
 })
 
@@ -93,6 +103,17 @@ describe('useSetCollectionProgressMutation', () => {
       onSettled(undefined, undefined, { collection_id: 3, lesson_id: 17, position_seconds: 42 })
 
       expect(setQueryDataSpy).not.toHaveBeenCalled()
+    })
+
+    test('never calls invalidateQueries — patches in place to avoid refetch loops [obligation]', () => {
+      getQueryDataSpy.mockImplementation((key) =>
+        key[0] === 'lesson-collection' ? { id: 3, title: 'Book', last_lesson_id: 1 } : undefined
+      )
+      const { onSettled } = configFrom(useSetCollectionProgressMutation)
+
+      onSettled(undefined, undefined, { collection_id: 3, lesson_id: 17, position_seconds: 42 })
+
+      expect(invalidateQueriesSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/composables/audio-reader/use-audio-player.test.js
+++ b/tests/unit/composables/audio-reader/use-audio-player.test.js
@@ -79,6 +79,12 @@ describe('useAudioPlayer', () => {
       app = a
       expect(result.duration.value).toBe(0)
     })
+
+    test('loaded starts as false [obligation]', () => {
+      const [result, a] = withSetup(() => useAudioPlayer(ref(null)))
+      app = a
+      expect(result.loaded.value).toBe(false)
+    })
   })
 
   describe('binding to an audio element', () => {
@@ -144,6 +150,81 @@ describe('useAudioPlayer', () => {
       await nextTick()
 
       expect(result.duration.value).toBe(180)
+    })
+
+    test('loaded becomes true when loadedmetadata event fires [obligation]', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      expect(result.loaded.value).toBe(false)
+      el._emit('loadedmetadata')
+      expect(result.loaded.value).toBe(true)
+    })
+
+    test('loaded returns to false and duration resets to 0 on emptied event (src swap) [obligation]', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      el.readyState = 1
+      el.duration = 120
+      target.value = el
+      await nextTick()
+      // loadedmetadata fired on bind because readyState >= 1
+      expect(result.loaded.value).toBe(true)
+      expect(result.duration.value).toBe(120)
+
+      el._emit('emptied')
+      expect(result.loaded.value).toBe(false)
+      expect(result.duration.value).toBe(0)
+    })
+
+    test('loaded returns to false on unbind (target ref becomes null) [obligation]', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      el.readyState = 1
+      target.value = el
+      await nextTick()
+      expect(result.loaded.value).toBe(true)
+
+      target.value = null
+      await nextTick()
+      expect(result.loaded.value).toBe(false)
+    })
+
+    test('loaded returns to false on unmount [obligation]', async () => {
+      const target = ref(null)
+      const [result, a] = withSetup(() => useAudioPlayer(target))
+
+      const el = makeAudioEl()
+      el.readyState = 1
+      target.value = el
+      await nextTick()
+      expect(result.loaded.value).toBe(true)
+
+      a.unmount()
+      expect(result.loaded.value).toBe(false)
+    })
+
+    test('attaches emptied event listener when element is bound [obligation]', async () => {
+      const target = ref(null)
+      const [, a] = withSetup(() => useAudioPlayer(target))
+      app = a
+
+      const el = makeAudioEl()
+      target.value = el
+      await nextTick()
+
+      expect(el.addEventListener).toHaveBeenCalledWith('emptied', expect.any(Function))
     })
   })
 

--- a/tests/unit/composables/audio-reader/use-reader-progress.test.js
+++ b/tests/unit/composables/audio-reader/use-reader-progress.test.js
@@ -37,6 +37,25 @@ function makePlayer(overrides = {}) {
   }
 }
 
+// Capture and control the visibilitychange handler registered on document.
+function spyOnVisibilityChange() {
+  let handler = null
+  const addSpy = vi.spyOn(document, 'addEventListener').mockImplementation((event, cb) => {
+    if (event === 'visibilitychange') handler = cb
+  })
+  const removeSpy = vi.spyOn(document, 'removeEventListener')
+  return {
+    fire() {
+      handler?.()
+    },
+    restore() {
+      addSpy.mockRestore()
+      removeSpy.mockRestore()
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+    }
+  }
+}
+
 describe('useReaderProgress', () => {
   let app
 
@@ -113,6 +132,34 @@ describe('useReaderProgress', () => {
 
       expect(player.seek).not.toHaveBeenCalled()
     })
+
+    test('stays paused after restoring — seek is called but play is never called [obligation]', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 42 })
+      const player = makePlayer({ play: vi.fn() })
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+
+      expect(player.seek).toHaveBeenCalledWith(42)
+      expect(player.play).not.toHaveBeenCalled()
+    })
+
+    test('different chapter starts at 0 with no seek but still writes bookmark at 0 [obligation]', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 99, last_position_seconds: 42 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+
+      expect(player.seek).not.toHaveBeenCalled()
+      expect(mutateSpy).toHaveBeenCalledWith({
+        collection_id: 5,
+        lesson_id: 2,
+        position_seconds: 0
+      })
+    })
   })
 
   describe('save', () => {
@@ -178,6 +225,100 @@ describe('useReaderProgress', () => {
         lesson_id: 2,
         position_seconds: 12
       })
+    })
+
+    test('saves on visibilitychange when document.hidden is true (tab switch / close) [obligation]', async () => {
+      const spy = spyOnVisibilityChange()
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 0 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+      player.current_time.value = 22
+      mutateSpy.mockClear()
+
+      Object.defineProperty(document, 'hidden', { value: true, configurable: true })
+      spy.fire()
+
+      expect(mutateSpy).toHaveBeenCalledWith({
+        collection_id: 5,
+        lesson_id: 2,
+        position_seconds: 22
+      })
+
+      spy.restore()
+    })
+
+    test('does not save on visibilitychange when document is visible (returning to foreground) [obligation]', async () => {
+      const spy = spyOnVisibilityChange()
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 0 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+      mutateSpy.mockClear()
+
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+      spy.fire()
+
+      expect(mutateSpy).not.toHaveBeenCalled()
+
+      spy.restore()
+    })
+
+    test('throttle by playback: does not save while playing when advance < 5s since last save [obligation]', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 0 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+      mutateSpy.mockClear()
+      player.is_playing.value = true
+
+      // Advance 4 seconds — below the 5s threshold
+      player.current_time.value = 4
+      await nextTick()
+
+      expect(mutateSpy).not.toHaveBeenCalled()
+    })
+
+    test('throttle by playback: saves once current_time advances ≥ 5s since last save [obligation]', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 0 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+      mutateSpy.mockClear()
+      player.is_playing.value = true
+
+      player.current_time.value = 5
+      await nextTick()
+
+      expect(mutateSpy).toHaveBeenCalledWith({
+        collection_id: 5,
+        lesson_id: 2,
+        position_seconds: 5
+      })
+    })
+
+    test('does not save via throttle watcher when not playing [obligation]', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 0 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+      mutateSpy.mockClear()
+      // is_playing stays false
+
+      player.current_time.value = 10
+      await nextTick()
+
+      expect(mutateSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/composables/audio-reader/use-reader-progress.test.js
+++ b/tests/unit/composables/audio-reader/use-reader-progress.test.js
@@ -1,0 +1,183 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { createApp, nextTick, ref } from 'vue'
+
+const { collectionRef, mutateSpy } = vi.hoisted(() => ({
+  collectionRef: { current: null },
+  mutateSpy: vi.fn()
+}))
+
+vi.mock('@/api/lessons', () => ({
+  useLessonCollectionQuery: () => ({ data: collectionRef.current }),
+  useSetCollectionProgressMutation: () => ({ mutate: mutateSpy })
+}))
+
+const { useReaderProgress } = await import('@/composables/audio-reader/use-reader-progress')
+
+// Run the composable inside a real app so watch() + onUnmounted fire.
+function withSetup(setup) {
+  let result
+  const app = createApp({
+    setup() {
+      result = setup()
+      return () => null
+    }
+  })
+  app.mount(document.createElement('div'))
+  return [result, app]
+}
+
+function makePlayer(overrides = {}) {
+  return {
+    loaded: ref(false),
+    current_time: ref(0),
+    duration: ref(120),
+    is_playing: ref(false),
+    seek: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('useReaderProgress', () => {
+  let app
+
+  beforeEach(() => {
+    collectionRef.current = ref(null)
+    mutateSpy.mockClear()
+  })
+
+  afterEach(() => {
+    app?.unmount()
+  })
+
+  describe('restore', () => {
+    test('seeks to the stored offset and re-bookmarks when this chapter is the bookmark', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 42 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+
+      expect(player.seek).toHaveBeenCalledWith(42)
+      expect(mutateSpy).toHaveBeenCalledWith({
+        collection_id: 5,
+        lesson_id: 2,
+        position_seconds: 42
+      })
+    })
+
+    test('starts at 0 (no seek) when a different chapter holds the bookmark', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 99, last_position_seconds: 42 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+
+      expect(player.seek).not.toHaveBeenCalled()
+      expect(mutateSpy).toHaveBeenCalledWith({
+        collection_id: 5,
+        lesson_id: 2,
+        position_seconds: 0
+      })
+    })
+
+    test('restarts the chapter when the stored offset is at the very end', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 119 })
+      const player = makePlayer({ duration: ref(120) })
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+
+      expect(player.seek).not.toHaveBeenCalled()
+      expect(mutateSpy).toHaveBeenCalledWith({
+        collection_id: 5,
+        lesson_id: 2,
+        position_seconds: 0
+      })
+    })
+
+    test('does not re-seek when the collection cache is patched under the same chapter', async () => {
+      const data = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 42 })
+      collectionRef.current = data
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+      player.seek.mockClear()
+
+      data.value = { id: 5, last_lesson_id: 2, last_position_seconds: 0 }
+      await nextTick()
+
+      expect(player.seek).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('save', () => {
+    test('writes the position once playback advances a step', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 0 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+      mutateSpy.mockClear()
+      player.is_playing.value = true
+
+      player.current_time.value = 4
+      await nextTick()
+      expect(mutateSpy).not.toHaveBeenCalled()
+
+      player.current_time.value = 6
+      await nextTick()
+      expect(mutateSpy).toHaveBeenCalledWith({
+        collection_id: 5,
+        lesson_id: 2,
+        position_seconds: 6
+      })
+    })
+
+    test('flushes the exact spot when playback pauses', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 0 })
+      const player = makePlayer()
+      ;[, app] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      player.is_playing.value = true
+      await nextTick()
+      mutateSpy.mockClear()
+
+      player.current_time.value = 3.5
+      player.is_playing.value = false
+      await nextTick()
+
+      expect(mutateSpy).toHaveBeenCalledWith({
+        collection_id: 5,
+        lesson_id: 2,
+        position_seconds: 3.5
+      })
+    })
+
+    test('saves on unmount so leaving the reader keeps the spot', async () => {
+      collectionRef.current = ref({ id: 5, last_lesson_id: 2, last_position_seconds: 0 })
+      const player = makePlayer()
+      let localApp
+      ;[, localApp] = withSetup(() => useReaderProgress(ref(5), ref(2), player))
+
+      player.loaded.value = true
+      await nextTick()
+      player.current_time.value = 12
+      mutateSpy.mockClear()
+
+      localApp.unmount()
+
+      expect(mutateSpy).toHaveBeenCalledWith({
+        collection_id: 5,
+        lesson_id: 2,
+        position_seconds: 12
+      })
+    })
+  })
+})

--- a/types/lesson.d.ts
+++ b/types/lesson.d.ts
@@ -62,6 +62,9 @@ type LessonCollection = {
   // The last chapter the member opened — the dashboard reopens the book here.
   // null/absent until they open the collection for the first time.
   last_lesson_id?: number | null
+  // Audio offset (seconds) within last_lesson_id where the member left off, so the
+  // reader resumes mid-chapter. One resume point per book; defaults to 0.
+  last_position_seconds?: number | null
   created_at?: string
   updated_at?: string
 }


### PR DESCRIPTION
## Summary

The reader already remembered **which** chapter you left off on (the collection's `last_lesson_id` bookmark); now it also remembers **where in that chapter** — at audio-timestamp precision, which maps straight back to the exact word via the existing transcript sync. A refresh mid-chapter now resumes in place instead of jumping to 0:00.

- **DB:** new `last_position_seconds` column on `lesson_collections`, paired with `last_lesson_id` (one resume point per book). View rebuilt to surface it. No new RLS/RPC — the owner-update policy already covers it.
- **API:** `setCollectionProgress` carries the offset; the mutation patches the collection caches in place (`setQueryData`) instead of invalidating, so the throttled position saves during playback don't refetch per tick.
- **Reader:** new `useReaderProgress` composable seeks to the stored offset when reopening the bookmarked chapter (staying paused) and saves while listening — throttled by playback progress, plus on pause, tab-hide, and unmount. `useAudioPlayer` gained a `loaded` flag so the restoring seek waits for the current chapter's metadata.

One resume point per book: opening a different chapter than the bookmark starts at 0 and becomes the new bookmark.