### PR TITLE
refactor(sfx): unify click-sound authority under staged-tap

### DIFF
--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -24,7 +24,7 @@ const { playing, tap } = useStagedTap()
 function onCaptureClick(e: MouseEvent) {
   const handler = attrs.onClick as ((ev: MouseEvent) => void) | undefined
   if (!handler) return
-  tap(handler, { pressAudio: click_sfx, captureMode: true })(e)
+  tap(handler, { audio: click_sfx, captureMode: true })(e)
 }
 </script>
 

--- a/src/components/modals/deck-settings/deck-save-button.vue
+++ b/src/components/modals/deck-settings/deck-save-button.vue
@@ -37,7 +37,7 @@ async function onSave() {
     full-width
     :loading="is_saving"
     :disabled="!is_dirty"
-    :sfx="{ click: 'ui.snappy_button_2' }"
+    :sfx="{ press: 'ui.snappy_button_2' }"
     click-when-disabled
     @click="onSave"
   >

--- a/src/components/modals/study-session/session-flashcard.vue
+++ b/src/components/modals/study-session/session-flashcard.vue
@@ -219,7 +219,7 @@ async function onCardReviewed(grade?: Grade) {
         size="lg"
         inverted
         icon-left="edit"
-        :sfx="{ click: 'ui.pop_window' }"
+        :sfx="{ press: 'ui.pop_window' }"
         @click="startEdit"
       >
         {{ $t('study-session.flashcard.edit-card-button') }}

--- a/src/components/modals/study-session/study-edit-footer.vue
+++ b/src/components/modals/study-session/study-edit-footer.vue
@@ -1,27 +1,43 @@
 <script setup lang="ts">
+import { useStagedTap } from '@/composables/ui/staged-tap'
+
 const { is_starting_side } = defineProps<{ is_starting_side: boolean }>()
 
 const emit = defineEmits<{
   (e: 'flip'): void
   (e: 'done'): void
 }>()
+
+const { playing: flip_playing, tap: tapFlip } = useStagedTap({ triggerAt: 'press' })
+const { playing: done_playing, tap: tapDone } = useStagedTap({ triggerAt: 'press' })
+
+function onCaptureFlip(e: MouseEvent) {
+  tapFlip(() => emit('flip'), {
+    audio: is_starting_side ? 'ui.transition_up' : 'ui.transition_down',
+    captureMode: true
+  })(e)
+}
+
+function onCaptureDone(e: MouseEvent) {
+  tapDone(() => emit('done'), { audio: 'ui.music_plink_ok', captureMode: true })(e)
+}
 </script>
 
 <template>
   <div data-testid="study-card-edit__actions" class="z-10 mt-4 flex justify-center gap-2 text-2xl">
     <button
       data-testid="study-card-edit__flip"
-      v-sfx="{ click: is_starting_side ? 'ui.transition_up' : 'ui.transition_down' }"
+      :data-playing="flip_playing || null"
       class="text-brown-700 cursor-pointer rounded-full bg-white px-13 py-4 hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
-      @click="emit('flip')"
+      @click.capture="onCaptureFlip"
     >
       {{ $t('study.flashcard.edit-footer.flip-button') }}
     </button>
     <button
       data-testid="study-card-edit__done"
-      v-sfx="{ click: 'ui.music_plink_ok' }"
+      :data-playing="done_playing || null"
       class="cursor-pointer rounded-full bg-(--theme-primary) px-13 py-4 text-white hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
-      @click="emit('done')"
+      @click.capture="onCaptureDone"
     >
       {{ $t('study-session.edit.done') }}
     </button>

--- a/src/components/modals/upload-lesson/script-select.vue
+++ b/src/components/modals/upload-lesson/script-select.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { useStagedTap } from '@/composables/ui/staged-tap'
 
 type ScriptOption = { value: TranscriptScript; label: string }
 
@@ -12,6 +13,17 @@ const OPTIONS: ScriptOption[] = [
 const script = defineModel<TranscriptScript>({ required: true })
 
 const { t } = useI18n()
+
+const { playing, tap } = useStagedTap({ triggerAt: 'press' })
+
+function onCaptureOption(e: MouseEvent, value: TranscriptScript) {
+  tap(
+    () => {
+      script.value = value
+    },
+    { audio: 'ui.select', captureMode: true }
+  )(e)
+}
 </script>
 
 <template>
@@ -29,8 +41,9 @@ const { t } = useI18n()
         :data-value="option.value"
         :data-active="script === option.value"
         class="flex-1 cursor-pointer rounded-4 px-3 py-2 text-sm transition-colors data-[active=false]:text-brown-600 data-[active=true]:bg-(--theme-primary) data-[active=true]:text-(--theme-on-primary) data-[active=false]:hover:bg-(--theme-primary)/10 dark:data-[active=false]:text-grey-300"
-        v-sfx="{ hover: 'ui.click_07', click: 'ui.select' }"
-        @click="script = option.value"
+        :data-playing="playing || null"
+        v-sfx="{ hover: 'ui.click_07' }"
+        @click.capture="(e) => onCaptureOption(e, option.value)"
       >
         {{ t(option.label) }}
       </button>

--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -55,11 +55,15 @@ const attrs = useAttrs()
 
 const { playing, tap } = useStagedTap({ animate: tapAnimate ? 'pop' : 'quiet' })
 
+// Only hover/focus/blur reach v-sfx — press-phase sounds are routed through
+// staged-tap in onCaptureClick so they fire at the correct phase for each pointer.
 const merged_sfx = computed<SfxOptions>(() => {
   if (disabled) return {}
   return {
-    ...sfx,
-    hover: sfx.hover ?? 'ui.click_07'
+    hover: sfx.hover ?? 'ui.click_07',
+    focus: sfx.focus,
+    blur: sfx.blur,
+    debounce: sfx.debounce
   }
 })
 
@@ -87,11 +91,13 @@ function onCaptureClick(e: MouseEvent) {
   if (!handler) return
 
   tap(handler, {
-    pressAudio: merged_sfx.value.click,
-    pressAudioOpts: {
-      debounce: merged_sfx.value.debounce,
-      blocking: merged_sfx.value.click_blocking
+    preAudio: sfx.tap_pre,
+    audio: sfx.press,
+    audioOpts: {
+      debounce: sfx.debounce,
+      blocking: sfx.press_blocking
     },
+    postAudio: sfx.tap_post,
     captureMode: true
   })(e)
 }

--- a/src/components/ui-kit/radio.vue
+++ b/src/components/ui-kit/radio.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import UiIcon from '@/components/ui-kit/icon.vue'
+import { useStagedTap } from '@/composables/ui/staged-tap'
 
 const { checked, theme = 'blue-500' } = defineProps<{
   checked: boolean
@@ -7,6 +8,9 @@ const { checked, theme = 'blue-500' } = defineProps<{
   theme?: Theme
   inverted?: boolean
 }>()
+
+const { playing, tap } = useStagedTap({ triggerAt: 'press' })
+const onCaptureClick = tap(undefined, { audio: 'ui.select' })
 </script>
 
 <template>
@@ -21,7 +25,9 @@ const { checked, theme = 'blue-500' } = defineProps<{
       'bg-(--theme-primary) outline-4': checked && inverted,
       'border-4 border-white bg-(--theme-primary)!': checked && !inverted
     }"
-    v-sfx="{ hover: 'ui.click_07', click: 'ui.select' }"
+    :data-playing="playing || null"
+    v-sfx="{ hover: 'ui.click_07' }"
+    @click.capture="onCaptureClick"
   >
     <ui-icon v-if="checked" class="text-white" src="check" />
     <ui-icon v-if="intermediate" src="minus" />

--- a/src/components/ui-kit/spinbox/button.vue
+++ b/src/components/ui-kit/spinbox/button.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import UiIcon from '@/components/ui-kit/icon.vue'
+import { useStagedTap } from '@/composables/ui/staged-tap'
 
 type SpinboxButtonProps = {
   icon: string
@@ -8,9 +9,15 @@ type SpinboxButtonProps = {
 
 const { icon, disabled = false } = defineProps<SpinboxButtonProps>()
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'click'): void
 }>()
+
+const { playing, tap } = useStagedTap({ triggerAt: 'press' })
+
+function onCaptureClick(e: MouseEvent) {
+  tap(() => emit('click'), { audio: 'ui.select', captureMode: true })(e)
+}
 </script>
 
 <template>
@@ -18,8 +25,9 @@ defineEmits<{
     type="button"
     :disabled="disabled"
     class="inline-flex items-center justify-center aspect-square h-8 rounded-3 text-brown-700 dark:text-brown-100 cursor-pointer transition-[background-color,color,transform] duration-100 hover:bg-(--theme-primary) hover:text-(--theme-on-primary) active:scale-95 disabled:opacity-[0.35] disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-brown-700 dark:disabled:hover:text-brown-100"
-    v-sfx="{ hover: 'ui.click_07', click: 'ui.select' }"
-    @click="$emit('click')"
+    :data-playing="playing || null"
+    v-sfx="{ hover: 'ui.click_07' }"
+    @click.capture="onCaptureClick"
   >
     <ui-icon :src="icon" class="size-5" />
   </button>

--- a/src/components/ui-kit/spinbox/index.vue
+++ b/src/components/ui-kit/spinbox/index.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import SpinboxButton from './button.vue'
 import { useNumericInput } from '@/composables/ui/numeric-input'
+import { useStagedTap } from '@/composables/ui/staged-tap'
 
 type SpinboxProps = {
   min?: number
@@ -51,8 +52,15 @@ function increment() {
   value.value = clamp(value.value + step)
 }
 
-function togglePill() {
-  pill_active.value = !pill_active.value
+const { playing: pill_playing, tap: tapPill } = useStagedTap({ triggerAt: 'press' })
+
+function onCapturePill(e: MouseEvent) {
+  tapPill(
+    () => {
+      pill_active.value = !pill_active.value
+    },
+    { audio: 'ui.select', captureMode: true }
+  )(e)
 }
 </script>
 
@@ -114,8 +122,9 @@ function togglePill() {
       data-testid="ui-kit-spinbox__pill"
       :data-active="pill_active"
       class="inline-flex items-center justify-center bg-input px-3 text-sm cursor-pointer text-brown-700 dark:text-brown-100 transition-colors rounded-4 rounded-l-2 data-[active=true]:bg-(--theme-primary) data-[active=true]:text-(--theme-on-primary) data-[active=false]:hover:bg-(--theme-primary) data-[active=false]:hover:text-(--theme-on-primary)"
-      v-sfx="{ hover: 'ui.click_07', click: 'ui.select' }"
-      @click="togglePill"
+      :data-playing="pill_playing || null"
+      v-sfx="{ hover: 'ui.click_07' }"
+      @click.capture="onCapturePill"
     >
       {{ pill_label }}
     </button>

--- a/src/components/ui-kit/tappable.vue
+++ b/src/components/ui-kit/tappable.vue
@@ -9,7 +9,7 @@ import type { NamespacedAudioKey } from '@/sfx/config'
 type UiTappableProps = {
   as?: string
   animate?: StagedTapAnimate
-  press_audio?: NamespacedAudioKey
+  audio?: NamespacedAudioKey
   triggerAt?: StagedTapPhase
   bgx_color?: string
 }
@@ -17,7 +17,7 @@ type UiTappableProps = {
 const {
   as = 'button',
   animate = 'quiet',
-  press_audio,
+  audio,
   triggerAt,
   bgx_color = 'var(--theme-neutral)'
 } = defineProps<UiTappableProps>()
@@ -28,7 +28,7 @@ const emit = defineEmits<{
 
 const { playing, tap } = useStagedTap({ animate, triggerAt })
 
-const handler = tap((e) => emit('tap', e), { pressAudio: press_audio })
+const handler = tap((e) => emit('tap', e), { audio })
 </script>
 
 <template>

--- a/src/composables/audio-reader/reader-highlights.ts
+++ b/src/composables/audio-reader/reader-highlights.ts
@@ -635,7 +635,10 @@ export function useReaderHighlights(
     // Mid-drag, ignore gaps (translation gloss, padding) so the range holds its
     // last extent instead of collapsing.
     if (anchor_index.value !== null) {
-      if (index !== null && index !== focus_index.value) focus_index.value = index
+      if (index !== null && index !== focus_index.value) {
+        focus_index.value = index
+        emitSfx('ui.tap_05')
+      }
       return
     }
 

--- a/src/composables/ui/staged-tap.ts
+++ b/src/composables/ui/staged-tap.ts
@@ -30,10 +30,21 @@ export interface StagedTapOptions {
 }
 
 export interface TapCallOptions {
-  /** Plays immediately on coarse press, before animation. */
-  pressAudio?: SfxKey
-  /** Options forwarded to emitSfx for pressAudio (debounce, blocking, etc.). */
-  pressAudioOpts?: PlayOptions
+  /**
+   * Coarse only — fires at press, before the animation starts. Use for an
+   * "arm" cue that has no fine-pointer equivalent (e.g. a haptic-style tick).
+   */
+  preAudio?: SfxKey
+  /**
+   * All pointers — the primary click-feedback sound.
+   * Fine pointer: fires immediately at capture, before the action.
+   * Coarse pointer: fires at the action phase (peak by default).
+   */
+  audio?: SfxKey
+  /** Options forwarded to emitSfx for the main audio key (blocking, debounce). */
+  audioOpts?: PlayOptions
+  /** Coarse only — fires after the animation completes. */
+  postAudio?: SfxKey
   /**
    * Set true when tap() is called from a @click.capture handler that coexists
    * with a natural @click (e.g. via v-bind="$attrs"). On fine pointers tap()
@@ -56,9 +67,14 @@ export interface TapCallOptions {
  * configured phase so a bgx sweep or pop animation plays first. On fine
  * pointers, the action fires immediately with no animation.
  *
+ * Sound phases:
+ * - preAudio  — coarse only, fires at press before animation (arm/haptic cue)
+ * - audio     — all pointers; fires immediately on fine, at the action phase on coarse
+ * - postAudio — coarse only, fires after animation completes
+ *
  * @example
  * const { playing, tap } = useStagedTap({ animate: 'pop', yoyo: true })
- * const handler = tap((e) => doThing(e), { pressAudio: 'ui.snappy_button_5' })
+ * const handler = tap((e) => doThing(e), { audio: 'ui.snappy_button_5' })
  * // <button @click="handler" :data-playing="playing || null">
  */
 export function useStagedTap(options: StagedTapOptions = {}) {
@@ -75,15 +91,16 @@ export function useStagedTap(options: StagedTapOptions = {}) {
   const is_coarse = useMatchMedia('coarse')
 
   /**
-   * Returns an async click handler. On fine pointers the action fires at once
-   * (unless captureMode). On coarse, plays the animation and fires the action
-   * at the configured phase.
+   * Returns an async click handler. On fine pointers the main audio fires
+   * immediately at capture and the action fires via the natural click. On
+   * coarse, plays the animation and fires the action at the configured phase.
    */
   function tap(action?: (e: MouseEvent) => void, tapOpts: TapCallOptions = {}) {
     return async (e: MouseEvent) => {
       tapOpts.onTap?.(e)
 
       if (activeOn === 'coarse-only' && !is_coarse.value) {
+        if (tapOpts.audio) emitSfx(tapOpts.audio, tapOpts.audioOpts)
         if (!tapOpts.captureMode) action?.(e)
         return
       }
@@ -93,11 +110,11 @@ export function useStagedTap(options: StagedTapOptions = {}) {
 
       const phase = tapOpts.triggerAt ?? triggerAt
 
-      if (tapOpts.pressAudio)
-        tapOpts.pressAudioOpts
-          ? emitSfx(tapOpts.pressAudio, tapOpts.pressAudioOpts)
-          : emitSfx(tapOpts.pressAudio)
-      if (phase === 'press') action?.(e)
+      if (tapOpts.preAudio) emitSfx(tapOpts.preAudio)
+      if (phase === 'press') {
+        if (tapOpts.audio) emitSfx(tapOpts.audio, tapOpts.audioOpts)
+        action?.(e)
+      }
 
       playing.value = true
 
@@ -105,12 +122,20 @@ export function useStagedTap(options: StagedTapOptions = {}) {
         const target = e.currentTarget as HTMLElement
         const { peak, done } = playButtonTap(target, duration, { yoyo, hold })
         await peak
-        if (phase === 'peak') action?.(e)
+        if (phase === 'peak') {
+          if (tapOpts.audio) emitSfx(tapOpts.audio, tapOpts.audioOpts)
+          action?.(e)
+        }
         await done
+        if (tapOpts.postAudio) emitSfx(tapOpts.postAudio)
         if (phase === 'done') action?.(e)
       } else {
         await new Promise<void>((resolve) => setTimeout(resolve, duration * 1000))
-        if (phase !== 'press') action?.(e)
+        if (phase !== 'press') {
+          if (tapOpts.audio) emitSfx(tapOpts.audio, tapOpts.audioOpts)
+          action?.(e)
+        }
+        if (tapOpts.postAudio) emitSfx(tapOpts.postAudio)
       }
 
       playing.value = false

--- a/src/phone/apps/settings/component/settings-save-button.vue
+++ b/src/phone/apps/settings/component/settings-save-button.vue
@@ -29,7 +29,7 @@ async function onSave() {
     full-width
     :loading="is_saving"
     :disabled="!is_dirty"
-    :sfx="{ click: 'ui.snappy_button_2' }"
+    :sfx="{ press: 'ui.snappy_button_2' }"
     click-when-disabled
     @click="onSave"
   >

--- a/src/sfx/directive.ts
+++ b/src/sfx/directive.ts
@@ -1,15 +1,18 @@
-// sfx/directive.ts
 import type { Directive, DirectiveBinding } from 'vue'
 import { emitSfx, emitHoverSfx } from './bus'
 import { type NamespacedAudioKey } from './config'
 
 export type SfxOptions = {
-  click?: NamespacedAudioKey
+  // Routed through staged-tap in button.vue — not handled by this directive.
+  press?: NamespacedAudioKey
+  tap_pre?: NamespacedAudioKey
+  tap_post?: NamespacedAudioKey
+  press_blocking?: boolean
+  // Handled by this directive.
   hover?: NamespacedAudioKey
   focus?: NamespacedAudioKey
   blur?: NamespacedAudioKey
   debounce?: number
-  click_blocking?: boolean
 }
 
 type SfxBindingValue = NamespacedAudioKey | SfxOptions
@@ -58,18 +61,6 @@ function _attach(el: HTMLElement, binding: DirectiveBinding<SfxBindingValue>) {
   const cleanups: Cleanup[] = []
 
   cleanups.push(
-    _add(el, 'click', (e) => {
-      if (!state.cfg.click) return
-      if (state.mods.prevent) e.preventDefault()
-      if (state.mods.stop) e.stopPropagation()
-      emitSfx(state.cfg.click, {
-        debounce: state.cfg.debounce,
-        blocking: state.cfg.click_blocking
-      })
-    })
-  )
-
-  cleanups.push(
     _add(el, 'pointerenter', (e) => {
       if (!state.cfg.hover) return
       if ((e as PointerEvent).pointerType !== 'mouse') return
@@ -105,17 +96,12 @@ function _parseBinding(
   mods: Partial<Record<string, boolean>>
 ): SfxOptions {
   if (typeof binding === 'string') {
-    // binding is an audio key
-    let c: SfxOptions = {}
-
-    // add audio key to all options specified in modifiers
-    if (mods.click) c.click = binding
+    const c: SfxOptions = {}
     if (mods.hover) c.hover = binding
     if (mods.focus) c.focus = binding
     if (mods.blur) c.blur = binding
-
-    return c // return new SfxOptions object
+    return c
   }
 
-  return binding // binding is an SfxOptions object
+  return binding
 }

--- a/src/views/audio-reader/lesson/audio-toolbar.vue
+++ b/src/views/audio-reader/lesson/audio-toolbar.vue
@@ -165,7 +165,7 @@ function setMode(next: 'expanded' | 'mini') {
             variant="ghost"
             icon-only
             play-on-tap
-            :sfx="{ click: 'ui.snappy_button_5' }"
+            :sfx="{ press: 'ui.snappy_button_5' }"
             @click="setMode('mini')"
           />
         </div>
@@ -219,7 +219,7 @@ function setMode(next: 'expanded' | 'mini') {
         variant="ghost"
         icon-only
         play-on-tap
-        :sfx="{ click: 'ui.snappy_button_5' }"
+        :sfx="{ press: 'ui.snappy_button_5' }"
         @click="setMode('expanded')"
       />
 

--- a/src/views/audio-reader/lesson/resume-follow-button.vue
+++ b/src/views/audio-reader/lesson/resume-follow-button.vue
@@ -20,7 +20,7 @@ const icon = computed(() => (direction === 'up' ? 'arcade-stick-up' : 'arcade-st
     rounded-full
     size="lg"
     class="shadow-sm"
-    :sfx="{ click: 'ui.snappy_button_5' }"
+    :sfx="{ press: 'ui.snappy_button_5' }"
     @click="emit('resume')"
   />
 </template>

--- a/src/views/audio-reader/term-popover/add-card-control.vue
+++ b/src/views/audio-reader/term-popover/add-card-control.vue
@@ -78,7 +78,7 @@ function onSelect(option: DropdownOption) {
     position="bottom-end"
     play-on-tap
     :tap-animate="false"
-    :sfx="{ click: 'ui.select' }"
+    :sfx="{ press: 'ui.select' }"
     :options="deck_options"
     :primary-disabled="already_a_card"
     :aria-disabled="disabled || undefined"

--- a/src/views/audio-reader/term-popover/add-card-panel.vue
+++ b/src/views/audio-reader/term-popover/add-card-panel.vue
@@ -152,7 +152,7 @@ async function onSave() {
         icon-only
         size="base"
         play-on-tap
-        :sfx="{ click: 'ui.snappy_button_5' }"
+        :sfx="{ press: 'ui.snappy_button_5' }"
         @click="emit('cancel')"
       >
         {{ t('audio-reader.add-card-modal.back-button') }}
@@ -211,7 +211,7 @@ async function onSave() {
         :disabled="!can_save || saving"
         play-on-tap
         :tap-animate="false"
-        :sfx="{ click: 'ui.select' }"
+        :sfx="{ press: 'ui.select' }"
         @click="onSave"
       >
         {{ t('audio-reader.add-card-modal.save-button') }}

--- a/src/views/audio-reader/term-popover/term-card.vue
+++ b/src/views/audio-reader/term-popover/term-card.vue
@@ -133,7 +133,7 @@ watch(
             icon-only
             size="base"
             play-on-tap
-            :sfx="{ click: 'ui.snappy_button_5' }"
+            :sfx="{ press: 'ui.snappy_button_5' }"
             @click="emit('back')"
           >
             {{ t('audio-reader.popover.close-button') }}
@@ -267,7 +267,7 @@ watch(
             full-width
             play-on-tap
             :tap-animate="false"
-            :sfx="{ click: 'ui.snappy_button_3' }"
+            :sfx="{ press: 'ui.snappy_button_3' }"
             @click="emit('play-from-here')"
           >
             {{ t('audio-reader.popover.play-from-here-button') }}

--- a/src/views/deck/deck-hero/actions.vue
+++ b/src/views/deck/deck-hero/actions.vue
@@ -52,7 +52,7 @@ function onEditOption(option: DropdownOption) {
       data-theme-dark="blue-650"
       full-width
       size="xl"
-      :sfx="{ click: 'ui.snappy_button_3' }"
+      :sfx="{ press: 'ui.snappy_button_3' }"
       :disabled="!has_due_cards"
       @click="onStudyClicked"
     >

--- a/src/views/welcome/sign-up/plan-option.vue
+++ b/src/views/welcome/sign-up/plan-option.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import UiRadio from '@/components/ui-kit/radio.vue'
+import { useStagedTap } from '@/composables/ui/staged-tap'
 
 const { theme = 'brown-100' } = defineProps<{
   theme?: Theme
@@ -11,8 +12,10 @@ const emit = defineEmits<{
   (e: 'select'): void
 }>()
 
-function onSelect() {
-  emit('select')
+const { playing, tap } = useStagedTap({ triggerAt: 'press' })
+
+function onCaptureClick(e: MouseEvent) {
+  tap(() => emit('select'), { audio: 'ui.etc_camera_shutter', captureMode: true })(e)
 }
 </script>
 
@@ -25,8 +28,8 @@ function onSelect() {
         'outline-3 outline-blue-500': selected,
         'outline-2 outline-brown-100 hover:outline-blue-500': !selected
       }"
-      @click="onSelect"
-      v-sfx.click="'ui.etc_camera_shutter'"
+      :data-playing="playing || null"
+      @click.capture="onCaptureClick"
     >
       <div
         class="w-full h-full flex gap-4 flex-col items-start bgx-leaf bgx-size-25 rounded-9 px-11 py-5 bgx-opacity-10"

--- a/tests/integration/components/deck/deck-thumbnail.test.js
+++ b/tests/integration/components/deck/deck-thumbnail.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, flushPromises } from '@vue/test-utils'
 
 const { coarseRef, mockEmitSfx } = vi.hoisted(() => ({
   coarseRef: { value: true },
@@ -153,7 +153,7 @@ describe('Deck', () => {
       vi.useRealTimers()
     })
 
-    test('emits click_sfx via beforePlay when provided', async () => {
+    test('emits click_sfx when tapped (fires at animation peak)', async () => {
       vi.useFakeTimers()
       const wrapper = shallowMount(Deck, {
         props: { deck: { title: 'X' }, click_sfx: 'ui.select' },
@@ -161,10 +161,10 @@ describe('Deck', () => {
       })
 
       wrapper.find('[data-testid="deck-thumbnail"]').trigger('click')
-      await Promise.resolve()
-
-      expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
       vi.advanceTimersByTime(500)
+      await flushPromises()
+
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.select', undefined)
       vi.useRealTimers()
     })
 

--- a/tests/integration/components/ui-kit/button.test.js
+++ b/tests/integration/components/ui-kit/button.test.js
@@ -185,15 +185,21 @@ describe('UiButton', () => {
       expect(onClick).toHaveBeenCalledTimes(1)
     })
 
-    test('emits click sfx at the start of the tap when sfx.click is set', async () => {
+    test('emits press sfx at the start of the tap when sfx.press is set', async () => {
+      vi.useFakeTimers()
       const wrapper = shallowMount(UiButton, {
-        props: { playOnTap: true, sfx: { click: 'ui.select' } },
+        props: { playOnTap: true, sfx: { press: 'ui.select' } },
         attrs: { onClick: vi.fn() }
       })
 
-      await wrapper.find('[data-testid="ui-kit-button"]').trigger('click')
+      wrapper
+        .find('[data-testid="ui-kit-button"]')
+        .element.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      vi.advanceTimersByTime(500)
+      await wrapper.vm.$nextTick()
 
       expect(mockEmitSfx).toHaveBeenCalledWith('ui.select', expect.any(Object))
+      vi.useRealTimers()
     })
 
     test('omits sfx when sfx.click is not set', async () => {
@@ -253,16 +259,17 @@ describe('UiButton', () => {
         expect(gsap.to).not.toHaveBeenCalled()
       })
 
-      test('tapAnimate=false still fires click sfx when sfx.click is set [obligation]', async () => {
+      test('tapAnimate=false still fires press sfx when sfx.press is set [obligation]', async () => {
         mockEmitSfx.mockClear()
         const wrapper = shallowMount(UiButton, {
-          props: { playOnTap: true, tapAnimate: false, sfx: { click: 'ui.select' } },
+          props: { playOnTap: true, tapAnimate: false, sfx: { press: 'ui.select' } },
           attrs: { onClick: vi.fn() }
         })
 
         wrapper
           .find('[data-testid="ui-kit-button"]')
           .element.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        vi.advanceTimersByTime(500)
         await wrapper.vm.$nextTick()
 
         expect(mockEmitSfx).toHaveBeenCalledWith('ui.select', expect.any(Object))

--- a/tests/integration/views/audio-reader/lesson/resume-follow-button.test.js
+++ b/tests/integration/views/audio-reader/lesson/resume-follow-button.test.js
@@ -76,7 +76,7 @@ describe('ResumeFollowButton', () => {
       const wrapper = mountButton()
 
       expect(wrapper.findComponent(UiButtonStub).props('sfx')).toEqual({
-        click: 'ui.snappy_button_5'
+        press: 'ui.snappy_button_5'
       })
     })
   })

--- a/tests/unit/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/unit/composables/audio-reader/use-reader-highlights.test.js
@@ -185,6 +185,96 @@ describe('useReaderHighlights', () => {
     })
   })
 
+  describe('mouse drag — fine-pointer ratchet [obligation]', () => {
+    test('onPointerMove emits ui.tap_05 when a new word is entered during active drag', async () => {
+      const { result, contentEl } = withHighlights()
+      const wordEl3 = addWord(contentEl, 3)
+      const wordEl5 = addWord(contentEl, 5)
+
+      stubElementFromPoint(() => wordEl3)
+      // Begin drag to set anchor_index
+      result.onPointerDown(
+        new PointerEvent('pointerdown', { pointerType: 'mouse', clientX: 50, clientY: 50 })
+      )
+      mockEmitSfx.mockClear()
+
+      // Move to word 5 — different index → ratchet tick
+      document.elementFromPoint = () => wordEl5
+      result.onPointerMove(
+        new PointerEvent('pointermove', { pointerType: 'mouse', clientX: 100, clientY: 50 })
+      )
+
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.tap_05')
+    })
+
+    test('onPointerMove does NOT emit ui.tap_05 when pointer stays on the same word', async () => {
+      const { result, contentEl } = withHighlights()
+      const wordEl3 = addWord(contentEl, 3)
+
+      stubElementFromPoint(() => wordEl3)
+      result.onPointerDown(
+        new PointerEvent('pointerdown', { pointerType: 'mouse', clientX: 50, clientY: 50 })
+      )
+      mockEmitSfx.mockClear()
+
+      // Move within word 3 — same index → no tick
+      result.onPointerMove(
+        new PointerEvent('pointermove', { pointerType: 'mouse', clientX: 55, clientY: 50 })
+      )
+
+      expect(mockEmitSfx).not.toHaveBeenCalled()
+    })
+
+    test('onPointerMove does NOT emit ui.tap_05 when wordIndexAt returns null (gap)', async () => {
+      const { result, contentEl } = withHighlights()
+      const wordEl3 = addWord(contentEl, 3)
+
+      stubElementFromPoint(() => wordEl3)
+      result.onPointerDown(
+        new PointerEvent('pointerdown', { pointerType: 'mouse', clientX: 50, clientY: 50 })
+      )
+      mockEmitSfx.mockClear()
+
+      // Move into a gap (no word element) — null index → no tick
+      document.elementFromPoint = () => contentEl
+      result.onPointerMove(
+        new PointerEvent('pointermove', { pointerType: 'mouse', clientX: 200, clientY: 50 })
+      )
+
+      expect(mockEmitSfx).not.toHaveBeenCalled()
+    })
+
+    test('touch path (extendTouchSelection) emits tap_05 when a word changes but the fine-pointer code path does NOT handle it', async () => {
+      // This is the existing touch ratchet via extendTouchSelection — separate from
+      // the fine-pointer path. Verifies the two paths are distinct: touch goes
+      // through trackTap→extendTouchSelection, not through the fine-pointer branch.
+      const { result, contentEl } = withHighlights()
+      const wordEl1 = addWord(contentEl, 1)
+      const wordEl2 = addWord(contentEl, 2)
+
+      vi.useFakeTimers()
+
+      stubElementFromPoint(() => wordEl1)
+      result.onPointerDown(
+        new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 10, clientY: 10 })
+      )
+      // Arm the long-press range select
+      vi.advanceTimersByTime(410)
+      await nextTick()
+      mockEmitSfx.mockClear()
+
+      // Drag to word 2 via TOUCH pointermove — goes through extendTouchSelection
+      document.elementFromPoint = () => wordEl2
+      result.onPointerMove(
+        new PointerEvent('pointermove', { pointerType: 'touch', clientX: 30, clientY: 10 })
+      )
+
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.tap_05')
+
+      vi.useRealTimers()
+    })
+  })
+
   describe('mouse drag', () => {
     test('pointerdown on a word sets interaction_range to that word', async () => {
       const { result, contentEl } = withHighlights()

--- a/tests/unit/composables/use-staged-tap.test.js
+++ b/tests/unit/composables/use-staged-tap.test.js
@@ -305,17 +305,136 @@ describe('useStagedTap — onTap call option', () => {
   })
 })
 
-describe('useStagedTap — pressAudio', () => {
-  test('pressAudio plays on coarse press before animation', async () => {
+describe('useStagedTap — audio', () => {
+  test('audio fires on fine pointer (core fix — fine pointer now gets audio)', async () => {
+    coarseRef.value = false
     const { tap } = useStagedTap()
-    await tap(vi.fn(), { pressAudio: 'ui.snappy_button_5' })(makeEvent())
+    await tap(vi.fn(), { audio: 'ui.snappy_button_5' })(makeEvent())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.snappy_button_5', undefined)
+  })
+
+  test('audio fires at peak on coarse with pop animate', async () => {
+    let peakResolve
+    mockPlayButtonTap.mockImplementation(() => ({
+      peak: new Promise((r) => (peakResolve = r)),
+      done: Promise.resolve()
+    }))
+    const { tap } = useStagedTap({ animate: 'pop' })
+    const action = vi.fn()
+
+    const p = tap(action, { audio: 'ui.snappy_button_5' })(makeEvent())
+    // Not yet — waiting for peak
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+
+    peakResolve()
+    await p
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.snappy_button_5', undefined)
+  })
+
+  test('audio fires after timer on coarse with quiet animate', async () => {
+    vi.useFakeTimers()
+    const { tap } = useStagedTap({ animate: 'quiet' })
+
+    const p = tap(vi.fn(), { audio: 'ui.snappy_button_5' })(makeEvent())
+    // Not yet — timer still pending
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(200)
+    await p
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.snappy_button_5', undefined)
+    vi.useRealTimers()
+  })
+
+  test('audio fires at press when triggerAt: "press" on coarse', async () => {
+    const { tap } = useStagedTap({ animate: 'pop' })
+
+    const p = tap(vi.fn(), { audio: 'ui.snappy_button_5', triggerAt: 'press' })(makeEvent())
+    // At press — synchronously — audio fires
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.snappy_button_5', undefined)
+    await p
+  })
+
+  test('audio + captureMode on fine: audio fires but action does NOT [obligation]', async () => {
+    coarseRef.value = false
+    const { tap } = useStagedTap()
+    const action = vi.fn()
+
+    await tap(action, { audio: 'ui.snappy_button_5', captureMode: true })(makeEvent())
+
+    // Audio fires on fine pointer even in captureMode
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.snappy_button_5', undefined)
+    // Action does NOT — the natural @click handles it
+    expect(action).not.toHaveBeenCalled()
+  })
+
+  test('audio NOT played twice on coarse pop animate with triggerAt peak [obligation]', async () => {
+    let peakResolve
+    mockPlayButtonTap.mockImplementation(() => ({
+      peak: new Promise((r) => (peakResolve = r)),
+      done: Promise.resolve()
+    }))
+    const { tap } = useStagedTap({ animate: 'pop' })
+
+    const p = tap(vi.fn(), { audio: 'ui.snappy_button_5' })(makeEvent())
+    peakResolve()
+    await p
+
+    // Exactly one call — not once at press AND once at peak
+    expect(mockEmitSfx).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useStagedTap — preAudio', () => {
+  test('preAudio fires on coarse press before animation [obligation]', async () => {
+    const { tap } = useStagedTap()
+    await tap(vi.fn(), { preAudio: 'ui.snappy_button_5' })(makeEvent())
     expect(mockEmitSfx).toHaveBeenCalledWith('ui.snappy_button_5')
   })
 
-  test('pressAudio does NOT play on fine pointer', async () => {
+  test('preAudio does NOT fire on fine pointer [obligation]', async () => {
     coarseRef.value = false
     const { tap } = useStagedTap()
-    await tap(vi.fn(), { pressAudio: 'ui.snappy_button_5' })(makeEvent())
+    await tap(vi.fn(), { preAudio: 'ui.snappy_button_5' })(makeEvent())
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+  })
+})
+
+describe('useStagedTap — postAudio', () => {
+  test('postAudio fires after animation completes on coarse pop animate [obligation]', async () => {
+    let doneResolve
+    mockPlayButtonTap.mockImplementation(() => ({
+      peak: Promise.resolve(),
+      done: new Promise((r) => (doneResolve = r))
+    }))
+    const { tap } = useStagedTap({ animate: 'pop' })
+
+    const p = tap(vi.fn(), { postAudio: 'ui.snappy_button_5' })(makeEvent())
+    // After peak, before done — no postAudio yet
+    await Promise.resolve()
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+
+    doneResolve()
+    await p
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.snappy_button_5')
+  })
+
+  test('postAudio fires after timer on coarse quiet animate [obligation]', async () => {
+    vi.useFakeTimers()
+    const { tap } = useStagedTap({ animate: 'quiet' })
+
+    const p = tap(vi.fn(), { postAudio: 'ui.snappy_button_5' })(makeEvent())
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(200)
+    await p
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.snappy_button_5')
+    vi.useRealTimers()
+  })
+
+  test('postAudio does NOT fire on fine pointer [obligation]', async () => {
+    coarseRef.value = false
+    const { tap } = useStagedTap()
+    await tap(vi.fn(), { postAudio: 'ui.snappy_button_5' })(makeEvent())
     expect(mockEmitSfx).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/sfx/directive.test.js
+++ b/tests/unit/sfx/directive.test.js
@@ -85,28 +85,31 @@ describe('vSfx directive', () => {
   })
 
   describe('click', () => {
-    test('still fires sfx on click regardless of pointer type', () => {
+    test('click key is accepted in the object shape without error [obligation]', () => {
+      // The `click` key remains in SfxOptions so button.vue can read it —
+      // v-sfx just no longer handles the click event itself.
+      expect(() => {
+        const el = mountDirective({ click: 'ui.click_07' })
+        unmount(el)
+      }).not.toThrow()
+    })
+
+    test('clicking an element with click key does NOT call emitSfx [obligation]', () => {
       const el = mountDirective({ click: 'ui.click_07' })
 
       el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
 
-      expect(emitSfx).toHaveBeenCalledWith('ui.click_07', {
-        debounce: undefined,
-        blocking: undefined
-      })
+      expect(emitSfx).not.toHaveBeenCalled()
       unmount(el)
     })
 
-    test('forwards click_blocking option as PlayOptions.blocking', () => {
-      const el = mountDirective({ click: 'ui.select', click_blocking: true })
-
-      el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-
-      expect(emitSfx).toHaveBeenCalledWith('ui.select', {
-        debounce: undefined,
-        blocking: true
-      })
-      unmount(el)
+    test('press_blocking key accepted without error — directive ignores it silently [obligation]', () => {
+      expect(() => {
+        const el = mountDirective({ press: 'ui.click_07', press_blocking: true })
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        unmount(el)
+      }).not.toThrow()
+      expect(emitSfx).not.toHaveBeenCalled()
     })
   })
 
@@ -169,6 +172,46 @@ describe('vSfx directive', () => {
     })
   })
 
+  describe('focus', () => {
+    test('plays sfx on focus', () => {
+      const el = mountDirective({ focus: 'ui.click_07' })
+
+      el.dispatchEvent(new Event('focus'))
+
+      expect(emitSfx).toHaveBeenCalledWith('ui.click_07', { debounce: undefined })
+      unmount(el)
+    })
+
+    test('does NOT play sfx on focus when no focus key configured', () => {
+      const el = mountDirective({ hover: 'ui.click_07' })
+
+      el.dispatchEvent(new Event('focus'))
+
+      expect(emitSfx).not.toHaveBeenCalled()
+      unmount(el)
+    })
+  })
+
+  describe('blur', () => {
+    test('plays sfx on blur', () => {
+      const el = mountDirective({ blur: 'ui.click_07' })
+
+      el.dispatchEvent(new Event('blur'))
+
+      expect(emitSfx).toHaveBeenCalledWith('ui.click_07', { debounce: undefined })
+      unmount(el)
+    })
+
+    test('does NOT play sfx on blur when no blur key configured', () => {
+      const el = mountDirective({ hover: 'ui.click_07' })
+
+      el.dispatchEvent(new Event('blur'))
+
+      expect(emitSfx).not.toHaveBeenCalled()
+      unmount(el)
+    })
+  })
+
   describe('binding shorthand', () => {
     test('string binding + .hover modifier wires hover sfx', () => {
       const el = mountDirective('ui.click_07', { hover: true })
@@ -185,6 +228,24 @@ describe('vSfx directive', () => {
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'touch' }))
 
       expect(emitHoverSfx).not.toHaveBeenCalled()
+      unmount(el)
+    })
+
+    test('string binding + .focus modifier wires focus sfx', () => {
+      const el = mountDirective('ui.click_07', { focus: true })
+
+      el.dispatchEvent(new Event('focus'))
+
+      expect(emitSfx).toHaveBeenCalledWith('ui.click_07', { debounce: undefined })
+      unmount(el)
+    })
+
+    test('string binding + .blur modifier wires blur sfx', () => {
+      const el = mountDirective('ui.click_07', { blur: true })
+
+      el.dispatchEvent(new Event('blur'))
+
+      expect(emitSfx).toHaveBeenCalledWith('ui.click_07', { debounce: undefined })
       unmount(el)
     })
   })


### PR DESCRIPTION
## Summary

Click sounds on fine (mouse) pointers were firing *after* the action rather than before it, because v-sfx registered its click listener in the bubble phase while Vue had already registered the action handler earlier. On modal-dismissing buttons this made sounds imperceptible. This PR redesigns the sound authority model so staged-tap owns all press-phase sounds for every pointer type.

## Changes

- **staged-tap** — new three-slot API: `preAudio` (coarse-only, before animation), `audio` (all pointers — immediate on fine, at animation peak on coarse), `postAudio` (coarse-only, after animation). Fine pointer now receives `audio` at capture phase, before the action fires in bubble.
- **v-sfx directive** — drops the `click` event listener entirely; now handles hover/focus/blur only. `SfxOptions` gains `press`, `tap_pre`, `tap_post`, `press_blocking`; renames `click` → `press`.
- **ui-button** — routes `sfx.press/tap_pre/tap_post` through staged-tap; v-sfx receives hover/focus/blur only.
- **Raw interactive elements** (spinbox buttons, radio, script-select, plan-option, study-edit-footer) — migrated from `v-sfx.click` to `useStagedTap({ triggerAt: 'press' })` + `@click.capture`.
- **audio-reader drag selection** — `onPointerMove` now emits `ui.tap_05` per word on fine-pointer drag, matching the existing touch ratchet in `extendTouchSelection`.
- **Tests** — staged-tap suite updated for new phase API; directive suite updated to assert click no longer fires; reader-highlights suite gains fine-pointer drag ratchet coverage.