### PR TITLE
fix(audio-reader): pin nav + footer to own compositor layer on iOS standalone

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <body class="bg-brown-100 dark:bg-grey-900 h-full">
     <div id="app" class="flex flex-col md:items-center h-full"></div>
 
+    <section data-testid="app-footer-container" app-footer-container class="contents"></section>
     <section
       data-testid="app-modal-container"
       class="pointer-events-none touch-none fixed inset-0 z-100 flex items-center justify-center"

--- a/src/components/nav-bar.vue
+++ b/src/components/nav-bar.vue
@@ -14,10 +14,12 @@ onMounted(() => {
 </script>
 
 <template>
+  <!-- translateZ(0) pins this sticky bar to its own compositor layer; without it,
+       iOS standalone lags it during scroll. -->
   <nav
     data-testid="nav-bar-container"
     ref="nav-bar"
-    class="w-full sticky top-0 z-50 pt-4 pb-8 mb-6 px-4 bg-blue-500 dark:bg-blue-650 wave-bottom-[30px] flex justify-center"
+    class="w-full sticky top-0 z-50 transform-[translateZ(0)] pt-4 pb-8 mb-6 px-4 bg-blue-500 dark:bg-blue-650 wave-bottom-[30px] flex justify-center"
   >
     <div
       data-testid="nav-bar"

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -240,64 +240,68 @@ useAnimatedHeight(footer_swap, footer_toolbar, () => !swapping)
         />
       </div>
 
-      <footer
-        ref="footer_bar"
-        data-testid="lesson-view__bar"
-        :class="{ 'xl:hidden': !show_term_in_footer }"
-        class="fixed bottom-0 left-0 right-0 z-30 rounded-t-6 bg-brown-300 p-5 pb-2 dark:bg-stone-900 sm:bottom-3 sm:left-auto sm:right-3 sm:w-96 sm:rounded-6 sm:pb-5"
-      >
-        <div ref="footer_swap" data-testid="lesson-view__footer-swap" class="relative w-full">
-          <transition
-            :css="false"
-            @before-leave="onFooterBeforeLeave"
-            @enter="onFooterEnter"
-            @after-enter="onFooterAfterEnter"
-            @leave="footerSwapLeave"
-          >
-            <div
-              v-if="show_term_in_footer && selection"
-              key="term"
-              ref="footer_term"
-              data-testid="lesson-view__footer-term"
-              class="pb-2"
+      <!-- Mounted at body level + translateZ(0) so iOS standalone pins it to its own
+           compositor layer; without both, fixed elements lag during scroll. -->
+      <teleport to="[app-footer-container]">
+        <footer
+          ref="footer_bar"
+          data-testid="lesson-view__bar"
+          :class="{ 'xl:hidden': !show_term_in_footer }"
+          class="fixed bottom-0 left-0 right-0 z-30 rounded-t-6 bg-brown-300 p-5 pb-2 transform-[translateZ(0)] dark:bg-stone-900 sm:bottom-3 sm:left-auto sm:right-3 sm:w-96 sm:rounded-6 sm:pb-5"
+        >
+          <div ref="footer_swap" data-testid="lesson-view__footer-swap" class="relative w-full">
+            <transition
+              :css="false"
+              @before-leave="onFooterBeforeLeave"
+              @enter="onFooterEnter"
+              @after-enter="onFooterAfterEnter"
+              @leave="footerSwapLeave"
             >
-              <term-card
-                :term="selection.term"
-                :sentence="selection.sentence"
-                :target_lang="target_lang"
-                :existing_decks="selected_term_decks"
-                show_back
-                @back="closeTerm"
-                @close="closeTerm"
-                @play-from-here="playFromHere"
-                @play-word="playClip"
-              />
-            </div>
+              <div
+                v-if="show_term_in_footer && selection"
+                key="term"
+                ref="footer_term"
+                data-testid="lesson-view__footer-term"
+                class="pb-2"
+              >
+                <term-card
+                  :term="selection.term"
+                  :sentence="selection.sentence"
+                  :target_lang="target_lang"
+                  :existing_decks="selected_term_decks"
+                  show_back
+                  @back="closeTerm"
+                  @close="closeTerm"
+                  @play-from-here="playFromHere"
+                  @play-word="playClip"
+                />
+              </div>
 
-            <div
-              v-else
-              key="toolbar"
-              ref="footer_toolbar"
-              data-testid="lesson-view__footer-toolbar"
-              class="xl:hidden"
-            >
-              <audio-toolbar
-                :player="player"
-                :chapters="chapters"
-                :current-lesson-id="lesson_id"
-                @select-chapter="goToChapter"
-              />
-            </div>
-          </transition>
-        </div>
+              <div
+                v-else
+                key="toolbar"
+                ref="footer_toolbar"
+                data-testid="lesson-view__footer-toolbar"
+                class="xl:hidden"
+              >
+                <audio-toolbar
+                  :player="player"
+                  :chapters="chapters"
+                  :current-lesson-id="lesson_id"
+                  @select-chapter="goToChapter"
+                />
+              </div>
+            </transition>
+          </div>
 
-        <audio
-          ref="audio"
-          data-testid="lesson-view__audio"
-          :src="audio_url ?? undefined"
-          class="hidden"
-        />
-      </footer>
+          <audio
+            ref="audio"
+            data-testid="lesson-view__audio"
+            :src="audio_url ?? undefined"
+            class="hidden"
+          />
+        </footer>
+      </teleport>
 
       <scroll-bar class="fixed top-(--nav-height) right-6 bottom-6" target="html" />
     </div>

--- a/tests/integration/views/audio-reader/lesson/index.test.js
+++ b/tests/integration/views/audio-reader/lesson/index.test.js
@@ -177,6 +177,7 @@ function mountView(props = {}) {
     props: { collectionId: COLLECTION_ID, lessonId: LESSON_ID, ...props },
     global: {
       stubs: {
+        Teleport: true,
         TranscriptView: TranscriptViewStub,
         TermCard: TermCardStub
       }


### PR DESCRIPTION
## Summary

On iOS Safari/standalone, the sticky nav and the audio-reader's fixed footer rode up with the page during scroll, then snapped back — WebKit paints sticky/fixed elements into the scroll layer instead of pinning them. Standalone shows it clearly since there's no URL-bar resize to mask it.

- Promote the nav and lesson footer to their own compositor layers with `transform-[translateZ(0)]` so iOS keeps them pinned through the scroll.
- Teleport the footer to a body-level `[app-footer-container]` mount (mirroring the modal/toast containers) so it stays viewport-relative regardless of any ancestor transform added later.
- Stub `Teleport` in the lesson view tests so the relocated footer stays queryable in the wrapper.

Mitigates a WebKit compositor quirk — needs on-device confirmation in the home-screen app.