### PR TITLE
Fix audio upload failures for large files

### DIFF
--- a/src/composables/audio-reader/audio-chunker.ts
+++ b/src/composables/audio-reader/audio-chunker.ts
@@ -58,7 +58,7 @@ const ENCODE_ARGS = ['-ac', '1', '-ar', '16000', '-b:a', '48k']
 // desyncs the word highlight after a skip; a CBR file seeks byte-accurately and
 // shares the timeline the word timings were measured on. Channels and sample rate
 // are left at the source's (no -ac/-ar).
-const PLAYBACK_ARGS = ['-c:a', 'libmp3lame', '-b:a', '128k']
+const PLAYBACK_ARGS = ['-c:a', 'libmp3lame', '-b:a', '64k']
 
 export type AudioChunk = { blob: Blob; offset: number }
 


### PR DESCRIPTION
## Summary

- Bumps the client-side source file gate from 500 MiB to 600 MiB to accommodate long audiobooks
- Lowers the playback CBR encode from 128k to 64k so the playback copy stays well under the bucket's 200 MiB file size limit (speech quality is indistinguishable at 64k mono)