### PR TITLE
Create deck modal redesign

### DIFF
--- a/src/components/layout-kit/modal/mobile-sheet.vue
+++ b/src/components/layout-kit/modal/mobile-sheet.vue
@@ -92,7 +92,7 @@ provide(mobileSheetOverlayKey, overlay_root)
 
     <div
       data-testid="mobile-sheet-container"
-      class="flex overflow-hidden w-full h-full rounded-t-8 rounded-b-8 mobile-modal:rounded-b-none shadow-lg border-brown-100 dark:border-grey-900 pointer-coarse:border-t pointer-coarse:border-l mobile-modal:pointer-coarse:border-r"
+      class="flex overflow-hidden w-full h-full rounded-t-8 rounded-b-8 mobile-modal:rounded-b-none shadow-lg border-brown-100 dark:border-grey-900 border-t border-l mobile-modal:border-r"
     >
       <slot name="sidebar"></slot>
 

--- a/src/components/modals/deck-create/index.vue
+++ b/src/components/modals/deck-create/index.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
-import { computed, provide, ref } from 'vue'
+import { computed, provide, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import DeckDesignPreview from '@/components/deck/deck-design-preview.vue'
 import CoverDesigner from '@/components/deck/cover-designer/index.vue'
 import { useDeckEditor, deckEditorKey } from '@/composables/deck-editor'
+import { useMatchMedia } from '@/composables/use-media-query'
 import { randomCoverConfig } from '@/utils/cover'
 import { emitSfx } from '@/sfx/bus'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiInput from '@/components/ui-kit/input.vue'
-import LabeledSection from '@/components/layout-kit/labeled-section.vue'
+import UiTextarea from '@/components/ui-kit/textarea.vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
+import Card from '@/components/card/index.vue'
 import MobileSheet from '@/components/layout-kit/modal/mobile-sheet.vue'
 
 export type DeckCreateResponse = boolean
@@ -24,9 +27,13 @@ const router = useRouter()
 const editor = useDeckEditor({ cover_config: randomCoverConfig() } as Deck)
 provide(deckEditorKey, editor)
 
+const is_mobile = useMatchMedia('w<md')
+
 const title_error = ref<string>()
 
 const has_title = computed(() => !!editor.settings.title?.trim())
+
+const sheet_px = computed(() => (is_mobile.value ? '2rem' : '4.5rem'))
 
 async function onSave() {
   if (!has_title.value) {
@@ -41,9 +48,12 @@ async function onSave() {
   router.push({ name: 'deck', params: { id: saved.id } })
 }
 
-function onTitleInput() {
-  title_error.value = undefined
-}
+watch(
+  () => editor.settings.title,
+  () => {
+    title_error.value = undefined
+  }
+)
 </script>
 
 <template>
@@ -51,40 +61,120 @@ function onTitleInput() {
     data-testid="deck-create-container"
     data-theme="green-500"
     data-theme-dark="green-800"
-    class="sm:w-200"
-    :title="t('deck.create-modal.title')"
+    class="w-full! max-w-205.5"
     :pattern_config="{ pattern: 'endless-clouds' }"
+    :sheet_px="sheet_px"
     @close="close(false)"
   >
-    <div data-testid="deck-create__body" class="grid grid-cols-[auto_1fr] items-start gap-6 p-6">
-      <div data-testid="deck-create__left" class="flex flex-col gap-6">
+    <template #header-content>
+      <h1 class="text-5xl text-white w-full">{{ t('deck.create-modal.title') }}</h1>
+    </template>
+
+    <template #overlay>
+      <div
+        v-if="!is_mobile"
+        data-testid="deck-create__floating-preview"
+        class="pointer-events-auto absolute right-(--sheet-px) top-6"
+      >
+        <div class="relative">
+          <card
+            size="xl"
+            class="absolute! -top-2 right-1"
+            face_classes="bg-white! dark:bg-stone-700!"
+          />
+
+          <div
+            data-testid="deck-create__preview-paperclip"
+            class="absolute -top-8 right-15 -translate-x-1/2 z-10 drop-shadow-2xs"
+          >
+            <ui-icon src="paperclip" class="w-16 h-16 -rotate-186 text-grey-300" />
+          </div>
+
+          <deck-design-preview
+            :cover="editor.cover"
+            :card_attributes="editor.card_attributes"
+            side="cover"
+            class="rotate-4 drop-shadow-sm"
+          />
+        </div>
+      </div>
+    </template>
+
+    <div
+      data-testid="deck-create__body"
+      :class="[
+        'px-(--sheet-px) pb-8 h-full',
+        is_mobile ? 'flex flex-col gap-6' : 'flex gap-14 items-start'
+      ]"
+    >
+      <div data-testid="deck-create__main" class="flex-1 flex flex-col gap-4 w-full min-w-0">
         <deck-design-preview
-          data-testid="deck-create__preview"
+          v-if="is_mobile"
+          data-testid="deck-create__inline-preview"
           :cover="editor.cover"
           :card_attributes="editor.card_attributes"
           side="cover"
+          class="mx-auto"
         />
 
-        <labeled-section :label="t('deck.create-modal.details-heading')">
+        <cover-designer :config="editor.cover" />
+      </div>
+
+      <aside
+        v-if="!is_mobile"
+        data-testid="deck-create__aside"
+        class="w-78.5 shrink-0 self-end pt-70 h-full flex flex-col justify-between gap-5 text-brown-700 dark:text-brown-100"
+      >
+        <div data-testid="deck-create__aside-inputs" class="flex flex-col gap-2">
           <ui-input
             :placeholder="t('deck.title-placeholder')"
+            :error="title_error"
             text-align="center"
             size="lg"
-            :error="title_error"
             v-model:value="editor.settings.title"
-            @input="onTitleInput"
+          />
+          <ui-textarea
+            :placeholder="t('deck.description-placeholder')"
+            :max_chars="100"
+            rows="3"
+            v-model:value="editor.settings.description"
+          />
+        </div>
+
+        <ui-button
+          data-testid="deck-create__aside-submit"
+          data-theme="blue-500"
+          data-theme-dark="blue-650"
+          icon-left="add"
+          size="lg"
+          full-width
+          :disabled="!has_title"
+          click-when-disabled
+          @click="onSave"
+        >
+          {{ t('deck.create-modal.submit') }}
+        </ui-button>
+      </aside>
+
+      <template v-if="is_mobile">
+        <div
+          data-testid="deck-create__mobile-inputs"
+          class="flex flex-col gap-2 text-brown-700 dark:text-brown-100"
+        >
+          <ui-input
+            :placeholder="t('deck.title-placeholder')"
+            :error="title_error"
+            text-align="center"
+            size="lg"
+            v-model:value="editor.settings.title"
           />
           <ui-input
             :placeholder="t('deck.description-placeholder')"
             v-model:value="editor.settings.description"
           />
-        </labeled-section>
-      </div>
+        </div>
 
-      <div data-testid="deck-create__right" class="h-full flex flex-col justify-between gap-6">
-        <cover-designer :config="editor.cover" />
-
-        <div data-testid="deck-create__actions" class="flex gap-3">
+        <div data-testid="deck-create__mobile-actions" class="flex gap-3">
           <ui-button
             data-theme="grey-400"
             icon-left="close"
@@ -108,7 +198,7 @@ function onTitleInput() {
             {{ t('deck.create-modal.submit') }}
           </ui-button>
         </div>
-      </div>
+      </template>
     </div>
   </mobile-sheet>
 </template>

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -350,7 +350,7 @@
   "deck.settings-modal.unsaved-alert.message": "You have unsaved changes. Exit anyway?",
   "deck.settings-modal.unsaved-alert.confirm": "Exit",
   "deck.settings-modal.unsaved-alert.cancel": "Keep editing",
-  "deck.create-modal.title": "New Deck",
+  "deck.create-modal.title": "Make A New Deck",
   "deck.create-modal.cover-heading": "Cover",
   "deck.create-modal.details-heading": "Details",
   "deck.create-modal.submit": "Create Deck",

--- a/tests/integration/components/modals/deck-create.test.js
+++ b/tests/integration/components/modals/deck-create.test.js
@@ -1,6 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent, h } from 'vue'
 
 const { mockEditor, mockRouterPush, mockRandomCover, mockEmitSfx, capturedSettings } = vi.hoisted(
   () => ({
@@ -25,11 +24,27 @@ vi.mock('@/utils/cover', async () => {
   return { ...actual, randomCoverConfig: mockRandomCover }
 })
 
+// useMatchMedia mock: exposes a shared ref and a setter so tests can control
+// the mobile/desktop branch before mounting the component.
+// 'coarse' queries always return false (fine/desktop pointer) so that
+// usePlayOnTap inside UiButton passes clicks straight through without intercepting.
+vi.mock('@/composables/use-media-query', async () => {
+  const { ref } = await import('vue')
+  const isMobile = ref(false)
+  const alwaysFalse = ref(false)
+  return {
+    useMatchMedia: vi.fn((query) => (query === 'coarse' ? alwaysFalse : isMobile)),
+    __setMobile: (v) => {
+      isMobile.value = v
+    }
+  }
+})
+
 vi.mock('@/composables/deck-editor', async () => {
   const { reactive } = await import('vue')
   return {
     useDeckEditor: vi.fn((deck) => {
-      const settings = reactive({ title: '' })
+      const settings = reactive({ title: '', description: '' })
       capturedSettings.current = settings
       return {
         settings,
@@ -85,6 +100,8 @@ vi.mock('@/components/layout-kit/modal/mobile-sheet.vue', async () => {
               'data-testid': 'mobile-sheet-stub__close',
               onClick: () => emit('close')
             }),
+            slots['header-content']?.(),
+            slots.overlay?.(),
             slots.default?.()
           ])
       }
@@ -92,7 +109,33 @@ vi.mock('@/components/layout-kit/modal/mobile-sheet.vue', async () => {
   }
 })
 
+vi.mock('@/components/card/index.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'Card',
+      setup() {
+        return () => h('div', { 'data-testid': 'card-stub' })
+      }
+    })
+  }
+})
+
+vi.mock('@/components/ui-kit/icon.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'UiIcon',
+      props: ['src'],
+      setup() {
+        return () => h('span', { 'data-testid': 'ui-icon-stub' })
+      }
+    })
+  }
+})
+
 import DeckCreate from '@/components/modals/deck-create/index.vue'
