### PR TITLE
Fix hover sounds leaking past a muted volume slider

### DIFF
--- a/src/sfx/bus.ts
+++ b/src/sfx/bus.ts
@@ -36,7 +36,7 @@ export function emitStudySfx(keys: SoundKey | SoundKey[], opts: PlayOptions = {}
 export function emitHoverSfx(keys: SoundKey | SoundKey[], opts: PlayOptions = {}): Promise<void> {
   if (_isTouchPrimary()) return Promise.resolve()
   if (pointerStationaryAfterClick()) return Promise.resolve()
-  return emitSfx(keys, opts)
+  return emitSfx(keys, { ...opts, bus: 'hover' })
 }
 
 function _pick(keys: SoundKey | SoundKey[]): SoundKey | undefined {

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -110,6 +110,13 @@ class AudioPlayer {
       throw new Error(`Sound "${key}" not loaded.`)
     }
 
+    // A muted bus (volume 0) has nothing to play. Bail before resuming the
+    // audio context — resume() steals media-session focus and pauses the
+    // user's background music, even for a silent buffer.
+    const volume = options.volume ?? sound.base_volume * this._getVolumeMultiplier(sound, options)
+
+    if (volume <= 0) return
+
     const running = await engine.resume()
 
     if (!running) return
@@ -130,7 +137,6 @@ class AudioPlayer {
         resolve()
       }
 
-      const volume = options.volume ?? sound.base_volume * this._getVolumeMultiplier(sound, options)
       const { ended } = engine.play(sound.buffer, volume)
       const fallbackMs = Math.ceil((sound.buffer.duration || 1) * 1000) + 500
       const timer = setTimeout(settle, fallbackMs)

--- a/tests/unit/sfx/bus.test.js
+++ b/tests/unit/sfx/bus.test.js
@@ -12,8 +12,13 @@ vi.mock('@/utils/logger', () => ({
   }
 }))
 
+vi.mock('@/sfx/pointer-activity', () => ({
+  pointerStationaryAfterClick: vi.fn(() => false)
+}))
+
 const { default: player } = await import('@/sfx/player')
 const { default: logger } = await import('@/utils/logger')
+const { pointerStationaryAfterClick } = await import('@/sfx/pointer-activity')
 const { emitSfx, emitHoverSfx, emitStudySfx } = await import('@/sfx/bus')
 
 describe('emitSfx', () => {
@@ -72,29 +77,53 @@ describe('emitSfx', () => {
 describe('emitHoverSfx', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: not a touch device, pointer has moved
+    if ('ontouchstart' in window) delete window.ontouchstart
+    pointerStationaryAfterClick.mockReturnValue(false)
   })
 
   test('plays sound when ontouchstart is not present', async () => {
-    const had = 'ontouchstart' in window
-    if (had) delete window.ontouchstart
     await emitHoverSfx('click_07')
-    expect(player.play).toHaveBeenCalledWith('click_07', {})
+    expect(player.play).toHaveBeenCalledWith('click_07', { bus: 'hover' })
   })
 
-  test('skips when ontouchstart is on window (touch-primary)', async () => {
+  test('forces bus:hover even for a key without defaultBus:hover (tap_05 in TYPE_SFX) [obligation]', async () => {
+    // tap_05 has no defaultBus in config — its default_bus resolves to 'interface'.
+    // emitHoverSfx must override and forward { bus: 'hover' } regardless.
+    await emitHoverSfx('tap_05')
+    expect(player.play).toHaveBeenCalledWith('tap_05', { bus: 'hover' })
+  })
+
+  test('preserves caller-supplied opts while forcing bus:hover [obligation]', async () => {
+    await emitHoverSfx('click_07', { debounce: 0 })
+    expect(player.play).toHaveBeenCalledWith('click_07', { debounce: 0, bus: 'hover' })
+  })
+
+  test('caller bus override is superseded by the forced hover bus [obligation]', async () => {
+    // Even if the caller passes { bus: 'interface' }, emitHoverSfx wins with 'hover'.
+    await emitHoverSfx('click_07', { bus: 'interface' })
+    expect(player.play).toHaveBeenCalledWith('click_07', { bus: 'hover' })
+  })
+
+  test('skips when ontouchstart is on window (touch-primary) [obligation]', async () => {
     window.ontouchstart = null
     await emitHoverSfx('click_07')
     expect(player.play).not.toHaveBeenCalled()
     delete window.ontouchstart
   })
 
-  test('array path — randomly picks one key and reaches player', async () => {
-    const had = 'ontouchstart' in window
-    if (had) delete window.ontouchstart
+  test('skips when pointerStationaryAfterClick returns true [obligation]', async () => {
+    pointerStationaryAfterClick.mockReturnValueOnce(true)
+    await emitHoverSfx('click_07')
+    expect(player.play).not.toHaveBeenCalled()
+  })
+
+  test('array path — picks one key and forwards bus:hover [obligation]', async () => {
     vi.spyOn(Math, 'random').mockReturnValue(0)
     await emitHoverSfx(['type_01', 'type_02', 'type_03'])
     expect(player.play).toHaveBeenCalledTimes(1)
-    expect(['type_01', 'type_02', 'type_03']).toContain(player.play.mock.calls[0][0])
+    expect(player.play.mock.calls[0][0]).toBe('type_01')
+    expect(player.play.mock.calls[0][1]).toMatchObject({ bus: 'hover' })
     Math.random.mockRestore()
   })
 })

--- a/tests/unit/sfx/player.test.js
+++ b/tests/unit/sfx/player.test.js
@@ -145,6 +145,54 @@ describe('audio_player._play', () => {
     playbacks[0].end()
     await promise
   })
+
+  test('returns early before engine.resume when hover bus is muted to 0 [obligation]', async () => {
+    // Regression: hover sounds on TYPE_SFX (e.g. tap_05) have default_bus 'interface',
+    // so WITHOUT the bus: 'hover' force they would use interface volume instead of hover.
+    // This gate must fire for hover-routed sounds when hover volume = 0.
+    audio_player.volume_settings = { ...BUS_DEFAULTS, hover: 0 }
+    loadSound('tap_05', { volume: 0.1, default_bus: 'hover' })
+
+    await audio_player.play('tap_05', { bus: 'hover' })
+
+    expect(engineMock.resume).not.toHaveBeenCalled()
+    expect(engineMock.play).not.toHaveBeenCalled()
+  })
+
+  test('returns early before engine.resume when options.volume is explicitly 0 [obligation]', async () => {
+    loadSound('click_04', { volume: 0.3, default_bus: 'interface' })
+
+    await audio_player.play('click_04', { volume: 0 })
+
+    expect(engineMock.resume).not.toHaveBeenCalled()
+    expect(engineMock.play).not.toHaveBeenCalled()
+  })
+
+  test('returns early before engine.resume for any bus muted to 0 — interface bus [obligation]', async () => {
+    // The volume gate is bus-agnostic: a muted interface bus also silences sounds.
+    audio_player.volume_settings = { ...BUS_DEFAULTS, interface: 0 }
+    loadSound('select', { volume: 0.3, default_bus: 'interface' })
+
+    await audio_player.play('select')
+
+    expect(engineMock.resume).not.toHaveBeenCalled()
+    expect(engineMock.play).not.toHaveBeenCalled()
+  })
+
+  test('resumes and plays with volume = base_volume × (bus_setting / 5) for non-zero bus [obligation]', async () => {
+    audio_player.volume_settings = { ...BUS_DEFAULTS, hover: 2 }
+    const buffer = loadSound('type_01', { volume: 0.4, default_bus: 'hover' })
+
+    const promise = audio_player.play('type_01', { bus: 'hover' })
+    await flush()
+
+    // multiplier = 2/5 = 0.4; resolved volume = 0.4 × 0.4 = 0.16
+    expect(engineMock.resume).toHaveBeenCalledTimes(1)
+    expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.4 * (2 / 5))
+
+    playbacks[0].end()
+    await promise
+  })
 })
 
 describe('audio_player._getVolumeMultiplier', () => {


### PR DESCRIPTION
## Summary

Setting the hover-audio volume to 0 still let hover sounds play ~1 in 6 times, and any muted bus briefly woke the audio context — pausing the user's background music.

- `emitHoverSfx` now pins `bus: 'hover'` at emit time (mirroring `emitStudySfx`). Previously each hover sound answered to its file's `defaultBus`, so the `tap_05` entry in `TYPE_SFX` (no `defaultBus` → `interface`) leaked at interface volume whenever the random pick landed on it (~1/6 ≈ the observed ~20%).
- `player._play` resolves the volume and returns **before** `engine.resume()` when it's `<= 0`. Resuming the AudioContext for a silent buffer steals media-session focus and pauses background music, even though nothing is audible. The gate is bus-agnostic — any bus muted to 0 is now truly silent.
- Tests cover both: forced hover-bus routing (incl. a key without `defaultBus`), opt preservation, the touch/pointer-stationary guards, and the zero-volume gate sitting ahead of `resume()`.