### PR TITLE
Reusable wobble-box turbulent-edge container

### DIFF
--- a/src/components/ui-kit/wobble-box.vue
+++ b/src/components/ui-kit/wobble-box.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+// imports
+import { useId } from 'vue'
+
+// defines
+const { seed = 7 } = defineProps<{
+  /** Turbulence seed — vary it to give reused instances a different wobble. */
+  seed?: number
+}>()
+
+defineSlots<{ default: () => unknown }>()
+
+// composables + state
+// Filter ids must be unique per instance, or multiple boxes on one page
+// reference the same <filter> and the later ones render unfiltered.
+const filter_id = useId()
+</script>
+
+<template>
+  <div
+    data-testid="ui-kit-wobble-box"
+    class="wobble-box relative isolate"
+    :style="{ '--wobble-filter': `url('#${filter_id}')` }"
+  >
+    <svg width="0" height="0" class="absolute" aria-hidden="true">
+      <filter :id="filter_id">
+        <feTurbulence
+          type="fractalNoise"
+          baseFrequency="0.0055"
+          numOctaves="1"
+          :seed="seed"
+          result="noise"
+        />
+        <feDisplacementMap in="SourceGraphic" in2="noise" scale="14" result="displaced" />
+        <!-- Blur smears the jagged displaced edge into a soft gradient, then the
+             colour-matrix steepens alpha (×11, −4.5 offset) to snap it back crisp —
+             leaving only a thin feathered band that reads as anti-aliasing. -->
+        <feGaussianBlur in="displaced" stdDeviation="4" result="blurred" />
+        <feColorMatrix
+          in="blurred"
+          type="matrix"
+          values="1 0 0 0 0
+                  0 1 0 0 0
+                  0 0 1 0 0
+                  0 0 0 11 -4.5"
+        />
+      </filter>
+    </svg>
+
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+/* The background lives on a pseudo-element so the displacement filter wobbles
+ * only the panel's edges — slotted content above it stays crisp. Uneven corner
+ * radii plus the SVG turbulence give a soft, hand-drawn, mis-shapen look. */
+.wobble-box::before {
+  content: '';
+  position: absolute;
+  z-index: 0;
+
+  /* Supersample: render the panel at 2x, run the displacement filter, then
+   * scale back to 0.5x so the browser smooths the downscale and anti-aliases
+   * the wavy edge. Geometry below is doubled to compensate for the 0.5 scale. */
+  left: 50%;
+  top: 50%;
+  width: 200%;
+  height: 200%;
+  transform: translate(-50%, -50%) scale(0.5);
+
+  background-color: var(--theme-primary);
+  border-radius: 4.4rem 5.8rem 4.8rem 6.2rem / 5.4rem 4.4rem 6rem 4.8rem;
+  filter: var(--wobble-filter);
+}
+</style>

--- a/src/views/welcome/section-features/community-callout.vue
+++ b/src/views/welcome/section-features/community-callout.vue
@@ -2,6 +2,7 @@
 import { useI18n } from 'vue-i18n'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiImage from '@/components/ui-kit/image.vue'
