### PR TITLE
fix(sfx): keep the AudioContext alive across iOS interruptions

### DIFF
--- a/src/sfx/lifecycle.ts
+++ b/src/sfx/lifecycle.ts
@@ -31,18 +31,19 @@ export function installAudioLifecycle(): () => void {
   if (installed || typeof window === 'undefined') return () => {}
   installed = true
 
+  // Resume whenever the context isn't running — this covers both 'suspended'
+  // and WebKit's non-standard 'interrupted' state (iOS device lock / app
+  // switch), which the page never reaches via a plain 'suspended' check.
   const tryResume = async () => {
     const ctx = Howler.ctx
-    if (!ctx) return
-    if (ctx.state === 'suspended') {
-      try {
-        await ctx.resume()
-      } catch {
-        armGestureRetry()
-        return
-      }
+    if (!ctx || ctx.state === 'running') return
+    try {
+      await ctx.resume()
+    } catch {
+      armGestureRetry()
+      return
     }
-    if (ctx.state !== 'running') armGestureRetry()
+    if (Howler.ctx?.state !== 'running') armGestureRetry()
   }
 
   const gestureResume = async () => {
@@ -75,14 +76,22 @@ export function installAudioLifecycle(): () => void {
     if (document.visibilityState === 'visible') void tryResume()
   }
 
+  // The context fires statechange the moment iOS interrupts it — a more direct
+  // signal than waiting for the page to become visible again.
+  const onStateChange = () => {
+    if (Howler.ctx && Howler.ctx.state !== 'running') void tryResume()
+  }
+
   document.addEventListener('visibilitychange', onVisibility)
   window.addEventListener('pageshow', tryResume)
   window.addEventListener('focus', tryResume)
+  Howler.ctx?.addEventListener('statechange', onStateChange)
 
   return () => {
     document.removeEventListener('visibilitychange', onVisibility)
     window.removeEventListener('pageshow', tryResume)
     window.removeEventListener('focus', tryResume)
+    Howler.ctx?.removeEventListener('statechange', onStateChange)
     removeGestureListeners()
     installed = false
     gestureArmed = false

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -30,6 +30,15 @@ const DEFAULT_CATEGORY_VOLUME = 1
 const DEBOUNCE_DELAY = 10
 const QUEUE_TIMEOUT = 10
 
+// Howler suspends the AudioContext after 30s of silence to save power, then
+// relies on _autoResume() to revive it. On iOS that desyncs badly: locking the
+// phone or backgrounding the tab also interrupts the audio session (WebKit's
+// 'interrupted' ctx state), and Howler's internal state machine wedges so every
+// later play() is silently dropped — while the audio-reader's HTMLAudioElement
+// keeps working on its own audio session. SFX are tiny and infrequent, so the
+// power saving isn't worth the silence; lifecycle.ts owns resume instead.
+Howler.autoSuspend = false
+
 class AudioPlayer {
   loaded_sounds = new Map<string, Howl>()
   initialized = false

--- a/tests/unit/sfx/lifecycle.test.js
+++ b/tests/unit/sfx/lifecycle.test.js
@@ -1,14 +1,28 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 
+const stateListeners = new Set()
+
 const mockCtx = {
   state: 'running',
-  resume: vi.fn()
+  resume: vi.fn(),
+  addEventListener: vi.fn((type, handler) => {
+    if (type === 'statechange') stateListeners.add(handler)
+  }),
+  removeEventListener: vi.fn((type, handler) => {
+    if (type === 'statechange') stateListeners.delete(handler)
+  })
 }
+
+function fireStateChange() {
+  for (const handler of stateListeners) handler()
+}
+
+let currentCtx = mockCtx
 
 vi.mock('howler', () => ({
   Howler: {
     get ctx() {
-      return mockCtx
+      return currentCtx
     }
   }
 }))
@@ -35,6 +49,8 @@ describe('installAudioLifecycle', () => {
 
   beforeEach(async () => {
     vi.resetModules()
+    stateListeners.clear()
+    currentCtx = mockCtx
     mockCtx.state = 'running'
     mockCtx.resume = vi.fn().mockResolvedValue(undefined)
   })
@@ -98,6 +114,47 @@ describe('installAudioLifecycle', () => {
     await flushMicrotasks()
 
     expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+  })
+
+  test('resumes interrupted context when tab becomes visible', async () => {
+    mockCtx.state = 'interrupted'
+    mockCtx.resume.mockImplementation(async () => {
+      mockCtx.state = 'running'
+    })
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireVisibility('visible')
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+  })
+
+  test('resumes context when it fires statechange away from running', async () => {
+    mockCtx.state = 'suspended'
+    mockCtx.resume.mockImplementation(async () => {
+      mockCtx.state = 'running'
+    })
+
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireStateChange()
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).toHaveBeenCalledTimes(1)
+  })
+
+  test('ignores statechange when context is already running', async () => {
+    mockCtx.state = 'running'
+    const installAudioLifecycle = await loadLifecycle()
+    teardown = installAudioLifecycle()
+
+    fireStateChange()
+    await flushMicrotasks()
+
+    expect(mockCtx.resume).not.toHaveBeenCalled()
   })
 
   test('skips resume when context already running', async () => {
@@ -183,6 +240,7 @@ describe('installAudioLifecycle', () => {
     fireVisibility('visible')
     window.dispatchEvent(new Event('pageshow'))
     window.dispatchEvent(new Event('focus'))
+    fireStateChange()
     await flushMicrotasks()
 
     expect(mockCtx.resume).not.toHaveBeenCalled()
@@ -205,11 +263,7 @@ describe('installAudioLifecycle', () => {
   })
 
   test('handles missing AudioContext gracefully', async () => {
-    const originalCtx = mockCtx.state
-    Object.defineProperty(mockCtx, 'state', {
-      configurable: true,
-      get: () => undefined
-    })
+    currentCtx = null
 
     const installAudioLifecycle = await loadLifecycle()
     teardown = installAudioLifecycle()
@@ -218,11 +272,5 @@ describe('installAudioLifecycle', () => {
     await flushMicrotasks()
 
     expect(mockCtx.resume).not.toHaveBeenCalled()
-
-    Object.defineProperty(mockCtx, 'state', {
-      configurable: true,
-      writable: true,
-      value: originalCtx
-    })
   })
 })


### PR DESCRIPTION
## Summary

UI sound effects went silent after the phone slept or the tab was backgrounded, while the audio-reader kept playing. The two run on separate audio paths — the audio-reader is a native `HTMLAudioElement` (own iOS audio session, survives), UI SFX are Howler/Web Audio — so only the SFX `AudioContext` died.

Two compounding Web Audio issues, both fixed:

- **Howler `autoSuspend`** suspended the context after 30s of silence and relied on `_autoResume()` to revive it. On iOS that desyncs with the system audio-session interruption (`'interrupted'` ctx state), wedging Howler's state machine so later plays are silently dropped. Disabled it — SFX are tiny and `lifecycle.ts` owns resume.
- The lifecycle watcher only recovered from `'suspended'`, never WebKit's `'interrupted'` state. Now resumes on any non-running state, and also listens to the context's own `statechange` event for the most direct signal.

Adds unit coverage for the interrupted-state and `statechange` recovery paths.

> [!NOTE]
> WebKit-on-device only — can't be reproduced in Chrome mobile mode (Blink). Needs a real-iPhone check: sleep/background for a minute, return, confirm SFX fire on the next tap.