### PR TITLE
Drag-to-reorder cards in the deck card editor

### DIFF
--- a/src/api/cards/db/cards-page.ts
+++ b/src/api/cards/db/cards-page.ts
@@ -17,6 +17,7 @@ export async function fetchCardsPageByDeckId({
     .select('*, review:reviews(*)')
     .eq('deck_id', deck_id)
     .order('rank', { ascending: true })
+    .order('id', { ascending: true })
     .range(offset, offset + limit - 1)
 
   if (error) {

--- a/src/api/cards/mutations/move.ts
+++ b/src/api/cards/mutations/move.ts
@@ -1,15 +1,82 @@
-import { useMutation, useQueryCache } from '@pinia/colada'
+import { setInfiniteQueryData, useMutation, useQueryCache } from '@pinia/colada'
 import { moveCard, type MoveCardParams } from '../db'
+import { cardsInDeckQueryKey } from '../queries/cards-page'
 import { invalidateDeck } from './_invalidate'
+
+type QueryCache = ReturnType<typeof useQueryCache>
 
 export type UseMoveCardMutationParams = MoveCardParams & {
   deck_id: number
 }
 
+type ReorderContext = { pages: Card[][]; pageParams: unknown[] } | undefined
+
+/** Split a flat card list back into pages of the given lengths. */
+function chunkBySizes(flat: Card[], sizes: number[]): Card[][] {
+  const pages: Card[][] = []
+  let offset = 0
+
+  for (const size of sizes) {
+    pages.push(flat.slice(offset, offset + size))
+    offset += size
+  }
+
+  return pages
+}
+
+/**
+ * Optimistically move `card_id` to sit `side` of `anchor_id` within the deck's
+ * cached pages, in place of waiting for the refetch. Keeps the rendered order
+ * in lockstep with the drop so the row doesn't snap back between drop and the
+ * server round-trip. Returns the pre-move snapshot for rollback, or `undefined`
+ * when the deck isn't cached (nothing to reorder).
+ */
+function reorderCardInDeckCache(
+  queryCache: QueryCache,
+  { deck_id, card_id, anchor_id, side }: UseMoveCardMutationParams
+): ReorderContext {
+  const key = cardsInDeckQueryKey(deck_id)
+  const snapshot = queryCache.getQueryData(key) as ReorderContext
+  if (!snapshot) return undefined
+
+  setInfiniteQueryData<Card[]>(queryCache, key, (old) => {
+    const pages = old?.pages ?? []
+    const sizes = pages.map((page) => page.length)
+    const flat = pages.flat()
+
+    const from_index = flat.findIndex((c) => c.id === card_id)
+    if (from_index === -1) return { pages, pageParams: old?.pageParams ?? [] }
+
+    const [moved] = flat.splice(from_index, 1)
+    const anchor_index = flat.findIndex((c) => c.id === anchor_id)
+    if (anchor_index === -1) return { pages, pageParams: old?.pageParams ?? [] }
+
+    flat.splice(side === 'after' ? anchor_index + 1 : anchor_index, 0, moved)
+
+    return { pages: chunkBySizes(flat, sizes), pageParams: old?.pageParams ?? [] }
+  })
+
+  return snapshot
+}
+
+/**
+ * Reposition a single card within its deck, relative to an anchor card.
+ *
+ * `onMutate` optimistically reorders the cached pages synchronously, so the
+ * drag-reorder UI can settle the dropped row immediately. `onError` restores
+ * the pre-move snapshot; `onSettled` invalidates the deck to reconcile with the
+ * server-authoritative ranks.
+ */
 export function useMoveCardMutation() {
   const queryCache = useQueryCache()
   return useMutation({
     mutation: ({ deck_id: _deck_id, ...params }: UseMoveCardMutationParams) => moveCard(params),
+    onMutate: (vars: UseMoveCardMutationParams) => ({
+      snapshot: reorderCardInDeckCache(queryCache, vars)
+    }),
+    onError: (_error, { deck_id }, { snapshot }) => {
+      if (snapshot) queryCache.setQueryData(cardsInDeckQueryKey(deck_id), snapshot)
+    },
     onSettled: (_data, _error, { deck_id }) => {
       invalidateDeck(queryCache, deck_id)
     }

--- a/src/composables/card/mutations.ts
+++ b/src/composables/card/mutations.ts
@@ -4,11 +4,13 @@ import {
   useDeleteCardsMutation,
   useDeleteCardsInDeckMutation,
   useInsertCardAtMutation,
+  useMoveCardMutation,
   useMoveCardsToDeckMutation,
   useSaveCardMutation,
   useSetCardImageMutation,
   type InsertCardAtParams,
-  type MoveCardsToDeckVars
+  type MoveCardsToDeckVars,
+  type UseMoveCardMutationParams
 } from '@/api/cards'
 
 export type CardMutations = ReturnType<typeof useCardMutations>
@@ -32,6 +34,7 @@ export function useCardMutations(deck_id: MaybeRefOrGetter<number | undefined>) 
   const delete_mutation = useDeleteCardsMutation()
   const delete_in_deck_mutation = useDeleteCardsInDeckMutation()
   const move_mutation = useMoveCardsToDeckMutation()
+  const reorder_mutation = useMoveCardMutation()
   const set_image_mutation = useSetCardImageMutation()
   const delete_image_mutation = useDeleteCardImageMutation()
 
@@ -73,6 +76,11 @@ export function useCardMutations(deck_id: MaybeRefOrGetter<number | undefined>) 
     await move_mutation.mutateAsync(vars)
   }
 
+  /** Reposition one card within its deck, relative to an anchor card. */
+  function reorderCard(params: UseMoveCardMutationParams): Promise<number> {
+    return reorder_mutation.mutateAsync(params)
+  }
+
   /** Upload and attach an image to one face of a card. */
   function setCardImage(card_id: number, side: 'front' | 'back', file: File): Promise<unknown> {
     return set_image_mutation.mutateAsync({ card_id, deck_id: toValue(deck_id)!, file, side })
@@ -83,5 +91,13 @@ export function useCardMutations(deck_id: MaybeRefOrGetter<number | undefined>) 
     return delete_image_mutation.mutateAsync({ card_id, deck_id: toValue(deck_id)!, side })
   }
 
-  return { insertCard, saveCard, deleteCards, moveCards, setCardImage, deleteCardImage }
+  return {
+    insertCard,
+    saveCard,
+    deleteCards,
+    moveCards,
+    reorderCard,
+    setCardImage,
+    deleteCardImage
+  }
 }

--- a/src/utils/animations/list-item.ts
+++ b/src/utils/animations/list-item.ts
@@ -20,3 +20,24 @@ export function expandListItemIn(el: HTMLElement) {
     clearProps: 'all'
   })
 }
+
+const LIFT_SCALE = 1.03
+
+/**
+ * Pickup pop for a reorder drag: a quick scale up with a little overshoot that
+ * settles to a held, slightly-lifted scale (the row reads as "picked up" for
+ * the whole drag). Pair with `dropListItem` on release. Animates `scale` only —
+ * no clearProps — so it composes with the row's reactive drag transform
+ * (translate) and the held scale persists until the drop.
+ */
+export function liftListItem(el: HTMLElement) {
+  gsap
+    .timeline()
+    .to(el, { scale: LIFT_SCALE * 1.02, duration: 0.09, ease: 'power2.out' })
+    .to(el, { scale: LIFT_SCALE, duration: 0.12, ease: 'back.out(3)' })
+}
+
+/** Settle a lifted row back to rest on drop, then clear the inline scale. */
+export function dropListItem(el: HTMLElement) {
+  gsap.to(el, { scale: 1, duration: 0.15, ease: 'power2.out', clearProps: 'scale' })
+}

--- a/src/utils/card-editor/selection-payload.ts
+++ b/src/utils/card-editor/selection-payload.ts
@@ -5,6 +5,33 @@ export type DeleteArgs = { except_ids: number[] } | { cards: Card[] }
 
 export type MoveArgs = { card_ids: number[] } | { source_deck_id: number; except_ids: number[] }
 
+export type ReorderAnchor = { anchor_id: number; side: 'before' | 'after' }
+
+/**
+ * Resolve the `move_card` anchor for a drag-reorder. `without` is the rendered
+ * card list with the dragged card already removed; `to` is the array index the
+ * dragged card should land at. Picks the nearest *persisted* neighbour to
+ * anchor against — temps (negative placeholder ids) can't anchor a server move.
+ *
+ * Walks left from the drop slot for a card to land `after`; if none (dropping
+ * at the very top, or only temps to the left) walks right for a card to land
+ * `before`. Returns `null` when no persisted neighbour exists — e.g. the deck
+ * holds a single persisted card, so there is nothing to reorder against.
+ */
+export function resolveReorderAnchor(without: Card[], to: number): ReorderAnchor | null {
+  for (let i = to - 1; i >= 0; i--) {
+    const id = without[i]?.id
+    if (id !== undefined && id > 0) return { anchor_id: id, side: 'after' }
+  }
+
+  for (let i = to; i < without.length; i++) {
+    const id = without[i]?.id
+    if (id !== undefined && id > 0) return { anchor_id: id, side: 'before' }
+  }
+
+  return null
+}
+
 /**
  * Loaded persisted cards covered by the current selection, with `review`
  * stripped so the result is safe to spread into write payloads.

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -7,13 +7,15 @@ import { cardEditorKey, type CardWithClientId } from '@/views/deck/composables'
 import { inject, computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ListItemCard from './list-item-card.vue'
+import { TYPE_SFX } from '@/sfx/config'
 
 type ListItemProps = {
   index: number
   card: CardWithClientId
+  dragging?: boolean
 }
 
-const { card, index } = defineProps<ListItemProps>()
+const { card, index, dragging = false } = defineProps<ListItemProps>()
 
 const emit = defineEmits<{ reorderPointerdown: [event: PointerEvent] }>()
 
@@ -55,7 +57,8 @@ function onClick(e: MouseEvent) {
   <div
     data-testid="card-list-item"
     :data-id="card.id"
-    class="group/listitem relative grid w-full grid-cols-1 sm:grid-cols-[1fr_auto_1fr] sm:gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-colors duration-100 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-stone-900"
+    :data-dragging="dragging"
+    class="group/listitem relative grid w-full grid-cols-1 sm:grid-cols-[1fr_auto_1fr] sm:gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-[color,background-color,box-shadow] duration-150 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-stone-900 data-[dragging=true]:not-focus-within:bg-brown-200 dark:data-[dragging=true]:not-focus-within:bg-stone-900 data-[dragging=true]:shadow-sm"
     :class="{
       'cursor-pointer': is_selecting,
       'focus-within:bg-brown-300 hover:focus-within:bg-brown-300 dark:focus-within:bg-blue-650 dark:hover:focus-within:bg-blue-650':
@@ -66,15 +69,22 @@ function onClick(e: MouseEvent) {
     <button
       data-testid="card-list-item__reorder"
       class="hidden h-12 w-12 cursor-grab touch-none items-center justify-center rounded-full bg-brown-300 text-lg text-brown-700 sm:flex group-focus-within/listitem:bg-brown-100 row-span-2 dark:bg-stone-700 dark:text-brown-100 dark:group-focus-within/listitem:bg-stone-900"
+      v-sfx="dragging ? {} : { hover: TYPE_SFX }"
       @click.stop
       @pointerdown="emit('reorderPointerdown', $event)"
     >
       <ui-icon
         src="reorder"
         class="hidden"
-        :class="{ 'group-hover/listitem:block': !is_selecting }"
+        :class="{
+          'group-hover/listitem:block group-data-[dragging=true]/listitem:block': !is_selecting
+        }"
       />
-      <span :class="{ 'group-hover/listitem:hidden': !is_selecting }">
+      <span
+        :class="{
+          'group-hover/listitem:hidden group-data-[dragging=true]/listitem:hidden': !is_selecting
+        }"
+      >
         {{ index + 1 }}
       </span>
     </button>
@@ -83,7 +93,7 @@ function onClick(e: MouseEvent) {
 
     <item-options
       v-if="!is_selecting"
-      class="hidden sm:grid opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto row-span-2"
+      class="hidden sm:grid opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-data-[dragging=true]/listitem:opacity-0! group-data-[dragging=true]/listitem:pointer-events-none! group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto row-span-2"
       @move="onMoveCards(card.id!)"
       @delete="onDeleteCards(card.id!)"
     />
@@ -97,7 +107,7 @@ function onClick(e: MouseEvent) {
       data-theme="brown-100"
       data-theme-dark="grey-900"
       size="sm"
-      class="absolute! z-1 top-0 -translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
+      class="absolute! z-1 top-0 -translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-data-[dragging=true]/listitem:opacity-0! group-data-[dragging=true]/listitem:pointer-events-none! group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="prependCard(card.id!)"
     >
       {{ t('deck-view.card-editor.list-item.add-above') }}
@@ -110,7 +120,7 @@ function onClick(e: MouseEvent) {
       data-theme="brown-100"
       data-theme-dark="grey-900"
       size="sm"
-      class="absolute! z-1 bottom-0 translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
+      class="absolute! z-1 bottom-0 translate-y-1/2 opacity-0 pointer-events-none transition-opacity duration-100 ease-in-out group-hover/listitem:opacity-100 group-hover/listitem:pointer-events-auto group-data-[dragging=true]/listitem:opacity-0! group-data-[dragging=true]/listitem:pointer-events-none! group-focus-within/listitem:opacity-100 group-focus-within/listitem:pointer-events-auto *:[.btn-icon]:text-brown-500"
       @click.stop="appendCard(card.id!)"
     >
       {{ t('deck-view.card-editor.list-item.add-below') }}

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -15,6 +15,8 @@ type ListItemProps = {
 
 const { card, index } = defineProps<ListItemProps>()
 
+const emit = defineEmits<{ reorderPointerdown: [event: PointerEvent] }>()
+
 const { t } = useI18n()
 const { selection, actions, appendCard, prependCard } = inject(cardEditorKey)!
 const { is_selecting, isCardSelected } = selection
@@ -63,8 +65,9 @@ function onClick(e: MouseEvent) {
   >
     <button
       data-testid="card-list-item__reorder"
-      class="hidden h-12 w-12 cursor-grab items-center justify-center rounded-full bg-brown-300 text-lg text-brown-700 sm:flex group-focus-within/listitem:bg-brown-100 row-span-2 dark:bg-stone-700 dark:text-brown-100 dark:group-focus-within/listitem:bg-stone-900"
+      class="hidden h-12 w-12 cursor-grab touch-none items-center justify-center rounded-full bg-brown-300 text-lg text-brown-700 sm:flex group-focus-within/listitem:bg-brown-100 row-span-2 dark:bg-stone-700 dark:text-brown-100 dark:group-focus-within/listitem:bg-stone-900"
       @click.stop
+      @pointerdown="emit('reorderPointerdown', $event)"
     >
       <ui-icon
         src="reorder"

--- a/src/views/deck/card-editor/list.vue
+++ b/src/views/deck/card-editor/list.vue
@@ -1,12 +1,22 @@
 <script setup lang="ts">
 import ListItem from './list-item.vue'
-import { inject, useTemplateRef, computed, ref, watchEffect, onMounted, onBeforeUnmount } from 'vue'
+import {
+  inject,
+  useTemplateRef,
+  computed,
+  ref,
+  watch,
+  watchEffect,
+  onMounted,
+  onBeforeUnmount
+} from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useWindowVirtualizer, defaultRangeExtractor } from '@tanstack/vue-virtual'
 import { cardEditorKey } from '@/views/deck/composables'
 import { usePinScrollWhileTyping } from '@/composables/ui/pin-scroll-while-typing'
 import { useMatchMedia } from '@/composables/ui/media-query'
 import { useReorderDrag } from './use-reorder-drag'
+import { liftListItem, dropListItem } from '@/utils/animations/list-item'
 
 const { t } = useI18n()
 
@@ -28,6 +38,7 @@ const reorder = useReorderDrag({
   pitch: ROW_PITCH,
   count: () => all_cards.value.length,
   enabled: () => is_above_md.value && !selection.is_selecting.value,
+  topInset: () => sticky_toolbar?.getBoundingClientRect().bottom ?? 0,
   onReorder: reorderCard
 })
 
@@ -60,10 +71,27 @@ function measureScrollMargin() {
   scroll_margin.value = container.getBoundingClientRect().top + window.scrollY
 }
 
+// Start a drag and, when it actually begins (gated to md+ / not selecting),
+// lift the grabbed row. The element is held so the matching drop can settle it
+// back — the drop fires from a window pointerup, not a DOM event on the row.
+function onReorderStart(index: number, event: PointerEvent) {
+  reorder.start(index, event)
+  if (reorder.dragging_index.value === null) return
+
+  lifted_row = (event.target as HTMLElement).closest<HTMLElement>('[data-testid="card-list-item"]')
+  if (lifted_row) liftListItem(lifted_row)
+}
+
 let resize_observer: ResizeObserver | undefined
+// The sticky toolbar (md+) covers the top of the list; its viewport-space
+// bottom is the inset where drag auto-scroll-up should start.
+let sticky_toolbar: HTMLElement | null = null
+// The row lifted on pickup, held so the drop can settle it back to rest.
+let lifted_row: HTMLElement | null = null
 
 onMounted(() => {
   measureScrollMargin()
+  sticky_toolbar = document.querySelector('[data-testid="deck-view__toolbar"]')
   resize_observer = new ResizeObserver(measureScrollMargin)
   resize_observer.observe(document.body)
 })
@@ -82,6 +110,17 @@ watchEffect(() => {
     loadNextPage()
   }
 })
+
+// Settle the lifted row back to rest the moment the drag ends (engine clears
+// dragging_index on the window pointerup).
+watch(
+  () => reorder.dragging_index.value,
+  (current, previous) => {
+    if (current !== null || previous === null || !lifted_row) return
+    dropListItem(lifted_row)
+    lifted_row = null
+  }
+)
 </script>
 
 <template>
@@ -120,7 +159,8 @@ watchEffect(() => {
           <list-item
             :index="vrow.index"
             :card="all_cards[vrow.index]"
-            @reorder-pointerdown="reorder.start(vrow.index, $event)"
+            :dragging="vrow.index === reorder.dragging_index.value"
+            @reorder-pointerdown="onReorderStart(vrow.index, $event)"
           />
         </div>
       </div>

--- a/src/views/deck/card-editor/list.vue
+++ b/src/views/deck/card-editor/list.vue
@@ -2,9 +2,11 @@
 import ListItem from './list-item.vue'
 import { inject, useTemplateRef, computed, ref, watchEffect, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useWindowVirtualizer } from '@tanstack/vue-virtual'
+import { useWindowVirtualizer, defaultRangeExtractor } from '@tanstack/vue-virtual'
 import { cardEditorKey } from '@/views/deck/composables'
 import { usePinScrollWhileTyping } from '@/composables/ui/pin-scroll-while-typing'
+import { useMatchMedia } from '@/composables/ui/media-query'
+import { useReorderDrag } from './use-reorder-drag'
 
 const { t } = useI18n()
 
@@ -12,13 +14,22 @@ const ROW_PITCH = 407
 const LOAD_MORE_THRESHOLD = 5
 const OVERSCAN = 3
 
-const { list, hasNextPage, isLoading, loadNextPage } = inject(cardEditorKey)!
+const { list, selection, reorderCard, hasNextPage, isLoading, loadNextPage } =
+  inject(cardEditorKey)!
 const { all_cards } = list
 
 const list_el = useTemplateRef<HTMLElement>('list_el')
 const scroll_margin = ref(0)
+const is_above_md = useMatchMedia('w>=md')
 
 usePinScrollWhileTyping(() => list_el.value)
+
+const reorder = useReorderDrag({
+  pitch: ROW_PITCH,
+  count: () => all_cards.value.length,
+  enabled: () => is_above_md.value && !selection.is_selecting.value,
+  onReorder: reorderCard
+})
 
 const virtualizer = useWindowVirtualizer(
   computed(() => ({
@@ -26,7 +37,15 @@ const virtualizer = useWindowVirtualizer(
     estimateSize: () => ROW_PITCH,
     overscan: OVERSCAN,
     scrollMargin: scroll_margin.value,
-    getItemKey: (i: number) => all_cards.value[i].client_id
+    getItemKey: (i: number) => all_cards.value[i].client_id,
+    // Keep the dragged row in the rendered range even after auto-scroll carries
+    // its slot out of the overscan window — otherwise it unmounts mid-drag.
+    rangeExtractor: (range) => {
+      const indexes = defaultRangeExtractor(range)
+      const dragging = reorder.dragging_index.value
+      if (dragging === null || indexes.includes(dragging)) return indexes
+      return [...indexes, dragging].sort((a, b) => a - b)
+    }
   }))
 )
 
@@ -80,13 +99,30 @@ watchEffect(() => {
         v-for="vrow in virtualizer.getVirtualItems()"
         :key="vrow.key as number"
         data-testid="card-list__row"
-        class="absolute top-0 left-0 w-full flex justify-center hover:z-10 focus-within:z-10"
+        class="absolute top-0 left-0 w-full"
+        :class="
+          vrow.index === reorder.dragging_index.value ? 'z-20' : 'hover:z-10 focus-within:z-10'
+        "
         :style="{
           height: `${vrow.size}px`,
           transform: `translateY(${vrow.start - scroll_margin}px)`
         }"
       >
-        <list-item :index="vrow.index" :card="all_cards[vrow.index]" />
+        <div
+          data-testid="card-list__row-inner"
+          class="flex justify-center will-change-transform"
+          :class="{
+            'transition-transform duration-150 ease-out': reorder.shouldTransition(vrow.index),
+            'cursor-grabbing': vrow.index === reorder.dragging_index.value
+          }"
+          :style="{ transform: `translateY(${reorder.dragOffset(vrow.index)}px)` }"
+        >
+          <list-item
+            :index="vrow.index"
+            :card="all_cards[vrow.index]"
+            @reorder-pointerdown="reorder.start(vrow.index, $event)"
+          />
+        </div>
       </div>
     </div>
 

--- a/src/views/deck/card-editor/use-reorder-drag.ts
+++ b/src/views/deck/card-editor/use-reorder-drag.ts
@@ -1,9 +1,24 @@
 import { computed, onBeforeUnmount, ref } from 'vue'
+import { emitSfx } from '@/sfx/bus'
 
 // Auto-scroll kicks in when the pointer is within this many px of a viewport
 // edge, advancing the page so a row can be dragged past the visible window.
+// Speed ramps through these tiers the longer the drag dwells in the edge
+// without leaving or switching direction — pick the last tier whose `afterMs`
+// has elapsed. Keep ascending by `afterMs`.
 const EDGE_ZONE = 90
-const EDGE_SPEED = 16
+
+type EdgeTier = { afterMs: number; speed: number }
+const EDGE_RAMP: EdgeTier[] = [
+  { afterMs: 0, speed: 16 },
+  { afterMs: 450, speed: 36 },
+  { afterMs: 2000, speed: 64 }
+]
+
+// Slots-past-midpoint the drag must travel before the target flips, and the
+// matching deadzone that keeps sub-pixel jitter at a boundary from re-flipping
+// (and double-firing the crossing tick).
+const HYSTERESIS = 0.15
 
 export type ReorderDragOptions = {
   // Fixed row pitch in px — the vertical distance between adjacent rows. The
@@ -12,6 +27,10 @@ export type ReorderDragOptions = {
   pitch: number
   count: () => number
   enabled: () => boolean
+  // Px of fixed chrome (e.g. a sticky toolbar) covering the top of the list.
+  // The top edge zone is offset by this so auto-scroll-up triggers at the
+  // visible list top, not behind the chrome. Defaults to 0.
+  topInset?: () => number
   // Commit the reorder: move the row at `from` to land at index `to`. Expected
   // to reorder the rendered list synchronously (optimistic cache write), so the
   // engine can drop its drag state in the same tick without a snap-back.
@@ -42,7 +61,7 @@ export type ReorderDrag = ReturnType<typeof useReorderDrag>
  *   onReorder: (from, to) => editor.reorderCard(from, to)
  * })
  */
-export function useReorderDrag({ pitch, count, enabled, onReorder }: ReorderDragOptions) {
+export function useReorderDrag({ pitch, count, enabled, topInset, onReorder }: ReorderDragOptions) {
   const from_index = ref<number | null>(null)
   const delta = ref(0)
 
@@ -51,12 +70,14 @@ export function useReorderDrag({ pitch, count, enabled, onReorder }: ReorderDrag
   let pointer_y = 0
   let raf = 0
 
-  // Round the live translate to a slot offset and clamp into list bounds.
-  const target_index = computed(() => {
-    if (from_index.value === null) return null
-    const raw = from_index.value + Math.round(delta.value / pitch)
-    return Math.max(0, Math.min(count() - 1, raw))
-  })
+  // Direction of the current continuous edge dwell (-1 up / +1 down / 0 none)
+  // and the rAF timestamp it began at, used to ramp the scroll speed.
+  let edge_dir = 0
+  let edge_since = 0
+
+  // Live drop slot. Stateful (not a pure round) so it can carry hysteresis:
+  // updated by `updateTarget` as the drag translate changes.
+  const target_index = ref<number | null>(null)
 
   /**
    * Extra `translateY` (px) the caller should apply to the row at `index`:
@@ -86,28 +107,59 @@ export function useReorderDrag({ pitch, count, enabled, onReorder }: ReorderDrag
 
   function updateDelta() {
     delta.value = pointer_y - start_client_y + (window.scrollY - start_scroll_y)
+    updateTarget()
   }
 
-  function edgeSpeed(): number {
-    if (pointer_y < EDGE_ZONE) return -EDGE_SPEED
-    if (window.innerHeight - pointer_y < EDGE_ZONE) return EDGE_SPEED
+  // Advance the target toward the drag's ideal slot, but only once it's pushed
+  // past the midpoint by HYSTERESIS — and clear that margin again to reverse.
+  // The while-loops absorb fast multi-slot drags; one tick per real crossing.
+  function updateTarget() {
+    if (from_index.value === null) return
+
+    const last = count() - 1
+    const ideal = from_index.value + delta.value / pitch
+    let next = target_index.value ?? from_index.value
+
+    while (ideal - next > 0.5 + HYSTERESIS && next < last) next++
+    while (next - ideal > 0.5 + HYSTERESIS && next > 0) next--
+
+    if (next === target_index.value) return
+    if (target_index.value !== null) emitSfx('tap_05')
+    target_index.value = next
+  }
+
+  // Which edge the pointer sits in: -1 top, +1 bottom, 0 neither. The top zone
+  // is offset by the sticky chrome so it triggers at the visible list top.
+  function edgeDirection(): number {
+    if (pointer_y < (topInset?.() ?? 0) + EDGE_ZONE) return -1
+    if (window.innerHeight - pointer_y < EDGE_ZONE) return 1
     return 0
   }
 
-  // Drive page scroll while the pointer sits in an edge zone. Re-reads pointer
-  // position each frame and folds the scroll delta into the dragged offset, so
-  // the row stays under the cursor as the list moves beneath it.
+  // Drive page scroll while the pointer sits in an edge zone, ramping through
+  // EDGE_RAMP tiers the longer the dwell lasts. Re-reads pointer position each
+  // frame and folds the scroll delta into the dragged offset, so the row stays
+  // under the cursor as the list moves beneath it.
   function autoScroll() {
     if (raf) return
 
-    const step = () => {
-      const speed = edgeSpeed()
-      if (speed === 0 || from_index.value === null) {
+    const step = (now: number) => {
+      const dir = edgeDirection()
+      if (dir === 0 || from_index.value === null) {
         raf = 0
+        edge_dir = 0
         return
       }
 
-      window.scrollBy(0, speed)
+      if (dir !== edge_dir) {
+        edge_dir = dir
+        edge_since = now
+      }
+
+      const held = now - edge_since
+      let tier = EDGE_RAMP[0]
+      for (const t of EDGE_RAMP) if (held >= t.afterMs) tier = t
+      window.scrollBy(0, dir * tier.speed)
       updateDelta()
       raf = requestAnimationFrame(step)
     }
@@ -132,6 +184,7 @@ export function useReorderDrag({ pitch, count, enabled, onReorder }: ReorderDrag
 
   function reset() {
     from_index.value = null
+    target_index.value = null
     delta.value = 0
   }
 
@@ -140,6 +193,8 @@ export function useReorderDrag({ pitch, count, enabled, onReorder }: ReorderDrag
     const to = target_index.value
 
     stopTracking()
+
+    if (from !== null) emitSfx('snappy_button_5')
 
     // Commit and clear in the same synchronous tick: `onReorder` reorders the
     // list optimistically and `reset` zeroes the offsets, so a single render
@@ -154,11 +209,14 @@ export function useReorderDrag({ pitch, count, enabled, onReorder }: ReorderDrag
     event.preventDefault()
 
     from_index.value = index
+    target_index.value = index
     start_client_y = event.clientY
     start_scroll_y = window.scrollY
     pointer_y = event.clientY
     delta.value = 0
+    edge_dir = 0
 
+    emitSfx('generic_button_15')
     document.body.style.userSelect = 'none'
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onEnd)

--- a/src/views/deck/card-editor/use-reorder-drag.ts
+++ b/src/views/deck/card-editor/use-reorder-drag.ts
@@ -1,0 +1,177 @@
+import { computed, onBeforeUnmount, ref } from 'vue'
+
+// Auto-scroll kicks in when the pointer is within this many px of a viewport
+// edge, advancing the page so a row can be dragged past the visible window.
+const EDGE_ZONE = 90
+const EDGE_SPEED = 16
+
+export type ReorderDragOptions = {
+  // Fixed row pitch in px — the vertical distance between adjacent rows. The
+  // engine is geometry-light because the list is uniform: target slot and gap
+  // offsets are pure arithmetic off this pitch, no per-row measurement.
+  pitch: number
+  count: () => number
+  enabled: () => boolean
+  // Commit the reorder: move the row at `from` to land at index `to`. Expected
+  // to reorder the rendered list synchronously (optimistic cache write), so the
+  // engine can drop its drag state in the same tick without a snap-back.
+  onReorder: (from: number, to: number) => void
+}
+
+export type ReorderDrag = ReturnType<typeof useReorderDrag>
+
+/**
+ * Pointer-driven drag-to-reorder engine for a fixed-pitch vertical list.
+ *
+ * Designed to coexist with a virtualizer: it never moves or clones DOM. The
+ * caller renders rows as usual and applies `dragOffset(index)` as an extra
+ * `translateY` on each row. The dragged row follows the pointer 1:1; the rows
+ * it passes shift by one pitch to open a gap. The caller is responsible for
+ * keeping the dragged row mounted (e.g. via the virtualizer's `rangeExtractor`)
+ * so it survives auto-scroll out of the overscan window.
+ *
+ * Lifecycle: bind `start(index, event)` to a handle's `pointerdown`. The engine
+ * attaches window-level move/up listeners for the drag duration and tears them
+ * down on drop, cancel, or unmount.
+ *
+ * @example
+ * const reorder = useReorderDrag({
+ *   pitch: ROW_PITCH,
+ *   count: () => all_cards.value.length,
+ *   enabled: () => is_above_md.value,
+ *   onReorder: (from, to) => editor.reorderCard(from, to)
+ * })
+ */
+export function useReorderDrag({ pitch, count, enabled, onReorder }: ReorderDragOptions) {
+  const from_index = ref<number | null>(null)
+  const delta = ref(0)
+
+  let start_client_y = 0
+  let start_scroll_y = 0
+  let pointer_y = 0
+  let raf = 0
+
+  // Round the live translate to a slot offset and clamp into list bounds.
+  const target_index = computed(() => {
+    if (from_index.value === null) return null
+    const raw = from_index.value + Math.round(delta.value / pitch)
+    return Math.max(0, Math.min(count() - 1, raw))
+  })
+
+  /**
+   * Extra `translateY` (px) the caller should apply to the row at `index`:
+   * the live pointer offset for the dragged row, ±pitch for rows the drag has
+   * passed (opening the gap), 0 otherwise.
+   */
+  function dragOffset(index: number): number {
+    const from = from_index.value
+    const to = target_index.value
+    if (from === null || to === null) return 0
+
+    if (index === from) return delta.value
+    if (from < to && index > from && index <= to) return -pitch
+    if (to < from && index >= to && index < from) return pitch
+    return 0
+  }
+
+  /**
+   * Whether the row at `index` should animate its offset. The dragged row
+   * tracks the pointer untransitioned (so it doesn't lag the cursor); every
+   * other row transitions so the gap opens and closes smoothly as it passes.
+   */
+  function shouldTransition(index: number): boolean {
+    if (from_index.value === null) return false
+    return index !== from_index.value
+  }
+
+  function updateDelta() {
+    delta.value = pointer_y - start_client_y + (window.scrollY - start_scroll_y)
+  }
+
+  function edgeSpeed(): number {
+    if (pointer_y < EDGE_ZONE) return -EDGE_SPEED
+    if (window.innerHeight - pointer_y < EDGE_ZONE) return EDGE_SPEED
+    return 0
+  }
+
+  // Drive page scroll while the pointer sits in an edge zone. Re-reads pointer
+  // position each frame and folds the scroll delta into the dragged offset, so
+  // the row stays under the cursor as the list moves beneath it.
+  function autoScroll() {
+    if (raf) return
+
+    const step = () => {
+      const speed = edgeSpeed()
+      if (speed === 0 || from_index.value === null) {
+        raf = 0
+        return
+      }
+
+      window.scrollBy(0, speed)
+      updateDelta()
+      raf = requestAnimationFrame(step)
+    }
+
+    raf = requestAnimationFrame(step)
+  }
+
+  function onMove(event: PointerEvent) {
+    pointer_y = event.clientY
+    updateDelta()
+    autoScroll()
+  }
+
+  function stopTracking() {
+    if (raf) cancelAnimationFrame(raf)
+    raf = 0
+    document.body.style.userSelect = ''
+    window.removeEventListener('pointermove', onMove)
+    window.removeEventListener('pointerup', onEnd)
+    window.removeEventListener('pointercancel', onEnd)
+  }
+
+  function reset() {
+    from_index.value = null
+    delta.value = 0
+  }
+
+  function onEnd() {
+    const from = from_index.value
+    const to = target_index.value
+
+    stopTracking()
+
+    // Commit and clear in the same synchronous tick: `onReorder` reorders the
+    // list optimistically and `reset` zeroes the offsets, so a single render
+    // shows the row in its new slot with no offset — no snap-back frame.
+    if (from !== null && to !== null && from !== to) onReorder(from, to)
+    reset()
+  }
+
+  /** Begin a drag from `index`. Bind to a handle's `pointerdown`. */
+  function start(index: number, event: PointerEvent) {
+    if (!enabled() || event.button !== 0) return
+    event.preventDefault()
+
+    from_index.value = index
+    start_client_y = event.clientY
+    start_scroll_y = window.scrollY
+    pointer_y = event.clientY
+    delta.value = 0
+
+    document.body.style.userSelect = 'none'
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onEnd)
+    window.addEventListener('pointercancel', onEnd)
+  }
+
+  onBeforeUnmount(stopTracking)
+
+  return {
+    dragging_index: computed(() => from_index.value),
+    target_index,
+    dragOffset,
+    shouldTransition,
+    start
+  }
+}

--- a/src/views/deck/composables/list-controller.ts
+++ b/src/views/deck/composables/list-controller.ts
@@ -5,6 +5,7 @@ import { useDeckQuery } from '@/api/decks'
 import { useVirtualCardList, type CardEntry } from './virtual-list'
 import { useCardActions } from './actions'
 import { useCardSelection, useCardMutations, useCardLimitGate } from '@/composables/card'
+import { resolveReorderAnchor } from '@/utils/card-editor/selection-payload'
 import { emitSfx } from '@/sfx/bus'
 import type { DeckViewShell } from './view-shell'
 
@@ -149,6 +150,29 @@ export function useCardListController(opts: Options) {
     return true
   }
 
+  /**
+   * Reposition a persisted card within the deck by drag index. `from`/`to` are
+   * indices into `list.all_cards`. Resolves the nearest persisted neighbour at
+   * the drop slot into a `move_card` anchor + side and fires the mutation, which
+   * optimistically reorders the cache synchronously (so the dropped row settles
+   * without a refetch) and reconciles on settle. Failures roll back in the
+   * mutation, so the floating promise is intentionally swallowed here.
+   *
+   * No-op when the dragged row is a temp (not yet persisted) or no persisted
+   * neighbour exists to anchor against.
+   */
+  function reorderCard(from: number, to: number) {
+    const cards = list.all_cards.value
+    const dragged = cards[from]
+    if (!dragged?.id || dragged.id < 0) return
+
+    const without = cards.filter((_, i) => i !== from)
+    const anchor = resolveReorderAnchor(without, to)
+    if (!anchor) return
+
+    mutations.reorderCard({ card_id: dragged.id, deck_id: opts.deck_id, ...anchor }).catch(() => {})
+  }
+
   const actions = useCardActions({
     list,
     selection,
@@ -230,6 +254,7 @@ export function useCardListController(opts: Options) {
     prependCard,
     addCardAtTop,
     newCard,
+    reorderCard,
     claimFocus,
     guardAddCards: limit_gate.guardAddCards,
     handleLimitError: limit_gate.handleLimitError,

--- a/supabase/migrations/20260626000000_reindex-duplicate-ranks.sql
+++ b/supabase/migrations/20260626000000_reindex-duplicate-ranks.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- Reindex decks with duplicate card ranks
+-- =============================================================================
+--
+-- A legacy import path created cards at the column's old default rank (1000),
+-- so some decks hold many cards sharing one rank. The 20260419 backfill only
+-- healed NULL ranks, not duplicates. Duplicate ranks break ordering two ways:
+--
+--   1. The cards page query orders by `rank` alone, so tied cards come back in
+--      arbitrary heap order — unstable across refetches, and offset pagination
+--      can skip or repeat cards across page boundaries.
+--   2. move_card resolves the missing neighbour by `rank`, so among a block of
+--      tied cards it bisects against an arbitrary one and the moved card lands
+--      somewhere unexpected in the tie block.
+--
+-- reindex_deck_ranks rewrites every card in a deck to `row_number() * 1000`
+-- ordered by (rank, id) — unique, evenly spaced, deterministic. We run it only
+-- on decks that actually have a collision: a deck is dirty when its card count
+-- differs from its distinct-rank count.
+-- =============================================================================
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_deck_id bigint;
+BEGIN
+  FOR v_deck_id IN
+    SELECT deck_id
+      FROM public.cards
+     WHERE deck_id IS NOT NULL
+     GROUP BY deck_id
+    HAVING count(*) <> count(DISTINCT rank)
+  LOOP
+    PERFORM public.reindex_deck_ranks(v_deck_id);
+  END LOOP;
+END $$;
+
+COMMIT;

--- a/tests/integration/components/modals/study-session/session-flashcard.test.js
+++ b/tests/integration/components/modals/study-session/session-flashcard.test.js
@@ -69,6 +69,7 @@ vi.mock('@/api/cards', () => {
     useDeleteCardImageMutation: passthrough,
     useUpsertCardsMutation: passthrough,
     useMoveCardsToDeckMutation: passthrough,
+    useMoveCardMutation: passthrough,
     useMemberCardCountQuery: () => ({ data: { value: 0 }, refetch: vi.fn(), refresh: vi.fn() })
   }
 })

--- a/tests/integration/views/deck/card-editor/list-item.test.js
+++ b/tests/integration/views/deck/card-editor/list-item.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
-import { defineComponent, h, ref, useAttrs } from 'vue'
+import { defineComponent, h, nextTick, ref, useAttrs } from 'vue'
 
 // Stub UiButton to render its default slot so label text is inspectable,
 // and forward attrs (including data-testid) for querying.
@@ -57,9 +57,9 @@ function makeProvide({ is_selecting = ref(false) } = {}) {
   }
 }
 
-function mount({ card, index = 0, is_selecting } = {}) {
+function mount({ card, index = 0, is_selecting, dragging } = {}) {
   return shallowMount(ListItem, {
-    props: { card: makeCard(card), index },
+    props: { card: makeCard(card), index, dragging },
     global: {
       stubs: { UiButton: UiButtonStub },
       provide: makeProvide({ is_selecting })
@@ -147,6 +147,34 @@ describe('ListItem', () => {
     expect(wrapper.findComponent(ItemOptions).exists()).toBe(false)
   })
 
+  // ── Drag handle — data-dragging attribute and reorderPointerdown emit ────────
+
+  // [obligation] data-dragging reflects the dragging prop on the row root
+  test('data-dragging is "true" when dragging prop is true [obligation]', () => {
+    const wrapper = mount({ dragging: true })
+    expect(wrapper.find('[data-testid="card-list-item"]').attributes('data-dragging')).toBe('true')
+  })
+
+  test('data-dragging is "false" when dragging prop is false (default)', () => {
+    const wrapper = mount({ dragging: false })
+    expect(wrapper.find('[data-testid="card-list-item"]').attributes('data-dragging')).toBe('false')
+  })
+
+  test('data-dragging is "false" when dragging prop is not set', () => {
+    const wrapper = mount()
+    expect(wrapper.find('[data-testid="card-list-item"]').attributes('data-dragging')).toBe('false')
+  })
+
+  test('reorder handle pointerdown emits reorderPointerdown with the event', async () => {
+    const wrapper = mount({ card: { id: 5 } })
+    const event = new PointerEvent('pointerdown', { button: 0, bubbles: true })
+    wrapper.find('[data-testid="card-list-item__reorder"]').element.dispatchEvent(event)
+    await nextTick()
+    const emitted = wrapper.emitted('reorderPointerdown')
+    expect(emitted).toBeTruthy()
+    expect(emitted[0][0]).toBe(event)
+  })
+
   // ── onClick — selection mode vs normal mode ───────────────────────────────
 
   test('mousedown in selection mode calls onSelectCard with the card id', async () => {
@@ -160,5 +188,19 @@ describe('ListItem', () => {
     const wrapper = mount({ card: { id: 3 }, is_selecting: ref(true) })
     const radio = wrapper.findComponent({ name: 'UiRadio' })
     expect(radio.props('checked')).toBe(true)
+  })
+
+  // ── onClick — normal mode branches ───────────────────────────────────────
+
+  // Dispatching mousedown on the reorder button exercises the 'button' branch of onClick:
+  // onClick detects e.target.closest('button'), calls preventDefault, and returns early.
+  test('mousedown on a button child calls preventDefault and does not propagate to onSelectCard', async () => {
+    const wrapper = mount()
+    const btn = wrapper.find('[data-testid="card-list-item__reorder"]')
+    const event = new MouseEvent('mousedown', { bubbles: true })
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+    btn.element.dispatchEvent(event)
+    expect(preventDefaultSpy).toHaveBeenCalled()
+    expect(mocks.onSelectCardMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/integration/views/deck/card-editor/list.test.js
+++ b/tests/integration/views/deck/card-editor/list.test.js
@@ -2,8 +2,40 @@ import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
 import { ref, computed, shallowRef } from 'vue'
 
-const { useWindowVirtualizerMock } = vi.hoisted(() => ({ useWindowVirtualizerMock: vi.fn() }))
-vi.mock('@tanstack/vue-virtual', () => ({ useWindowVirtualizer: useWindowVirtualizerMock }))
+const { useWindowVirtualizerMock, useReorderDragMock, startMock } = vi.hoisted(() => {
+  const startMock = vi.fn()
+  const useReorderDragMock = vi.fn(() => ({
+    dragging_index: ref(null),
+    target_index: ref(null),
+    dragOffset: vi.fn(() => 0),
+    shouldTransition: vi.fn(() => false),
+    start: startMock
+  }))
+  const useWindowVirtualizerMock = vi.fn()
+  return { useWindowVirtualizerMock, useReorderDragMock, startMock }
+})
+
+vi.mock('@tanstack/vue-virtual', () => ({
+  useWindowVirtualizer: useWindowVirtualizerMock,
+  // Used by list.vue rangeExtractor option — must be exported so the import resolves
+  defaultRangeExtractor: (range) => {
+    const arr = []
+    for (let i = range.startIndex; i <= range.endIndex; i++) arr.push(i)
+    return arr
+  }
+}))
+vi.mock('@/views/deck/card-editor/use-reorder-drag', () => ({
+  useReorderDrag: useReorderDragMock
+}))
+vi.mock('@/composables/ui/media-query', () => ({ useMatchMedia: () => ref(true) }))
+vi.mock('@/utils/animations/list-item', () => ({
+  expandListItemIn: vi.fn(),
+  liftListItem: vi.fn(),
+  dropListItem: vi.fn()
+}))
+vi.mock('@/composables/ui/pin-scroll-while-typing', () => ({
+  usePinScrollWhileTyping: vi.fn()
+}))
 
 import List from '@/views/deck/card-editor/list.vue'
 import { cardEditorKey } from '@/views/deck/composables/list-controller'
@@ -23,12 +55,15 @@ function makeEditor({
   cards = [],
   hasNextPage = ref(false),
   isLoading = ref(false),
-  loadNextPage = vi.fn()
+  loadNextPage = vi.fn(),
+  reorderCard = vi.fn()
 } = {}) {
   return {
     list: {
       all_cards: computed(() => cards.map((c) => ({ ...c, client_id: `cid-${c.id}` })))
     },
+    selection: { is_selecting: ref(false) },
+    reorderCard,
     hasNextPage,
     isLoading,
     loadNextPage
@@ -184,5 +219,107 @@ describe('CardList (list.vue)', () => {
     })
 
     expect(loadNextPage).not.toHaveBeenCalled()
+  })
+
+  // ── Drag-to-reorder — dragging prop forwarded to list-item ────────────────
+
+  test('forwards dragging=true to the list-item whose index matches dragging_index', () => {
+    const cards = [{ id: 1 }, { id: 2 }]
+    setupVirtualizer({ items: makeVirtualItems([0, 1]), totalSize: 2 * ROW_PITCH })
+    // Seed dragging_index=0 so the first item gets dragging=true
+    useReorderDragMock.mockReturnValueOnce({
+      dragging_index: ref(0),
+      target_index: ref(null),
+      dragOffset: vi.fn(() => 0),
+      shouldTransition: vi.fn(() => false),
+      start: vi.fn()
+    })
+
+    const wrapper = mount({ editor: makeEditor({ cards }) })
+    const items = wrapper.findAllComponents({ name: 'ListItem' })
+    expect(items[0].props('dragging')).toBe(true)
+    expect(items[1].props('dragging')).toBe(false)
+  })
+
+  test('forwards dragging=false to all list-items when no drag is active', () => {
+    const cards = [{ id: 1 }, { id: 2 }]
+    setupVirtualizer({ items: makeVirtualItems([0, 1]), totalSize: 2 * ROW_PITCH })
+
+    const wrapper = mount({ editor: makeEditor({ cards }) })
+    const items = wrapper.findAllComponents({ name: 'ListItem' })
+    items.forEach((item) => expect(item.props('dragging')).toBe(false))
+  })
+
+  // ── Drag lifecycle — reorderPointerdown wiring and lift/drop ──────────────
+
+  test('reorder-pointerdown on a list-item calls reorder.start with the correct index', async () => {
+    const cards = [{ id: 1 }, { id: 2 }]
+    setupVirtualizer({ items: makeVirtualItems([0, 1]), totalSize: 2 * ROW_PITCH })
+
+    const wrapper = mount({ editor: makeEditor({ cards }) })
+    const item = wrapper.findAllComponents({ name: 'ListItem' })[1]
+    const event = new Event('reorder-pointerdown')
+    item.vm.$emit('reorderPointerdown', event)
+    await wrapper.vm.$nextTick()
+
+    expect(startMock).toHaveBeenCalledWith(1, event)
+  })
+
+  test('drop (dragging_index transitions from non-null to null) fires the watch without throwing', async () => {
+    const dragging_index = ref(1)
+    const cards = [{ id: 1 }, { id: 2 }]
+    setupVirtualizer({ items: makeVirtualItems([0, 1]), totalSize: 2 * ROW_PITCH })
+    useReorderDragMock.mockReturnValueOnce({
+      dragging_index,
+      target_index: ref(null),
+      dragOffset: vi.fn(() => 0),
+      shouldTransition: vi.fn(() => false),
+      start: vi.fn()
+    })
+
+    mount({ editor: makeEditor({ cards }) })
+
+    // Transition: dragging_index goes from 1 → null (drop)
+    dragging_index.value = null
+    await new Promise((r) => setTimeout(r, 0))
+
+    // dropListItem would be called if lifted_row was set; since no real DOM row was
+    // lifted the lifted_row is null so dropListItem is not called — test that the
+    // watch fires without throwing
+    expect(() => (dragging_index.value = null)).not.toThrow()
+  })
+
+  test('liftListItem called when drag is enabled and event target resolves to card-list-item', async () => {
+    const { liftListItem: liftMock } = await import('@/utils/animations/list-item')
+    const dragging_index = ref(null)
+    const cards = [{ id: 1 }, { id: 2 }]
+    setupVirtualizer({ items: makeVirtualItems([0, 1]), totalSize: 2 * ROW_PITCH })
+
+    // Make start() set dragging_index to simulate a successful drag start
+    const startFn = vi.fn(() => {
+      dragging_index.value = 1
+    })
+    useReorderDragMock.mockReturnValueOnce({
+      dragging_index,
+      target_index: ref(null),
+      dragOffset: vi.fn(() => 0),
+      shouldTransition: vi.fn(() => false),
+      start: startFn
+    })
+
+    const wrapper = mount({ editor: makeEditor({ cards }) })
+
+    // Create a real DOM element that .closest('[data-testid="card-list-item"]') can find
+    const rowEl = document.createElement('div')
+    rowEl.setAttribute('data-testid', 'card-list-item')
+    document.body.appendChild(rowEl)
+
+    const fakeEvent = { target: rowEl, button: 0, preventDefault: vi.fn() }
+    const item = wrapper.findAllComponents({ name: 'ListItem' })[1]
+    item.vm.$emit('reorderPointerdown', fakeEvent)
+    await wrapper.vm.$nextTick()
+
+    expect(liftMock).toHaveBeenCalledWith(rowEl)
+    document.body.removeChild(rowEl)
   })
 })

--- a/tests/unit/api/cards/cards-page.test.js
+++ b/tests/unit/api/cards/cards-page.test.js
@@ -2,9 +2,10 @@ import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 
 const { fromMock, rangeMock, orderMock, eqMock, selectMock } = vi.hoisted(() => {
   const rangeMock = vi.fn()
-  const orderMock = vi.fn(() => ({ range: rangeMock }))
+  // order() returns { order, range } so two sequential .order() calls chain correctly
+  const orderMock = vi.fn(() => ({ order: orderMock, range: rangeMock }))
   const eqMock = vi.fn(() => ({ order: orderMock }))
-  const selectMock = vi.fn(() => ({ eq: eqMock, order: orderMock }))
+  const selectMock = vi.fn(() => ({ eq: eqMock }))
   const fromMock = vi.fn(() => ({ select: selectMock }))
   return { fromMock, rangeMock, orderMock, eqMock, selectMock }
 })
@@ -33,6 +34,15 @@ describe('fetchCardsPageByDeckId', () => {
     expect(selectMock).toHaveBeenCalledWith('*, review:reviews(*)')
     expect(eqMock).toHaveBeenCalledWith('deck_id', 10)
     expect(orderMock).toHaveBeenCalledWith('rank', { ascending: true })
+  })
+
+  // [obligation] both .order() calls in sequence — rank primary, id tiebreak
+  test('applies id as secondary sort key after rank so duplicate ranks paginate deterministically', async () => {
+    rangeMock.mockResolvedValueOnce({ data: [], error: null })
+    await fetchCardsPageByDeckId({ deck_id: 10, offset: 0, limit: 50 })
+    const calls = orderMock.mock.calls
+    expect(calls[0]).toEqual(['rank', { ascending: true }])
+    expect(calls[1]).toEqual(['id', { ascending: true }])
   })
 
   test('translates offset+limit into a Postgrest inclusive range', async () => {

--- a/tests/unit/api/cards/mutations/move.test.js
+++ b/tests/unit/api/cards/mutations/move.test.js
@@ -1,0 +1,217 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { useMutationSpy, moveCardMock } = vi.hoisted(() => ({
+  useMutationSpy: vi.fn((cfg) => cfg),
+  moveCardMock: vi.fn().mockResolvedValue(9001)
+}))
+
+// Shared mutable cache state — reset in beforeEach
+let cached_data
+const invalidateSpy = vi.fn()
+const setQueryDataSpy = vi.fn((key, data) => {
+  cached_data = data
+})
+const getQueryDataSpy = vi.fn(() => cached_data)
+
+vi.mock('@pinia/colada', () => ({
+  useMutation: useMutationSpy,
+  useQueryCache: () => ({
+    getQueryData: getQueryDataSpy,
+    setQueryData: setQueryDataSpy,
+    invalidateQueries: invalidateSpy
+  }),
+  // Apply the updater to the current cached data and store the result, mirroring
+  // what Pinia Colada's real setInfiniteQueryData does for optimistic updates.
+  setInfiniteQueryData: (cache, key, updater) => {
+    const current = cache.getQueryData(key)
+    const next = updater(current)
+    cache.setQueryData(key, next)
+  }
+}))
+
+vi.mock('@/api/cards/db', () => ({ moveCard: moveCardMock }))
+
+import { useMoveCardMutation } from '@/api/cards/mutations/move'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function card(id) {
+  return { id, rank: id * 1000 }
+}
+
+/** Build a cache snapshot with the given pages array */
+function makeSnapshot(pages) {
+  return { pages, pageParams: pages.map((_, i) => i * 50) }
+}
+
+/** Extract the mutation config registered by the last useMutation call */
+function config() {
+  useMoveCardMutation()
+  return useMutationSpy.mock.calls.at(-1)[0]
+}
+
+beforeEach(() => {
+  cached_data = undefined
+  useMutationSpy.mockClear()
+  moveCardMock.mockClear()
+  invalidateSpy.mockClear()
+  setQueryDataSpy.mockClear()
+  getQueryDataSpy.mockClear()
+})
+
+// ── mutation() delegates to moveCard db function ──────────────────────────────
+
+describe('useMoveCardMutation — mutation()', () => {
+  test('calls moveCard with the db params (deck_id stripped)', async () => {
+    const { mutation } = config()
+    await mutation({ deck_id: 10, card_id: 1, anchor_id: 2, side: 'after' })
+    expect(moveCardMock).toHaveBeenCalledWith({ card_id: 1, anchor_id: 2, side: 'after' })
+  })
+
+  test('does not forward deck_id to moveCard (it is a mutation-level concern only)', async () => {
+    const { mutation } = config()
+    await mutation({ deck_id: 10, card_id: 1, anchor_id: 2, side: 'before' })
+    const call = moveCardMock.mock.calls[0][0]
+    expect('deck_id' in call).toBe(false)
+  })
+})
+
+// ── onMutate — optimistic cache reorder ───────────────────────────────────────
+
+describe('useMoveCardMutation — onMutate()', () => {
+  // [obligation] optimistically reorders cached pages synchronously before RPC resolves
+  test('reorders the card to after the anchor synchronously on mutate [obligation]', () => {
+    cached_data = makeSnapshot([[card(1), card(2), card(3)]])
+    const { onMutate } = config()
+
+    onMutate({ deck_id: 10, card_id: 3, anchor_id: 1, side: 'after' })
+
+    expect(setQueryDataSpy).toHaveBeenCalledOnce()
+    const { pages } = setQueryDataSpy.mock.calls[0][1]
+    expect(pages[0].map((c) => c.id)).toEqual([1, 3, 2])
+  })
+
+  test('reorders the card to before the anchor on side=before', () => {
+    cached_data = makeSnapshot([[card(1), card(2), card(3)]])
+    const { onMutate } = config()
+
+    onMutate({ deck_id: 10, card_id: 3, anchor_id: 2, side: 'before' })
+
+    const { pages } = setQueryDataSpy.mock.calls[0][1]
+    expect(pages[0].map((c) => c.id)).toEqual([1, 3, 2])
+  })
+
+  // [obligation] anchor index computed AFTER removing moved card (regression guard)
+  test('places card correctly when moving first card to after a later card [obligation]', () => {
+    // A=1, B=2, C=3. Move A (idx 0) to after B.
+    // If anchor_index was computed BEFORE removing A: B is at idx 1 (stale) → splice(2,0,A) → [B,C,A] (wrong)
+    // Correct: remove A → [B,C], B is now at idx 0 → splice(1,0,A) → [B,A,C] ✓
+    cached_data = makeSnapshot([[card(1), card(2), card(3)]])
+    const { onMutate } = config()
+
+    onMutate({ deck_id: 10, card_id: 1, anchor_id: 2, side: 'after' })
+
+    const { pages } = setQueryDataSpy.mock.calls[0][1]
+    expect(pages[0].map((c) => c.id)).toEqual([2, 1, 3])
+  })
+
+  // [obligation] re-chunks into original page sizes on cross-page move
+  test('preserves original page sizes when moving a card across page boundaries [obligation]', () => {
+    // Two pages of 2. Move card 4 (page 2) to after card 1 (page 1).
+    cached_data = makeSnapshot([
+      [card(1), card(2)],
+      [card(3), card(4)]
+    ])
+    const { onMutate } = config()
+
+    onMutate({ deck_id: 10, card_id: 4, anchor_id: 1, side: 'after' })
+
+    const { pages } = setQueryDataSpy.mock.calls[0][1]
+    expect(pages).toHaveLength(2)
+    expect(pages[0]).toHaveLength(2)
+    expect(pages[1]).toHaveLength(2)
+    expect(pages[0].map((c) => c.id)).toEqual([1, 4])
+    expect(pages[1].map((c) => c.id)).toEqual([2, 3])
+  })
+
+  // [obligation] no-op when deck not cached — returns { snapshot: undefined }
+  test('is a no-op and returns { snapshot: undefined } when the deck is not cached [obligation]', () => {
+    cached_data = undefined
+    const { onMutate } = config()
+
+    const ctx = onMutate({ deck_id: 10, card_id: 1, anchor_id: 2, side: 'after' })
+
+    expect(setQueryDataSpy).not.toHaveBeenCalled()
+    expect(ctx).toEqual({ snapshot: undefined })
+  })
+
+  test('returns { snapshot } with the pre-mutate cache state for rollback', () => {
+    const initial = makeSnapshot([[card(1), card(2)]])
+    cached_data = initial
+    const { onMutate } = config()
+
+    const ctx = onMutate({ deck_id: 10, card_id: 2, anchor_id: 1, side: 'before' })
+
+    expect(ctx.snapshot).toBe(initial)
+  })
+
+  test('is a no-op (no crash) when card_id is not in the cache', () => {
+    cached_data = makeSnapshot([[card(1), card(2)]])
+    const { onMutate } = config()
+
+    // card 99 doesn't exist — should return snapshot without patching
+    onMutate({ deck_id: 10, card_id: 99, anchor_id: 1, side: 'after' })
+
+    // setQueryData IS called by setInfiniteQueryData but updater bails early
+    // so page order is unchanged
+    const { pages } = setQueryDataSpy.mock.calls[0][1]
+    expect(pages[0].map((c) => c.id)).toEqual([1, 2])
+  })
+})
+
+// ── onError — rollback ────────────────────────────────────────────────────────
+
+describe('useMoveCardMutation — onError()', () => {
+  // [obligation] onError restores the snapshot on failure
+  test('restores the pre-mutate snapshot when the mutation errors [obligation]', () => {
+    const snapshot = makeSnapshot([[card(1), card(2)]])
+    const { onError } = config()
+
+    onError(new Error('timeout'), { deck_id: 10 }, { snapshot })
+
+    expect(setQueryDataSpy).toHaveBeenCalledWith(['cards', 10, 'pages', 50], snapshot)
+  })
+
+  test('does not call setQueryData when context.snapshot is undefined (deck was not cached)', () => {
+    const { onError } = config()
+
+    onError(new Error('timeout'), { deck_id: 10 }, { snapshot: undefined })
+
+    expect(setQueryDataSpy).not.toHaveBeenCalled()
+  })
+})
+
+// ── onSettled — invalidation ──────────────────────────────────────────────────
+
+describe('useMoveCardMutation — onSettled()', () => {
+  // [obligation] invalidates ['deck', deck_id] and ['cards', deck_id] on settle
+  test('invalidates the deck query on settle [obligation]', () => {
+    const { onSettled } = config()
+    onSettled(undefined, undefined, { deck_id: 10 })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['deck', 10] })
+  })
+
+  test('invalidates the cards query on settle [obligation]', () => {
+    const { onSettled } = config()
+    onSettled(undefined, undefined, { deck_id: 10 })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 10] })
+  })
+
+  test('fires exactly two invalidations (deck + cards prefix)', () => {
+    const { onSettled } = config()
+    onSettled(undefined, undefined, { deck_id: 10 })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/composables/card-editor/card-list-controller.test.js
+++ b/tests/unit/composables/card-editor/card-list-controller.test.js
@@ -10,6 +10,7 @@ const {
   deleteCardsMock,
   deleteCardsInDeckMock,
   moveCardsMock,
+  reorderCardMock,
   setCardImageMock,
   deleteCardImageMock,
   modalOpenMock,
@@ -26,6 +27,7 @@ const {
   deleteCardsMock: vi.fn(),
   deleteCardsInDeckMock: vi.fn(),
   moveCardsMock: vi.fn(),
+  reorderCardMock: vi.fn(),
   setCardImageMock: vi.fn(),
   deleteCardImageMock: vi.fn(),
   modalOpenMock: vi.fn(),
@@ -46,6 +48,7 @@ vi.mock('@/api/cards', () => ({
     mutateAsync: deleteCardsInDeckMock
   }),
   useMoveCardsToDeckMutation: () => ({ mutate: moveCardsMock, mutateAsync: moveCardsMock }),
+  useMoveCardMutation: () => ({ mutate: reorderCardMock, mutateAsync: reorderCardMock }),
   useSetCardImageMutation: () => ({ mutate: setCardImageMock, mutateAsync: setCardImageMock }),
   useDeleteCardImageMutation: () => ({
     mutate: deleteCardImageMock,
@@ -158,6 +161,8 @@ describe('useCardListController', () => {
     deleteCardsInDeckMock.mockResolvedValue(0)
     moveCardsMock.mockReset()
     moveCardsMock.mockResolvedValue(undefined)
+    reorderCardMock.mockReset()
+    reorderCardMock.mockResolvedValue(9999)
     setCardImageMock.mockReset()
     setCardImageMock.mockResolvedValue(undefined)
     deleteCardImageMock.mockReset()
@@ -755,6 +760,46 @@ describe('useCardListController', () => {
       await ctrl.newCard()
       // setMode is still called (gate check happens inside addCardAtTop)
       expect(ctrl.list.all_cards.value).toHaveLength(0)
+    })
+  })
+
+  // ── reorderCard — moves a persisted card to a new slot ───────────────────────
+
+  describe('reorderCard', () => {
+    // [obligation] no-op when dragged card is a temp (id < 0)
+    test('is a no-op when the dragged card is a temp (id < 0)', () => {
+      const { all_cards, addCard, reorderCard } = makeController([makeCard({ id: 100 })])
+      addCard()
+      const temp_idx = all_cards.value.findIndex((c) => c.id < 0)
+      reorderCard(temp_idx, 1)
+      expect(reorderCardMock).not.toHaveBeenCalled()
+    })
+
+    // [obligation] no-op when no persisted anchor resolves
+    test('is a no-op when no persisted anchor can be resolved at the drop slot', () => {
+      // Only one persisted card; if we drag it, without = [], so resolveReorderAnchor returns null
+      const { reorderCard } = makeController([makeCard({ id: 1 })])
+      reorderCard(0, 0)
+      expect(reorderCardMock).not.toHaveBeenCalled()
+    })
+
+    test('calls the reorder mutation with card_id, deck_id, and the resolved anchor', () => {
+      const ctrl = makeController([makeCard({ id: 1 }), makeCard({ id: 2 }), makeCard({ id: 3 })])
+      ctrl.reorderCard(2, 0)
+      // Without card at idx 2 (id=3): [id=1, id=2]. to=0 → walks right for 'before' → anchor_id=1
+      expect(reorderCardMock).toHaveBeenCalledWith({
+        card_id: 3,
+        deck_id: 10,
+        anchor_id: 1,
+        side: 'before'
+      })
+    })
+
+    test('swallows rejection from the mutation (floating promise)', async () => {
+      reorderCardMock.mockRejectedValueOnce(new Error('network'))
+      const ctrl = makeController([makeCard({ id: 1 }), makeCard({ id: 2 })])
+      // Should not throw
+      expect(() => ctrl.reorderCard(1, 0)).not.toThrow()
     })
   })
 

--- a/tests/unit/composables/card-editor/card-mutations.test.js
+++ b/tests/unit/composables/card-editor/card-mutations.test.js
@@ -8,6 +8,7 @@ const {
   deleteCardsMock,
   deleteCardsInDeckMock,
   moveCardsMock,
+  reorderCardMock,
   setCardImageMock,
   deleteCardImageMock
 } = vi.hoisted(() => ({
@@ -16,6 +17,7 @@ const {
   deleteCardsMock: vi.fn(),
   deleteCardsInDeckMock: vi.fn(),
   moveCardsMock: vi.fn(),
+  reorderCardMock: vi.fn(),
   setCardImageMock: vi.fn(),
   deleteCardImageMock: vi.fn()
 }))
@@ -29,6 +31,7 @@ vi.mock('@/api/cards', () => ({
     mutateAsync: deleteCardsInDeckMock
   }),
   useMoveCardsToDeckMutation: () => ({ mutate: moveCardsMock, mutateAsync: moveCardsMock }),
+  useMoveCardMutation: () => ({ mutate: reorderCardMock, mutateAsync: reorderCardMock }),
   useSetCardImageMutation: () => ({ mutate: setCardImageMock, mutateAsync: setCardImageMock }),
   useDeleteCardImageMutation: () => ({
     mutate: deleteCardImageMock,
@@ -57,6 +60,8 @@ beforeEach(() => {
   deleteCardsInDeckMock.mockResolvedValue(0)
   moveCardsMock.mockReset()
   moveCardsMock.mockResolvedValue(undefined)
+  reorderCardMock.mockReset()
+  reorderCardMock.mockResolvedValue(9999)
   setCardImageMock.mockReset()
   setCardImageMock.mockResolvedValue(undefined)
   deleteCardImageMock.mockReset()
@@ -160,6 +165,22 @@ describe('useCardMutations', () => {
       const m = makeMutations(10)
       await m.deleteCardImage(42, 'back')
       expect(deleteCardImageMock).toHaveBeenCalledWith({ card_id: 42, deck_id: 10, side: 'back' })
+    })
+  })
+
+  describe('reorderCard', () => {
+    test('forwards all params to useMoveCardMutation.mutateAsync', async () => {
+      const m = makeMutations(10)
+      const params = { card_id: 7, deck_id: 10, anchor_id: 3, side: 'after' }
+      await m.reorderCard(params)
+      expect(reorderCardMock).toHaveBeenCalledWith(params)
+    })
+
+    test('returns the resolved value from the mutation', async () => {
+      reorderCardMock.mockResolvedValueOnce(1234)
+      const m = makeMutations(10)
+      const result = await m.reorderCard({ card_id: 7, deck_id: 10, anchor_id: 3, side: 'after' })
+      expect(result).toBe(1234)
     })
   })
 })

--- a/tests/unit/utils/animations/list-item.test.js
+++ b/tests/unit/utils/animations/list-item.test.js
@@ -1,10 +1,16 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 
-const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }))
+const { mockFrom, mockTo, mockTimeline, mockTimelineTo } = vi.hoisted(() => {
+  const mockTimelineTo = vi.fn().mockReturnThis()
+  const mockTimeline = vi.fn(() => ({ to: mockTimelineTo }))
+  const mockTo = vi.fn()
+  const mockFrom = vi.fn()
+  return { mockFrom, mockTo, mockTimeline, mockTimelineTo }
+})
 
-vi.mock('gsap', () => ({ gsap: { from: mockFrom } }))
+vi.mock('gsap', () => ({ gsap: { from: mockFrom, to: mockTo, timeline: mockTimeline } }))
 
-import { expandListItemIn } from '@/utils/animations/list-item'
+import { expandListItemIn, liftListItem, dropListItem } from '@/utils/animations/list-item'
 
 const el = document.createElement('div')
 
@@ -40,6 +46,67 @@ describe('expandListItemIn', () => {
   test('uses a positive duration', () => {
     expandListItemIn(el)
     const opts = mockFrom.mock.calls[0][1]
+    expect(opts.duration).toBeGreaterThan(0)
+  })
+})
+
+describe('liftListItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('creates a gsap timeline', () => {
+    liftListItem(el)
+    expect(mockTimeline).toHaveBeenCalledOnce()
+  })
+
+  test('animates to scale above 1 on the first tween (overshoot)', () => {
+    liftListItem(el)
+    const first_opts = mockTimelineTo.mock.calls[0][1]
+    expect(first_opts.scale).toBeGreaterThan(1)
+  })
+
+  test('settles at a scale above 1 on the second tween (held lift)', () => {
+    liftListItem(el)
+    const second_opts = mockTimelineTo.mock.calls[1][1]
+    expect(second_opts.scale).toBeGreaterThan(1)
+  })
+
+  test('first tween overshoot scale exceeds the settled lift scale', () => {
+    liftListItem(el)
+    const first_scale = mockTimelineTo.mock.calls[0][1].scale
+    const second_scale = mockTimelineTo.mock.calls[1][1].scale
+    expect(first_scale).toBeGreaterThan(second_scale)
+  })
+
+  test('does not use clearProps so the lifted scale persists during the drag', () => {
+    liftListItem(el)
+    mockTimelineTo.mock.calls.forEach(([, opts]) => {
+      expect(opts.clearProps).toBeUndefined()
+    })
+  })
+})
+
+describe('dropListItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('animates to scale=1 (settling back to rest)', () => {
+    dropListItem(el)
+    const opts = mockTo.mock.calls[0][1]
+    expect(opts.scale).toBe(1)
+  })
+
+  test('clears the inline scale after settling so no leftover transform remains', () => {
+    dropListItem(el)
+    const opts = mockTo.mock.calls[0][1]
+    expect(opts.clearProps).toBe('scale')
+  })
+
+  test('uses a positive duration', () => {
+    dropListItem(el)
+    const opts = mockTo.mock.calls[0][1]
     expect(opts.duration).toBeGreaterThan(0)
   })
 })

--- a/tests/unit/utils/card-editor/selection-payload.test.js
+++ b/tests/unit/utils/card-editor/selection-payload.test.js
@@ -5,12 +5,68 @@ import {
   loadedSelectedCards,
   collectCards,
   resolveDeleteArgs,
-  resolveMoveArgs
+  resolveMoveArgs,
+  resolveReorderAnchor
 } from '@/utils/card-editor/selection-payload'
 
 function makeCard(overrides = {}) {
   return card.one({ overrides })
 }
+
+// Minimal plain card for resolveReorderAnchor — only needs id
+function c(id) {
+  return { id }
+}
+
+describe('resolveReorderAnchor', () => {
+  // [obligation] dropping after 2nd card resolves to { anchor_id: that card, side: 'after' }
+  test('dropping after the 2nd card (to=2) picks the card before as after-anchor [obligation]', () => {
+    const without = [c(1), c(2), c(3)]
+    expect(resolveReorderAnchor(without, 2)).toEqual({ anchor_id: 2, side: 'after' })
+  })
+
+  // [obligation] dropping at top (to=0) resolves to nearest right card with side='before'
+  test('dropping at top (to=0) walks right and picks the first card as before-anchor [obligation]', () => {
+    const without = [c(1), c(2)]
+    expect(resolveReorderAnchor(without, 0)).toEqual({ anchor_id: 1, side: 'before' })
+  })
+
+  // [obligation] skips temp cards (id<=0) when walking outward
+  test('skips temp cards (id <= 0) and walks to the nearest persisted neighbour [obligation]', () => {
+    // Drop at slot 1: walking left hits a temp at idx 0, no valid left neighbour,
+    // so walks right from slot 1 and picks id=3.
+    const without = [c(-1), c(3)]
+    expect(resolveReorderAnchor(without, 1)).toEqual({ anchor_id: 3, side: 'before' })
+  })
+
+  test('skips temp on the left and finds a persisted card further left', () => {
+    // Drop at slot 2: idx 0=persisted(1), idx 1=temp(-2), so walk left skips -2 then picks 1.
+    const without = [c(1), c(-2), c(5)]
+    expect(resolveReorderAnchor(without, 2)).toEqual({ anchor_id: 1, side: 'after' })
+  })
+
+  // [obligation] returns null when no persisted neighbour exists
+  test('returns null when no persisted neighbour exists (all temps or empty list) [obligation]', () => {
+    expect(resolveReorderAnchor([], 0)).toBeNull()
+    expect(resolveReorderAnchor([c(-1), c(-2)], 0)).toBeNull()
+  })
+
+  test('returns null when the only persisted card was the dragged one (single-card deck)', () => {
+    // without=[] because the single card is removed before calling this fn
+    expect(resolveReorderAnchor([], 0)).toBeNull()
+  })
+
+  test('walking left from to takes the immediate left neighbour when it is persisted', () => {
+    const without = [c(10), c(20), c(30)]
+    expect(resolveReorderAnchor(without, 3)).toEqual({ anchor_id: 30, side: 'after' })
+  })
+
+  test('falls back to right walk when left has only temps', () => {
+    // to=2: left candidates are idx 0 (temp) and idx 1 (temp); right candidate is idx 2 (persisted)
+    const without = [c(0), c(-5), c(7)]
+    expect(resolveReorderAnchor(without, 2)).toEqual({ anchor_id: 7, side: 'before' })
+  })
+})
 
 // Minimal stand-ins — just enough to satisfy the helpers' Pick<> shapes.
 function makeSelection({ selected_ids = [], select_all = false, deselected = [] } = {}) {

--- a/tests/unit/views/deck/card-editor/use-reorder-drag.test.js
+++ b/tests/unit/views/deck/card-editor/use-reorder-drag.test.js
@@ -1,0 +1,513 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { createApp } from 'vue'
+
+// jsdom does not implement PointerEvent; shim it as a MouseEvent subclass so
+// clientY / button are readable and window.dispatchEvent works correctly.
+if (!globalThis.PointerEvent) {
+  globalThis.PointerEvent = class PointerEvent extends MouseEvent {
+    constructor(type, init = {}) {
+      super(type, init)
+    }
+  }
+}
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const { emitSfxMock } = vi.hoisted(() => ({ emitSfxMock: vi.fn() }))
+vi.mock('@/sfx/bus', () => ({ emitSfx: emitSfxMock }))
+
+import { useReorderDrag } from '@/views/deck/card-editor/use-reorder-drag'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const PITCH = 100
+
+/**
+ * Mount the composable inside a minimal app so onBeforeUnmount fires correctly,
+ * then return the composable's API and the app for teardown.
+ */
+function withSetup(composable) {
+  let result
+  const app = createApp({
+    setup() {
+      result = composable()
+      return () => {}
+    }
+  })
+  app.mount(document.createElement('div'))
+  return { result, app }
+}
+
+function pointerEvent(type, { clientY = 0, button = 0 } = {}) {
+  return new PointerEvent(type, { bubbles: true, clientY, button })
+}
+
+function moveTo(clientY) {
+  window.dispatchEvent(pointerEvent('pointermove', { clientY }))
+}
+
+function pointerUp() {
+  window.dispatchEvent(pointerEvent('pointerup'))
+}
+
+let app
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  emitSfxMock.mockReset()
+  // Clean up any lingering window listeners by dispatching a cancel event
+  window.dispatchEvent(pointerEvent('pointercancel'))
+})
+
+// ── start() — guard conditions ────────────────────────────────────────────────
+
+describe('useReorderDrag — start()', () => {
+  // [obligation] no-op when enabled() is false
+  test('does nothing when enabled() returns false [obligation]', () => {
+    const onReorder = vi.fn()
+    const setup = withSetup(() =>
+      useReorderDrag({
+        pitch: PITCH,
+        count: () => 3,
+        enabled: () => false,
+        onReorder
+      })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 100 }))
+
+    expect(result.dragging_index.value).toBeNull()
+    expect(emitSfxMock).not.toHaveBeenCalled()
+  })
+
+  // [obligation] no-op when event.button !== 0
+  test('does nothing when event.button is not 0 [obligation]', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 2, clientY: 100 }))
+
+    expect(result.dragging_index.value).toBeNull()
+    expect(emitSfxMock).not.toHaveBeenCalled()
+  })
+
+  test('sets dragging_index and target_index to the given index on start', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(2, pointerEvent('pointerdown', { button: 0, clientY: 100 }))
+
+    expect(result.dragging_index.value).toBe(2)
+    expect(result.target_index.value).toBe(2)
+  })
+
+  // [obligation] emits generic_button_15 on drag start
+  test('emits generic_button_15 on successful start [obligation]', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 100 }))
+
+    expect(emitSfxMock).toHaveBeenCalledWith('generic_button_15')
+    expect(emitSfxMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── hysteresis — target_index and tap_05 gating ───────────────────────────────
+
+describe('useReorderDrag — hysteresis', () => {
+  let result
+
+  beforeEach(() => {
+    const setup = withSetup(() =>
+      useReorderDrag({
+        pitch: PITCH,
+        count: () => 3,
+        enabled: () => true,
+        onReorder: vi.fn()
+      })
+    )
+    app = setup.app
+    result = setup.result
+    // Start drag from index 1 at clientY=0
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    emitSfxMock.mockClear()
+  })
+
+  // [obligation] within 0.65*pitch: target_index stays unchanged, no tap_05
+  test('target_index stays at from when delta < 0.65*pitch [obligation]', () => {
+    // 0.5 + HYSTERESIS(0.15) = 0.65 → need ideal - next > 0.65 to advance
+    // At delta=65: ideal = 1 + 65/100 = 1.65, 1.65 - 1 = 0.65 which is NOT > 0.65
+    moveTo(65)
+
+    expect(result.target_index.value).toBe(1)
+    expect(emitSfxMock).not.toHaveBeenCalled()
+  })
+
+  test('target_index advances to next slot when delta crosses the 0.65*pitch boundary [obligation]', () => {
+    // At delta=66: ideal = 1.66, 1.66 - 1 = 0.66 > 0.65 → advances to 2
+    moveTo(66)
+
+    expect(result.target_index.value).toBe(2)
+    expect(emitSfxMock).toHaveBeenCalledWith('tap_05')
+    expect(emitSfxMock).toHaveBeenCalledTimes(1)
+  })
+
+  // [obligation] boundary jitter must not double-fire the crossing tick
+  test('moving back within the hysteresis band does not fire another tap_05 [obligation]', () => {
+    // Cross forward: target flips to 2
+    moveTo(66)
+    emitSfxMock.mockClear()
+
+    // Move back to 65 — ideal=1.65, next=2, 2-1.65=0.35 which is NOT > 0.65 → stays at 2
+    moveTo(65)
+
+    expect(result.target_index.value).toBe(2)
+    expect(emitSfxMock).not.toHaveBeenCalled()
+  })
+
+  test('tap_05 fires again only after the reverse threshold (0.65 back) is crossed', () => {
+    moveTo(66) // target → 2, tap fires
+    emitSfxMock.mockClear()
+
+    // Need to move back far enough: 2 - ideal > 0.65, so ideal < 1.35, delta < 35
+    moveTo(34)
+
+    expect(result.target_index.value).toBe(1)
+    expect(emitSfxMock).toHaveBeenCalledWith('tap_05')
+    expect(emitSfxMock).toHaveBeenCalledTimes(1)
+  })
+
+  // [obligation] no tap_05 on the initial pickup that seeds target = from
+  test('no tap_05 is emitted when target is seeded to from on start [obligation]', () => {
+    // emitSfxMock was cleared after start(); no tap_05 should have fired during start
+    expect(emitSfxMock).not.toHaveBeenCalled()
+  })
+})
+
+// ── sfx contract ──────────────────────────────────────────────────────────────
+
+describe('useReorderDrag — sfx contract', () => {
+  // [obligation] snappy_button_5 fires on drop
+  test('emits snappy_button_5 on pointerup (drop) [obligation]', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    emitSfxMock.mockClear()
+
+    pointerUp()
+
+    expect(emitSfxMock).toHaveBeenCalledWith('snappy_button_5')
+  })
+
+  // [obligation] tap_05 only when target_index changes between two non-null slots
+  test('tap_05 fires once per genuine slot crossing, not on drop [obligation]', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(0, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    emitSfxMock.mockClear()
+
+    moveTo(66) // crosses into slot 1 → one tap_05
+    pointerUp()
+
+    const tap_calls = emitSfxMock.mock.calls.filter((c) => c[0] === 'tap_05')
+    const drop_calls = emitSfxMock.mock.calls.filter((c) => c[0] === 'snappy_button_5')
+    expect(tap_calls).toHaveLength(1)
+    expect(drop_calls).toHaveLength(1)
+  })
+})
+
+// ── onReorder — called only when from !== to ──────────────────────────────────
+
+describe('useReorderDrag — onReorder callback', () => {
+  // [obligation] onReorder called only when from !== to
+  test('calls onReorder with (from, to) when drop position differs from start [obligation]', () => {
+    const onReorder = vi.fn()
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(0, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    moveTo(66) // → target 1
+    pointerUp()
+
+    expect(onReorder).toHaveBeenCalledWith(0, 1)
+  })
+
+  test('does NOT call onReorder when drop position equals start position [obligation]', () => {
+    const onReorder = vi.fn()
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    // No movement — from and to are both 1
+    pointerUp()
+
+    expect(onReorder).not.toHaveBeenCalled()
+  })
+})
+
+// ── dragOffset ────────────────────────────────────────────────────────────────
+
+describe('useReorderDrag — dragOffset(index)', () => {
+  // [obligation] returns live delta for the dragged row, ±pitch for passed rows, 0 otherwise
+  test('dragged row returns the current delta [obligation]', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    moveTo(66)
+
+    expect(result.dragOffset(1)).toBe(66)
+  })
+
+  test('row shifted by a downward drag returns -pitch [obligation]', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(0, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    moveTo(66) // target → 1: row at index 1 shifts up
+
+    expect(result.dragOffset(1)).toBe(-PITCH)
+  })
+
+  test('row shifted by an upward drag returns +pitch [obligation]', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    // Start at index 2 and drag up past 0.65 threshold toward index 1
+    result.start(2, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    moveTo(-66) // delta=-66, ideal=2-0.66=1.34, crosses back to 1
+
+    expect(result.dragOffset(1)).toBe(PITCH)
+  })
+
+  test('returns 0 for rows not in the drag window', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 5, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    moveTo(66) // target → 2
+
+    expect(result.dragOffset(0)).toBe(0)
+    expect(result.dragOffset(3)).toBe(0)
+    expect(result.dragOffset(4)).toBe(0)
+  })
+
+  test('returns 0 for all rows when no drag is active', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    expect(result.dragOffset(0)).toBe(0)
+    expect(result.dragOffset(1)).toBe(0)
+    expect(result.dragOffset(2)).toBe(0)
+  })
+})
+
+// ── shouldTransition ─────────────────────────────────────────────────────────
+
+describe('useReorderDrag — shouldTransition(index)', () => {
+  test('returns false for all indices when no drag is active', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    expect(result.shouldTransition(0)).toBe(false)
+    expect(result.shouldTransition(1)).toBe(false)
+  })
+
+  test('returns false for the dragged row index during a drag', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    expect(result.shouldTransition(1)).toBe(false)
+  })
+
+  test('returns true for non-dragged rows during a drag (they animate to open the gap)', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    expect(result.shouldTransition(0)).toBe(true)
+    expect(result.shouldTransition(2)).toBe(true)
+  })
+})
+
+// ── state resets on drop ──────────────────────────────────────────────────────
+
+describe('useReorderDrag — state reset on drop', () => {
+  test('dragging_index returns null after drop', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    pointerUp()
+
+    expect(result.dragging_index.value).toBeNull()
+  })
+
+  test('target_index returns null after drop', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 0 }))
+    moveTo(66)
+    pointerUp()
+
+    expect(result.target_index.value).toBeNull()
+  })
+})
+
+// ── autoScroll / edgeDirection — edge zone scroll behaviour ──────────────────
+
+describe('useReorderDrag — autoScroll and edgeDirection', () => {
+  let rafSpy
+  let scrollBySpy
+
+  beforeEach(() => {
+    // Fire the RAF callback exactly once to avoid the infinite step() loop.
+    let fired = false
+    rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+      if (!fired) {
+        fired = true
+        cb(0)
+      }
+      return 1
+    })
+    scrollBySpy = vi.spyOn(window, 'scrollBy').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    rafSpy.mockRestore()
+    scrollBySpy.mockRestore()
+  })
+
+  test('scrolls up when pointer is in the top edge zone during a drag', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    // Start mid-list; move pointer to y=0 which is inside the top EDGE_ZONE (90px)
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 400 }))
+    moveTo(0)
+
+    expect(scrollBySpy).toHaveBeenCalledWith(0, expect.any(Number))
+    const [, dy] = scrollBySpy.mock.calls[0]
+    expect(dy).toBeLessThan(0)
+  })
+
+  test('scrolls down when pointer is near the bottom edge', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 400 }))
+    // Move to near bottom: window.innerHeight - EDGE_ZONE + 10 would be inside bottom zone
+    const near_bottom = Math.max(window.innerHeight - 50, 400)
+    moveTo(near_bottom)
+
+    expect(scrollBySpy).toHaveBeenCalledWith(0, expect.any(Number))
+    const [, dy] = scrollBySpy.mock.calls[0]
+    expect(dy).toBeGreaterThan(0)
+  })
+
+  test('does not scroll when pointer is in the middle of the viewport', () => {
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+    const { result } = setup
+
+    result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 400 }))
+    // middle of viewport: not in any edge zone (above 90 from top, above 90 from bottom)
+    moveTo(Math.floor(window.innerHeight / 2))
+
+    expect(scrollBySpy).not.toHaveBeenCalled()
+  })
+
+  test('ramps scroll speed up the longer the pointer dwells in the edge', () => {
+    // Queue rAF callbacks so we can run frames at chosen timestamps and watch
+    // the dwell-based speed tiers (afterMs 0 / 450 / 2000) escalate.
+    const frames = []
+    rafSpy.mockImplementation((cb) => frames.push(cb))
+    const runFrame = (t) => frames.shift()?.(t)
+    const lastSpeed = () => Math.abs(scrollBySpy.mock.calls.at(-1)[1])
+
+    const setup = withSetup(() =>
+      useReorderDrag({ pitch: PITCH, count: () => 10, enabled: () => true, onReorder: vi.fn() })
+    )
+    app = setup.app
+
+    setup.result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 400 }))
+    moveTo(0) // top edge → schedules the first frame; dwell clock starts at t=0
+
+    runFrame(0)
+    const tier0 = lastSpeed()
+    runFrame(500) // past the 450ms tier
+    const tier1 = lastSpeed()
+    runFrame(2500) // past the 2000ms tier
+    const tier2 = lastSpeed()
+
+    expect(tier1).toBeGreaterThan(tier0)
+    expect(tier2).toBeGreaterThan(tier1)
+  })
+})