+import UiWobbleBox from '@/components/ui-kit/wobble-box.vue'
 
 type CommunityCalloutProps = {
   seeRoadmap: () => void
@@ -13,24 +14,11 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <div
+  <ui-wobble-box
     data-testid="community-callout"
     data-theme="green-500"
-    class="community-callout relative isolate flex flex-col sm:flex-row items-center justify-center gap-6 sm:gap-10 px-8 py-10 sm:px-12 mx-auto mt-16"
+    class="flex flex-col sm:flex-row items-center justify-center gap-6 sm:gap-10 px-8 py-10 sm:px-12 mx-auto mt-16"
   >
-    <svg width="0" height="0" class="absolute" aria-hidden="true">
-      <filter id="community-callout-wobble">
-        <feTurbulence
-          type="fractalNoise"
-          baseFrequency="0.0055"
-          numOctaves="1"
-          seed="7"
-          result="noise"
-        />
-        <feDisplacementMap in="SourceGraphic" in2="noise" scale="14" />
-      </filter>
-    </svg>
-
     <ui-image
       data-testid="community-callout__image"
       src="feedback-hover"
@@ -64,29 +52,5 @@ const { t } = useI18n()
         {{ t('welcome-view.features.callout.roadmap-link') }}
       </ui-button>
     </div>
-  </div>
+  </ui-wobble-box>
 </template>
-
-<style scoped>
-/* The background lives on a pseudo-element so the displacement filter wobbles
- * only the panel's edges — the text and image above it stay crisp. Uneven
- * corner radii plus the SVG turbulence give a soft, hand-drawn, mis-shapen look. */
-.community-callout::before {
-  content: '';
-  position: absolute;
-  z-index: 0;
-
-  /* Supersample: render the panel at 2x, run the displacement filter, then
-   * scale back to 0.5x so the browser smooths the downscale and anti-aliases
-   * the wavy edge. Geometry below is doubled to compensate for the 0.5 scale. */
-  left: 50%;
-  top: 50%;
-  width: 200%;
-  height: 200%;
-  transform: translate(-50%, -50%) scale(0.5);
-
-  background-color: var(--theme-primary);
-  border-radius: 4.4rem 5.8rem 4.8rem 6.2rem / 5.4rem 4.4rem 6rem 4.8rem;
-  filter: url('#community-callout-wobble');
-}
-</style>

--- a/tests/integration/components/ui-kit/wobble-box.test.js
+++ b/tests/integration/components/ui-kit/wobble-box.test.js
@@ -1,0 +1,114 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import UiWobbleBox from '@/components/ui-kit/wobble-box.vue'
+
+function mountWobbleBox(props = {}, slotContent = undefined) {
+  return mount(UiWobbleBox, {
+    props,
+    slots: slotContent ? { default: slotContent } : {}
+  })
+}
+
+describe('UiWobbleBox', () => {
+  // ── Root ────────────────────────────────────────────────────────────────────
+
+  test('renders the root element with the default data-testid', () => {
+    const wrapper = mountWobbleBox()
+    expect(wrapper.find('[data-testid="ui-kit-wobble-box"]').exists()).toBe(true)
+  })
+
+  // ── Slot ────────────────────────────────────────────────────────────────────
+
+  test('renders default slot content [obligation]', () => {
+    const wrapper = mount(UiWobbleBox, {
+      slots: { default: () => h('span', { 'data-testid': 'slot-child' }, 'hello') }
+    })
+    expect(wrapper.find('[data-testid="slot-child"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="slot-child"]').text()).toBe('hello')
+  })
+
+  // ── Seed prop ───────────────────────────────────────────────────────────────
+
+  test('seed defaults to 7 on feTurbulence [obligation]', () => {
+    const wrapper = mountWobbleBox()
+    expect(wrapper.find('feTurbulence').attributes('seed')).toBe('7')
+  })
+
+  test('custom seed is forwarded to feTurbulence [obligation]', () => {
+    const wrapper = mountWobbleBox({ seed: 42 })
+    expect(wrapper.find('feTurbulence').attributes('seed')).toBe('42')
+  })
+
+  // ── Unique filter id per instance ───────────────────────────────────────────
+  // Two instances rendered in the same app must have distinct filter ids so
+  // that CSS url('#id') references on each ::before pseudo resolve to the
+  // correct filter, not a shared one that makes later instances render unfiltered.
+
+  test('two instances in the same app have different filter ids [obligation]', () => {
+    // Wrap both instances in a single mount so they share the same Vue app
+    // and the same useId() counter — this is the real-world scenario.
+    const Host = defineComponent({
+      setup() {
+        return () =>
+          h('div', [
+            h(UiWobbleBox, { 'data-testid': 'box-a' }),
+            h(UiWobbleBox, { 'data-testid': 'box-b' })
+          ])
+      }
+    })
+
+    const wrapper = mount(Host)
+
+    const boxes = wrapper.findAllComponents(UiWobbleBox)
+    expect(boxes).toHaveLength(2)
+
+    const filterId1 = boxes[0].find('filter').attributes('id')
+    const filterId2 = boxes[1].find('filter').attributes('id')
+
+    expect(filterId1).toBeTruthy()
+    expect(filterId2).toBeTruthy()
+    expect(filterId1).not.toBe(filterId2)
+  })
+
+  test('each instance --wobble-filter url references only its own filter id [obligation]', () => {
+    const Host = defineComponent({
+      setup() {
+        return () => h('div', [h(UiWobbleBox), h(UiWobbleBox)])
+      }
+    })
+
+    const wrapper = mount(Host)
+
+    const boxes = wrapper.findAllComponents(UiWobbleBox)
+    const filterId1 = boxes[0].find('filter').attributes('id')
+    const filterId2 = boxes[1].find('filter').attributes('id')
+
+    const style1 = boxes[0].find('[data-testid="ui-kit-wobble-box"]').attributes('style')
+    const style2 = boxes[1].find('[data-testid="ui-kit-wobble-box"]').attributes('style')
+
+    // Each instance's CSS var must point to its own filter id
+    expect(style1).toContain(`url('#${filterId1}')`)
+    expect(style2).toContain(`url('#${filterId2}')`)
+
+    // And must NOT point to the other instance's id
+    expect(style1).not.toContain(`url('#${filterId2}')`)
+    expect(style2).not.toContain(`url('#${filterId1}')`)
+  })
+
+  // ── SVG structure ───────────────────────────────────────────────────────────
+
+  test('renders an SVG with aria-hidden for the filter definition', () => {
+    const wrapper = mountWobbleBox()
+    const svg = wrapper.find('svg')
+    expect(svg.exists()).toBe(true)
+    expect(svg.attributes('aria-hidden')).toBe('true')
+  })
+
+  test('filter id on the <filter> element matches the id used in --wobble-filter', () => {
+    const wrapper = mountWobbleBox()
+    const filterId = wrapper.find('filter').attributes('id')
+    const style = wrapper.find('[data-testid="ui-kit-wobble-box"]').attributes('style')
+    expect(style).toContain(`url('#${filterId}')`)
+  })
+})

--- a/tests/integration/views/welcome/section-features/community-callout.test.js
+++ b/tests/integration/views/welcome/section-features/community-callout.test.js
@@ -1,8 +1,18 @@
 import { describe, test, expect, vi } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, useAttrs } from 'vue'
 
 // ── Stubs ──────────────────────────────────────────────────────────────────────
