### PR TITLE
Bump audio upload size cap from 500 MiB to 600 MiB

### DIFF
--- a/src/components/modals/upload-lesson/index.vue
+++ b/src/components/modals/upload-lesson/index.vue
@@ -15,7 +15,7 @@ export type UploadLessonResponse = Lesson | undefined
 // A generous sanity cap on the SOURCE file: long audio is fine (it's chunked),
 // but ffmpeg.wasm decodes the original in memory, so a huge file would OOM the
 // tab. This is NOT Whisper's old 25 MiB cap — the client compresses + slices.
-const MAX_BYTES = 524288000
+const MAX_BYTES = 629145600
 
 const { collection_id, close } = defineProps<{
   collection_id: number


### PR DESCRIPTION
## Summary

Raises the client-side file-size gate from 500 MiB (524,288,000 bytes) to 600 MiB (629,145,600 bytes). The cap exists to guard against OOM during the ffmpeg.wasm in-memory decode step — not a Whisper or Supabase limit — so a modest bump is safe.