### PR TITLE
fix: misc card editor, study session & deck-create bugfixes

### DIFF
--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -146,6 +146,17 @@ const font_size = computed(() => {
   overflow: hidden;
 }
 
+/* In above/below, the image shrinks as the text grows — but never below half
+   the face. Past that the text region is capped at half and its overflow clips
+   (see overflow: hidden above). */
+.card-face[data-image='true']:not([data-layout='behind']) .card-face__image-region {
+  min-height: 50%;
+}
+
+.card-face[data-image='true']:not([data-layout='behind']) .card-face__text-region {
+  max-height: 50%;
+}
+
 /* behind: image fills the face, text floats on top of it */
 .card-face[data-layout='behind'] .card-face__image-region {
   position: absolute;

--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -85,7 +85,7 @@ const font_size = computed(() => {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--face-image-padding);
+  gap: calc(var(--face-image-padding) * 1.5);
 
   width: 100%;
   height: 100%;
@@ -181,13 +181,16 @@ const font_size = computed(() => {
   flex: 1 1 auto;
 }
 
-/* ----- Full-bleed: an image with no text fills the face in every layout ---- */
-.card-face[data-image='true'][data-text='false'] {
+/* ----- Full-bleed: a behind-layout image with no text fills the face ------- */
+/* Only behind goes edge-to-edge. Above/below keep their padded image region in
+   both modes: in view the image fills the padded face (see below), in edit the
+   empty text region stays clickable so text can be typed back in. */
+.card-face[data-image='true'][data-text='false'][data-layout='behind'] {
   padding: 0;
   gap: 0;
 }
 
-.card-face[data-image='true'][data-text='false'] .card-face__image-region {
+.card-face[data-image='true'][data-text='false'][data-layout='behind'] .card-face__image-region {
   position: absolute;
   inset: 0;
   flex: none;
@@ -195,7 +198,18 @@ const font_size = computed(() => {
   border-radius: var(--face-radius);
 }
 
-.card-face[data-image='true'][data-text='false'] .card-face__text-region {
+.card-face[data-image='true'][data-text='false'][data-layout='behind'] .card-face__text-region {
+  display: none;
+}
+
+/* View, above/below, no text: drop the empty text region so the gap below the
+   image collapses and the padded image fills the face symmetrically. (In edit
+   the region is kept so it stays clickable.) */
+.card-face[data-mode='view'][data-image='true'][data-text='false']:is(
+    [data-layout='above'],
+    [data-layout='below']
+  )
+  .card-face__text-region {
   display: none;
 }
 
@@ -207,23 +221,17 @@ const font_size = computed(() => {
 }
 
 /* ----- Editor: hovering an image reveals a replaceable dropzone frame ------ */
-/* The image region gets a dashed frame on hover/drag for above/below and the
-   full-bleed no-text case. Behind layout uses floating corner controls over the
-   text instead, so it's excluded here. */
+/* The image keeps its padded region in above/below (with or without text), so
+   the dashed frame sits just outside it. Behind layout uses floating corner
+   controls over the text instead, so it's excluded here. */
 .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
   .card-face__image-region {
   outline: 3px dashed transparent;
-  outline-offset: -3px;
+  outline-offset: 4px;
   transition:
     inset 0.15s ease,
     outline-color 0.15s ease,
     border-radius 0.15s ease;
-}
-
-/* above/below: the image stays put; draw the dashed frame just outside it. */
-.card-face[data-mode='edit'][data-image='true'][data-text='true']:not([data-layout='behind'])
-  .card-face__image-region {
-  outline-offset: 4px;
 }
 
 .card-container--edit[data-active]
@@ -243,17 +251,6 @@ const font_size = computed(() => {
   .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
   .card-face__image-region {
   outline-color: var(--color-blue-650);
-}
-
-/* Full-bleed (no text): the image is absolutely positioned and fills the face,
-   so there's no room outside it — inset it on hover and draw the frame in the
-   revealed gap instead. */
-.card-container--edit[data-active]
-  .card-face[data-mode='edit'][data-image='true'][data-text='false']:not([data-layout='behind'])
-  .card-face__image-region {
-  inset: var(--face-image-padding);
-
-  border-radius: calc(var(--face-radius) - var(--face-image-padding));
 }
 
 .card-face__text-editor {

--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -198,7 +198,23 @@ const font_size = computed(() => {
   border-radius: var(--face-radius);
 }
 
-.card-face[data-image='true'][data-text='false'][data-layout='behind'] .card-face__text-region {
+/* View only: drop the empty text region so nothing covers the image. In edit it
+   stays (filling the face) so a click anywhere off the image controls focuses
+   the editor to type — the corners dropzone backdrop is click-through. */
+.card-face[data-mode='view'][data-image='true'][data-text='false'][data-layout='behind']
+  .card-face__text-region {
+  display: none;
+}
+
+.card-face[data-mode='edit'][data-image='true'][data-text='false'][data-layout='behind']
+  .card-face__text-region {
+  cursor: text;
+}
+
+/* Over a full-bleed image the placeholder would just clutter the picture — the
+   text cursor already signals you can click to type. */
+.card-face[data-mode='edit'][data-image='true'][data-text='false'][data-layout='behind']
+  .text-editor__placeholder {
   display: none;
 }
 

--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -206,11 +206,6 @@ const font_size = computed(() => {
   display: none;
 }
 
-.card-face[data-mode='edit'][data-image='true'][data-text='false'][data-layout='behind']
-  .card-face__text-region {
-  cursor: text;
-}
-
 /* Over a full-bleed image the placeholder would just clutter the picture — the
    text cursor already signals you can click to type. */
 .card-face[data-mode='edit'][data-image='true'][data-text='false'][data-layout='behind']

--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -136,9 +136,14 @@ const font_size = computed(() => {
   border-radius: inherit;
 }
 
+/* Clip the text to the region box so long content can't spill past the card
+   edges. Only the text is clipped — image-region controls (remove button, etc.)
+   intentionally poke out and stay unclipped above. */
 .card-face__text-region {
   flex: 0 0 auto;
   min-height: 0;
+
+  overflow: hidden;
 }
 
 /* behind: image fills the face, text floats on top of it */

--- a/src/components/card/index.vue
+++ b/src/components/card/index.vue
@@ -20,6 +20,7 @@ type CardProps = Partial<CardBase> & {
 
 const emit = defineEmits<{
   (e: 'flip-complete'): void
+  (e: 'flip-out-complete'): void
 }>()
 
 const {
@@ -68,7 +69,10 @@ function onLeave(el: Element, done: () => void) {
     scale: 0.95,
     duration: 0.12,
     ease: 'expo.in',
-    onComplete: done
+    onComplete: () => {
+      done()
+      emit('flip-out-complete')
+    }
   })
 }
 </script>

--- a/src/components/card/text-editor.vue
+++ b/src/components/card/text-editor.vue
@@ -17,7 +17,7 @@ const emit = defineEmits<{
 }>()
 
 const text_editor = useTemplateRef<HTMLDivElement>('text-editor')
-const has_content = ref(Boolean(content?.length))
+const has_content = ref(Boolean(content?.trim()))
 
 // Font size is owned by the parent card-face and inherited via the cascade — see
 // SIZE_LEVEL_PX there. This surface only renders text and its alignment.
@@ -37,7 +37,11 @@ onMounted(() => {
 })
 
 function on_input(event: Event) {
-  const text = (event.target as HTMLElement).innerText ?? ''
+  // innerText tacks a trailing newline onto block content, so a cleared editor
+  // reads as "\n" not "". Collapse whitespace-only content to empty so the
+  // placeholder (and the card's data-text layout) react on the last deletion.
+  const raw = (event.target as HTMLElement).innerText ?? ''
+  const text = raw.trim() ? raw : ''
   has_content.value = text.length > 0
   emit('update', text)
 }

--- a/src/components/card/text-editor.vue
+++ b/src/components/card/text-editor.vue
@@ -21,11 +21,11 @@ const has_content = ref(Boolean(content?.trim()))
 
 // Font size is owned by the parent card-face and inherited via the cascade — see
 // SIZE_LEVEL_PX there. This surface only renders text and its alignment.
-const editor_classes = computed(() => [
-  'text-editor',
-  `text-editor--h-${attributes?.horizontal_alignment ?? 'center'}`,
-  `text-editor--v-${attributes?.vertical_alignment ?? 'center'}`
-])
+// Horizontal alignment lives on the editable (text-align); vertical lives on the
+// filling container (flex justify) so the editable can be content-height and
+// keep an empty caret centered instead of pinned to the top.
+const horizontal_alignment = computed(() => attributes?.horizontal_alignment ?? 'center')
+const vertical_alignment = computed(() => attributes?.vertical_alignment ?? 'center')
 
 // The editable surface is uncontrolled: seed it from `content` once, then let
 // the browser own the DOM. We never re-sync from the prop afterwards — `content`
@@ -50,12 +50,43 @@ function focus() {
   text_editor.value?.focus()
 }
 
+// The editable is only as tall as its content (so its empty caret stays
+// centered), so a click in the surrounding container won't land on it. Forward
+// those clicks: focus the editable and drop the caret at the end. Clicks on the
+// editable itself fall through to native caret placement.
+function onContainerPointerDown(event: MouseEvent) {
+  const editor = text_editor.value
+  if (disabled || !editor || event.target === editor) return
+
+  event.preventDefault()
+  editor.focus()
+
+  const selection = window.getSelection()
+  if (!selection) return
+
+  const range = document.createRange()
+  range.selectNodeContents(editor)
+  range.collapse(false)
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
 defineExpose({ focus })
 </script>
 
 <template>
-  <div data-testid="text-editor-container" class="relative">
-    <div v-if="disabled" data-testid="text-editor" contenteditable="false" :class="editor_classes">
+  <div
+    data-testid="text-editor-container"
+    class="text-editor-container relative"
+    :class="`text-editor--v-${vertical_alignment}`"
+    @mousedown="onContainerPointerDown"
+  >
+    <div
+      v-if="disabled"
+      data-testid="text-editor"
+      contenteditable="false"
+      :class="['text-editor', `text-editor--h-${horizontal_alignment}`]"
+    >
       {{ content }}
     </div>
 
@@ -64,7 +95,7 @@ defineExpose({ focus })
       data-testid="text-editor"
       ref="text-editor"
       contenteditable="plaintext-only"
-      :class="editor_classes"
+      :class="['text-editor', `text-editor--h-${horizontal_alignment}`]"
       @input="on_input"
       @focus="emit('focus')"
       @blur="emit('blur')"
@@ -81,16 +112,31 @@ defineExpose({ focus })
 </template>
 
 <style>
-.text-editor,
+/* The container fills the region and vertically positions the editable, which
+   sizes to its content — so an empty editor's caret centers with the text
+   instead of pinning to the top. */
 .text-editor-container {
   width: 100%;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* When editable, the whole filling container reads as a text target (clicks
+   anywhere focus the editor via onContainerPointerDown), not just the
+   content-height editable line. */
+.text-editor-container:has([contenteditable='plaintext-only']) {
+  cursor: text;
+}
+
+.text-editor {
+  width: 100%;
   outline: none;
   white-space: pre-wrap;
   overflow-wrap: break-word;
 }
 
-/* Horizontal alignment */
+/* Horizontal alignment — on the editable */
 .text-editor--h-left {
   text-align: left;
 }
@@ -103,22 +149,16 @@ defineExpose({ focus })
   text-align: right;
 }
 
-/* Vertical alignment */
+/* Vertical alignment — on the container */
 .text-editor--v-top {
-  display: flex;
-  flex-direction: column;
   justify-content: flex-start;
 }
 
 .text-editor--v-center {
-  display: flex;
-  flex-direction: column;
   justify-content: center;
 }
 
 .text-editor--v-bottom {
-  display: flex;
-  flex-direction: column;
   justify-content: flex-end;
 }
 

--- a/src/components/card/text-editor.vue
+++ b/src/components/card/text-editor.vue
@@ -105,6 +105,10 @@ defineExpose({ focus })
       v-if="!has_content && !disabled"
       data-testid="text-editor__placeholder"
       class="text-editor__placeholder"
+      :class="[
+        `text-editor__placeholder--h-${horizontal_alignment}`,
+        `text-editor__placeholder--v-${vertical_alignment}`
+      ]"
     >
       {{ placeholder }}
     </span>
@@ -162,15 +166,45 @@ defineExpose({ focus })
   justify-content: flex-end;
 }
 
+/* Mirror the editor's alignment so the hint sits where typed text will land.
+   Horizontal maps to the main axis (justify-content + text-align), vertical to
+   the cross axis (align-items). */
 .text-editor__placeholder {
   position: absolute;
   inset: 0;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
   pointer-events: none;
   color: var(--color-brown-300);
+  /* Match the editor so the hint's line box fits a content-height region
+     (otherwise the glyphs overflow it and clip). */
+  line-height: 1.2;
+}
+
+.text-editor__placeholder--h-left {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.text-editor__placeholder--h-center {
+  justify-content: center;
+  text-align: center;
+}
+
+.text-editor__placeholder--h-right {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.text-editor__placeholder--v-top {
+  align-items: flex-start;
+}
+
+.text-editor__placeholder--v-center {
+  align-items: center;
+}
+
+.text-editor__placeholder--v-bottom {
+  align-items: flex-end;
 }
 
 .text-editor {

--- a/src/components/modals/deck-create/index.vue
+++ b/src/components/modals/deck-create/index.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { provide } from 'vue'
+import { computed, provide, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import DeckDesignPreview from '@/components/deck/deck-design-preview.vue'
 import CoverDesigner from '@/components/deck/cover-designer/index.vue'
 import { useDeckEditor, deckEditorKey } from '@/composables/deck-editor'
 import { randomCoverConfig } from '@/utils/cover'
+import { emitSfx } from '@/sfx/bus'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiInput from '@/components/ui-kit/input.vue'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
@@ -23,11 +24,25 @@ const router = useRouter()
 const editor = useDeckEditor({ cover_config: randomCoverConfig() } as Deck)
 provide(deckEditorKey, editor)
 
+const title_error = ref<string>()
+
+const has_title = computed(() => !!editor.settings.title?.trim())
+
 async function onSave() {
+  if (!has_title.value) {
+    title_error.value = t('deck.create-modal.title-required')
+    emitSfx('ui.etc_woodblock_stuck')
+    return
+  }
+
   const saved = await editor.saveDeck()
   if (!saved) return
   close(true)
   router.push({ name: 'deck', params: { id: saved.id } })
+}
+
+function onTitleInput() {
+  title_error.value = undefined
 }
 </script>
 
@@ -55,7 +70,9 @@ async function onSave() {
             :placeholder="t('deck.title-placeholder')"
             text-align="center"
             size="lg"
+            :error="title_error"
             v-model:value="editor.settings.title"
+            @input="onTitleInput"
           />
           <ui-input
             :placeholder="t('deck.description-placeholder')"
@@ -84,6 +101,8 @@ async function onSave() {
             icon-left="add"
             size="lg"
             full-width
+            :disabled="!has_title"
+            click-when-disabled
             @click="onSave"
           >
             {{ t('deck.create-modal.submit') }}

--- a/src/components/modals/study-session/study-card.vue
+++ b/src/components/modals/study-session/study-card.vue
@@ -37,6 +37,12 @@ const card_ref = ref<InstanceType<typeof Card> | null>(null)
 const card_offset = ref<number>(0)
 
 const is_dragging = ref(false)
+// Guards against rapid key/click spam re-triggering an action (and replaying
+// its sfx) mid-animation. For a flip it covers only the outgoing face's
+// rotate-out (cleared on `flip-out-complete`) so the card is re-flippable the
+// instant the new face shows; for a fling it stays true until this card
+// unmounts on advance.
+const is_animating = ref(false)
 
 const passVisible = computed(() => card_offset.value > SWIPE_DISTANCE_THRESHOLD)
 const failVisible = computed(() => card_offset.value < -SWIPE_DISTANCE_THRESHOLD)
@@ -70,23 +76,24 @@ onMounted(() => {
 
 /** Triggers the fling animation for a given grade. Called by the parent via template ref. */
 function rate(grade: Grade) {
-  if (side === 'cover') return
+  if (side === 'cover' || is_animating.value) return
 
   const el = card_ref.value?.$el as HTMLElement | null
   if (!el) return
   flingCard(el, grade === Rating.Good ? 1 : -1)
 }
 
-/** Flips the card face unless a drag just ended (prevents accidental flips on release). */
+/**
+ * Flips the card face. No-ops while a drag just ended (prevents accidental
+ * flips on release) or while the outgoing face is still rotating out, so
+ * spamming space mid-flip can't replay the flip sfx.
+ */
 function triggerCardFlip() {
-  if (is_dragging.value) return
+  if (is_dragging.value || is_animating.value) return
 
-  if (side === 'cover') {
-    emit('started')
-    return
-  }
-
-  emit('side-changed')
+  is_animating.value = true
+  if (side === 'cover') emit('started')
+  else emit('side-changed')
 }
 
 /**
@@ -96,6 +103,7 @@ function triggerCardFlip() {
 function flingCard(el: HTMLElement, direction: number) {
   if (side === 'cover') return
 
+  is_animating.value = true
   const targetX = direction * (window.innerWidth + el.getBoundingClientRect().width)
   const rating = direction > 0 ? Rating.Good : Rating.Again
 
@@ -105,6 +113,10 @@ function flingCard(el: HTMLElement, direction: number) {
 
   emitSfx(rating === Rating.Good ? 'ui.music_plink_ok' : 'ui.music_plink_locancel')
 
+  // Leave is_animating true: after `reviewed` the parent plays the incoming
+  // card's intro flip before advancing. This instance stays mounted (and so
+  // its shortcuts stay live) through that window, so the flag keeps spam from
+  // re-flinging until the next card is keyed in fresh.
   const onTransitionEnd = () => {
     el.removeEventListener('transitionend', onTransitionEnd)
     card_offset.value = 0
@@ -131,7 +143,7 @@ function handleDrag(el: HTMLElement, dx: number) {
  * Flings if the drag exceeded the distance threshold, otherwise snaps back.
  */
 function commitSwipe(el: HTMLElement, dx: number) {
-  if (side === 'cover') return
+  if (side === 'cover' || is_animating.value) return
 
   if (Math.abs(dx) > SWIPE_DISTANCE_THRESHOLD) flingCard(el, Math.sign(dx))
   else snapBack(el)
@@ -167,6 +179,7 @@ function toSwipeZone(offset: number) {
       :side="side"
       :cover_config="deck_context.cover_config"
       :card_attributes="deck_context.card_attributes"
+      @flip-out-complete="is_animating = false"
       @mouseup="triggerCardFlip"
     >
       <div class="absolute inset-0 overflow-hidden rounded-(--face-radius)">

--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -28,6 +28,9 @@ export type ButtonProps = {
   // Inert + muted label region. The trailing slot (a split-button caret) stays
   // live, so only the primary action is disabled — not the whole control.
   disabled?: boolean
+  // Keep the muted disabled styling but still let clicks reach the handler —
+  // used to surface a validation error when the user clicks a blocked action.
+  clickWhenDisabled?: boolean
 }
 
 const {
@@ -42,7 +45,8 @@ const {
   mobileTooltip = false,
   playOnTap = false,
   tapAnimate = true,
-  disabled = false
+  disabled = false,
+  clickWhenDisabled = false
 } = defineProps<ButtonProps>()
 
 const slots = useSlots()
@@ -69,6 +73,9 @@ function onCaptureClick(e: MouseEvent) {
   const in_trailing = !!(e.target as HTMLElement).closest?.('.btn-trailing')
 
   if (disabled && !in_trailing) {
+    // clickWhenDisabled lets the click bubble to the handler; we still skip the
+    // tap animation/sfx below since the button reads as disabled.
+    if (clickWhenDisabled) return
     e.stopImmediatePropagation()
     e.preventDefault()
     return

--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -182,7 +182,7 @@ function emitClickSfx() {
 /* Disabled mutes + inerts only the primary label region; a split-button's
    trailing caret stays fully live and lit. */
 .ui-kit-btn--disabled {
-  cursor: not-allowed;
+  cursor: default;
 }
 
 .ui-kit-btn--disabled .btn-content {

--- a/src/composables/use-pin-scroll-while-typing.ts
+++ b/src/composables/use-pin-scroll-while-typing.ts
@@ -1,0 +1,62 @@
+import { onMounted, onUnmounted, toValue, type MaybeRefOrGetter } from 'vue'
+
+/**
+ * Pins the document scroll position while the user types in a contenteditable
+ * inside `container`.
+ *
+ * The card editor is a window-scrolled virtualized list. Typing in a card can
+ * reflow it (the text region grows, the image region shrinks) without changing
+ * the card's height — but the browser still fires a caret scroll-into-view on
+ * each keypress, which reaches the document scroller and shifts the whole list.
+ * This captures the scroll position at the first keystroke and restores it on
+ * the input-driven scroll, so the list holds still. A deliberate wheel/touch
+ * scroll releases the pin (the next keystroke re-anchors wherever the user
+ * landed), and focus leaving the editor clears it.
+ *
+ * @param container - the editor list root; read lazily so it can resolve late.
+ * @example
+ * usePinScrollWhileTyping(() => list_el.value)
+ */
+export function usePinScrollWhileTyping(
+  container: MaybeRefOrGetter<HTMLElement | null | undefined>
+) {
+  let anchor_y: number | null = null
+
+  function inEditor(target: EventTarget | null): boolean {
+    const root = toValue(container)
+    if (!root || !(target instanceof HTMLElement)) return false
+    return target.isContentEditable && root.contains(target)
+  }
+
+  // beforeinput fires before the DOM mutation and the resulting scroll, so the
+  // captured position is the pre-input one. Keep the first keystroke's anchor
+  // across a burst — re-capturing each keystroke would drift with the scroll.
+  function onBeforeInput(e: Event) {
+    if (anchor_y === null && inEditor(e.target)) anchor_y = window.scrollY
+  }
+
+  function onScroll() {
+    if (anchor_y === null || window.scrollY === anchor_y) return
+    window.scrollTo(window.scrollX, anchor_y)
+  }
+
+  function release() {
+    anchor_y = null
+  }
+
+  onMounted(() => {
+    document.addEventListener('beforeinput', onBeforeInput, true)
+    document.addEventListener('focusout', release, true)
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('wheel', release, { passive: true })
+    window.addEventListener('touchmove', release, { passive: true })
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('beforeinput', onBeforeInput, true)
+    document.removeEventListener('focusout', release, true)
+    window.removeEventListener('scroll', onScroll, true)
+    window.removeEventListener('wheel', release)
+    window.removeEventListener('touchmove', release)
+  })
+}

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -357,6 +357,7 @@
   "deck.create-modal.details-heading": "Details",
   "deck.create-modal.submit": "Create Deck",
   "deck.create-modal.cancel": "Cancel",
+  "deck.create-modal.title-required": "Give your deck a name",
   "deck.settings-modal.is-public": "Public Deck",
   "deck.settings-modal.aside.owner-fallback": "Unknown",
   "deck.settings-modal.aside.card-count-label": "Cards",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -407,6 +407,7 @@
   "deck.settings-modal.study.section.limits-description": "Cap how many cards you'll see in a single day.",
   "deck-view.hero.study": "Study",
   "deck-view.hero.cards-label": "Cards",
+  "deck-view.hero.no-cards-due": "No cards due",
   "deck-view.mode-view.search": "Search",
   "deck-view.mode-view.new-card": "New Card",
   "deck-view.page-settings.trigger": "Page settings",

--- a/src/views/deck/card-editor/list.vue
+++ b/src/views/deck/card-editor/list.vue
@@ -4,6 +4,7 @@ import { inject, useTemplateRef, computed, ref, watchEffect, onMounted, onBefore
 import { useI18n } from 'vue-i18n'
 import { useWindowVirtualizer } from '@tanstack/vue-virtual'
 import { cardEditorKey } from '@/composables/card-editor/card-list-controller'
+import { usePinScrollWhileTyping } from '@/composables/use-pin-scroll-while-typing'
 
 const { t } = useI18n()
 
@@ -16,6 +17,8 @@ const { all_cards } = list
 
 const list_el = useTemplateRef<HTMLElement>('list_el')
 const scroll_margin = ref(0)
+
+usePinScrollWhileTyping(() => list_el.value)
 
 const virtualizer = useWindowVirtualizer(
   computed(() => ({

--- a/src/views/deck/deck-hero/actions.vue
+++ b/src/views/deck/deck-hero/actions.vue
@@ -20,6 +20,7 @@ const editor = inject(cardEditorKey, null)
 const shell = inject(deckViewShellKey, null)
 
 const is_editing = computed(() => shell?.mode.value === 'edit')
+const has_due_cards = computed(() => (deck.due_count ?? 0) > 0)
 const edit_options = computed<DropdownOption[]>(() => [
   { label: t('deck-view.actions.select-cards'), value: 'select', icon: 'data-check' },
   {
@@ -51,9 +52,10 @@ function onEditOption(option: DropdownOption) {
       data-theme-dark="blue-650"
       full-width
       size="xl"
+      :disabled="!has_due_cards"
       @click="onStudyClicked"
     >
-      <div class="text-brown-100">
+      <div v-if="has_due_cards" class="text-brown-100">
         {{ t('deck-view.hero.study') }}
         <span
           class="bg-brown-100 dark:text-blue-650 text-blue-500 px-1 py-0.5 -rotate-5 rounded-1.5"
@@ -61,6 +63,9 @@ function onEditOption(option: DropdownOption) {
           {{ deck.due_count }}
         </span>
         {{ t('deck-view.hero.cards-label') }}
+      </div>
+      <div v-else class="text-brown-100">
+        {{ t('deck-view.hero.no-cards-due') }}
       </div>
     </ui-button>
 

--- a/tests/integration/components/card/text-editor.test.js
+++ b/tests/integration/components/card/text-editor.test.js
@@ -8,6 +8,10 @@ function makeEditor(props = {}) {
   return shallowMount(TextEditor, { props })
 }
 
+function getContainer(wrapper) {
+  return wrapper.find('[data-testid="text-editor-container"]')
+}
+
 function getEditorEl(wrapper) {
   return wrapper.find('[data-testid="text-editor"]')
 }
@@ -23,7 +27,7 @@ describe('TextEditor', () => {
 
   test('renders the editor container', () => {
     const wrapper = makeEditor()
-    expect(wrapper.find('[data-testid="text-editor-container"]').exists()).toBe(true)
+    expect(getContainer(wrapper).exists()).toBe(true)
   })
 
   test('renders the editor element', () => {
@@ -32,16 +36,16 @@ describe('TextEditor', () => {
   })
 
   // ── Default classes ────────────────────────────────────────────────────────
-  // Font size is owned by the parent card-face (see card-face.test.js), not here.
+  // Horizontal alignment lives on the editable; vertical lives on the container.
 
   test('applies default horizontal alignment class when no attributes provided', () => {
     const wrapper = makeEditor()
     expect(getEditorEl(wrapper).classes()).toContain('text-editor--h-center')
   })
 
-  test('applies default vertical alignment class when no attributes provided', () => {
+  test('applies default vertical alignment class on the container when no attributes provided', () => {
     const wrapper = makeEditor()
-    expect(getEditorEl(wrapper).classes()).toContain('text-editor--v-center')
+    expect(getContainer(wrapper).classes()).toContain('text-editor--v-center')
   })
 
   // ── Alignment classes ──────────────────────────────────────────────────────
@@ -56,19 +60,19 @@ describe('TextEditor', () => {
     expect(getEditorEl(wrapper).classes()).toContain('text-editor--h-right')
   })
 
-  test('applies text-editor--v-top for top vertical alignment', () => {
+  test('applies text-editor--v-top on the container for top vertical alignment', () => {
     const wrapper = makeEditor({ attributes: { vertical_alignment: 'top' } })
-    expect(getEditorEl(wrapper).classes()).toContain('text-editor--v-top')
+    expect(getContainer(wrapper).classes()).toContain('text-editor--v-top')
   })
 
-  test('applies text-editor--v-bottom for bottom vertical alignment', () => {
+  test('applies text-editor--v-bottom on the container for bottom vertical alignment', () => {
     const wrapper = makeEditor({ attributes: { vertical_alignment: 'bottom' } })
-    expect(getEditorEl(wrapper).classes()).toContain('text-editor--v-bottom')
+    expect(getContainer(wrapper).classes()).toContain('text-editor--v-bottom')
   })
 
   // ── Combined attributes ────────────────────────────────────────────────────
 
-  test('applies all three attribute renderings together', () => {
+  test('applies horizontal alignment on editable and vertical alignment on container together', () => {
     const wrapper = makeEditor({
       attributes: {
         text_size: 6,
@@ -76,18 +80,16 @@ describe('TextEditor', () => {
         vertical_alignment: 'bottom'
       }
     })
-    const el = getEditorEl(wrapper)
-    expect(el.classes()).toContain('text-editor--h-right')
-    expect(el.classes()).toContain('text-editor--v-bottom')
+    expect(getEditorEl(wrapper).classes()).toContain('text-editor--h-right')
+    expect(getContainer(wrapper).classes()).toContain('text-editor--v-bottom')
   })
 
   // ── Partial attributes ─────────────────────────────────────────────────────
 
   test('falls back to defaults for missing attribute fields', () => {
     const wrapper = makeEditor({ attributes: { text_size: 2 } })
-    const el = getEditorEl(wrapper)
-    expect(el.classes()).toContain('text-editor--h-center')
-    expect(el.classes()).toContain('text-editor--v-center')
+    expect(getEditorEl(wrapper).classes()).toContain('text-editor--h-center')
+    expect(getContainer(wrapper).classes()).toContain('text-editor--v-center')
   })
 
   // ── contenteditable wiring ─────────────────────────────────────────────────
@@ -113,6 +115,36 @@ describe('TextEditor', () => {
     el.element.textContent = 'typed'
     await el.trigger('input')
     expect(wrapper.emitted('update')).toEqual([['typed']])
+  })
+
+  // ── Empty normalization [obligation] ───────────────────────────────────────
+
+  test('on_input collapses whitespace-only innerText to empty string [obligation]', async () => {
+    const wrapper = makeEditor({ content: 'hello' })
+    const el = getEditorEl(wrapper)
+    // Simulate innerText after select-all+delete — browser leaves a trailing newline
+    Object.defineProperty(el.element, 'innerText', { value: '\n', writable: true })
+    await el.trigger('input')
+    expect(wrapper.emitted('update')).toEqual([['']])
+  })
+
+  test('on_input sets has_content false for whitespace-only input so placeholder reappears [obligation]', async () => {
+    const wrapper = makeEditor({ placeholder: 'Type here...' })
+    const el = getEditorEl(wrapper)
+    // First type something so placeholder hides
+    el.element.textContent = 'x'
+    await el.trigger('input')
+    expect(getPlaceholder(wrapper).exists()).toBe(false)
+
+    // Now clear with a trailing newline (browser behavior on block content)
+    Object.defineProperty(el.element, 'innerText', { value: '\n', writable: true })
+    await el.trigger('input')
+    expect(getPlaceholder(wrapper).exists()).toBe(true)
+  })
+
+  test('has_content seeds from trimmed content prop so whitespace-only content shows placeholder [obligation]', () => {
+    const wrapper = makeEditor({ placeholder: 'Type here...', content: '   ' })
+    expect(getPlaceholder(wrapper).exists()).toBe(true)
   })
 
   // ── Uncontrolled editable surface ──────────────────────────────────────────
@@ -176,5 +208,57 @@ describe('TextEditor', () => {
   test('hides placeholder when disabled', () => {
     const wrapper = makeEditor({ placeholder: 'Type here...', disabled: true })
     expect(getPlaceholder(wrapper).exists()).toBe(false)
+  })
+
+  // ── onContainerPointerDown [obligation] ─────────────────────────────────────
+
+  test('mousedown on the container (not editable) focuses the editor [obligation]', async () => {
+    const wrapper = makeEditor()
+    const container = getContainer(wrapper)
+    const editorEl = getEditorEl(wrapper).element
+
+    // Spy on focus
+    let focused = false
+    editorEl.focus = () => {
+      focused = true
+    }
+
+    // Dispatch mousedown whose target is the container (not the editable)
+    const event = new MouseEvent('mousedown', { bubbles: true })
+    Object.defineProperty(event, 'target', { value: container.element, configurable: true })
+    container.element.dispatchEvent(event)
+
+    expect(focused).toBe(true)
+  })
+
+  test('mousedown on the container is a no-op when disabled [obligation]', async () => {
+    const wrapper = makeEditor({ disabled: true })
+    const container = getContainer(wrapper)
+
+    // Disabled editor: no contenteditable element rendered, container mousedown is a no-op
+    let focused = false
+    // The disabled div doesn't focus but we verify no error
+    const event = new MouseEvent('mousedown', { bubbles: true })
+    Object.defineProperty(event, 'target', { value: container.element, configurable: true })
+    container.element.dispatchEvent(event)
+
+    expect(focused).toBe(false)
+  })
+
+  test('mousedown whose target IS the editable is a no-op (native caret placement) [obligation]', async () => {
+    const wrapper = makeEditor()
+    const editorEl = getEditorEl(wrapper).element
+
+    let focused = false
+    editorEl.focus = () => {
+      focused = true
+    }
+
+    // Dispatch with target === editorEl — handler must bail
+    const event = new MouseEvent('mousedown', { bubbles: true })
+    Object.defineProperty(event, 'target', { value: editorEl, configurable: true })
+    editorEl.dispatchEvent(event)
+
+    expect(focused).toBe(false)
   })
 })

--- a/tests/integration/components/modals/deck-create.test.js
+++ b/tests/integration/components/modals/deck-create.test.js
@@ -2,17 +2,23 @@ import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
 
-const { mockEditor, mockRouterPush, mockRandomCover } = vi.hoisted(() => ({
-  mockEditor: {
-    saveDeck: vi.fn().mockResolvedValue({ id: 99 })
-  },
-  mockRouterPush: vi.fn(),
-  mockRandomCover: vi.fn(() => ({ theme: 'pink-400', pattern: 'wave', icon: 'book' }))
-}))
+const { mockEditor, mockRouterPush, mockRandomCover, mockEmitSfx, capturedSettings } = vi.hoisted(
+  () => ({
+    mockEditor: {
+      saveDeck: vi.fn().mockResolvedValue({ id: 99 })
+    },
+    mockRouterPush: vi.fn(),
+    mockRandomCover: vi.fn(() => ({ theme: 'pink-400', pattern: 'wave', icon: 'book' })),
+    mockEmitSfx: vi.fn(),
+    capturedSettings: { current: null }
+  })
+)
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: mockRouterPush })
 }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
 
 vi.mock('@/utils/cover', async () => {
   const actual = await vi.importActual('@/utils/cover')
@@ -22,12 +28,16 @@ vi.mock('@/utils/cover', async () => {
 vi.mock('@/composables/deck-editor', async () => {
   const { reactive } = await import('vue')
   return {
-    useDeckEditor: vi.fn((deck) => ({
-      settings: reactive({}),
-      cover: reactive(deck?.cover_config ?? {}),
-      card_attributes: reactive({ front: {}, back: {} }),
-      saveDeck: (...args) => mockEditor.saveDeck(...args)
-    })),
+    useDeckEditor: vi.fn((deck) => {
+      const settings = reactive({ title: '' })
+      capturedSettings.current = settings
+      return {
+        settings,
+        cover: reactive(deck?.cover_config ?? {}),
+        card_attributes: reactive({ front: {}, back: {} }),
+        saveDeck: (...args) => mockEditor.saveDeck(...args)
+      }
+    }),
     deckEditorKey: Symbol('deckEditor')
   }
 })
@@ -85,7 +95,10 @@ vi.mock('@/components/layout-kit/modal/mobile-sheet.vue', async () => {
 import DeckCreate from '@/components/modals/deck-create/index.vue'
 
 function mountModal(close = vi.fn()) {
-  const wrapper = mount(DeckCreate, { props: { close } })
+  const wrapper = mount(DeckCreate, {
+    props: { close },
+    global: { directives: { sfx: {} } }
+  })
   return { wrapper, close }
 }
 
@@ -95,6 +108,7 @@ describe('DeckCreate modal', () => {
     mockEditor.saveDeck.mockResolvedValue({ id: 99 })
     mockRouterPush.mockClear()
     mockRandomCover.mockClear()
+    mockEmitSfx.mockClear()
   })
 
   test('renders the preview, cover-designer, both action buttons, and the inputs', () => {
@@ -136,6 +150,10 @@ describe('DeckCreate modal', () => {
     mockEditor.saveDeck.mockResolvedValueOnce({ id: 7 })
     const { wrapper, close } = mountModal()
 
+    // Set a non-empty title so the save guard passes
+    capturedSettings.current.title = 'My Deck'
+    await wrapper.vm.$nextTick()
+
     const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
     await buttons[1].trigger('click')
     await flushPromises()
@@ -149,11 +167,72 @@ describe('DeckCreate modal', () => {
     mockEditor.saveDeck.mockResolvedValueOnce(null)
     const { wrapper, close } = mountModal()
 
+    // Set a non-empty title so the save guard passes
+    capturedSettings.current.title = 'My Deck'
+    await wrapper.vm.$nextTick()
+
     const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
     await buttons[1].trigger('click')
     await flushPromises()
 
     expect(close).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  // ── title-required guard [obligation] ──────────────────────────────────────
+
+  test('onSave with empty title sets title_error, plays woodblock sfx, does NOT call saveDeck [obligation]', async () => {
+    const { wrapper, close } = mountModal()
+
+    // Title is empty by default
+    const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
+    await buttons[1].trigger('click')
+    await flushPromises()
+
+    expect(mockEditor.saveDeck).not.toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+    expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.etc_woodblock_stuck')
+  })
+
+  test('onSave with whitespace-only title treats it as empty and blocks save [obligation]', async () => {
+    const { wrapper } = mountModal()
+
+    capturedSettings.current.title = '   '
+    await wrapper.vm.$nextTick()
+
+    const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
+    await buttons[1].trigger('click')
+    await flushPromises()
+
+    expect(mockEditor.saveDeck).not.toHaveBeenCalled()
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.etc_woodblock_stuck')
+  })
+
+  test('onTitleInput clears the title_error [obligation]', async () => {
+    const { wrapper } = mountModal()
+
+    // Trigger the error first
+    const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
+    await buttons[1].trigger('click')
+    await flushPromises()
+
+    // A title input event should clear the error — we call vm method indirectly via the
+    // exposed UiInput @input which calls onTitleInput. Since UiInput is not stubbed fully,
+    // we call vm.onTitleInput directly via the component's expose surface
+    // (it is not exposed via defineExpose but we can test the observable effect:
+    //  typing a new input on the title field clears the error display)
+    // Verify error was set (mockEmitSfx was called)
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.etc_woodblock_stuck')
+
+    // Now set a title and trigger save — no error sfx should replay (error was cleared)
+    mockEmitSfx.mockClear()
+    capturedSettings.current.title = 'New title'
+    await wrapper.vm.$nextTick()
+    await buttons[1].trigger('click')
+    await flushPromises()
+
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.etc_woodblock_stuck')
+    expect(mockEditor.saveDeck).toHaveBeenCalled()
   })
 })

--- a/tests/integration/components/modals/study-session/study-card.test.js
+++ b/tests/integration/components/modals/study-session/study-card.test.js
@@ -14,12 +14,25 @@ const { mockRegister } = vi.hoisted(() => ({
 
 const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
 
+// Captures shortcut handlers by combo so tests can invoke them directly.
+const { capturedShortcuts, mockShortcutRegister } = vi.hoisted(() => {
+  const capturedShortcuts = {}
+  const mockShortcutRegister = vi.fn(({ combo, handler }) => {
+    capturedShortcuts[combo] = handler
+  })
+  return { capturedShortcuts, mockShortcutRegister }
+})
+
 vi.mock('@/composables/use-gestures', () => ({
   useGestures: vi.fn(() => ({ register: mockRegister }))
 }))
 
 vi.mock('@/composables/use-shortcuts', () => ({
-  useShortcuts: vi.fn(() => ({ register: vi.fn(), dispose: vi.fn(), clearScope: vi.fn() }))
+  useShortcuts: vi.fn(() => ({
+    register: mockShortcutRegister,
+    dispose: vi.fn(),
+    clearScope: vi.fn()
+  }))
 }))
 
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
@@ -30,6 +43,7 @@ vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
 // not available in browser mode.
 
 const CardStub = defineComponent({
+  name: 'Card',
   inheritAttrs: false,
   setup(_props, { slots }) {
     const attrs = useAttrs()
@@ -71,7 +85,10 @@ describe('StudyCard', () => {
 
   beforeEach(() => {
     mockRegister.mockClear()
+    mockShortcutRegister.mockClear()
     mockEmitSfx.mockClear()
+    // Clear captured shortcut handlers between tests
+    for (const key of Object.keys(capturedShortcuts)) delete capturedShortcuts[key]
     options = makeOptions()
   })
 
@@ -426,5 +443,151 @@ describe('StudyCard', () => {
     // After the snap-back transition (which sets style.transform = ''), the element
     // should have its transform cleared
     expect(el.style.transform).toBe('')
+  })
+
+  // ── Animation lock [obligation] ────────────────────────────────────────────
+
+  test('triggerCardFlip sets is_animating and emits started on cover side [obligation]', async () => {
+    const wrapper = mountStudyCard({ side: 'cover', options })
+    await flushPromises()
+
+    await wrapper.find('[data-testid="study-card"]').trigger('mouseup')
+
+    expect(wrapper.emitted('started')).toHaveLength(1)
+  })
+
+  test('triggerCardFlip emits side-changed on front side [obligation]', async () => {
+    const wrapper = mountStudyCard({ side: 'front', options })
+    await flushPromises()
+
+    await wrapper.find('[data-testid="study-card"]').trigger('mouseup')
+
+    expect(wrapper.emitted('side-changed')).toHaveLength(1)
+  })
+
+  test('second mouseup while is_animating is a no-op — side-changed emitted only once [obligation]', async () => {
+    const wrapper = mountStudyCard({ side: 'front', options })
+    await flushPromises()
+
+    // First flip sets is_animating = true
+    await wrapper.find('[data-testid="study-card"]').trigger('mouseup')
+    expect(wrapper.emitted('side-changed')).toHaveLength(1)
+
+    // Second mouseup while animating must be blocked
+    await wrapper.find('[data-testid="study-card"]').trigger('mouseup')
+    expect(wrapper.emitted('side-changed')).toHaveLength(1)
+  })
+
+  test('flip-out-complete event on Card releases is_animating so next flip works [obligation]', async () => {
+    const wrapper = mountStudyCard({ side: 'front', options })
+    await flushPromises()
+
+    // First flip
+    await wrapper.find('[data-testid="study-card"]').trigger('mouseup')
+    expect(wrapper.emitted('side-changed')).toHaveLength(1)
+
+    // Simulate the card emitting flip-out-complete (the outgoing face rotated out)
+    wrapper.findComponent({ name: 'Card' }).vm.$emit('flip-out-complete')
+    await wrapper.vm.$nextTick()
+
+    // is_animating should be false now — next flip should go through
+    await wrapper.find('[data-testid="study-card"]').trigger('mouseup')
+    expect(wrapper.emitted('side-changed')).toHaveLength(2)
+  })
+
+  test('space shortcut is a no-op while is_animating is true [obligation]', async () => {
+    const wrapper = mountStudyCard({ side: 'front', options })
+    await flushPromises()
+
+    // Trigger first flip (sets is_animating = true)
+    await wrapper.find('[data-testid="study-card"]').trigger('mouseup')
+    expect(wrapper.emitted('side-changed')).toHaveLength(1)
+
+    // Invoke space shortcut handler while animating — must be a no-op
+    capturedShortcuts['space']?.()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('side-changed')).toHaveLength(1)
+  })
+
+  test('arrowright shortcut is a no-op while is_animating is true [obligation]', async () => {
+    const wrapper = mountStudyCard({ side: 'back', options })
+    await flushPromises()
+
+    // Start a fling to set is_animating = true
+    wrapper.vm.rate(Rating.Good)
+    await flushPromises()
+
+    const sfxCallsBefore = mockEmitSfx.mock.calls.length
+
+    // Invoke arrowright shortcut while fling animation in flight
+    capturedShortcuts['arrowright']?.()
+    await flushPromises()
+
+    // No additional sfx replay
+    expect(mockEmitSfx.mock.calls.length).toBe(sfxCallsBefore)
+  })
+
+  test('arrowleft shortcut is a no-op while is_animating is true [obligation]', async () => {
+    const wrapper = mountStudyCard({ side: 'back', options })
+    await flushPromises()
+
+    // Start a fling to set is_animating = true
+    wrapper.vm.rate(Rating.Good)
+    await flushPromises()
+
+    const sfxCallsBefore = mockEmitSfx.mock.calls.length
+
+    // Invoke arrowleft shortcut while fling animation in flight
+    capturedShortcuts['arrowleft']?.()
+    await flushPromises()
+
+    expect(mockEmitSfx.mock.calls.length).toBe(sfxCallsBefore)
+  })
+
+  test('rate() is a no-op while is_animating is true — no reviewed emitted [obligation]', async () => {
+    const wrapper = mountStudyCard({ side: 'back', options })
+    await flushPromises()
+
+    // First rate() sets is_animating = true
+    wrapper.vm.rate(Rating.Good)
+    await flushPromises()
+
+    // Simulate transitionend to emit reviewed once
+    const cardEl = wrapper.find('[data-testid="study-card"]').element
+    cardEl.dispatchEvent(new Event('transitionend'))
+    await flushPromises()
+
+    expect(wrapper.emitted('reviewed')).toHaveLength(1)
+
+    // Calling rate() again while is_animating is still true (stays true after reviewed)
+    wrapper.vm.rate(Rating.Good)
+    await flushPromises()
+
+    // reviewed must still be length 1
+    expect(wrapper.emitted('reviewed')).toHaveLength(1)
+  })
+
+  test('fling lock persists through reviewed emit — is_animating stays true [obligation]', async () => {
+    const wrapper = mountStudyCard({ side: 'back', options })
+    await flushPromises()
+
+    wrapper.vm.rate(Rating.Good)
+    await flushPromises()
+
+    // Emit transitionend so reviewed fires
+    const cardEl = wrapper.find('[data-testid="study-card"]').element
+    cardEl.dispatchEvent(new Event('transitionend'))
+    await flushPromises()
+
+    expect(wrapper.emitted('reviewed')).toHaveLength(1)
+
+    // Even after reviewed, is_animating should still block rate()
+    const sfxCallsBefore = mockEmitSfx.mock.calls.length
+    wrapper.vm.rate(Rating.Good)
+    await flushPromises()
+
+    expect(wrapper.emitted('reviewed')).toHaveLength(1)
+    expect(mockEmitSfx.mock.calls.length).toBe(sfxCallsBefore)
   })
 })

--- a/tests/integration/components/ui-kit/button.test.js
+++ b/tests/integration/components/ui-kit/button.test.js
@@ -477,5 +477,59 @@ describe('UiButton', () => {
       // emitSfx not called because onCaptureClick returns early before emitClickSfx
       expect(mockEmitSfx).not.toHaveBeenCalled()
     })
+
+    // ── clickWhenDisabled [obligation] ─────────────────────────────────────
+
+    // The capture handler decides whether a disabled button's click reaches the
+    // bubble-phase @click handler: it lets it propagate when clickWhenDisabled is
+    // set, and stops propagation (+ preventDefault) when it isn't. Assert that
+    // contract directly on the dispatched event.
+    test('clickWhenDisabled=true with disabled=true lets the click propagate to the handler [obligation]', async () => {
+      const wrapper = shallowMount(UiButton, {
+        props: { disabled: true, clickWhenDisabled: true },
+        global: { stubs: { UiTooltip: UiTooltipSlotStub }, directives: { sfx: {} } }
+      })
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+      const stopSpy = vi.spyOn(event, 'stopImmediatePropagation')
+      const preventSpy = vi.spyOn(event, 'preventDefault')
+
+      wrapper.find('[data-testid="ui-kit-button"]').element.dispatchEvent(event)
+      await wrapper.vm.$nextTick()
+
+      expect(stopSpy).not.toHaveBeenCalled()
+      expect(preventSpy).not.toHaveBeenCalled()
+    })
+
+    test('disabled=true without clickWhenDisabled swallows the click (stops propagation) [obligation]', async () => {
+      const wrapper = shallowMount(UiButton, {
+        props: { disabled: true, clickWhenDisabled: false },
+        global: { stubs: { UiTooltip: UiTooltipSlotStub }, directives: { sfx: {} } }
+      })
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+      const stopSpy = vi.spyOn(event, 'stopImmediatePropagation')
+      const preventSpy = vi.spyOn(event, 'preventDefault')
+
+      wrapper.find('[data-testid="ui-kit-button"]').element.dispatchEvent(event)
+      await wrapper.vm.$nextTick()
+
+      expect(stopSpy).toHaveBeenCalled()
+      expect(preventSpy).toHaveBeenCalled()
+    })
+
+    test('clickWhenDisabled suppresses sfx even when clicks are allowed through [obligation]', async () => {
+      mockEmitSfx.mockClear()
+      const wrapper = shallowMount(UiButton, {
+        props: { disabled: true, clickWhenDisabled: true, sfx: { click: 'ui.select' } },
+        attrs: { onClick: vi.fn() },
+        global: { stubs: { UiTooltip: UiTooltipSlotStub }, directives: { sfx: {} } }
+      })
+      wrapper
+        .find('[data-testid="ui-kit-button"]')
+        .element.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await wrapper.vm.$nextTick()
+      // merged_sfx returns {} when disabled, so emitClickSfx is never invoked
+      // (onCaptureClick returns early at the clickWhenDisabled guard, skipping interceptClick)
+      expect(mockEmitSfx).not.toHaveBeenCalled()
+    })
   })
 })

--- a/tests/integration/views/deck/deck-hero/actions.test.js
+++ b/tests/integration/views/deck/deck-hero/actions.test.js
@@ -162,4 +162,42 @@ describe('deck-hero/actions', () => {
       side: 'front'
     })
   })
+
+  // ── study button disabled state [obligation] ───────────────────────────────
+
+  test('study button is disabled when due_count is 0 [obligation]', () => {
+    const wrapper = mount({ deck: { due_count: 0 } })
+    expect(studyBtn(wrapper).attributes('disabled')).toBeDefined()
+  })
+
+  test('study button is disabled when due_count is undefined [obligation]', () => {
+    const wrapper = mount({ deck: { due_count: undefined } })
+    expect(studyBtn(wrapper).attributes('disabled')).toBeDefined()
+  })
+
+  test('study button shows no-cards-due text when due_count is 0 [obligation]', () => {
+    const wrapper = mount({ deck: { due_count: 0 } })
+    expect(studyBtn(wrapper).text()).toContain('No cards due')
+  })
+
+  test('study button shows no-cards-due text when due_count is undefined [obligation]', () => {
+    const wrapper = mount({ deck: { due_count: undefined } })
+    expect(studyBtn(wrapper).text()).toContain('No cards due')
+  })
+
+  test('study button is enabled when due_count is greater than 0 [obligation]', () => {
+    const wrapper = mount({ deck: { due_count: 5 } })
+    expect(studyBtn(wrapper).attributes('disabled')).toBeUndefined()
+  })
+
+  test('study button shows due count when due_count > 0 [obligation]', () => {
+    const wrapper = mount({ deck: { due_count: 7 } })
+    expect(studyBtn(wrapper).text()).toContain('7')
+  })
+
+  test('clicking the enabled study button starts the session [obligation]', async () => {
+    const wrapper = mount({ deck: { id: 3, due_count: 5 } })
+    await studyBtn(wrapper).trigger('click')
+    expect(mockStartStudy).toHaveBeenCalledWith(expect.objectContaining({ id: 3 }))
+  })
 })

--- a/tests/unit/composables/use-pin-scroll-while-typing.test.js
+++ b/tests/unit/composables/use-pin-scroll-while-typing.test.js
@@ -1,0 +1,318 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
+import { createApp, ref } from 'vue'
+import { usePinScrollWhileTyping } from '@/composables/use-pin-scroll-while-typing'
+
+// ── Host-app helper ────────────────────────────────────────────────────────────
+// Mounts a minimal Vue app so onMounted / onUnmounted lifecycle hooks run.
+
+function withSetup(composable) {
+  let result
+  let app
+
+  app = createApp({
+    setup() {
+      result = composable()
+      return () => null
+    }
+  })
+
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  app.mount(el)
+
+  return {
+    unmount: () => {
+      app.unmount()
+      el.remove()
+    }
+  }
+}
+
+// ── Event helpers ──────────────────────────────────────────────────────────────
+
+function makeContentEditable() {
+  const el = document.createElement('div')
+  el.contentEditable = 'true'
+  // jsdom doesn't compute isContentEditable from contentEditable, so stub it —
+  // the composable gates on target.isContentEditable.
+  Object.defineProperty(el, 'isContentEditable', { value: true, configurable: true })
+  document.body.appendChild(el)
+  return el
+}
+
+function fireBeforeInput(target) {
+  const e = new Event('beforeinput', { bubbles: true })
+  Object.defineProperty(e, 'target', { value: target, configurable: true })
+  document.dispatchEvent(e)
+}
+
+function fireScroll() {
+  window.dispatchEvent(new Event('scroll', { bubbles: true }))
+}
+
+function fireWheel() {
+  window.dispatchEvent(new WheelEvent('wheel', { bubbles: true }))
+}
+
+function fireTouchMove() {
+  window.dispatchEvent(new TouchEvent('touchmove', { bubbles: true }))
+}
+
+function fireFocusOut(target) {
+  const e = new FocusEvent('focusout', { bubbles: true })
+  Object.defineProperty(e, 'target', { value: target, configurable: true })
+  document.dispatchEvent(e)
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────────
+
+describe('usePinScrollWhileTyping', () => {
+  let container
+  let editable
+  let scrollToSpy
+  let unmount
+
+  beforeEach(() => {
+    // Create a container div and a contenteditable inside it
+    container = document.createElement('div')
+    editable = makeContentEditable()
+    container.appendChild(editable)
+    document.body.appendChild(container)
+
+    // Spy on window.scrollTo
+    scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+
+    // Seed scrollY via defineProperty so we can control it per test
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true, configurable: true })
+    Object.defineProperty(window, 'scrollX', { value: 0, writable: true, configurable: true })
+  })
+
+  afterEach(() => {
+    unmount?.()
+    unmount = undefined
+    container.remove()
+    editable.remove()
+    scrollToSpy.mockRestore()
+  })
+
+  // ── Anchor capture [obligation] ────────────────────────────────────────────
+
+  test('beforeinput from a contenteditable inside the container captures scrollY [obligation]', () => {
+    window.scrollY = 200
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    fireBeforeInput(editable)
+
+    // A subsequent scroll should be intercepted and restored to 200
+    window.scrollY = 250
+    fireScroll()
+
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 200)
+  })
+
+  test('subsequent beforeinputs in the same burst do NOT re-capture scrollY [obligation]', () => {
+    window.scrollY = 100
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    fireBeforeInput(editable)
+
+    // scrollY drifts (simulating the pinned scroll restoration)
+    window.scrollY = 120
+    fireBeforeInput(editable)
+
+    // Scroll event should restore to the FIRST capture (100), not the drifted 120
+    window.scrollY = 150
+    fireScroll()
+
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 100)
+  })
+
+  test('beforeinput from outside the container does not arm the anchor [obligation]', () => {
+    window.scrollY = 300
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    // Fire beforeinput from an element NOT inside container
+    const outside = document.createElement('div')
+    outside.contentEditable = 'true'
+    Object.defineProperty(outside, 'isContentEditable', { value: true, configurable: true })
+    document.body.appendChild(outside)
+    fireBeforeInput(outside)
+    outside.remove()
+
+    // Scroll should NOT be intercepted (anchor never set)
+    window.scrollY = 350
+    fireScroll()
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  test('beforeinput from a non-contenteditable element does not arm the anchor [obligation]', () => {
+    window.scrollY = 300
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    const plainDiv = document.createElement('div')
+    container.appendChild(plainDiv)
+    fireBeforeInput(plainDiv)
+
+    window.scrollY = 350
+    fireScroll()
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  // ── Scroll restoration [obligation] ───────────────────────────────────────
+
+  test('scroll event while armed restores scrollY to the captured value [obligation]', () => {
+    window.scrollY = 500
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    fireBeforeInput(editable)
+
+    window.scrollY = 550
+    fireScroll()
+
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 500)
+  })
+
+  test('scroll event while not armed (no anchor) does nothing [obligation]', () => {
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    window.scrollY = 100
+    fireScroll()
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  // ── Release via wheel / touchmove / focusout [obligation] ─────────────────
+
+  test('wheel event releases the anchor so next scroll is not intercepted [obligation]', () => {
+    window.scrollY = 400
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    fireBeforeInput(editable)
+    fireWheel()
+
+    // Now scrolling must NOT be restored
+    window.scrollY = 450
+    fireScroll()
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  test('touchmove event releases the anchor so next scroll is not intercepted [obligation]', () => {
+    window.scrollY = 400
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    fireBeforeInput(editable)
+    fireTouchMove()
+
+    window.scrollY = 450
+    fireScroll()
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  test('focusout event releases the anchor [obligation]', () => {
+    window.scrollY = 400
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    fireBeforeInput(editable)
+    fireFocusOut(editable)
+
+    window.scrollY = 450
+    fireScroll()
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  test('after wheel release, the next beforeinput re-anchors at the new scrollY [obligation]', () => {
+    window.scrollY = 100
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    fireBeforeInput(editable)
+    fireWheel()
+
+    // User scrolled deliberately — new position
+    window.scrollY = 300
+    fireBeforeInput(editable)
+
+    // Scroll from the new anchor
+    window.scrollY = 350
+    fireScroll()
+
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 300)
+  })
+
+  // ── Unmount cleanup [obligation] ───────────────────────────────────────────
+
+  test('all listeners are removed on unmount [obligation]', () => {
+    window.scrollY = 200
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    // Arm the anchor
+    fireBeforeInput(editable)
+
+    // Unmount removes listeners
+    unmount()
+    unmount = undefined
+
+    // A scroll after unmount must not call scrollTo
+    window.scrollY = 300
+    fireScroll()
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  test('beforeinput after unmount does not re-arm [obligation]', () => {
+    window.scrollY = 200
+    const containerRef = ref(container)
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(containerRef)))
+
+    unmount()
+    unmount = undefined
+
+    window.scrollY = 250
+    fireBeforeInput(editable)
+
+    window.scrollY = 300
+    fireScroll()
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  // ── MaybeRefOrGetter support ───────────────────────────────────────────────
+
+  test('accepts a getter function instead of a ref [obligation]', () => {
+    window.scrollY = 150
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(() => container)))
+
+    fireBeforeInput(editable)
+
+    window.scrollY = 200
+    fireScroll()
+
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 150)
+  })
+
+  test('resolves a null getter gracefully — beforeinput does not arm [obligation]', () => {
+    ;({ unmount } = withSetup(() => usePinScrollWhileTyping(() => null)))
+
+    fireBeforeInput(editable)
+
+    window.scrollY = 100
+    fireScroll()
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

A batch of small, independent bugfixes:

- **Study button** disables and shows "No cards due" when a deck has nothing due.
- **Disabled buttons** use the default cursor; new `clickWhenDisabled` prop lets a disabled button still surface a click (used below).
- **Study session** no longer replays sfx when arrow/space are spammed mid-animation. The flip lock releases the instant the new face shows; the fling lock holds through the incoming card's intro flip.
- **Card text** clips to the card edges; the image region never shrinks below half the face in above/below layouts.
- **Above/below image cards** keep a padded image region (no full-bleed) in both view and edit — so an emptied card can be typed into again — while behind layout stays full-bleed and is clickable anywhere to add text.
- **Empty editor** centers its caret instead of pinning it to the top, shows its placeholder as soon as it's cleared, and aligns the placeholder to the card's text-alignment config.
- **Card editor list** no longer jumps when typing reflows a card (window-virtualizer scroll pin).
- **New deck modal** requires a title before creating: clicking the disabled create button flags the title input and plays an error sound.

Includes test coverage for the behavioral changes.