### PR TITLE
Fix supabase config push blocking on interactive prompt in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -255,7 +255,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Push config
-        run: supabase config push
+        run: supabase config push --yes
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 


### PR DESCRIPTION
## Summary

Adds `--yes` to `supabase config push` so CI doesn't hang waiting for a confirmation prompt when the storage config has changed.