### PR TITLE
feat: add web app manifest and iOS standalone meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     <meta name="description" content="A Spaced Repetition Flashcard App" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.svg" sizes="180x180" />
     <meta name="theme-color" content="#f3f1ea" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <link rel="manifest" href="/manifest.json" />
     <meta name="google-site-verification" content="RYCZPlH19cDxgk_7N4FFqu8RVBS2CbUImLfmFFlFpL4" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "TaroFlash",
+  "short_name": "TaroFlash",
+  "description": "A Spaced Repetition Flashcard App",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f3f1ea",
+  "theme_color": "#f3f1ea",
+  "icons": [
+    {
+      "src": "/pwa-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/pwa-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `manifest.json` with `display: standalone` so iOS/Android respect standalone mode during navigation
- Adds `apple-mobile-web-app-capable` and `apple-mobile-web-app-status-bar-style` meta tags to keep the app chrome-free when navigating between routes
- Reuses existing PWA icons (`pwa-192x192.png`, `pwa-512x512.png`)

> Note: after deploying, remove and re-add the home screen shortcut on iOS for the changes to take effect.