### PR TITLE
Rebuild ui-kit slider with live audio volume preview

### DIFF
--- a/src/components/ui-kit/slider.vue
+++ b/src/components/ui-kit/slider.vue
@@ -1,45 +1,50 @@
 <script setup lang="ts">
-import UiTooltip from '@/components/ui-kit/tooltip.vue'
-import { onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
+import { computed, onMounted, ref, useTemplateRef } from 'vue'
 import { useGestures } from '@/composables/ui/gestures'
+import { emitSfx } from '@/sfx/bus'
 
-const { theme = 'brown-800' } = defineProps<{
-  theme?: Theme
-}>()
-const percent = defineModel<number>()
+type SliderProps = {
+  min?: number
+  max?: number
+  step?: number
+  label?: string
+  ticks?: boolean
+}
+
+const MAX_TICKS = 20
+const EDGE_PX = 20
+const EDGE = `${EDGE_PX}px`
+
+const { min = 0, max = 100, step = 1, label, ticks = true } = defineProps<SliderProps>()
+
+const value = defineModel<number>({ required: true })
 
 const container = useTemplateRef('container')
-const fill = useTemplateRef('fill')
-
-const is_dragging = ref(false)
-
-let gap = 0
-let thumb: HTMLElement | null
-let drag_container_left = 0
-let drag_container_width = 0
-let drag_thumb_half = 0
 
 const { register } = useGestures()
 
-let resize_observer: ResizeObserver | null = null
+const is_dragging = ref(false)
+
+let rect_left = 0
+let rect_width = 0
+
+const fill_width = computed(() => `calc(${offsetOf(value.value)} + ${EDGE})`)
+
+const tick_values = computed(() => {
+  if (!ticks) return []
+  const count = (max - min) / step
+  if (!Number.isFinite(count) || count < 2 || count > MAX_TICKS) return []
+  return Array.from({ length: count - 1 }, (_, i) => min + (i + 1) * step)
+})
 
 onMounted(() => {
-  thumb = container.value!.querySelector('[data-testid="ui-kit-slider__thumb"]')
-
-  resize_observer = new ResizeObserver(([entry]) => {
-    if (entry.contentRect.width === 0) return
-    gap = parseInt(getComputedStyle(container.value!).columnGap) || 0
-    if (percent.value !== undefined) setFillWidth(percent.value)
-  })
-  resize_observer.observe(container.value!)
-
   register(container.value!, {
-    onStart() {
+    onStart({ x }) {
       const rect = container.value!.getBoundingClientRect()
-      drag_container_left = rect.left
-      drag_container_width = rect.width
-      drag_thumb_half = thumb!.clientWidth / 2
+      rect_left = rect.left
+      rect_width = rect.width
       is_dragging.value = true
+      applyX(x)
     },
     onMove({ x }) {
       applyX(x)
@@ -54,63 +59,116 @@ onMounted(() => {
   })
 })
 
-onUnmounted(() => {
-  resize_observer?.disconnect()
-})
-
-function applyX(clientX: number) {
-  const pos = clientX - drag_container_left - drag_thumb_half
-  let ratio = pos / (drag_container_width - drag_thumb_half)
-  ratio = Math.min(Math.max(ratio, 0), 1)
-
-  const new_percent = ratio * 100
-  const rounded = Math.round(new_percent)
-  const clamped = Math.min(Math.max(rounded, 0), 100)
-  const final = clamped === 0 ? 0 : clamped === 100 ? 100 : new_percent
-
-  percent.value = clamped
-  setFillWidth(final)
+function offsetOf(v: number) {
+  if (max === min) return EDGE
+  const fraction = clamp((v - min) / (max - min), 0, 1)
+  return `calc(${EDGE} + ${fraction} * (100% - ${EDGE} * 2))`
 }
 
-function setFillWidth(new_percent: number) {
-  if (!container.value || !fill.value || !thumb) return
+function clamp(n: number, lo: number, hi: number) {
+  return Math.min(Math.max(n, lo), hi)
+}
 
-  const width = container.value.offsetWidth
-  const new_width = width * (new_percent / 100)
-  const clamped = Math.min(Math.max(new_width, 0), width - gap)
+function applyX(client_x: number) {
+  const ratio = clamp((client_x - rect_left - EDGE_PX) / (rect_width - EDGE_PX * 2), 0, 1)
+  const raw = min + ratio * (max - min)
+  const stepped = clamp(min + Math.round((raw - min) / step) * step, min, max)
 
-  fill.value.style.width = `${clamped}px`
+  if (stepped === value.value) return
+
+  value.value = stepped
+  emitSfx('tap_05')
+}
+
+function onKeydown(e: KeyboardEvent) {
+  const delta = KEY_DELTAS[e.key]
+  if (delta === undefined) return
+
+  e.preventDefault()
+  const next = e.key === 'Home' ? min : e.key === 'End' ? max : value.value + delta * step
+  value.value = clamp(next, min, max)
+}
+
+const KEY_DELTAS: Record<string, number> = {
+  ArrowRight: 1,
+  ArrowUp: 1,
+  ArrowLeft: -1,
+  ArrowDown: -1,
+  Home: 0,
+  End: 0
 }
 </script>
 
 <template>
   <div
     ref="container"
-    :data-theme="theme"
     data-testid="ui-kit-slider"
-    class="grid grid-cols-[auto_1fr] items-center gap-7.5"
+    role="slider"
+    tabindex="0"
+    :aria-label="label"
+    :aria-valuemin="min"
+    :aria-valuemax="max"
+    :aria-valuenow="value"
+    :data-active="is_dragging"
+    class="relative h-12 w-full select-none overflow-hidden rounded-4 bg-input touch-none outline-none"
+    :class="is_dragging ? 'cursor-grabbing' : 'cursor-grab'"
+    @keydown="onKeydown"
   >
     <div
-      ref="fill"
       data-testid="ui-kit-slider__fill"
-      class="h-2.5 bg-(--theme-primary) rounded-full relative flex items-center"
+      class="absolute inset-y-0 left-0 rounded-4 bg-(--theme-primary)"
+      :style="{ width: fill_width }"
+    ></div>
+
+    <div
+      data-testid="ui-kit-slider__handle"
+      class="absolute inset-y-2.5 w-1 -translate-x-1/2 rounded-full bg-(--theme-on-primary) dark:bg-brown-100"
+      :style="{ left: offsetOf(value) }"
+    ></div>
+
+    <span
+      v-for="tick in tick_values"
+      :key="tick"
+      aria-hidden="true"
+      data-testid="ui-kit-slider__tick"
+      :data-visible="tick > value"
+      class="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-(--theme-secondary) transition-opacity dark:bg-grey-600"
+      :class="tick > value ? 'opacity-100' : 'opacity-0'"
+      :style="{ left: offsetOf(tick) }"
+    ></span>
+
+    <div
+      data-testid="ui-kit-slider__content"
+      class="pointer-events-none absolute inset-0 flex items-center justify-between px-4 text-base text-(--theme-on-neutral)"
+      :style="{ clipPath: `inset(0 0 0 ${fill_width})` }"
     >
-      <ui-tooltip
-        data-testid="ui-kit-slider__thumb"
-        :text="`${percent}%`"
-        :visible="is_dragging"
-        element="div"
-        class="absolute -right-6.5 w-5.5 h-5.5 bg-(--theme-accent) rounded-full shrink-0 cursor-pointer hover:ring-4 hover:ring-(--theme-accent) transition-all duration-75 z-10"
-      ></ui-tooltip>
+      <span
+        v-if="label"
+        data-testid="ui-kit-slider__label"
+        class="flex items-center self-stretch bg-input px-1"
+      >
+        {{ label }}
+      </span>
+      <span
+        data-testid="ui-kit-slider__value"
+        class="flex items-center self-stretch bg-input px-1 tabular-nums"
+      >
+        {{ value }}
+      </span>
     </div>
 
     <div
-      data-testid="ui-kit-slider__track"
-      class="h-2.5 bg-brown-100 dark:bg-grey-900 rounded-full"
-    ></div>
-
-    <!-- <div data-testid="ui-kit-slider__spinbox">
-      <input value="5" class="w-7.5 h-7.5 bg-brown-100 rounded-2.5 px-2.5 py-1" />
-    </div> -->
+      aria-hidden="true"
+      data-testid="ui-kit-slider__content-fill"
+      class="pointer-events-none absolute inset-0 flex items-center justify-between px-4 text-base text-(--theme-on-primary)"
+      :style="{ clipPath: `inset(0 calc(100% - ${fill_width}) 0 0 round 16px)` }"
+    >
+      <span v-if="label" class="flex items-center self-stretch bg-(--theme-primary)/70 px-1">
+        {{ label }}
+      </span>
+      <span class="flex items-center self-stretch bg-(--theme-primary)/70 px-1 tabular-nums">
+        {{ value }}
+      </span>
+    </div>
   </div>
 </template>

--- a/src/components/ui-kit/slider.vue
+++ b/src/components/ui-kit/slider.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref, useTemplateRef } from 'vue'
 import { useGestures } from '@/composables/ui/gestures'
 import { emitSfx } from '@/sfx/bus'
+import type { Bus, SoundKey } from '@/sfx/config'
 
 type SliderProps = {
   min?: number
@@ -9,13 +10,15 @@ type SliderProps = {
   step?: number
   label?: string
   ticks?: boolean
+  /** Sound played on each notch while dragging; `bus` routes its volume. */
+  sfx?: { tick?: SoundKey; bus?: Bus }
 }
 
 const MAX_TICKS = 20
 const EDGE_PX = 20
 const EDGE = `${EDGE_PX}px`
 
-const { min = 0, max = 100, step = 1, label, ticks = true } = defineProps<SliderProps>()
+const { min = 0, max = 100, step = 1, label, ticks = true, sfx = {} } = defineProps<SliderProps>()
 
 const value = defineModel<number>({ required: true })
 
@@ -77,7 +80,7 @@ function applyX(client_x: number) {
   if (stepped === value.value) return
 
   value.value = stepped
-  emitSfx('tap_05')
+  emitSfx(sfx.tick ?? 'tap_05', { bus: sfx.bus })
 }
 
 function onKeydown(e: KeyboardEvent) {
@@ -132,14 +135,14 @@ const KEY_DELTAS: Record<string, number> = {
       aria-hidden="true"
       data-testid="ui-kit-slider__tick"
       :data-visible="tick > value"
-      class="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-(--theme-secondary) transition-opacity dark:bg-grey-600"
+      class="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-brown-500 transition-opacity dark:bg-grey-600"
       :class="tick > value ? 'opacity-100' : 'opacity-0'"
       :style="{ left: offsetOf(tick) }"
     ></span>
 
     <div
       data-testid="ui-kit-slider__content"
-      class="pointer-events-none absolute inset-0 flex items-center justify-between px-4 text-base text-(--theme-on-neutral)"
+      class="pointer-events-none absolute inset-0 flex items-center justify-between px-4 text-base text-brown-700"
       :style="{ clipPath: `inset(0 0 0 ${fill_width})` }"
     >
       <span

--- a/src/phone/apps/settings/component/tab-app/index.vue
+++ b/src/phone/apps/settings/component/tab-app/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { inject } from 'vue'
 import { useI18n } from 'vue-i18n'
-import UiSpinbox from '@/components/ui-kit/spinbox/index.vue'
+import UiSlider from '@/components/ui-kit/slider.vue'
 import UiToggle from '@/components/ui-kit/toggle.vue'
 import SectionList from '@/components/layout-kit/section-list.vue'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
@@ -22,16 +22,25 @@ const emit = defineEmits<{ back: [] }>()
     <settings-back-button @back="emit('back')" />
 
     <labeled-section :label="t('settings.app.section.audio')">
-      <div
-        data-testid="tab-app__audio"
-        class="grid grid-cols-[auto_1fr] items-center gap-y-6 gap-x-8 text-brown-700 dark:text-brown-300 select-none"
-      >
-        <span>{{ t('settings.app.audio.study-sounds') }}</span>
-        <ui-spinbox v-model:value="editor.preferences.audio.study_sounds" :min="1" :max="10" />
-        <span>{{ t('settings.app.audio.interface-sounds') }}</span>
-        <ui-spinbox v-model:value="editor.preferences.audio.interface_sounds" :min="1" :max="10" />
-        <span>{{ t('settings.app.audio.hover-sounds') }}</span>
-        <ui-spinbox v-model:value="editor.preferences.audio.hover_sounds" :min="1" :max="10" />
+      <div data-testid="tab-app__audio" class="flex flex-col gap-3">
+        <ui-slider
+          v-model="editor.preferences.audio.study_sounds"
+          :min="1"
+          :max="10"
+          :label="t('settings.app.audio.study-sounds')"
+        />
+        <ui-slider
+          v-model="editor.preferences.audio.interface_sounds"
+          :min="1"
+          :max="10"
+          :label="t('settings.app.audio.interface-sounds')"
+        />
+        <ui-slider
+          v-model="editor.preferences.audio.hover_sounds"
+          :min="1"
+          :max="10"
+          :label="t('settings.app.audio.hover-sounds')"
+        />
       </div>
     </labeled-section>
 

--- a/src/phone/apps/settings/component/tab-app/index.vue
+++ b/src/phone/apps/settings/component/tab-app/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject } from 'vue'
+import { inject, onBeforeUnmount, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import UiSlider from '@/components/ui-kit/slider.vue'
 import UiToggle from '@/components/ui-kit/toggle.vue'
@@ -9,12 +9,22 @@ import SettingsBackButton from '../settings-back-button.vue'
 import SettingsSaveButton from '../settings-save-button.vue'
 import { memberEditorKey } from '@/composables/member/editor'
 import { settingsLayoutKey } from '../../layout'
+import { toBusVolumes } from '@/utils/member/preferences'
+import audio_player from '@/sfx/player'
+
+const emit = defineEmits<{ back: [] }>()
 
 const { t } = useI18n()
 const editor = inject(memberEditorKey)!
 const layout_mode = inject(settingsLayoutKey)!
 
-const emit = defineEmits<{ back: [] }>()
+onBeforeUnmount(() => audio_player.resetSettings())
+
+watch(
+  () => editor.preferences.audio,
+  (audio) => audio_player.previewVolumeConfig(toBusVolumes(audio)),
+  { deep: true }
+)
 </script>
 
 <template>
@@ -25,21 +35,24 @@ const emit = defineEmits<{ back: [] }>()
       <div data-testid="tab-app__audio" class="flex flex-col gap-3">
         <ui-slider
           v-model="editor.preferences.audio.study_sounds"
-          :min="1"
+          :min="0"
           :max="10"
           :label="t('settings.app.audio.study-sounds')"
+          :sfx="{ bus: 'study' }"
         />
         <ui-slider
           v-model="editor.preferences.audio.interface_sounds"
-          :min="1"
+          :min="0"
           :max="10"
           :label="t('settings.app.audio.interface-sounds')"
+          :sfx="{ bus: 'interface' }"
         />
         <ui-slider
           v-model="editor.preferences.audio.hover_sounds"
-          :min="1"
+          :min="0"
           :max="10"
           :label="t('settings.app.audio.hover-sounds')"
+          :sfx="{ bus: 'hover' }"
         />
       </div>
     </labeled-section>

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -40,9 +40,24 @@ class AudioPlayer {
   // Resting setting per bus. setVolumeConfig (called from App.vue) overwrites
   // this once member prefs load. Inline defaults avoid a config.ts init cycle.
   volume_settings: Record<Bus, number> = { interface: 5, study: 5, hover: 5 }
+  // The committed baseline — what the server gave us (or defaults). previewVolumeConfig
+  // can drift volume_settings off this for live UI feedback; resetSettings restores it.
+  committed_volume_settings: Record<Bus, number> = { ...this.volume_settings }
 
+  // Commit a new baseline and apply it (App.vue, on member-pref load/save).
   setVolumeConfig = (settings: Record<Bus, number>) => {
-    this.volume_settings = settings
+    this.committed_volume_settings = { ...settings }
+    this.volume_settings = { ...settings }
+  }
+
+  // Apply settings live without committing — for previewing edits mid-drag.
+  previewVolumeConfig = (settings: Record<Bus, number>) => {
+    this.volume_settings = { ...settings }
+  }
+
+  // Discard any preview and fall back to the committed baseline.
+  resetSettings = () => {
+    this.volume_settings = { ...this.committed_volume_settings }
   }
 
   setup = () => {

--- a/tests/integration/components/ui-kit/slider.test.js
+++ b/tests/integration/components/ui-kit/slider.test.js
@@ -1,0 +1,381 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { _resetGestureState } from '@/composables/ui/gestures'
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: vi.fn() }))
+vi.mock('@/sfx/config', () => ({
+  TYPE_SFX: [],
+  SOUNDS: {},
+  BUS_DEFAULTS: { interface: 5, study: 5, hover: 5 }
+}))
+
+import UiSlider from '@/components/ui-kit/slider.vue'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const EDGE_PX = 20
+
+let _activeWrappers = []
+
+afterEach(() => {
+  for (const w of _activeWrappers) w.unmount()
+  _activeWrappers = []
+  _resetGestureState()
+})
+
+/**
+ * Mount a slider attached to document.body with a two-way-bound model value.
+ * Returns wrapper + a `getValue()` accessor that returns the current model.
+ * Wrappers are auto-unmounted in afterEach.
+ */
+function makeSlider(props = {}, initialValue = 5) {
+  let model = initialValue
+  const wrapper = mount(UiSlider, {
+    attachTo: document.body,
+    props: {
+      modelValue: model,
+      'onUpdate:modelValue': (v) => {
+        model = v
+        wrapper.setProps({ modelValue: v })
+      },
+      ...props
+    }
+  })
+  _activeWrappers.push(wrapper)
+  return { wrapper, getValue: () => model }
+}
+
+function root(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-slider"]')
+}
+
+// ── Structure ─────────────────────────────────────────────────────────────────
+
+describe('UiSlider — structure', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+  })
+
+  test('renders the root, fill, handle, content, and content-fill parts', () => {
+    const { wrapper } = makeSlider()
+    expect(root(wrapper).exists()).toBe(true)
+    expect(wrapper.find('[data-testid="ui-kit-slider__fill"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="ui-kit-slider__handle"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="ui-kit-slider__content"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="ui-kit-slider__content-fill"]').exists()).toBe(true)
+  })
+
+  test('shows value in the content overlay', () => {
+    const { wrapper } = makeSlider({}, 7)
+    const value_el = wrapper.find('[data-testid="ui-kit-slider__value"]')
+    expect(value_el.exists()).toBe(true)
+    expect(value_el.text()).toBe('7')
+  })
+
+  test('renders label when label prop is provided', () => {
+    const { wrapper } = makeSlider({ label: 'Volume' })
+    expect(wrapper.find('[data-testid="ui-kit-slider__label"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="ui-kit-slider__label"]').text()).toBe('Volume')
+  })
+
+  test('does not render label when label prop is omitted', () => {
+    const { wrapper } = makeSlider()
+    expect(wrapper.find('[data-testid="ui-kit-slider__label"]').exists()).toBe(false)
+  })
+
+  test('root has role="slider" and aria attributes', () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, label: 'Gain' }, 4)
+    const el = root(wrapper)
+    expect(el.attributes('role')).toBe('slider')
+    expect(el.attributes('aria-valuemin')).toBe('0')
+    expect(el.attributes('aria-valuemax')).toBe('10')
+    expect(el.attributes('aria-valuenow')).toBe('4')
+    expect(el.attributes('aria-label')).toBe('Gain')
+    expect(el.attributes('tabindex')).toBe('0')
+  })
+})
+
+// ── Tick markers ──────────────────────────────────────────────────────────────
+
+describe('UiSlider — tick markers', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+  })
+
+  test('renders tick markers when step count is between 2 and 20', () => {
+    // min=0, max=10, step=1 → 10 steps → 9 interior ticks (count-1)
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1, ticks: true }, 0)
+    const ticks = wrapper.findAll('[data-testid="ui-kit-slider__tick"]')
+    expect(ticks).toHaveLength(9)
+  })
+
+  test('renders no ticks when step count is 1 (below minimum of 2)', () => {
+    // min=0, max=1, step=1 → 1 step → 0 interior ticks
+    const { wrapper } = makeSlider({ min: 0, max: 1, step: 1, ticks: true }, 0)
+    const ticks = wrapper.findAll('[data-testid="ui-kit-slider__tick"]')
+    expect(ticks).toHaveLength(0)
+  })
+
+  test('renders no ticks when step count exceeds MAX_TICKS (20)', () => {
+    // min=0, max=21, step=1 → 21 steps → suppressed
+    const { wrapper } = makeSlider({ min: 0, max: 21, step: 1, ticks: true }, 0)
+    const ticks = wrapper.findAll('[data-testid="ui-kit-slider__tick"]')
+    expect(ticks).toHaveLength(0)
+  })
+
+  test('renders no ticks when ticks prop is false', () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1, ticks: false }, 0)
+    const ticks = wrapper.findAll('[data-testid="ui-kit-slider__tick"]')
+    expect(ticks).toHaveLength(0)
+  })
+
+  test('ticks at or before the value are hidden (data-visible=false)', async () => {
+    // min=0, max=4, step=1 → ticks at 1,2,3
+    // value=2 → tick at 1 hidden, tick at 2 hidden, tick at 3 visible
+    const { wrapper } = makeSlider({ min: 0, max: 4, step: 1, ticks: true }, 2)
+    const ticks = wrapper.findAll('[data-testid="ui-kit-slider__tick"]')
+    // tick[0] = value 1, tick[1] = value 2, tick[2] = value 3
+    expect(ticks[0].attributes('data-visible')).toBe('false') // 1 <= 2 → hidden
+    expect(ticks[1].attributes('data-visible')).toBe('false') // 2 <= 2 → hidden
+    expect(ticks[2].attributes('data-visible')).toBe('true') // 3 > 2 → visible
+  })
+
+  test('renders exactly MAX_TICKS-1 ticks when step count is exactly 20', () => {
+    // min=0, max=20, step=1 → 20 steps → 19 interior ticks
+    const { wrapper } = makeSlider({ min: 0, max: 20, step: 1, ticks: true }, 0)
+    const ticks = wrapper.findAll('[data-testid="ui-kit-slider__tick"]')
+    expect(ticks).toHaveLength(19)
+  })
+})
+
+// ── Keyboard accessibility ─────────────────────────────────────────────────────
+
+describe('UiSlider — keyboard a11y', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+  })
+
+  test('ArrowRight increments value by step', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    await root(wrapper).trigger('keydown', { key: 'ArrowRight' })
+    expect(getValue()).toBe(6)
+  })
+
+  test('ArrowUp increments value by step', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    await root(wrapper).trigger('keydown', { key: 'ArrowUp' })
+    expect(getValue()).toBe(6)
+  })
+
+  test('ArrowLeft decrements value by step', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    await root(wrapper).trigger('keydown', { key: 'ArrowLeft' })
+    expect(getValue()).toBe(4)
+  })
+
+  test('ArrowDown decrements value by step', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    await root(wrapper).trigger('keydown', { key: 'ArrowDown' })
+    expect(getValue()).toBe(4)
+  })
+
+  test('Home sets value to min', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 7)
+    await root(wrapper).trigger('keydown', { key: 'Home' })
+    expect(getValue()).toBe(0)
+  })
+
+  test('End sets value to max', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 3)
+    await root(wrapper).trigger('keydown', { key: 'End' })
+    expect(getValue()).toBe(10)
+  })
+
+  test('ArrowRight at max is clamped to max', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 10)
+    await root(wrapper).trigger('keydown', { key: 'ArrowRight' })
+    expect(getValue()).toBe(10)
+  })
+
+  test('ArrowLeft at min is clamped to min', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 0)
+    await root(wrapper).trigger('keydown', { key: 'ArrowLeft' })
+    expect(getValue()).toBe(0)
+  })
+
+  test('ArrowRight with step=2 increments by 2', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 2 }, 4)
+    await root(wrapper).trigger('keydown', { key: 'ArrowRight' })
+    expect(getValue()).toBe(6)
+  })
+
+  test('unrecognised key does not change value', async () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    await root(wrapper).trigger('keydown', { key: 'Enter' })
+    expect(getValue()).toBe(5)
+  })
+
+  test('unrecognised key does not call emitSfx', async () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    await root(wrapper).trigger('keydown', { key: 'Tab' })
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+  })
+})
+
+// ── applyX / drag stepping math ───────────────────────────────────────────────
+
+describe('UiSlider — applyX stepping and clamping', () => {
+  /**
+   * To test applyX we simulate pointer events on the mounted element.
+   * We spoof getBoundingClientRect so the math is deterministic:
+   *   rect_left = 0, rect_width = 200
+   *   effective travel = 200 - 2*20 = 160px starting at x=20
+   *   clientX=20 → min, clientX=180 → max
+   */
+
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+  })
+
+  function simulateDrag(wrapper, clientX) {
+    const el = root(wrapper).element
+    el.getBoundingClientRect = () => ({
+      left: 0,
+      width: 200,
+      top: 0,
+      bottom: 0,
+      right: 200,
+      height: 0
+    })
+    el.setPointerCapture = vi.fn()
+    el.dispatchEvent(
+      new PointerEvent('pointerdown', { clientX, clientY: 0, pointerId: 1, bubbles: true })
+    )
+    document.dispatchEvent(
+      new PointerEvent('pointerup', { clientX, clientY: 0, pointerId: 1, bubbles: true })
+    )
+  }
+
+  test('pointer at left edge (x <= EDGE_PX) snaps to min', () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    simulateDrag(wrapper, EDGE_PX) // x = 20 → ratio 0 → value 0
+    expect(getValue()).toBe(0)
+  })
+
+  test('pointer at right edge (x >= width - EDGE_PX) snaps to max', () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    simulateDrag(wrapper, 200 - EDGE_PX) // x = 180 → ratio 1 → value 10
+    expect(getValue()).toBe(10)
+  })
+
+  test('pointer beyond right edge is clamped to max', () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    simulateDrag(wrapper, 250)
+    expect(getValue()).toBe(10)
+  })
+
+  test('pointer before left edge is clamped to min', () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    simulateDrag(wrapper, 0)
+    expect(getValue()).toBe(0)
+  })
+
+  test('pointer at midpoint yields mid value', () => {
+    // min=0, max=10, step=1; travel 160px from x=20 to x=180
+    // midpoint x=100 → (100-20)/160=0.5 → raw=5 → stepped=5
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 0)
+    simulateDrag(wrapper, 100)
+    expect(getValue()).toBe(5)
+  })
+
+  test('stepped value rounds to nearest notch', () => {
+    // min=0, max=10, step=2; x=36 → ratio=(36-20)/160=0.1 → raw=1 → nearest step=0 vs 2=2 rounds to 0... ratio 0.1 * 10 = 1.0 → round(1/2)*2 = 2
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 2 }, 0)
+    // x=36: ratio=(36-20)/160=0.1 → raw=0+0.1*10=1 → round(1/2)*2=2
+    simulateDrag(wrapper, 36)
+    expect(getValue()).toBe(2)
+  })
+
+  test('emitSfx is called with tick sound when value changes', () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1, sfx: { tick: 'tap_05' } }, 5)
+    simulateDrag(wrapper, EDGE_PX) // will change from 5 → 0
+    expect(mockEmitSfx).toHaveBeenCalledWith('tap_05', { bus: undefined })
+  })
+
+  test('emitSfx is NOT called when drag lands on current value', () => {
+    // value already at 0; drag to left edge → stepped=0=current → no emit
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1 }, 0)
+    simulateDrag(wrapper, EDGE_PX)
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+  })
+
+  test('sfx.bus is forwarded to emitSfx', () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1, sfx: { bus: 'study' } }, 5)
+    simulateDrag(wrapper, EDGE_PX) // 5 → 0 = change
+    expect(mockEmitSfx).toHaveBeenCalledWith('tap_05', { bus: 'study' })
+  })
+
+  test('sfx.tick defaults to tap_05 when not specified', () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    simulateDrag(wrapper, EDGE_PX)
+    expect(mockEmitSfx).toHaveBeenCalledWith('tap_05', { bus: undefined })
+  })
+
+  test('pointermove mid-drag updates the value (onMove path)', () => {
+    const { wrapper, getValue } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    const el = root(wrapper).element
+    el.getBoundingClientRect = () => ({
+      left: 0,
+      width: 200,
+      top: 0,
+      bottom: 0,
+      right: 200,
+      height: 0
+    })
+    el.setPointerCapture = vi.fn()
+    // start at midpoint (value 5)
+    el.dispatchEvent(
+      new PointerEvent('pointerdown', { clientX: 100, clientY: 0, pointerId: 1, bubbles: true })
+    )
+    // move to left edge (value 0)
+    document.dispatchEvent(
+      new PointerEvent('pointermove', { clientX: EDGE_PX, clientY: 0, pointerId: 1, bubbles: true })
+    )
+    document.dispatchEvent(
+      new PointerEvent('pointerup', { clientX: EDGE_PX, clientY: 0, pointerId: 1, bubbles: true })
+    )
+    expect(getValue()).toBe(0)
+  })
+
+  test('pointercancel clears the dragging state (onCancel path)', async () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
+    const el = root(wrapper).element
+    el.getBoundingClientRect = () => ({
+      left: 0,
+      width: 200,
+      top: 0,
+      bottom: 0,
+      right: 200,
+      height: 0
+    })
+    el.setPointerCapture = vi.fn()
+    el.dispatchEvent(
+      new PointerEvent('pointerdown', { clientX: 100, clientY: 0, pointerId: 1, bubbles: true })
+    )
+    document.dispatchEvent(
+      new PointerEvent('pointercancel', {
+        clientX: 100,
+        clientY: 0,
+        pointerId: 1,
+        bubbles: true
+      })
+    )
+    await nextTick()
+    // After cancel the root is no longer in the dragging state
+    expect(root(wrapper).attributes('data-active')).toBe('false')
+  })
+})