+import { __setMobile } from '@/composables/use-media-query'
 
 function mountModal(close = vi.fn()) {
   const wrapper = mount(DeckCreate, {
@@ -109,53 +152,129 @@ describe('DeckCreate modal', () => {
     mockRouterPush.mockClear()
     mockRandomCover.mockClear()
     mockEmitSfx.mockClear()
+    __setMobile(false)
   })
 
-  test('renders the preview, cover-designer, both action buttons, and the inputs', () => {
+  // ── Non-mobile layout ──────────────────────────────────────────────────────
+
+  test('non-mobile: renders deck-create__aside with submit button (no cancel) [obligation]', () => {
+    const { wrapper } = mountModal()
+
+    expect(wrapper.find('[data-testid="deck-create__aside"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="deck-create__aside-submit"]').exists()).toBe(true)
+    // Cancel button is NOT present in the aside on non-mobile [obligation]
+    expect(wrapper.find('[data-testid="deck-create__mobile-actions"]').exists()).toBe(false)
+  })
+
+  test('non-mobile: renders the floating preview in the overlay slot [obligation]', () => {
+    const { wrapper } = mountModal()
+
+    expect(wrapper.find('[data-testid="deck-create__floating-preview"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="deck-create__inline-preview"]').exists()).toBe(false)
+  })
+
+  test('non-mobile: does not render mobile-only sections [obligation]', () => {
+    const { wrapper } = mountModal()
+
+    expect(wrapper.find('[data-testid="deck-create__mobile-inputs"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="deck-create__mobile-actions"]').exists()).toBe(false)
+  })
+
+  test('non-mobile: renders the cover designer and body', () => {
     const { wrapper } = mountModal()
 
     expect(wrapper.find('[data-testid="deck-create__body"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="deck-create__preview"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="cover-designer-stub"]').exists()).toBe(true)
-    expect(wrapper.findAll('[data-testid="deck-create__actions"] button')).toHaveLength(2)
   })
 
   test('seeds the editor cover with randomCoverConfig() values', () => {
-    const { wrapper } = mountModal()
+    mountModal()
     expect(mockRandomCover).toHaveBeenCalledTimes(1)
-    // Cover seeded from random helper flows into the preview stub's data-theme attr.
-    expect(wrapper.find('[data-testid="deck-create__preview"]').attributes('data-theme')).toBe(
-      'pink-400'
-    )
   })
 
-  test('cancel button closes with false', async () => {
+  // ── Mobile layout ──────────────────────────────────────────────────────────
+
+  test('mobile: renders deck-create__inline-preview instead of floating preview [obligation]', async () => {
+    __setMobile(true)
+    const { wrapper } = mountModal()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="deck-create__inline-preview"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="deck-create__floating-preview"]').exists()).toBe(false)
+  })
+
+  test('mobile: renders deck-create__mobile-inputs and deck-create__mobile-actions [obligation]', async () => {
+    __setMobile(true)
+    const { wrapper } = mountModal()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="deck-create__mobile-inputs"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="deck-create__mobile-actions"]').exists()).toBe(true)
+  })
+
+  test('mobile: does not render the aside [obligation]', async () => {
+    __setMobile(true)
+    const { wrapper } = mountModal()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="deck-create__aside"]').exists()).toBe(false)
+  })
+
+  test('mobile: cancel button in mobile-actions closes with false [obligation]', async () => {
+    __setMobile(true)
     const { wrapper, close } = mountModal()
-    const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
+    await wrapper.vm.$nextTick()
+
+    const mobileActions = wrapper.find('[data-testid="deck-create__mobile-actions"]')
+    // UiButton renders with data-testid="ui-kit-button" on its inner button element
+    const buttons = mobileActions.findAll('[data-testid="ui-kit-button"]')
+    // First button in mobile-actions is the cancel button
     await buttons[0].trigger('click')
 
     expect(close).toHaveBeenCalledWith(false)
     expect(mockEditor.saveDeck).not.toHaveBeenCalled()
-    expect(mockRouterPush).not.toHaveBeenCalled()
   })
 
-  test('mobile-sheet @close also closes with false', async () => {
+  test('mobile: submit button in mobile-actions calls saveDeck', async () => {
+    __setMobile(true)
+    mockEditor.saveDeck.mockResolvedValueOnce({ id: 42 })
+    const { wrapper, close } = mountModal()
+    await wrapper.vm.$nextTick()
+
+    capturedSettings.current.title = 'Mobile Deck'
+    await wrapper.vm.$nextTick()
+
+    const mobileActions = wrapper.find('[data-testid="deck-create__mobile-actions"]')
+    // UiButton renders with data-testid="ui-kit-button" on its inner button element
+    const buttons = mobileActions.findAll('[data-testid="ui-kit-button"]')
+    // Second button in mobile-actions is the submit button
+    await buttons[1].trigger('click')
+    await flushPromises()
+
+    expect(mockEditor.saveDeck).toHaveBeenCalled()
+    expect(close).toHaveBeenCalledWith(true)
+    expect(mockRouterPush).toHaveBeenCalledWith({ name: 'deck', params: { id: 42 } })
+  })
+
+  // ── Close behaviour ────────────────────────────────────────────────────────
+
+  test('mobile-sheet @close closes with false', async () => {
     const { wrapper, close } = mountModal()
     await wrapper.find('[data-testid="mobile-sheet-stub__close"]').trigger('click')
 
     expect(close).toHaveBeenCalledWith(false)
   })
 
+  // ── Submit (non-mobile) ────────────────────────────────────────────────────
+
   test('submit calls saveDeck, then close(true), then routes to the new deck', async () => {
     mockEditor.saveDeck.mockResolvedValueOnce({ id: 7 })
     const { wrapper, close } = mountModal()
 
-    // Set a non-empty title so the save guard passes
     capturedSettings.current.title = 'My Deck'
     await wrapper.vm.$nextTick()
 
-    const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
-    await buttons[1].trigger('click')
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
     await flushPromises()
 
     expect(mockEditor.saveDeck).toHaveBeenCalled()
@@ -167,26 +286,22 @@ describe('DeckCreate modal', () => {
     mockEditor.saveDeck.mockResolvedValueOnce(null)
     const { wrapper, close } = mountModal()
 
-    // Set a non-empty title so the save guard passes
     capturedSettings.current.title = 'My Deck'
     await wrapper.vm.$nextTick()
 
-    const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
-    await buttons[1].trigger('click')
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
     await flushPromises()
 
     expect(close).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
   })
 
-  // ── title-required guard [obligation] ──────────────────────────────────────
+  // ── Title-required guard ───────────────────────────────────────────────────
 
-  test('onSave with empty title sets title_error, plays woodblock sfx, does NOT call saveDeck [obligation]', async () => {
+  test('onSave with empty title plays woodblock sfx and does NOT call saveDeck [obligation]', async () => {
     const { wrapper, close } = mountModal()
 
-    // Title is empty by default
-    const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
-    await buttons[1].trigger('click')
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
     await flushPromises()
 
     expect(mockEditor.saveDeck).not.toHaveBeenCalled()
@@ -201,38 +316,69 @@ describe('DeckCreate modal', () => {
     capturedSettings.current.title = '   '
     await wrapper.vm.$nextTick()
 
-    const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
-    await buttons[1].trigger('click')
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
     await flushPromises()
 
     expect(mockEditor.saveDeck).not.toHaveBeenCalled()
     expect(mockEmitSfx).toHaveBeenCalledWith('ui.etc_woodblock_stuck')
   })
 
-  test('onTitleInput clears the title_error [obligation]', async () => {
+  // ── Title-error watcher [obligation] ──────────────────────────────────────
+
+  test('title error clears reactively via watcher when title changes [obligation]', async () => {
     const { wrapper } = mountModal()
 
-    // Trigger the error first
-    const buttons = wrapper.findAll('[data-testid="deck-create__actions"] button')
-    await buttons[1].trigger('click')
+    // Trigger the error first by submitting with empty title
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
     await flushPromises()
-
-    // A title input event should clear the error — we call vm method indirectly via the
-    // exposed UiInput @input which calls onTitleInput. Since UiInput is not stubbed fully,
-    // we call vm.onTitleInput directly via the component's expose surface
-    // (it is not exposed via defineExpose but we can test the observable effect:
-    //  typing a new input on the title field clears the error display)
-    // Verify error was set (mockEmitSfx was called)
     expect(mockEmitSfx).toHaveBeenCalledWith('ui.etc_woodblock_stuck')
 
-    // Now set a title and trigger save — no error sfx should replay (error was cleared)
+    // Clear sfx mock so we can detect if the woodblock fires again
     mockEmitSfx.mockClear()
-    capturedSettings.current.title = 'New title'
+
+    // Reactively update the title — the watch() should clear the error
+    capturedSettings.current.title = 'New Title'
     await wrapper.vm.$nextTick()
-    await buttons[1].trigger('click')
+
+    // Now submitting should succeed (no woodblock sfx, saveDeck called)
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
     await flushPromises()
 
     expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.etc_woodblock_stuck')
     expect(mockEditor.saveDeck).toHaveBeenCalled()
+  })
+
+  // ── Locale title ───────────────────────────────────────────────────────────
+
+  test('renders the modal title "Make A New Deck" (updated locale value) [obligation]', () => {
+    const { wrapper } = mountModal()
+    // The mobile-sheet stub renders the header-content slot; we find the h1
+    const h1 = wrapper.find('h1')
+    expect(h1.exists()).toBe(true)
+    expect(h1.text()).toContain('Make A New Deck')
+  })
+
+  // ── Description binding (non-mobile aside + mobile inputs) ─────────────────
+
+  test('non-mobile: aside renders inputs bound to editor settings', async () => {
+    const { wrapper } = mountModal()
+
+    capturedSettings.current.title = 'Deck Title'
+    capturedSettings.current.description = 'A description'
+    await wrapper.vm.$nextTick()
+
+    // Aside inputs render (proxy for the v-model bindings being active)
+    expect(wrapper.find('[data-testid="deck-create__aside-inputs"]').exists()).toBe(true)
+  })
+
+  test('mobile: mobile-inputs renders description input bound to editor settings', async () => {
+    __setMobile(true)
+    const { wrapper } = mountModal()
+    await wrapper.vm.$nextTick()
+
+    capturedSettings.current.description = 'Mobile description'
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="deck-create__mobile-inputs"]').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Redesigns the create deck modal to match the deck settings cover designer layout — floating preview with paperclip decoration, an aside with title/description inputs and a Create button, and a fully stacked layout on mobile.

## Changes

- **deck-create modal**: replaces the old two-column grid with the deck-settings aside/overlay pattern — floating `DeckDesignPreview` (with card backdrop + paperclip) in the overlay on non-mobile; `DeckAside`-style inputs + Create button in the aside; inline preview + stacked inputs/actions on mobile
- **mobile-sheet**: border (`border-t border-l`) now applies on pointer-fine as well as pointer-coarse
- **Locale**: create modal header copy changed to "Make A New Deck"
- **Tests**: deck-create test suite fully rewritten to cover both mobile and non-mobile layout branches, reactive title-error watcher, and updated locale string