### PR TITLE
Transcript chapter windowing and inline chapter headings

### DIFF
--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -311,6 +311,7 @@ useAnimatedHeight(footer_swap_el, footer_toolbar, () => !swapping)
         <transcript-view
           ref="transcript"
           :paragraphs="windowed_paragraphs"
+          :chapters="lesson_chapters"
           :matches="matches"
           :active_word="active_word"
           :popover_open="popover_open"

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -87,6 +87,33 @@ const chapter_of = computed(() => ({
 const lesson_chapters = computed(() => lesson.value?.transcript?.chapters ?? [])
 const has_lesson_chapters = computed(() => lesson_chapters.value.length > 1)
 
+// The last chapter whose start time the playhead has reached.
+const active_chapter_index = computed(() => {
+  const chapters = lesson_chapters.value
+  if (chapters.length <= 1) return 0
+  const time = player.current_time.value
+  let idx = 0
+  for (let i = 0; i < chapters.length; i++) {
+    if (chapters[i].start <= time + 0.001) idx = i
+  }
+  return idx
+})
+
+// Mount only the current chapter's paragraphs plus one buffer chapter on each
+// side. Keeps DOM size bounded for long audiobooks (a 4-hour book with 10-min
+// chapters has ~24 chapters; we mount at most 3 at a time). Falls back to the
+// full list when the lesson has no internal chapters.
+const windowed_paragraphs = computed(() => {
+  if (!has_lesson_chapters.value) return paragraphs.value
+  const chapters = lesson_chapters.value
+  const ci = active_chapter_index.value
+  const lo = Math.max(0, ci - 1)
+  const hi = Math.min(chapters.length - 1, ci + 1)
+  const start_time = chapters[lo].start
+  const end_time = chapters[hi + 1]?.start ?? Infinity
+  return paragraphs.value.filter((p) => p.start >= start_time && p.start < end_time)
+})
+
 const show_term = computed(() => popover_open.value && !!selection.value)
 
 // The term card lives in the mobile dock below xl and in the desktop sidebar at
@@ -283,7 +310,7 @@ useAnimatedHeight(footer_swap_el, footer_toolbar, () => !swapping)
       <div data-testid="lesson-view__transcript" class="px-0 pt-6 pb-2 sm:px-6">
         <transcript-view
           ref="transcript"
-          :paragraphs="paragraphs"
+          :paragraphs="windowed_paragraphs"
           :matches="matches"
           :active_word="active_word"
           :popover_open="popover_open"

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -156,7 +156,7 @@ function commitSelection({
           <h2 class="text-xl font-medium text-brown-500 dark:text-brown-400">
             {{ chapter_headings.get(paragraph.index) }}
           </h2>
-          <hr class="w-16 border-brown-300 dark:border-brown-600" />
+          <hr class="w-16 border-brown-700 dark:border-brown-700" />
         </div>
         <transcript-segment :group="paragraph" :index="paragraph.index" />
       </template>

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -13,19 +13,23 @@ import {
 import TranscriptSegment from './segment.vue'
 import SelectionPreview from './selection-preview.vue'
 
-const {
-  paragraphs,
-  matches = new Map(),
-  active_word,
-  popover_open = false,
-  is_playing = false
-} = defineProps<{
+type TranscriptViewProps = {
   paragraphs: SentenceWords[]
+  chapters?: TranscriptChapter[]
   matches?: Map<number, CardMatch>
   active_word: number
   popover_open?: boolean
   is_playing?: boolean
-}>()
+}
+
+const {
+  paragraphs,
+  chapters = [],
+  matches = new Map(),
+  active_word,
+  popover_open = false,
+  is_playing = false
+} = defineProps<TranscriptViewProps>()
 
 const emit = defineEmits<{
   (e: 'select', selection: TermSelection): void
@@ -68,6 +72,16 @@ provide(
   readerMatchesKey,
   computed(() => matches)
 )
+
+// Maps paragraph.index → chapter title for the first paragraph of each chapter.
+const chapter_headings = computed(() => {
+  const map = new Map<number, string>()
+  for (const chapter of chapters) {
+    const first = paragraphs.find((p) => p.start >= chapter.start)
+    if (first) map.set(first.index, chapter.title)
+  }
+  return map
+})
 
 // A tap/click on a word inside a card match selects the whole matched phrase;
 // null for an unmatched word, so the caller falls back to single-word select.
@@ -133,12 +147,16 @@ function commitSelection({
           class="absolute inset-0 hidden rounded-2 bgx-diagonal-stripes animation-safe:bgx-slide bgx-color-[currentColor] group-data-[playing=true]/pill:block"
         />
       </div>
-      <transcript-segment
-        v-for="paragraph in paragraphs"
-        :key="paragraph.index"
-        :group="paragraph"
-        :index="paragraph.index"
-      />
+      <template v-for="paragraph in paragraphs" :key="paragraph.index">
+        <h2
+          v-if="chapter_headings.get(paragraph.index)"
+          data-testid="transcript-view__chapter-heading"
+          class="text-xl font-medium text-brown-500 dark:text-brown-400 -mb-3 mt-4 first:mt-0"
+        >
+          {{ chapter_headings.get(paragraph.index) }}
+        </h2>
+        <transcript-segment :group="paragraph" :index="paragraph.index" />
+      </template>
     </div>
 
     <selection-preview :preview="selection_preview" />

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -99,8 +99,9 @@ function commitSelection({
   end_index: number
 }) {
   const index = paragraphIndexOf(anchor)
-  const raw_sentence = (index !== null && paragraphs[index]?.sentence) || term
-  const words = index !== null ? (paragraphs[index]?.words ?? []) : []
+  const paragraph = index !== null ? paragraphs.find((p) => p.index === index) : undefined
+  const raw_sentence = paragraph?.sentence || term
+  const words = paragraph?.words ?? []
   const sentence = markTermInSentence(raw_sentence, words, word_index, term)
   emit('select', { term, sentence, rect, word_index, word_end_index })
 }

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -148,13 +148,16 @@ function commitSelection({
         />
       </div>
       <template v-for="paragraph in paragraphs" :key="paragraph.index">
-        <h2
+        <div
           v-if="chapter_headings.get(paragraph.index)"
           data-testid="transcript-view__chapter-heading"
-          class="text-center text-xl font-medium text-brown-500 dark:text-brown-400 mt-32 first:mt-0"
+          class="mt-32 flex flex-col items-center gap-3 first:mt-0"
         >
-          {{ chapter_headings.get(paragraph.index) }}
-        </h2>
+          <h2 class="text-xl font-medium text-brown-500 dark:text-brown-400">
+            {{ chapter_headings.get(paragraph.index) }}
+          </h2>
+          <hr class="w-16 border-brown-300 dark:border-brown-600" />
+        </div>
         <transcript-segment :group="paragraph" :index="paragraph.index" />
       </template>
     </div>

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -151,7 +151,7 @@ function commitSelection({
         <h2
           v-if="chapter_headings.get(paragraph.index)"
           data-testid="transcript-view__chapter-heading"
-          class="text-xl font-medium text-brown-500 dark:text-brown-400 -mb-3 mt-4 first:mt-0"
+          class="text-center text-xl font-medium text-brown-500 dark:text-brown-400 mt-16 first:mt-0"
         >
           {{ chapter_headings.get(paragraph.index) }}
         </h2>

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -151,7 +151,7 @@ function commitSelection({
         <h2
           v-if="chapter_headings.get(paragraph.index)"
           data-testid="transcript-view__chapter-heading"
-          class="text-center text-xl font-medium text-brown-500 dark:text-brown-400 mt-16 first:mt-0"
+          class="text-center text-xl font-medium text-brown-500 dark:text-brown-400 mt-32 first:mt-0"
         >
           {{ chapter_headings.get(paragraph.index) }}
         </h2>


### PR DESCRIPTION
## Summary

- Windows the transcript to the active chapter ± 1 buffer, cutting mounted DOM nodes from ~36k words (full 4-hour book) to ~4.5k at a time — eliminates the lag from long audiobooks
- Fixes a latent bug where tapping a word in any chapter other than chapter 0 would fail to find its sentence context (was using segment index as an array offset into a slice)
- Renders each chapter's title inline above its first paragraph, with a centered brown divider line and generous spacing between chapters