--- a/tests/integration/phone/apps/settings/component/tab-app.test.js
+++ b/tests/integration/phone/apps/settings/component/tab-app.test.js
@@ -1,6 +1,6 @@
-import { describe, test, expect, vi } from 'vite-plus/test'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
-import { computed, defineComponent, h, reactive, useAttrs } from 'vue'
+import { computed, defineComponent, h, nextTick, reactive, useAttrs } from 'vue'
 import TabApp from '@/phone/apps/settings/component/tab-app/index.vue'
 import { memberEditorKey } from '@/composables/member/editor'
 import { settingsLayoutKey } from '@/phone/apps/settings/layout'
@@ -13,21 +13,33 @@ vi.mock('@/sfx/config', () => ({
   BUS_DEFAULTS: { interface: 5, study: 5, hover: 5 }
 }))
 
+const { mockResetSettings, mockPreviewVolumeConfig } = vi.hoisted(() => ({
+  mockResetSettings: vi.fn(),
+  mockPreviewVolumeConfig: vi.fn()
+}))
+vi.mock('@/sfx/player', () => ({
+  default: {
+    resetSettings: mockResetSettings,
+    previewVolumeConfig: mockPreviewVolumeConfig
+  }
+}))
+
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
-const SpinboxStub = defineComponent({
-  name: 'UiSpinbox',
+const SliderStub = defineComponent({
+  name: 'UiSlider',
   inheritAttrs: false,
-  props: { value: Number, min: Number, max: Number },
-  emits: ['update:value'],
+  props: { modelValue: Number, min: Number, max: Number, sfx: Object, label: String },
+  emits: ['update:modelValue'],
   setup(props, { emit }) {
     const attrs = useAttrs()
     return () =>
       h('div', {
         ...attrs,
-        'data-testid': 'spinbox-stub',
-        'data-value': String(props.value),
-        onClick: () => emit('update:value', (props.value ?? 0) + 1)
+        'data-testid': 'slider-stub',
+        'data-value': String(props.modelValue),
+        'data-bus': props.sfx?.bus ?? '',
+        onClick: () => emit('update:modelValue', (props.modelValue ?? 0) + 1)
       })
   }
 })
@@ -69,6 +81,8 @@ const NullStub = defineComponent({ setup: () => () => h('div') })
 
 // ── Factory ───────────────────────────────────────────────────────────────────
 
+let _wrappers = []
+
 function makeTab({ audio = {}, accessibility = {} } = {}) {
   const editor = {
     preferences: reactive({
@@ -80,7 +94,7 @@ function makeTab({ audio = {}, accessibility = {} } = {}) {
   const wrapper = mount(TabApp, {
     global: {
       stubs: {
-        UiSpinbox: SpinboxStub,
+        UiSlider: SliderStub,
         UiToggle: ToggleStub,
         SectionList: SectionListStub,
         LabeledSection: LabeledSectionStub,
@@ -96,8 +110,16 @@ function makeTab({ audio = {}, accessibility = {} } = {}) {
     }
   })
 
+  _wrappers.push(wrapper)
   return { wrapper, editor }
 }
+
+afterEach(() => {
+  for (const w of _wrappers) w.unmount()
+  _wrappers = []
+  mockResetSettings.mockClear()
+  mockPreviewVolumeConfig.mockClear()
+})
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -107,43 +129,55 @@ describe('TabApp', () => {
     expect(wrapper.find('[data-testid="tab-app"]').exists()).toBe(true)
   })
 
-  // Replaced UiSlider with UiSpinbox — three spinboxes must render in the audio section
-  test('renders three spinbox controls in the audio section', () => {
+  test('renders three slider controls in the audio section', () => {
     const { wrapper } = makeTab()
     expect(wrapper.find('[data-testid="tab-app__audio"]').exists()).toBe(true)
-    expect(wrapper.findAll('[data-testid="spinbox-stub"]')).toHaveLength(3)
+    expect(wrapper.findAll('[data-testid="slider-stub"]')).toHaveLength(3)
   })
 
-  test('does not render any slider controls (removed in favour of spinboxes)', () => {
-    const { wrapper } = makeTab()
-    expect(wrapper.find('[data-testid="slider-stub"]').exists()).toBe(false)
-  })
-
-  test('spinboxes reflect editor audio values', () => {
+  test('sliders reflect editor audio values', () => {
     const { wrapper } = makeTab({
       audio: { study_sounds: 3, interface_sounds: 7, hover_sounds: 1 }
     })
-    const spinboxes = wrapper.findAll('[data-testid="spinbox-stub"]')
-    expect(spinboxes[0].attributes('data-value')).toBe('3')
-    expect(spinboxes[1].attributes('data-value')).toBe('7')
-    expect(spinboxes[2].attributes('data-value')).toBe('1')
+    const sliders = wrapper.findAll('[data-testid="slider-stub"]')
+    expect(sliders[0].attributes('data-value')).toBe('3')
+    expect(sliders[1].attributes('data-value')).toBe('7')
+    expect(sliders[2].attributes('data-value')).toBe('1')
   })
 
-  test('clicking a spinbox increments the corresponding editor audio value', async () => {
+  test('first slider (study_sounds) routes sfx through study bus', () => {
+    const { wrapper } = makeTab()
+    const sliders = wrapper.findAll('[data-testid="slider-stub"]')
+    expect(sliders[0].attributes('data-bus')).toBe('study')
+  })
+
+  test('second slider (interface_sounds) routes sfx through interface bus', () => {
+    const { wrapper } = makeTab()
+    const sliders = wrapper.findAll('[data-testid="slider-stub"]')
+    expect(sliders[1].attributes('data-bus')).toBe('interface')
+  })
+
+  test('third slider (hover_sounds) routes sfx through hover bus', () => {
+    const { wrapper } = makeTab()
+    const sliders = wrapper.findAll('[data-testid="slider-stub"]')
+    expect(sliders[2].attributes('data-bus')).toBe('hover')
+  })
+
+  test('clicking first slider increments study_sounds on the editor', async () => {
     const { wrapper, editor } = makeTab()
-    await wrapper.findAll('[data-testid="spinbox-stub"]')[0].trigger('click')
+    await wrapper.findAll('[data-testid="slider-stub"]')[0].trigger('click')
     expect(editor.preferences.audio.study_sounds).toBe(6)
   })
 
-  test('second spinbox (interface_sounds) updates independently', async () => {
+  test('clicking second slider increments interface_sounds on the editor', async () => {
     const { wrapper, editor } = makeTab()
-    await wrapper.findAll('[data-testid="spinbox-stub"]')[1].trigger('click')
+    await wrapper.findAll('[data-testid="slider-stub"]')[1].trigger('click')
     expect(editor.preferences.audio.interface_sounds).toBe(6)
   })
 
-  test('third spinbox (hover_sounds) updates independently', async () => {
+  test('clicking third slider increments hover_sounds on the editor', async () => {
     const { wrapper, editor } = makeTab()
-    await wrapper.findAll('[data-testid="spinbox-stub"]')[2].trigger('click')
+    await wrapper.findAll('[data-testid="slider-stub"]')[2].trigger('click')
     expect(editor.preferences.audio.hover_sounds).toBe(6)
   })
 
@@ -158,5 +192,33 @@ describe('TabApp', () => {
     const { wrapper, editor } = makeTab()
     await wrapper.find('[data-testid="toggle-stub"]').trigger('click')
     expect(editor.preferences.accessibility.left_hand).toBe(true)
+  })
+
+  // ── Preview/reset obligation tests ────────────────────────────────────────
+
+  test('changing audio prefs calls previewVolumeConfig with mapped bus volumes [obligation]', async () => {
+    const { editor } = makeTab()
+    editor.preferences.audio.study_sounds = 8
+    await nextTick()
+    await nextTick()
+    expect(mockPreviewVolumeConfig).toHaveBeenCalledWith(expect.objectContaining({ study: 8 }))
+  })
+
+  test('previewVolumeConfig receives all three buses on audio change [obligation]', async () => {
+    const { editor } = makeTab({
+      audio: { study_sounds: 3, interface_sounds: 7, hover_sounds: 1 }
+    })
+    editor.preferences.audio.interface_sounds = 9
+    await nextTick()
+    await nextTick()
+    expect(mockPreviewVolumeConfig).toHaveBeenCalledWith({ study: 3, interface: 9, hover: 1 })
+  })
+
+  test('unmounting the tab calls resetSettings to discard any preview [obligation]', () => {
+    const { wrapper } = makeTab()
+    wrapper.unmount()
+    // remove from _wrappers so afterEach doesn't double-unmount
+    _wrappers = _wrappers.filter((w) => w !== wrapper)
+    expect(mockResetSettings).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/sfx/player.test.js
+++ b/tests/unit/sfx/player.test.js
@@ -248,6 +248,85 @@ describe('audio_player.setVolumeConfig', () => {
   })
 })
 
+describe('audio_player.previewVolumeConfig / resetSettings', () => {
+  beforeEach(() => {
+    playbacks.length = 0
+    engineMock.resume.mockReset().mockResolvedValue(true)
+    engineMock.play.mockClear()
+    audio_player.loaded_sounds.clear()
+    audio_player.unlocked = true
+    audio_player.queued_sound = undefined
+    audio_player.volume_settings = { ...BUS_DEFAULTS }
+    audio_player.committed_volume_settings = { ...BUS_DEFAULTS }
+    vi.useRealTimers()
+  })
+
+  test('setVolumeConfig sets both volume_settings and committed_volume_settings [obligation]', () => {
+    const cfg = { study: 3, interface: 7, hover: 2 }
+    audio_player.setVolumeConfig(cfg)
+    expect(audio_player.volume_settings).toEqual(cfg)
+    expect(audio_player.committed_volume_settings).toEqual(cfg)
+  })
+
+  test('previewVolumeConfig sets volume_settings but leaves committed_volume_settings untouched [obligation]', () => {
+    const committed = { study: 5, interface: 5, hover: 5 }
+    audio_player.setVolumeConfig(committed)
+    audio_player.previewVolumeConfig({ study: 2, interface: 2, hover: 2 })
+    expect(audio_player.volume_settings).toEqual({ study: 2, interface: 2, hover: 2 })
+    expect(audio_player.committed_volume_settings).toEqual(committed)
+  })
+
+  test('commit→preview→reset restores the committed value, not the preview [obligation]', () => {
+    const committed = { study: 3, interface: 3, hover: 3 }
+    audio_player.setVolumeConfig(committed)
+    audio_player.previewVolumeConfig({ study: 9, interface: 9, hover: 9 })
+    audio_player.resetSettings()
+    expect(audio_player.volume_settings).toEqual(committed)
+  })
+
+  test('resetSettings uses committed baseline for volume multiplier after preview [obligation]', async () => {
+    // commit interface=2 → multiplier 2/5=0.4; preview interface=10 → 2.0; reset → back to 0.4
+    audio_player.setVolumeConfig({ study: 5, interface: 2, hover: 5 })
+    audio_player.previewVolumeConfig({ study: 5, interface: 10, hover: 5 })
+    audio_player.resetSettings()
+
+    const buffer = loadSound('select', { volume: 0.5 })
+    const promise = audio_player.play('select')
+    await flush()
+    // multiplier = 2/5 = 0.4; volume = 0.5 * 0.4 = 0.2
+    expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.2)
+    playbacks[0].end()
+    await promise
+  })
+
+  test('previewVolumeConfig stores a copy — mutating the caller object does not change player state [obligation]', () => {
+    const cfg = { study: 5, interface: 5, hover: 5 }
+    audio_player.previewVolumeConfig(cfg)
+    cfg.interface = 99
+    expect(audio_player.volume_settings.interface).toBe(5)
+  })
+
+  test('setVolumeConfig stores a copy — mutating the caller object does not change committed baseline [obligation]', () => {
+    const cfg = { study: 5, interface: 5, hover: 5 }
+    audio_player.setVolumeConfig(cfg)
+    cfg.study = 99
+    expect(audio_player.committed_volume_settings.study).toBe(5)
+  })
+
+  test('volume multiplier uses live volume_settings (previewed value) during preview [obligation]', async () => {
+    audio_player.setVolumeConfig({ study: 5, interface: 5, hover: 5 })
+    audio_player.previewVolumeConfig({ study: 5, interface: 10, hover: 5 })
+
+    const buffer = loadSound('select', { volume: 0.5 })
+    const promise = audio_player.play('select')
+    await flush()
+    // multiplier = 10/5 = 2.0; volume = 0.5 * 2.0 = 1.0
+    expect(engineMock.play).toHaveBeenCalledWith(buffer, 1.0)
+    playbacks[0].end()
+    await promise
+  })
+})
+
 describe('audio_player._enqueue timeout', () => {
   beforeEach(() => {
     audio_player.loaded_sounds.clear()


### PR DESCRIPTION
## Summary

Rebuilds the `ui-kit/slider` primitive as a value-driven, full-row fill control and uses it for the audio-level settings, where dragging a slider now previews that bus's volume live via the drag-tick sound.

## Changes

- **feat(ui-kit): rebuild slider** — value-driven (`min`/`max`/`step`) full-row fill control replacing the old buggy percent-only slider. Built-in label + value with two-tone clipping over the fill, step-marker dots that fade as passed, grab/grabbing cursor, keyboard a11y, and a per-notch drag tick. Theme inherits via `data-theme` (no `theme` prop).
- **feat(settings): audio sliders** — replaces the three audio-level spinboxes in the app-settings tab with `UiSlider`.
- **feat(settings): live volume preview** — slider gains an `sfx` prop routing its drag tick through a bus, so the tick's volume reflects the level being set. The audio player tracks a committed baseline and exposes `previewVolumeConfig` (apply live, uncommitted) + `resetSettings` (revert); the settings tab previews the editor's audio draft live and resets on unmount so cancelling discards the preview.

## Test plan

- [ ] Drag each audio slider in Settings → App → Audio; tick volume tracks the level, `0` is muted
- [ ] Close settings without saving → volumes revert to committed values
- [ ] Slider handle/fill/ticks render correctly at min, mid, and max; no overflow past rounded corners
- [ ] Keyboard: arrows/Home/End adjust value