### PR TITLE
fix(pwa): restore apple-mobile-web-app-capable for iOS standalone

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.svg" sizes="180x180" />
     <meta name="theme-color" content="#f3f1ea" />
     <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="google-site-verification" content="RYCZPlH19cDxgk_7N4FFqu8RVBS2CbUImLfmFFlFpL4" />


### PR DESCRIPTION
## Summary

#290 replaced `apple-mobile-web-app-capable` with `mobile-web-app-capable` to silence Chrome's deprecation warning. But iOS Safari only honours **`apple-mobile-web-app-capable`** for standalone mode — it ignores the standard tag. Swapping it dropped iOS standalone behaviour (notably: tapping an input no longer opened the keyboard in the home-screen app).

Fix-forward: ship **both** tags. The standard `mobile-web-app-capable` keeps Chrome quiet; `apple-mobile-web-app-capable` keeps iOS standalone working (and re-activates the already-present `apple-mobile-web-app-status-bar-style`, which only applies when the apple capable tag is set).

> Note: iOS caches the home-screen app's config — remove and re-add the shortcut after this deploys to pick up the change.