### PR TITLE
SFX unlock and mobile-dock fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
   <body class="bg-brown-100 dark:bg-grey-900 h-full">
     <div id="app" class="flex flex-col md:items-center h-full"></div>
 
-    <section data-testid="mobile-dock-container" mobile-dock-container class="contents"></section>
     <section
       data-testid="app-modal-container"
       class="pointer-events-none touch-none fixed inset-0 z-100 flex items-center justify-center"

--- a/src/components/mobile-dock/mobile-dock-host.vue
+++ b/src/components/mobile-dock/mobile-dock-host.vue
@@ -9,7 +9,7 @@ const bar = useTemplateRef<HTMLElement>('bar')
 let observer: ResizeObserver | null = null
 
 // Publish the dock's live height to :root so any view can pad its content clear
-// of the fixed bar. 0 while the dock is empty/hidden so layouts collapse the gap.
+// of the bar. 0 while the dock is empty/hidden so layouts collapse the gap.
 function publishHeight() {
   const height = fills.value > 0 ? (bar.value?.offsetHeight ?? 0) : 0
   document.documentElement.style.setProperty('--mobile-dock-height', `${height}px`)
@@ -33,24 +33,18 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <teleport to="[mobile-dock-container]">
-    <footer
-      v-show="fills > 0"
-      ref="bar"
-      data-testid="mobile-dock-host"
-      class="fixed bottom-0 left-0 right-0 z-30 rounded-t-6 bg-brown-300 transform-[translateZ(0)] dark:bg-stone-900 sm:bottom-3 sm:left-auto sm:right-3 sm:w-96 sm:rounded-6 xl:hidden [--dock-px:1.25rem] [--dock-pt:1rem] [--dock-pb:0.5rem] ring-1 ring-brown-100 dark:ring-grey-900"
-    >
-      <div
-        mobile-dock-above
-        data-testid="mobile-dock-host__above"
-        class="pointer-events-none absolute inset-x-0 bottom-full flex justify-end px-(--dock-px) pb-3"
-      ></div>
+  <footer
+    v-show="fills > 0"
+    ref="bar"
+    data-testid="mobile-dock-host"
+    class="sticky bottom-0 z-30 mt-auto w-full rounded-t-6 bg-brown-300 transform-[translateZ(0)] dark:bg-stone-900 sm:fixed sm:bottom-3 sm:left-auto sm:right-3 sm:mt-0 sm:w-96 sm:rounded-6 xl:hidden [--dock-px:1.25rem] [--dock-pt:1rem] [--dock-pb:0.5rem] ring-1 ring-brown-100 dark:ring-grey-900"
+  >
+    <div
+      mobile-dock-above
+      data-testid="mobile-dock-host__above"
+      class="pointer-events-none absolute inset-x-0 bottom-full flex justify-end px-(--dock-px) pb-3"
+    ></div>
 
-      <div
-        mobile-dock-content
-        data-testid="mobile-dock-host__content"
-        class="relative w-full"
-      ></div>
-    </footer>
-  </teleport>
+    <div mobile-dock-content data-testid="mobile-dock-host__content" class="relative w-full"></div>
+  </footer>
 </template>

--- a/src/components/ui-kit/dropdown-button/menu.vue
+++ b/src/components/ui-kit/dropdown-button/menu.vue
@@ -3,7 +3,6 @@ import { ref } from 'vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import { type ButtonProps } from '../button.vue'
 import { useStagedTap } from '@/composables/ui/staged-tap'
-import { emitSfx } from '@/sfx/bus'
 import { TYPE_SFX } from '@/sfx/config'
 import type { DropdownOption } from './types'
 
@@ -41,7 +40,6 @@ const playing_value = ref<DropdownOption['value'] | null>(null)
 function onOptionTap(option: DropdownOption, e: MouseEvent) {
   if (option.disabled) return
 
-  emitSfx('snappy_button_5')
   playing_value.value = option.value
   tap(() => {
     emit('select', option)

--- a/src/sfx/lifecycle.ts
+++ b/src/sfx/lifecycle.ts
@@ -55,17 +55,21 @@ export function installAudioLifecycle(): () => void {
     engine.unlock()
   }
 
+  // Capture phase, not bubble: handlers like the dropdown caret's `@click.stop`
+  // swallow propagation before the event reaches `window` in the bubble phase,
+  // so a bubble-phase listener would miss those gestures and leave audio locked.
+  // Capture runs window→target first, ahead of any descendant's stopPropagation.
   const armGestureRetry = () => {
     if (gesture_armed) return
     gesture_armed = true
     for (const ev of GESTURE_EVENTS) {
-      window.addEventListener(ev, gestureRecover, { once: true, passive: true })
+      window.addEventListener(ev, gestureRecover, { once: true, passive: true, capture: true })
     }
   }
 
   const removeGestureListeners = () => {
     for (const ev of GESTURE_EVENTS) {
-      window.removeEventListener(ev, gestureRecover)
+      window.removeEventListener(ev, gestureRecover, { capture: true })
     }
   }
 

--- a/src/views/deck/mobile-footer/footer-actions.vue
+++ b/src/views/deck/mobile-footer/footer-actions.vue
@@ -65,7 +65,7 @@ function onActionsLeave(el: Element, done: () => void) {
           v-else
           data-testid="deck-footer-actions__new-card"
           class="pointer-events-auto"
-          icon-left="add"
+          icon-left="card-add"
           data-theme="brown-100"
           data-theme-dark="stone-700"
           variant="ghost"

--- a/tests/integration/components/ui-kit/dropdown-button/menu.test.js
+++ b/tests/integration/components/ui-kit/dropdown-button/menu.test.js
@@ -121,10 +121,12 @@ describe('DropdownMenu', () => {
       expect(wrapper.emitted('select')[0][0]).toEqual(SAMPLE_OPTIONS[0])
     })
 
-    test('fine-pointer click does NOT call emitSfx [obligation]', async () => {
+    test('fine-pointer click does NOT call emitSfx at all [obligation]', async () => {
       const wrapper = mountMenu()
       await wrapper.findAll('[data-testid="dropdown-button__option"]')[0].trigger('click')
-      expect(mockEmitSfx).not.toHaveBeenCalledWith('select')
+      // menu.vue removed the hard-coded emitSfx('snappy_button_5') call — option-select
+      // sounds now come from the callsite. Assert no sfx is played by the menu itself.
+      expect(mockEmitSfx).not.toHaveBeenCalled()
     })
 
     test('clicking the second option emits select with the correct option', async () => {

--- a/tests/unit/sfx/lifecycle.test.js
+++ b/tests/unit/sfx/lifecycle.test.js
@@ -153,6 +153,31 @@ describe('installAudioLifecycle', () => {
     expect(engineMock.unlock).toHaveBeenCalledTimes(1)
   })
 
+  test('gesture unlock fires even when a bubble-phase stopPropagation blocks the event [obligation]', async () => {
+    // Regression guard: the lifecycle listener must be in CAPTURE phase so that a
+    // descendant's @click.stop (bubble-phase stopPropagation) cannot swallow the
+    // event before window sees it. Capture runs window→target, ahead of any
+    // descendant stopPropagation call.
+    const install = await loadLifecycle()
+    teardown = install()
+    await flushMicrotasks()
+
+    // Simulate a descendant with @click.stop (e.g. the dropdown caret)
+    const el = document.createElement('button')
+    document.body.appendChild(el)
+    el.addEventListener('click', (e) => e.stopPropagation()) // bubble-phase, blocks window
+
+    // Dispatch a bubbling click from the child element. A bubble-phase window
+    // listener would never receive this (stopPropagation blocks it), but a
+    // capture-phase listener fires before stopPropagation has any effect.
+    el.dispatchEvent(new Event('click', { bubbles: true }))
+    await flushMicrotasks()
+
+    expect(engineMock.unlock).toHaveBeenCalledTimes(1)
+
+    document.body.removeChild(el)
+  })
+
   test('the gesture unlock fires only once across event types', async () => {
     const install = await loadLifecycle()
     teardown = install()


### PR DESCRIPTION
## Summary

A batch of small SFX and mobile-dock fixes. The headline fix: the deck hero's dropdown trigger couldn't unlock the audio context on a fresh page load, because the unlock gesture listener missed any click swallowed by a descendant's `@click.stop` (the dropdown caret). Also drops a doubled option-select sound and repositions the mobile dock to scroll naturally.

## Changes

**SFX**
- Register the one-shot audio-unlock gesture listeners in the **capture phase**, so a descendant's `@click.stop` (e.g. the dropdown caret) can no longer swallow the first unlock gesture and leave audio locked.
- Drop the hard-coded `emitSfx('snappy_button_5')` baked into the dropdown menu's option rows — each callsite owns its own select sound, so options no longer double up.

**Mobile dock / footer**
- Position the dock `sticky` in the authenticated layout's scroll flow instead of teleporting to a body-level fixed container, giving `position: sticky` real scroll range (`sm+` keeps the floating-card variant). Drops the now-dead `[mobile-dock-container]` teleport target.
- Use the card-add icon for the mobile new-card button.

**Tests**
- Cover the capture-phase unlock (fires `engine.unlock()` even when a bubble-phase `stopPropagation` blocks the event) and assert the dropdown menu emits no baked-in sfx on option select.