+
+// Stub UiWobbleBox — forwards attrs (including data-testid) to a div and renders slot.
+const UiWobbleBoxStub = defineComponent({
+  name: 'UiWobbleBox',
+  inheritAttrs: false,
+  setup(_props, { slots }) {
+    const attrs = useAttrs()
+    return () => h('div', attrs, slots.default?.())
+  }
+})
 
 // Stub UiButton to expose the @press handler via a data-testid button element.
 const UiButtonStub = defineComponent({
@@ -41,7 +51,11 @@ function mountCallout({ seeRoadmap = vi.fn() } = {}) {
   return shallowMount(CommunityCallout, {
     props: { seeRoadmap },
     global: {
-      stubs: { UiButton: UiButtonStub, UiImage: UiImageStub }
+      stubs: {
+        UiWobbleBox: UiWobbleBoxStub,
+        UiButton: UiButtonStub,
+        UiImage: UiImageStub
+      }
     }
   })
 }


### PR DESCRIPTION
## Summary

Extracts the community callout's turbulent SVG background into a reusable `UiWobbleBox` ui-kit primitive, and resolves the edge aliasing that the displacement filter left behind.

## Changes

- **`UiWobbleBox`** — themed container rendering a hand-drawn, turbulent edge behind its default slot. Sources colour from inherited `data-theme` (`--theme-primary`), exposes a `seed` prop for per-instance shape variety, and uses `useId()` to keep each instance's `<filter>` id unique (shared ids would make later instances render unfiltered).
- **Anti-aliasing** — the displaced edge is smoothed via a blur-then-alpha-steepen chain (blur smears the jaggies into a gradient, a colour-matrix snaps the edge back crisp) over a 2x supersample, fixing the aliasing without softening the shape.
- **`community-callout`** — drops its inline SVG filter and pseudo-element style block in favour of the new primitive.