### PR DESCRIPTION
## Summary

Drag to reorder cards in the deck card-editor list (md+ only). The grabbed row lifts and follows the pointer while the rows it passes open a gap; on drop the new order persists through the `move_card` RPC with a synchronous optimistic cache reorder, so the row settles in place with no snap-back. Also heals a pre-existing data bug where legacy decks held many cards at a duplicate default rank, which made ordering (and offset pagination) non-deterministic.

## Changes

- **Reorder engine** (`use-reorder-drag.ts`) — pointer-driven, virtualizer-friendly (no DOM cloning; dragged row kept mounted via `rangeExtractor`). Hysteresis on the drop slot, gap offsets, edge auto-scroll that respects the sticky-toolbar inset and ramps through speed tiers the longer you dwell.
- **Optimistic `move_card` mutation** — `onMutate` reorders the cached pages synchronously (page sizes preserved), `onError` rolls back, `onSettled` invalidates the deck + cards queries.
- **Feel** — pickup lift to a held scale + `shadow-sm`, sounds (handle hover, pickup, slot-crossing tick, drop), the row keeps its picked-up look for the whole drag, and the add-card / item-options buttons fade out while dragging.
- **Anchoring** — reorder resolves to the nearest *persisted* neighbour, skipping unsaved temp cards; no-op when the dragged card itself is a temp.
- **Data fix** — migration reindexes every deck whose card count differs from its distinct-rank count; the cards page query gains an `id` tiebreak so tied ranks order deterministically.
- **Tests** — engine (hysteresis, sfx, edge-scroll tiers, gap offsets), mutation (optimistic reorder, rollback, invalidation), anchor resolver, controller guards, animations, and the wiring.