### PR TITLE
Fix SFX system reliability after tab switch, sleep, and app switch

### DIFF
--- a/src/sfx/engine.ts
+++ b/src/sfx/engine.ts
@@ -12,7 +12,6 @@
  */
 
 type AudioContextCtor = new () => AudioContext
-type Playback = { ended: Promise<void> }
 
 let ctx: AudioContext | undefined
 let unlocked = false
@@ -89,25 +88,36 @@ async function decode(url: string): Promise<AudioBuffer> {
   return context.decodeAudioData(data)
 }
 
-function play(buffer: AudioBuffer, volume: number): Playback {
-  if (!ctx || ctx.state !== 'running') return { ended: Promise.resolve() }
+// Resumes the context if needed, starts the buffer, and returns a promise that
+// settles when the sound ends. The fallback timer ensures settlement even when
+// the context suspends mid-play and onended never fires.
+async function play(buffer: AudioBuffer, volume: number): Promise<void> {
+  const running = await resume()
+  if (!running) return
 
-  const source = ctx.createBufferSource()
+  const source = ctx!.createBufferSource()
   source.buffer = buffer
-  const gain = ctx.createGain()
+  const gain = ctx!.createGain()
   gain.gain.value = volume
-  source.connect(gain).connect(ctx.destination)
+  source.connect(gain).connect(ctx!.destination)
 
-  const ended = new Promise<void>((resolve) => {
-    source.onended = () => {
+  return new Promise((resolve) => {
+    let settled = false
+    const settle = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
       source.disconnect()
       gain.disconnect()
       resolve()
     }
-  })
 
-  source.start()
-  return { ended }
+    source.onended = settle
+    const fallbackMs = Math.ceil((buffer.duration || 1) * 1000) + 500
+    const timer = setTimeout(settle, fallbackMs)
+
+    source.start()
+  })
 }
 
 // Wake a suspended context and report whether it ended up running. Used to gate
@@ -176,5 +186,4 @@ function state(): AudioContextState | undefined {
   return ctx?.state
 }
 
-export type { Playback }
 export default { decode, play, resume, unlock, onStateChange, onUnlock, isUnlocked, state }

--- a/src/sfx/engine.ts
+++ b/src/sfx/engine.ts
@@ -29,16 +29,22 @@ function resolveCtor(): AudioContextCtor | undefined {
   return win.AudioContext ?? win.webkitAudioContext
 }
 
-// The context fires statechange on every transition; the first 'running' is also
-// the unlock signal, since a suspended context can never reach it without a gesture.
+// The context fires statechange on every transition. 'running' fires the unlock
+// signal. Any non-running state resets the latch so the next 'running' transition
+// re-fires unlock_listeners — allowing queued sounds to retry after recovery.
 function notifyState(): void {
-  if (ctx?.state === 'running') markUnlocked()
+  if (ctx?.state === 'running') {
+    markUnlocked()
+  } else {
+    unlocked = false
+  }
   state_listeners.forEach((cb) => cb())
 }
 
-// Unlock is a one-shot edge fired when the context first reaches 'running' —
-// either via the statechange event or the synchronous check in unlock() when a
-// fresh context is born running. It gates all playback.
+// Fires whenever the context transitions to 'running' — either via statechange
+// or the synchronous check in unlock() when a fresh context is born running.
+// notifyState() resets `unlocked` on every non-running transition, so this fires
+// again on each recovery, re-draining any queued sounds.
 function markUnlocked(): void {
   if (unlocked) return
   unlocked = true
@@ -153,6 +159,10 @@ function onStateChange(cb: () => void): () => void {
   return () => state_listeners.delete(cb)
 }
 
+function isUnlocked(): boolean {
+  return unlocked
+}
+
 function onUnlock(cb: () => void): () => void {
   if (unlocked) {
     cb()
@@ -167,4 +177,4 @@ function state(): AudioContextState | undefined {
 }
 
 export type { Playback }
-export default { decode, play, resume, unlock, onStateChange, onUnlock, state }
+export default { decode, play, resume, unlock, onStateChange, onUnlock, isUnlocked, state }

--- a/src/sfx/engine.ts
+++ b/src/sfx/engine.ts
@@ -177,11 +177,8 @@ function isUnlocked(): boolean {
 }
 
 function onUnlock(cb: () => void): () => void {
-  if (unlocked) {
-    cb()
-    return () => {}
-  }
   unlock_listeners.add(cb)
+  if (unlocked) cb()
   return () => unlock_listeners.delete(cb)
 }
 

--- a/src/sfx/engine.ts
+++ b/src/sfx/engine.ts
@@ -95,11 +95,14 @@ async function play(buffer: AudioBuffer, volume: number): Promise<void> {
   const running = await resume()
   if (!running) return
 
-  const source = ctx!.createBufferSource()
+  const context = ctx
+  if (!context) return
+
+  const source = context.createBufferSource()
   source.buffer = buffer
-  const gain = ctx!.createGain()
+  const gain = context.createGain()
   gain.gain.value = volume
-  source.connect(gain).connect(ctx!.destination)
+  source.connect(gain).connect(context.destination)
 
   return new Promise((resolve) => {
     let settled = false

--- a/src/sfx/engine.ts
+++ b/src/sfx/engine.ts
@@ -133,11 +133,12 @@ async function resume(): Promise<boolean> {
   if (context.state === 'running') return true
 
   try {
+    let id: ReturnType<typeof setTimeout>
     await Promise.race([
-      context.resume(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('timeout')), RESUME_TIMEOUT_MS)
-      )
+      context.resume().finally(() => clearTimeout(id)),
+      new Promise<never>((_, reject) => {
+        id = setTimeout(() => reject(new Error('timeout')), RESUME_TIMEOUT_MS)
+      })
     ])
   } catch {
     return false

--- a/src/sfx/engine.ts
+++ b/src/sfx/engine.ts
@@ -13,6 +13,8 @@
 
 type AudioContextCtor = new () => AudioContext
 
+const RESUME_TIMEOUT_MS = 2000
+
 let ctx: AudioContext | undefined
 let unlocked = false
 
@@ -131,7 +133,12 @@ async function resume(): Promise<boolean> {
   if (context.state === 'running') return true
 
   try {
-    await context.resume()
+    await Promise.race([
+      context.resume(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), RESUME_TIMEOUT_MS)
+      )
+    ])
   } catch {
     return false
   }

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -103,44 +103,14 @@ class AudioPlayer {
     }
 
     const sound = this.loaded_sounds.get(key)
+    if (!sound) throw new Error(`Sound "${key}" not loaded.`)
 
-    if (!sound) {
-      throw new Error(`Sound "${key}" not loaded.`)
-    }
-
-    // A muted bus (volume 0) has nothing to play. Bail before resuming the
-    // audio context — resume() steals media-session focus and pauses the
-    // user's background music, even for a silent buffer.
+    // Bail before touching the context — resume() steals media-session focus
+    // and pauses background music even for a silent buffer.
     const volume = options.volume ?? sound.base_volume * this._getVolumeMultiplier(sound, options)
-
     if (volume <= 0) return
 
-    const running = await engine.resume()
-
-    if (!running) return
-
-    return new Promise((resolve) => {
-      // The returned Promise must settle in one of two ways:
-      //   1. 'ended'  — the BufferSource finished playing.
-      //   2. Timer    — the safety net: if the context suspends mid-play (tab
-      //                 hides, device locks) `onended` never fires and the
-      //                 promise would hang forever, stalling awaiters of emitSfx.
-      //
-      // Whichever wins, settle() cancels the timer so the loser can't double-fire.
-      let settled = false
-      const settle = () => {
-        if (settled) return
-        settled = true
-        clearTimeout(timer)
-        resolve()
-      }
-
-      const { ended } = engine.play(sound.buffer, volume)
-      const fallbackMs = Math.ceil((sound.buffer.duration || 1) * 1000) + 500
-      const timer = setTimeout(settle, fallbackMs)
-
-      void ended.then(settle)
-    })
+    return engine.play(sound.buffer, volume)
   }
 
   // Bus is resolved most-specific-first: explicit option, then the sound's own

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -34,8 +34,6 @@ const QUEUE_TIMEOUT = 10
 class AudioPlayer {
   loaded_sounds = new Map<SoundKey, LoadedSound>()
   initialized = false
-  unlock_registered = false
-  unlocked = false
   queued_sound: { key: SoundKey; options: PlayOptions } | undefined
   // Resting setting per bus. setVolumeConfig (called from App.vue) overwrites
   // this once member prefs load. Inline defaults avoid a config.ts init cycle.
@@ -64,7 +62,7 @@ class AudioPlayer {
     if (this.initialized) return Promise.resolve()
     this.initialized = true
 
-    this._registerUnlock()
+    engine.onUnlock(this._onUnlock)
 
     const loads = Object.entries(SOUNDS).map(([name, cfg]) => {
       const key = name as SoundKey
@@ -99,7 +97,7 @@ class AudioPlayer {
   }
 
   private _play = async (key: SoundKey, options: PlayOptions = {}): Promise<void> => {
-    if (!this.unlocked) {
+    if (!engine.isUnlocked()) {
       this._enqueue(key, options)
       return
     }
@@ -166,28 +164,12 @@ class AudioPlayer {
     })
   }
 
-  /**
-   * Callback for when the audio system is unlocked.
-   * Plays any queued sound.
-   */
   private _onUnlock = () => {
-    this.unlocked = true
-
     if (this.queued_sound) {
       const { key, options } = this.queued_sound
       this.play(key, options)
       this.queued_sound = undefined
     }
-  }
-
-  /**
-   * Registers the unlock callback for the audio system.
-   * Only registers once.
-   */
-  private _registerUnlock = () => {
-    if (this.unlock_registered) return
-    this.unlock_registered = true
-    engine.onUnlock(this._onUnlock)
   }
 }
 

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -1,6 +1,6 @@
 import engine from '@/sfx/engine'
 import { debounce } from '@/utils/debounce'
-import { SOUNDS, type Bus, type SoundDef, type SoundKey } from '@/sfx/config'
+import { BUS_DEFAULTS, SOUNDS, type Bus, type SoundDef, type SoundKey } from '@/sfx/config'
 
 export type PlayOptions = {
   volume?: number
@@ -36,11 +36,11 @@ class AudioPlayer {
   initialized = false
   queued_sound: { key: SoundKey; options: PlayOptions } | undefined
   // Resting setting per bus. setVolumeConfig (called from App.vue) overwrites
-  // this once member prefs load. Inline defaults avoid a config.ts init cycle.
-  volume_settings: Record<Bus, number> = { interface: 5, study: 5, hover: 5 }
+  // this once member prefs load.
+  volume_settings: Record<Bus, number> = { ...BUS_DEFAULTS }
   // The committed baseline — what the server gave us (or defaults). previewVolumeConfig
   // can drift volume_settings off this for live UI feedback; resetSettings restores it.
-  committed_volume_settings: Record<Bus, number> = { ...this.volume_settings }
+  committed_volume_settings: Record<Bus, number> = { ...BUS_DEFAULTS }
 
   // Commit a new baseline and apply it (App.vue, on member-pref load/save).
   setVolumeConfig = (settings: Record<Bus, number>) => {
@@ -126,8 +126,9 @@ class AudioPlayer {
     const def: SoundDef = SOUNDS[key]
     const ext = def.ext ?? 'wav'
     const path = `/src/assets/audio/${key}.${ext}`
-
     const url = AUDIO_FILES[path]
+
+    if (!url) throw new Error(`Audio file not found for "${key}" (expected ${path})`)
 
     return engine.decode(url).catch((err) => {
       throw new Error(`Failed to load audio "${key}": ${String(err)}`)
@@ -137,8 +138,8 @@ class AudioPlayer {
   private _onUnlock = () => {
     if (this.queued_sound) {
       const { key, options } = this.queued_sound
-      this.play(key, options)
       this.queued_sound = undefined
+      void this._play(key, options)
     }
   }
 }

--- a/tests/unit/sfx/engine.test.js
+++ b/tests/unit/sfx/engine.test.js
@@ -355,7 +355,7 @@ describe('onStateChange()', () => {
 // ─── play() ──────────────────────────────────────────────────────────────────
 
 describe('play()', () => {
-  test('is a no-op returning a resolved `ended` when context is not running [obligation]', async () => {
+  test('resolves without starting playback when context is not running [obligation]', async () => {
     const contexts = []
     installCtor(makeCtorWithContexts(contexts, ['suspended', 'suspended']))
     const engine = await loadFreshEngine()
@@ -369,12 +369,13 @@ describe('play()', () => {
     const fake_buffer = { duration: 0.5 }
     const result = engine.play(fake_buffer, 1.0)
 
-    await expect(result.ended).resolves.toBeUndefined()
+    // play() is now async and returns Promise<void> (no longer { ended })
+    await expect(result).resolves.toBeUndefined()
     // play() itself must NOT create a BufferSource when context isn't running
     expect(fresh.createBufferSource.mock.calls.length).toBe(calls_before)
   })
 
-  test('wires BufferSource→GainNode(volume)→destination, calls start(), resolves ended on onended [obligation]', async () => {
+  test('wires BufferSource→GainNode(volume)→destination, calls start(), resolves on onended [obligation]', async () => {
     const contexts = []
     installCtor(makeCtorWithContexts(contexts, ['running']))
     const engine = await loadFreshEngine()
@@ -382,7 +383,9 @@ describe('play()', () => {
     engine.unlock() // creates context[0] which is already running (no rebuild)
 
     const fake_buffer = { duration: 0.3 }
-    const { ended } = engine.play(fake_buffer, 0.75)
+    // play() is now async — flush the `await resume()` microtask before asserting
+    const played = engine.play(fake_buffer, 0.75)
+    await Promise.resolve()
 
     const ctx = contexts[0]
     expect(ctx.createBufferSource).toHaveBeenCalledTimes(1)
@@ -395,9 +398,9 @@ describe('play()', () => {
     expect(gain_node.gain.value).toBe(0.75)
     expect(source.start).toHaveBeenCalledTimes(1)
 
-    // Resolve the ended promise by triggering onended
+    // Resolve by triggering onended; played settles when the inner Promise resolves
     let resolved = false
-    const done = ended.then(() => {
+    const done = played.then(() => {
       resolved = true
     })
 
@@ -407,6 +410,32 @@ describe('play()', () => {
     expect(resolved).toBe(true)
     expect(source.disconnect).toHaveBeenCalled()
     expect(gain_node.disconnect).toHaveBeenCalled()
+  })
+
+  test('disconnects both source and gain via the fallback timer when onended never fires [obligation]', async () => {
+    vi.useFakeTimers()
+    const contexts = []
+    installCtor(makeCtorWithContexts(contexts, ['running']))
+    const engine = await loadFreshEngine()
+    engine.unlock()
+
+    const fake_buffer = { duration: 0.5 }
+    const played = engine.play(fake_buffer, 0.75)
+
+    // Flush the await resume() microtask — advanceByTime(0) also drains microtasks
+    await vi.advanceTimersByTimeAsync(0)
+
+    const ctx = contexts[0]
+    const source = ctx.createBufferSource.mock.results[0].value
+    const gain_node = ctx.createGain.mock.results[0].value
+
+    // Don't fire onended; advance past fallback (Math.ceil(0.5*1000)+500 = 1000ms)
+    await vi.advanceTimersByTimeAsync(1000)
+    await played
+
+    expect(source.disconnect).toHaveBeenCalled()
+    expect(gain_node.disconnect).toHaveBeenCalled()
+    vi.useRealTimers()
   })
 })
 
@@ -508,6 +537,149 @@ describe('decode()', () => {
     const engine = await loadFreshEngine()
 
     await expect(engine.decode('/sound.wav')).rejects.toThrow('Web Audio is unavailable')
+  })
+})
+
+// ─── notifyState() — recovery cycle ──────────────────────────────────────────
+
+describe('notifyState() recovery cycle [obligation]', () => {
+  test('unlock listener fires twice across running→suspended→running', async () => {
+    // Both suspended: unlock() creates ctx[0] (ensureContext) + ctx[1] (rebuild)
+    const contexts = []
+    installCtor(makeCtorWithContexts(contexts, ['suspended', 'suspended']))
+    const engine = await loadFreshEngine()
+
+    engine.unlock()
+
+    const cb = vi.fn()
+    engine.onUnlock(cb)
+
+    const current = contexts[1] // the fresh context; notifyState is attached here
+
+    current._setState('running') // notifyState → markUnlocked → cb fires (1)
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    current._setState('suspended') // notifyState → unlocked = false (latch reset)
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    current._setState('running') // notifyState → markUnlocked (latch was reset) → cb fires (2)
+    expect(cb).toHaveBeenCalledTimes(2)
+  })
+
+  test('cb registered while already unlocked still fires on the next recovery cycle [obligation]', async () => {
+    const contexts = []
+    installCtor(makeCtorWithContexts(contexts, ['suspended', 'suspended']))
+    const engine = await loadFreshEngine()
+
+    engine.unlock()
+    const current = contexts[1]
+
+    // Drive the context to running to set the unlocked latch
+    current._setState('running')
+    expect(engine.isUnlocked()).toBe(true)
+
+    // Register cb while already unlocked — fires immediately AND stays in unlock_listeners
+    const cb = vi.fn()
+    engine.onUnlock(cb)
+    expect(cb).toHaveBeenCalledTimes(1)
+
+    // Suspension resets the latch
+    current._setState('suspended')
+
+    // Next running transition re-fires cb because it is still in unlock_listeners
+    current._setState('running')
+    expect(cb).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ─── isUnlocked() ────────────────────────────────────────────────────────────
+
+describe('isUnlocked() [obligation]', () => {
+  test('returns false before context reaches running', async () => {
+    const contexts = []
+    installCtor(makeCtorWithContexts(contexts, ['suspended', 'suspended']))
+    const engine = await loadFreshEngine()
+
+    engine.unlock() // both contexts suspended — never calls markUnlocked
+    expect(engine.isUnlocked()).toBe(false)
+  })
+
+  test('returns true after context reaches running', async () => {
+    const contexts = []
+    installCtor(makeCtorWithContexts(contexts, ['suspended', 'suspended']))
+    const engine = await loadFreshEngine()
+
+    engine.unlock()
+    contexts[1]._setState('running')
+    expect(engine.isUnlocked()).toBe(true)
+  })
+
+  test('returns false after suspend, true again after the next running transition', async () => {
+    const contexts = []
+    installCtor(makeCtorWithContexts(contexts, ['suspended', 'suspended']))
+    const engine = await loadFreshEngine()
+
+    engine.unlock()
+    const ctx = contexts[1]
+
+    ctx._setState('running')
+    expect(engine.isUnlocked()).toBe(true)
+
+    ctx._setState('suspended')
+    expect(engine.isUnlocked()).toBe(false)
+
+    ctx._setState('running')
+    expect(engine.isUnlocked()).toBe(true)
+  })
+})
+
+// ─── resume() timeout & clearTimeout ─────────────────────────────────────────
+
+describe('resume() — timeout & clearTimeout [obligation]', () => {
+  test('returns false and does not hang when context.resume() never settles', async () => {
+    vi.useFakeTimers()
+    const contexts = []
+    function NeverSettlingCtor() {
+      const ctx = makeFakeContext('suspended')
+      ctx.resume = vi.fn(() => new Promise(() => {})) // never resolves or rejects
+      contexts.push(ctx)
+      return ctx
+    }
+    installCtor(NeverSettlingCtor)
+    const engine = await loadFreshEngine()
+
+    const promise = engine.resume()
+
+    // Just before the 2000ms threshold: still pending
+    await vi.advanceTimersByTimeAsync(1999)
+
+    // At 2000ms: timeout fires, race rejects, catch() returns false
+    await vi.advanceTimersByTimeAsync(1)
+    const result = await promise
+
+    expect(result).toBe(false)
+    vi.useRealTimers()
+  })
+
+  test('clears the timeout when context.resume() settles before RESUME_TIMEOUT_MS', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const contexts = []
+    function QuickResumeCtor() {
+      const ctx = makeFakeContext('suspended')
+      ctx.resume = vi.fn(async () => {
+        ctx._state = 'running'
+      })
+      contexts.push(ctx)
+      return ctx
+    }
+    installCtor(QuickResumeCtor)
+    const engine = await loadFreshEngine()
+
+    await engine.resume()
+
+    // context.resume().finally(() => clearTimeout(id)) must have run
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+    clearTimeoutSpy.mockRestore()
   })
 })
 

--- a/tests/unit/sfx/player.test.js
+++ b/tests/unit/sfx/player.test.js
@@ -3,21 +3,14 @@ import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 // Bus defaults mirror BUS_DEFAULTS in config.ts (5 → 1.0× multiplier).
 const BUS_DEFAULTS = { interface: 5, study: 5, hover: 5 }
 
-// Each engine.play() returns a controllable handle so tests can fire 'ended'
-// (or never fire it, to exercise the timeout fallback).
-const playbacks = []
-
+// engine.play() is now async and returns Promise<void>.
 const engineMock = {
   resume: vi.fn().mockResolvedValue(true),
-  play: vi.fn(() => {
-    let resolve
-    const ended = new Promise((r) => (resolve = r))
-    playbacks.push({ ended, end: () => resolve() })
-    return { ended }
-  }),
+  play: vi.fn().mockResolvedValue(undefined),
   decode: vi.fn(),
   onStateChange: vi.fn(() => () => {}),
   onUnlock: vi.fn(),
+  isUnlocked: vi.fn().mockReturnValue(true),
   state: vi.fn(() => 'running')
 }
 
@@ -29,13 +22,6 @@ vi.mock('@/utils/debounce', () => ({
 
 const { default: audio_player } = await import('@/sfx/player')
 
-// Two microtask turns: one for the awaited engine.resume(), one for the
-// continuation that calls engine.play().
-const flush = async () => {
-  await Promise.resolve()
-  await Promise.resolve()
-}
-
 function loadSound(key, { volume = 0.5, duration = 0.2, default_bus = 'interface' } = {}) {
   const buffer = { duration }
   audio_player.loaded_sounds.set(key, { buffer, base_volume: volume, default_bus })
@@ -44,11 +30,10 @@ function loadSound(key, { volume = 0.5, duration = 0.2, default_bus = 'interface
 
 describe('audio_player._play', () => {
   beforeEach(() => {
-    playbacks.length = 0
     engineMock.resume.mockReset().mockResolvedValue(true)
-    engineMock.play.mockClear()
+    engineMock.play.mockReset().mockResolvedValue(undefined)
+    engineMock.isUnlocked.mockReturnValue(true)
     audio_player.loaded_sounds.clear()
-    audio_player.unlocked = true
     audio_player.queued_sound = undefined
     audio_player.volume_settings = { ...BUS_DEFAULTS }
     vi.useRealTimers()
@@ -57,56 +42,38 @@ describe('audio_player._play', () => {
   test('plays through the engine when the context is running', async () => {
     loadSound('click_04')
 
-    const promise = audio_player.play('click_04')
-    await flush()
-    expect(engineMock.play).toHaveBeenCalledTimes(1)
-
-    playbacks[0].end()
-    await promise
-
-    expect(engineMock.resume).toHaveBeenCalledTimes(1)
-  })
-
-  test('skips play when the context cannot be resumed', async () => {
-    engineMock.resume.mockResolvedValue(false)
-    loadSound('click_04')
-
     await audio_player.play('click_04')
 
-    expect(engineMock.resume).toHaveBeenCalledTimes(1)
-    expect(engineMock.play).not.toHaveBeenCalled()
+    expect(engineMock.play).toHaveBeenCalledTimes(1)
   })
 
-  test('resolves when the playback ends', async () => {
+  test('resolves when engine.play resolves', async () => {
     loadSound('click_04')
 
-    const promise = audio_player.play('click_04')
-    await flush()
-    playbacks[0].end()
-
-    await expect(promise).resolves.toBeUndefined()
+    await expect(audio_player.play('click_04')).resolves.toBeUndefined()
   })
 
-  test('resolves via the duration timeout fallback when playback never ends', async () => {
-    vi.useFakeTimers()
-    loadSound('click_04', { duration: 0.1 })
+  test('awaits engine.play — does not resolve until engine.play resolves', async () => {
+    loadSound('click_04')
+    let outer_resolve
+    engineMock.play.mockReturnValueOnce(new Promise((r) => (outer_resolve = r)))
 
     let settled = false
     const promise = audio_player.play('click_04').then(() => {
       settled = true
     })
-    await vi.advanceTimersByTimeAsync(0)
-    expect(engineMock.play).toHaveBeenCalledTimes(1)
+
+    // engine.play has not resolved yet
+    await Promise.resolve()
     expect(settled).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(700)
+    outer_resolve()
     await promise
-
     expect(settled).toBe(true)
   })
 
-  test('enqueues when the audio system is not yet unlocked', async () => {
-    audio_player.unlocked = false
+  test('enqueues when the audio system is not yet unlocked [obligation]', async () => {
+    engineMock.isUnlocked.mockReturnValue(false)
     loadSound('click_04')
 
     await audio_player.play('click_04')
@@ -124,84 +91,62 @@ describe('audio_player._play', () => {
   test('passes the volume option through to the engine', async () => {
     const buffer = loadSound('click_04', { volume: 0.5 })
 
-    const promise = audio_player.play('click_04', { volume: 0.9 })
-    await flush()
+    await audio_player.play('click_04', { volume: 0.9 })
 
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.9)
-
-    playbacks[0].end()
-    await promise
   })
 
   test('falls back to the loaded volume when no volume option is given', async () => {
     const buffer = loadSound('click_04', { volume: 0.3 })
 
-    const promise = audio_player.play('click_04')
-    await flush()
+    await audio_player.play('click_04')
 
     // Default interface setting is 5; multiplier = 5/5 = 1.0, so volume is unchanged
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.3)
-
-    playbacks[0].end()
-    await promise
   })
 
-  test('returns early before engine.resume when hover bus is muted to 0 [obligation]', async () => {
-    // Regression: hover sounds on TYPE_SFX (e.g. tap_05) have default_bus 'interface',
-    // so WITHOUT the bus: 'hover' force they would use interface volume instead of hover.
-    // This gate must fire for hover-routed sounds when hover volume = 0.
+  test('skips engine.play when effective volume is zero — hover bus muted [obligation]', async () => {
     audio_player.volume_settings = { ...BUS_DEFAULTS, hover: 0 }
     loadSound('tap_05', { volume: 0.1, default_bus: 'hover' })
 
     await audio_player.play('tap_05', { bus: 'hover' })
 
-    expect(engineMock.resume).not.toHaveBeenCalled()
     expect(engineMock.play).not.toHaveBeenCalled()
   })
 
-  test('returns early before engine.resume when options.volume is explicitly 0 [obligation]', async () => {
+  test('skips engine.play when options.volume is explicitly 0 [obligation]', async () => {
     loadSound('click_04', { volume: 0.3, default_bus: 'interface' })
 
     await audio_player.play('click_04', { volume: 0 })
 
-    expect(engineMock.resume).not.toHaveBeenCalled()
     expect(engineMock.play).not.toHaveBeenCalled()
   })
 
-  test('returns early before engine.resume for any bus muted to 0 — interface bus [obligation]', async () => {
-    // The volume gate is bus-agnostic: a muted interface bus also silences sounds.
+  test('skips engine.play for any bus muted to 0 — interface bus [obligation]', async () => {
     audio_player.volume_settings = { ...BUS_DEFAULTS, interface: 0 }
     loadSound('select', { volume: 0.3, default_bus: 'interface' })
 
     await audio_player.play('select')
 
-    expect(engineMock.resume).not.toHaveBeenCalled()
     expect(engineMock.play).not.toHaveBeenCalled()
   })
 
-  test('resumes and plays with volume = base_volume × (bus_setting / 5) for non-zero bus [obligation]', async () => {
+  test('plays with volume = base_volume × (bus_setting / 5) for non-zero bus [obligation]', async () => {
     audio_player.volume_settings = { ...BUS_DEFAULTS, hover: 2 }
     const buffer = loadSound('type_01', { volume: 0.4, default_bus: 'hover' })
 
-    const promise = audio_player.play('type_01', { bus: 'hover' })
-    await flush()
+    await audio_player.play('type_01', { bus: 'hover' })
 
     // multiplier = 2/5 = 0.4; resolved volume = 0.4 × 0.4 = 0.16
-    expect(engineMock.resume).toHaveBeenCalledTimes(1)
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.4 * (2 / 5))
-
-    playbacks[0].end()
-    await promise
   })
 })
 
 describe('audio_player._getVolumeMultiplier', () => {
   beforeEach(() => {
-    playbacks.length = 0
-    engineMock.resume.mockReset().mockResolvedValue(true)
-    engineMock.play.mockClear()
+    engineMock.play.mockReset().mockResolvedValue(undefined)
+    engineMock.isUnlocked.mockReturnValue(true)
     audio_player.loaded_sounds.clear()
-    audio_player.unlocked = true
     audio_player.queued_sound = undefined
     audio_player.volume_settings = { ...BUS_DEFAULTS }
     vi.useRealTimers()
@@ -211,36 +156,27 @@ describe('audio_player._getVolumeMultiplier', () => {
     // base_volume = 0.4; default interface = 5; multiplier = 5/5 = 1.0
     const buffer = loadSound('select', { volume: 0.4 })
 
-    const promise = audio_player.play('select')
-    await flush()
+    await audio_player.play('select')
 
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.4)
-    playbacks[0].end()
-    await promise
   })
 
   test('type_01 (defaultBus hover) routes to hover bus setting', async () => {
     // hover = 5 → multiplier = 1.0
     const buffer = loadSound('type_01', { volume: 0.2, default_bus: 'hover' })
 
-    const promise = audio_player.play('type_01')
-    await flush()
+    await audio_player.play('type_01')
 
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.2)
-    playbacks[0].end()
-    await promise
   })
 
   test('transition_up with bus:study option routes to study bus setting', async () => {
     // study = 5 → multiplier = 1.0
     const buffer = loadSound('transition_up', { volume: 0.6 })
 
-    const promise = audio_player.play('transition_up', { bus: 'study' })
-    await flush()
+    await audio_player.play('transition_up', { bus: 'study' })
 
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.6)
-    playbacks[0].end()
-    await promise
   })
 
   test('select uses interface bus — not hover — because its default_bus is interface', async () => {
@@ -248,12 +184,9 @@ describe('audio_player._getVolumeMultiplier', () => {
     audio_player.setVolumeConfig({ study: 5, interface: 10, hover: 5 })
     const buffer = loadSound('select', { volume: 0.3 })
 
-    const promise = audio_player.play('select')
-    await flush()
+    await audio_player.play('select')
 
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.6)
-    playbacks[0].end()
-    await promise
   })
 
   test('type_01 uses hover bus, not interface bus', async () => {
@@ -261,22 +194,17 @@ describe('audio_player._getVolumeMultiplier', () => {
     audio_player.setVolumeConfig({ study: 5, interface: 10, hover: 5 })
     const buffer = loadSound('type_01', { volume: 0.2, default_bus: 'hover' })
 
-    const promise = audio_player.play('type_01')
-    await flush()
+    await audio_player.play('type_01')
 
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.2)
-    playbacks[0].end()
-    await promise
   })
 })
 
 describe('audio_player.setVolumeConfig', () => {
   beforeEach(() => {
-    playbacks.length = 0
-    engineMock.resume.mockReset().mockResolvedValue(true)
-    engineMock.play.mockClear()
+    engineMock.play.mockReset().mockResolvedValue(undefined)
+    engineMock.isUnlocked.mockReturnValue(true)
     audio_player.loaded_sounds.clear()
-    audio_player.unlocked = true
     audio_player.queued_sound = undefined
     audio_player.volume_settings = { ...BUS_DEFAULTS }
     vi.useRealTimers()
@@ -286,23 +214,18 @@ describe('audio_player.setVolumeConfig', () => {
     audio_player.setVolumeConfig({ study: 5, interface: 10, hover: 5 })
     const buffer = loadSound('select', { volume: 0.3 })
 
-    const promise = audio_player.play('select')
-    await flush()
+    await audio_player.play('select')
 
     // multiplier = 10/5 = 2.0
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.6)
-    playbacks[0].end()
-    await promise
   })
 })
 
 describe('audio_player.previewVolumeConfig / resetSettings', () => {
   beforeEach(() => {
-    playbacks.length = 0
-    engineMock.resume.mockReset().mockResolvedValue(true)
-    engineMock.play.mockClear()
+    engineMock.play.mockReset().mockResolvedValue(undefined)
+    engineMock.isUnlocked.mockReturnValue(true)
     audio_player.loaded_sounds.clear()
-    audio_player.unlocked = true
     audio_player.queued_sound = undefined
     audio_player.volume_settings = { ...BUS_DEFAULTS }
     audio_player.committed_volume_settings = { ...BUS_DEFAULTS }
@@ -339,12 +262,9 @@ describe('audio_player.previewVolumeConfig / resetSettings', () => {
     audio_player.resetSettings()
 
     const buffer = loadSound('select', { volume: 0.5 })
-    const promise = audio_player.play('select')
-    await flush()
+    await audio_player.play('select')
     // multiplier = 2/5 = 0.4; volume = 0.5 * 0.4 = 0.2
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.2)
-    playbacks[0].end()
-    await promise
   })
 
   test('previewVolumeConfig stores a copy — mutating the caller object does not change player state [obligation]', () => {
@@ -366,19 +286,29 @@ describe('audio_player.previewVolumeConfig / resetSettings', () => {
     audio_player.previewVolumeConfig({ study: 5, interface: 10, hover: 5 })
 
     const buffer = loadSound('select', { volume: 0.5 })
-    const promise = audio_player.play('select')
-    await flush()
+    await audio_player.play('select')
     // multiplier = 10/5 = 2.0; volume = 0.5 * 2.0 = 1.0
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 1.0)
-    playbacks[0].end()
-    await promise
+  })
+
+  test('volume_settings and committed_volume_settings default to BUS_DEFAULTS, not hardcoded literals [obligation]', async () => {
+    // Verify the bus keys match BUS_DEFAULTS — if a new bus is added to config the player
+    // picks it up automatically because it spreads BUS_DEFAULTS rather than inlining values
+    const { BUS_DEFAULTS: defaults } = await import('@/sfx/config')
+    const expected_keys = Object.keys(defaults).sort()
+    audio_player.setVolumeConfig({ ...defaults })
+    audio_player.resetSettings()
+    expect(Object.keys(audio_player.volume_settings).sort()).toEqual(expected_keys)
+    expect(Object.keys(audio_player.committed_volume_settings).sort()).toEqual(expected_keys)
+    expect(audio_player.volume_settings).toEqual(defaults)
+    expect(audio_player.committed_volume_settings).toEqual(defaults)
   })
 })
 
 describe('audio_player._enqueue timeout', () => {
   beforeEach(() => {
+    engineMock.isUnlocked.mockReturnValue(false)
     audio_player.loaded_sounds.clear()
-    audio_player.unlocked = false
     audio_player.queued_sound = undefined
     audio_player.volume_settings = { ...BUS_DEFAULTS }
   })
@@ -397,48 +327,33 @@ describe('audio_player._enqueue timeout', () => {
   })
 })
 
-describe('audio_player._onUnlock / _registerUnlock', () => {
+describe('audio_player._onUnlock', () => {
   beforeEach(() => {
-    playbacks.length = 0
-    engineMock.resume.mockReset().mockResolvedValue(true)
-    engineMock.play.mockClear()
+    engineMock.play.mockReset().mockResolvedValue(undefined)
+    engineMock.isUnlocked.mockReturnValue(true)
     engineMock.onUnlock.mockClear()
     audio_player.loaded_sounds.clear()
-    audio_player.unlocked = false
     audio_player.queued_sound = undefined
     audio_player.volume_settings = { ...BUS_DEFAULTS }
     vi.useRealTimers()
   })
 
-  test('_registerUnlock calls engine.onUnlock exactly once even when setup is called twice', () => {
-    audio_player.unlock_registered = false
-    audio_player._registerUnlock()
-    audio_player._registerUnlock()
-    expect(engineMock.onUnlock).toHaveBeenCalledTimes(1)
-    // clean up: reset so other tests don't see a double-registered state
-    audio_player.unlock_registered = false
-  })
-
-  test('_onUnlock sets unlocked = true and plays any queued sound', async () => {
+  test('plays queued sound by calling _play directly — engine.play fires synchronously [obligation]', () => {
+    // _onUnlock calls this._play() (not this.play()), bypassing the 10ms debounce.
+    // _play() itself has no awaits before calling engine.play(), so engine.play fires
+    // within the same synchronous call stack as _onUnlock().
     loadSound('click_04')
     audio_player.queued_sound = { key: 'click_04', options: {} }
 
-    // Manually fire the unlock callback
     audio_player._onUnlock()
 
-    expect(audio_player.unlocked).toBe(true)
     expect(audio_player.queued_sound).toBeUndefined()
-
-    // debounce mock resolves synchronously; let play settle
-    await flush()
     expect(engineMock.play).toHaveBeenCalledTimes(1)
-    playbacks[0]?.end()
   })
 
-  test('_onUnlock with no queued sound just sets unlocked and does not throw', () => {
+  test('does not play when there is no queued sound', () => {
     audio_player.queued_sound = undefined
     audio_player._onUnlock()
-    expect(audio_player.unlocked).toBe(true)
     expect(engineMock.play).not.toHaveBeenCalled()
   })
 })
@@ -449,7 +364,6 @@ describe('audio_player.setup', () => {
     engineMock.onUnlock.mockClear()
     audio_player.loaded_sounds.clear()
     audio_player.initialized = false
-    audio_player.unlock_registered = false
   })
 
   test('setup is idempotent — calling it twice does not double-load sounds', async () => {
@@ -459,8 +373,6 @@ describe('audio_player.setup', () => {
     await audio_player.setup()
     const count_after_first = audio_player.loaded_sounds.size
 
-    // Mark uninitialized to allow a second call, but the flag check prevents it
-    // Reset initialized manually to confirm the guard
     audio_player.initialized = true
     await audio_player.setup()
 
@@ -473,9 +385,7 @@ describe('audio_player.setup', () => {
 
     await audio_player.setup()
 
-    // At minimum, some sounds should be loaded
     expect(audio_player.loaded_sounds.size).toBeGreaterThan(0)
-    // 'select' is a known flat key in SOUNDS
     expect(audio_player.loaded_sounds.has('select')).toBe(true)
   })
 
@@ -492,5 +402,25 @@ describe('audio_player.setup', () => {
     engineMock.decode.mockRejectedValue(new Error('network error'))
 
     await expect(audio_player.setup()).rejects.toThrow('Failed to load audio')
+  })
+
+  test('_loadSound throws descriptive error when audio file is not in the glob [obligation]', async () => {
+    // Temporarily add a key with an extension not captured by the glob (flac is excluded)
+    // so that AUDIO_FILES[path] is undefined, triggering the new early-throw guard.
+    const { SOUNDS } = await import('@/sfx/config')
+    const test_key = '__test_missing_audio__'
+    SOUNDS[test_key] = { ext: 'flac' }
+
+    try {
+      await audio_player['_loadSound'](test_key)
+      expect.fail('expected _loadSound to throw')
+    } catch (e) {
+      expect(e.message).toMatch(/Audio file not found for "__test_missing_audio__"/)
+      expect(e.message).toContain('/src/assets/audio/__test_missing_audio__.flac')
+      // engine.decode must NOT be called with undefined
+      expect(engineMock.decode).not.toHaveBeenCalledWith(undefined)
+    } finally {
+      delete SOUNDS[test_key]
+    }
   })
 })


### PR DESCRIPTION
## Summary

The SFX system was silently dropping sounds after any AudioContext suspension (tab switch, device sleep, app switch) because the \`unlocked\` latch never reset — sounds bypassed the enqueue path and went straight to \`engine.resume()\`, which hangs permanently on iOS 'interrupted'. This caused both missing sounds and frozen UI flows that awaited \`emitSfx()\`.

## Changes

- **Core fix**: reset \`unlocked\` on every non-running \`statechange\` so \`markUnlocked()\` re-fires on recovery, re-draining any queued sound
- **Responsibility cleanup**: moved \`resume()\` call and fallback timer into \`engine.play()\` — player now just resolves what to play and at what volume
- **Hang prevention**: \`resume()\` races against a 2s timeout (cleared on the happy path) so iOS 'interrupted' can never permanently block a play promise
- **\`onUnlock\` fix**: always adds cb to \`unlock_listeners\` before checking current state, so subscribers registered while already-unlocked still fire on future recovery cycles
- **Type safety**: replaced \`ctx!\` non-null assertions with a local capture that TypeScript can actually narrow
- **Defensive guards**: \`_onUnlock\` calls \`_play()\` directly (bypasses debounce), \`_loadSound\` throws a clear error for missing glob keys, player initialises bus volumes from \`BUS_DEFAULTS\`