### PR TITLE
Migrate Stripe checkout to embedded Checkout Sessions API

### DIFF
--- a/src/api/billing/db/index.ts
+++ b/src/api/billing/db/index.ts
@@ -2,11 +2,8 @@ import { supabase } from '@/supabase-client'
 import logger from '@/utils/logger'
 import type { StripeInvoice, StripePaymentMethod, StripeSubscription } from '../stripe'
 
-export type CreateSubscriptionArgs = { planId: string }
-export type CreateSubscriptionResult = {
-  clientSecret: string
-  subscriptionId: string
-}
+export type CreateSubscriptionArgs = { planId: string; returnUrl: string }
+export type CreateSubscriptionResult = { clientSecret: string }
 
 export async function createSubscription(
   args: CreateSubscriptionArgs
@@ -30,7 +27,7 @@ type ManagePayload =
   | { action: 'list-payment-methods' }
   | { action: 'set-default-payment-method'; paymentMethodId: string }
   | { action: 'detach-payment-method'; paymentMethodId: string }
-  | { action: 'create-setup-intent' }
+  | { action: 'create-setup-intent'; returnUrl: string }
   | { action: 'change-plan'; planId: string }
   | { action: 'cancel'; atPeriodEnd: boolean }
   | { action: 'resume' }
@@ -86,8 +83,8 @@ export function detachPaymentMethod(paymentMethodId: string) {
   })
 }
 
-export function createSetupIntent() {
-  return manage<{ clientSecret: string }>({ action: 'create-setup-intent' })
+export function createSetupIntent(returnUrl: string) {
+  return manage<{ clientSecret: string }>({ action: 'create-setup-intent', returnUrl })
 }
 
 export function changePlan(planId: string) {

--- a/src/api/billing/mutations/use-create-setup-intent-mutation.ts
+++ b/src/api/billing/mutations/use-create-setup-intent-mutation.ts
@@ -2,9 +2,9 @@ import { useMutation, useQueryCache } from '@pinia/colada'
 import { createSetupIntent } from '../db'
 
 /**
- * Requests a Stripe SetupIntent and returns its `clientSecret` so the
- * client can mount a Payment Element and call `stripe.confirmSetup` to
- * attach a new card to the customer without an immediate charge.
+ * Requests a Stripe Checkout Session (setup mode) and returns its
+ * `clientSecret` so the client can mount a Payment Element and confirm it
+ * to attach a new card to the customer without an immediate charge.
  * Used by the add-credit-card modal.
  *
  * Invalidates the payment-methods list so the newly attached card appears.
@@ -12,7 +12,7 @@ import { createSetupIntent } from '../db'
 export function useCreateSetupIntentMutation() {
   const queryCache = useQueryCache()
   return useMutation({
-    mutation: () => createSetupIntent(),
+    mutation: (returnUrl: string) => createSetupIntent(returnUrl),
     onSettled: () => {
       queryCache.invalidateQueries({ key: ['billing', 'payment-methods'] })
     }

--- a/src/api/billing/mutations/use-create-subscription-mutation.ts
+++ b/src/api/billing/mutations/use-create-subscription-mutation.ts
@@ -2,10 +2,10 @@ import { useMutation } from '@pinia/colada'
 import { createSubscription, type CreateSubscriptionArgs } from '../db'
 
 /**
- * Creates an incomplete Stripe subscription for the caller's selected plan
- * and returns the PaymentIntent `clientSecret`. The client mounts a Payment
- * Element against that secret and calls `stripe.confirmPayment` to activate
- * the subscription. Used by the initial checkout flow, not plan changes.
+ * Creates a Stripe Checkout Session (subscription mode) for the caller's
+ * selected plan and returns its `clientSecret`. The client mounts a Payment
+ * Element against that secret and confirms it to activate the subscription.
+ * Used by the initial checkout flow, not plan changes.
  */
 export function useCreateSubscriptionMutation() {
   return useMutation({

--- a/src/components/modals/checkout.vue
+++ b/src/components/modals/checkout.vue
@@ -1,18 +1,10 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useQueryCache } from '@pinia/colada'
-import {
-  loadStripe,
-  type Stripe,
-  type StripeElements,
-  type StripePaymentElement
-} from '@stripe/stripe-js'
 import mobileSheet from '@/components/layout-kit/modal/mobile-sheet.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import { useCreateSubscriptionMutation } from '@/api/billing'
-import { getStripeAppearance, STRIPE_FONTS } from '@/utils/billing/stripe-theme'
-import logger from '@/utils/logger'
+import { useCheckoutElements } from '@/composables/billing/use-checkout-elements'
 
 export type CheckoutResponse = { upgraded: boolean }
 
@@ -24,78 +16,25 @@ const { t } = useI18n()
 const queryCache = useQueryCache()
 const { mutateAsync: createSubscription } = useCreateSubscriptionMutation()
 
-const container_ref = useTemplateRef<HTMLDivElement>('container')
-
-const is_loading = ref(true)
-const is_submitting = ref(false)
-const is_ready = ref(false)
-const load_error = ref(false)
-const submit_error = ref<string | null>(null)
-
-let stripe: Stripe | null = null
-let elements: StripeElements | null = null
-let payment_element: StripePaymentElement | null = null
-
-onMounted(async () => {
-  try {
-    const [subscription, stripeInstance] = await Promise.all([
-      createSubscription({ planId: 'paid' }),
-      loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY)
-    ])
-    if (!stripeInstance) throw new Error('Stripe.js failed to load')
-    stripe = stripeInstance
-
-    elements = stripe.elements({
-      clientSecret: subscription.clientSecret,
-      appearance: getStripeAppearance(),
-      fonts: STRIPE_FONTS
-    })
-
-    payment_element = elements.create('payment', { layout: 'tabs' })
-    payment_element.on('ready', () => {
-      is_ready.value = true
-    })
-
-    if (container_ref.value) payment_element.mount(container_ref.value)
-  } catch (err) {
-    logger.error((err as Error).message)
-    load_error.value = true
-  } finally {
-    is_loading.value = false
-  }
-})
-
-onBeforeUnmount(() => {
-  payment_element?.destroy()
-})
-
-async function onSubmit() {
-  if (!stripe || !elements) return
-  is_submitting.value = true
-  submit_error.value = null
-
-  const result = await stripe.confirmPayment({
-    elements,
-    confirmParams: {
-      return_url: window.location.origin
-    },
-    redirect: 'if_required'
+const { container_ref, is_loading, is_submitting, is_ready, load_error, submit_error, confirm } =
+  useCheckoutElements({
+    publicKey: import.meta.env.VITE_STRIPE_PUBLIC_KEY,
+    genericErrorMessage: t('billing.checkout.submit-error'),
+    getClientSecret: async () => {
+      const { clientSecret } = await createSubscription({
+        planId: 'paid',
+        returnUrl: window.location.origin
+      })
+      return clientSecret
+    }
   })
 
-  if (result.error) {
-    submit_error.value = result.error.message ?? t('billing.checkout.submit-error')
-    is_submitting.value = false
-    return
-  }
+async function onSubmit() {
+  const outcome = await confirm()
+  if (outcome.status !== 'success') return
 
-  if (result.paymentIntent?.status === 'succeeded') {
-    queryCache.invalidateQueries({ key: ['member'] })
-    close({ upgraded: true })
-    return
-  }
-
-  submit_error.value = t('billing.checkout.submit-error')
-  is_submitting.value = false
+  queryCache.invalidateQueries({ key: ['member'] })
+  close({ upgraded: true })
 }
 </script>
 

--- a/src/composables/billing/use-checkout-elements.ts
+++ b/src/composables/billing/use-checkout-elements.ts
@@ -1,0 +1,105 @@
+import { onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
+import {
+  loadStripe,
+  type Stripe,
+  type StripeCheckoutElementsSdk,
+  type StripeCheckoutSession,
+  type StripePaymentElement
+} from '@stripe/stripe-js'
+import { getStripeAppearance, STRIPE_FONTS } from '@/utils/billing/stripe-theme'
+import logger from '@/utils/logger'
+
+type UseCheckoutElementsOptions = {
+  getClientSecret: () => Promise<string>
+  publicKey: string
+  genericErrorMessage: string
+}
+
+export type ConfirmOutcome =
+  | { status: 'success'; session: StripeCheckoutSession }
+  | { status: 'error'; message: string }
+
+/**
+ * Owns the generic embedded-Checkout-Elements lifecycle shared by the
+ * subscription checkout and add-credit-card flows: load Stripe.js, init the
+ * Checkout Elements SDK against a Checkout Session client_secret, mount a
+ * Payment Element, and confirm on submit. Stays agnostic of subscription vs.
+ * setup mode and of what the caller does with a successful session.
+ */
+export function useCheckoutElements(options: UseCheckoutElementsOptions) {
+  const container_ref = useTemplateRef<HTMLDivElement>('container')
+
+  const is_loading = ref(true)
+  const is_submitting = ref(false)
+  const is_ready = ref(false)
+  const load_error = ref(false)
+  const submit_error = ref<string | null>(null)
+
+  let stripe: Stripe | null = null
+  let checkout: StripeCheckoutElementsSdk | null = null
+  let payment_element: StripePaymentElement | null = null
+
+  onMounted(async () => {
+    try {
+      const [clientSecret, stripeInstance] = await Promise.all([
+        options.getClientSecret(),
+        loadStripe(options.publicKey)
+      ])
+      if (!stripeInstance) throw new Error('Stripe.js failed to load')
+      stripe = stripeInstance
+
+      checkout = stripe.initCheckoutElementsSdk({
+        clientSecret,
+        elementsOptions: { appearance: getStripeAppearance(), fonts: STRIPE_FONTS }
+      })
+
+      payment_element = checkout.createPaymentElement({ layout: 'tabs' })
+      payment_element.on('ready', () => {
+        is_ready.value = true
+      })
+
+      if (container_ref.value) payment_element.mount(container_ref.value)
+    } catch (err) {
+      logger.error((err as Error).message)
+      load_error.value = true
+    } finally {
+      is_loading.value = false
+    }
+  })
+
+  onBeforeUnmount(() => {
+    payment_element?.destroy()
+  })
+
+  async function confirm(): Promise<ConfirmOutcome> {
+    if (!checkout) return { status: 'error', message: options.genericErrorMessage }
+    is_submitting.value = true
+    submit_error.value = null
+
+    const loadActionsResult = await checkout.loadActions()
+    if (loadActionsResult.type === 'error') {
+      submit_error.value = loadActionsResult.error.message ?? options.genericErrorMessage
+      is_submitting.value = false
+      return { status: 'error', message: submit_error.value }
+    }
+
+    // return_url is already set when the Checkout Session was created
+    // server-side — Stripe rejects passing it again here.
+    const result = await loadActionsResult.actions.confirm({ redirect: 'if_required' })
+    is_submitting.value = false
+
+    if (result.type === 'error') {
+      submit_error.value = result.error.message ?? options.genericErrorMessage
+      return { status: 'error', message: submit_error.value }
+    }
+
+    if (result.session.status.type !== 'complete') {
+      submit_error.value = options.genericErrorMessage
+      return { status: 'error', message: submit_error.value }
+    }
+
+    return { status: 'success', session: result.session }
+  }
+
+  return { container_ref, is_loading, is_submitting, is_ready, load_error, submit_error, confirm }
+}

--- a/src/composables/billing/use-checkout-elements.ts
+++ b/src/composables/billing/use-checkout-elements.ts
@@ -76,29 +76,35 @@ export function useCheckoutElements(options: UseCheckoutElementsOptions) {
     is_submitting.value = true
     submit_error.value = null
 
-    const loadActionsResult = await checkout.loadActions()
-    if (loadActionsResult.type === 'error') {
-      submit_error.value = loadActionsResult.error.message ?? options.genericErrorMessage
-      is_submitting.value = false
-      return { status: 'error', message: submit_error.value }
-    }
+    try {
+      const loadActionsResult = await checkout.loadActions()
+      if (loadActionsResult.type === 'error') {
+        submit_error.value = loadActionsResult.error.message ?? options.genericErrorMessage
+        return { status: 'error', message: submit_error.value }
+      }
 
-    // return_url is already set when the Checkout Session was created
-    // server-side — Stripe rejects passing it again here.
-    const result = await loadActionsResult.actions.confirm({ redirect: 'if_required' })
-    is_submitting.value = false
+      // return_url is already set when the Checkout Session was created
+      // server-side — Stripe rejects passing it again here.
+      const result = await loadActionsResult.actions.confirm({ redirect: 'if_required' })
 
-    if (result.type === 'error') {
-      submit_error.value = result.error.message ?? options.genericErrorMessage
-      return { status: 'error', message: submit_error.value }
-    }
+      if (result.type === 'error') {
+        submit_error.value = result.error.message ?? options.genericErrorMessage
+        return { status: 'error', message: submit_error.value }
+      }
 
-    if (result.session.status.type !== 'complete') {
+      if (result.session.status.type !== 'complete') {
+        submit_error.value = options.genericErrorMessage
+        return { status: 'error', message: submit_error.value }
+      }
+
+      return { status: 'success', session: result.session }
+    } catch (err) {
+      logger.error((err as Error).message)
       submit_error.value = options.genericErrorMessage
       return { status: 'error', message: submit_error.value }
+    } finally {
+      is_submitting.value = false
     }
-
-    return { status: 'success', session: result.session }
   }
 
   return { container_ref, is_loading, is_submitting, is_ready, load_error, submit_error, confirm }

--- a/src/phone/apps/settings/component/tab-subscription/add-credit-card-modal.vue
+++ b/src/phone/apps/settings/component/tab-subscription/add-credit-card-modal.vue
@@ -1,18 +1,10 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useQueryCache } from '@pinia/colada'
-import {
-  loadStripe,
-  type Stripe,
-  type StripeElements,
-  type StripePaymentElement
-} from '@stripe/stripe-js'
 import mobileSheet from '@/components/layout-kit/modal/mobile-sheet.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import { useCreateSetupIntentMutation } from '@/api/billing'
-import { getStripeAppearance, STRIPE_FONTS } from '@/utils/billing/stripe-theme'
-import logger from '@/utils/logger'
+import { useCheckoutElements } from '@/composables/billing/use-checkout-elements'
 
 export type AddCreditCardResponse = { added: boolean; paymentMethodId: string | null }
 
@@ -24,81 +16,23 @@ const { t } = useI18n()
 const queryCache = useQueryCache()
 const { mutateAsync: createSetupIntent } = useCreateSetupIntentMutation()
 
-const container_ref = useTemplateRef<HTMLDivElement>('container')
-
-const is_loading = ref(true)
-const is_submitting = ref(false)
-const is_ready = ref(false)
-const load_error = ref(false)
-const submit_error = ref<string | null>(null)
-
-let stripe: Stripe | null = null
-let elements: StripeElements | null = null
-let payment_element: StripePaymentElement | null = null
-
-onMounted(async () => {
-  try {
-    const [setup, stripeInstance] = await Promise.all([
-      createSetupIntent(),
-      loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY)
-    ])
-    if (!stripeInstance) throw new Error('Stripe.js failed to load')
-    stripe = stripeInstance
-
-    elements = stripe.elements({
-      clientSecret: setup.clientSecret,
-      appearance: getStripeAppearance(),
-      fonts: STRIPE_FONTS
-    })
-
-    payment_element = elements.create('payment', { layout: 'tabs' })
-    payment_element.on('ready', () => {
-      is_ready.value = true
-    })
-
-    if (container_ref.value) payment_element.mount(container_ref.value)
-  } catch (err) {
-    logger.error((err as Error).message)
-    load_error.value = true
-  } finally {
-    is_loading.value = false
-  }
-})
-
-onBeforeUnmount(() => {
-  payment_element?.destroy()
-})
-
-async function onSubmit() {
-  if (!stripe || !elements) return
-  is_submitting.value = true
-  submit_error.value = null
-
-  const result = await stripe.confirmSetup({
-    elements,
-    confirmParams: {
-      return_url: window.location.origin
-    },
-    redirect: 'if_required'
+const { container_ref, is_loading, is_submitting, is_ready, load_error, submit_error, confirm } =
+  useCheckoutElements({
+    publicKey: import.meta.env.VITE_STRIPE_PUBLIC_KEY,
+    genericErrorMessage: t('settings.subscription.add-credit-card.submit-error'),
+    getClientSecret: async () => {
+      const { clientSecret } = await createSetupIntent(window.location.origin)
+      return clientSecret
+    }
   })
 
-  if (result.error) {
-    submit_error.value =
-      result.error.message ?? t('settings.subscription.add-credit-card.submit-error')
-    is_submitting.value = false
-    return
-  }
+async function onSubmit() {
+  const outcome = await confirm()
+  if (outcome.status !== 'success') return
 
-  if (result.setupIntent?.status === 'succeeded') {
-    queryCache.invalidateQueries({ key: ['billing', 'payment-methods'] })
-    const pm = result.setupIntent.payment_method
-    const paymentMethodId = typeof pm === 'string' ? pm : (pm?.id ?? null)
-    close({ added: true, paymentMethodId })
-    return
-  }
-
-  submit_error.value = t('settings.subscription.add-credit-card.submit-error')
-  is_submitting.value = false
+  queryCache.invalidateQueries({ key: ['billing', 'payment-methods'] })
+  const paymentMethodId = outcome.session.savedPaymentMethods?.[0]?.id ?? null
+  close({ added: true, paymentMethodId })
 }
 </script>
 

--- a/supabase/functions/create-subscription/index.test.ts
+++ b/supabase/functions/create-subscription/index.test.ts
@@ -1,0 +1,203 @@
+import { assertEquals } from '@std/assert'
+import { handler, type Deps } from './index.ts'
+
+type FakeOpts = {
+  plan?: { stripe_price_id: string } | null
+  member?: { stripe_customer_id: string | null } | null
+  existingCustomers?: { id: string }[]
+  sessionClientSecret?: string | null
+}
+
+function makeDeps(opts: FakeOpts = {}) {
+  const calls = {
+    checkoutSessionsCreate: [] as any[],
+    customersCreate: [] as any[],
+    membersUpdate: [] as any[]
+  }
+
+  const admin = {
+    from: (table: string) => {
+      if (table === 'plans') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: () =>
+                  Promise.resolve({
+                    data: opts.plan === undefined ? { stripe_price_id: 'price_1' } : opts.plan
+                  })
+              })
+            })
+          })
+        }
+      }
+      // members
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () =>
+              Promise.resolve({
+                data: opts.member === undefined ? { stripe_customer_id: 'cus_1' } : opts.member
+              })
+          })
+        }),
+        update: (vals: any) => ({
+          eq: () => {
+            calls.membersUpdate.push(vals)
+            return Promise.resolve({ data: null, error: null })
+          }
+        })
+      }
+    }
+  } as any
+
+  const stripe = {
+    customers: {
+      list: () => Promise.resolve({ data: opts.existingCustomers ?? [] }),
+      create: (args: any) => {
+        calls.customersCreate.push(args)
+        return Promise.resolve({ id: 'cus_new' })
+      }
+    },
+    checkout: {
+      sessions: {
+        create: (args: any) => {
+          calls.checkoutSessionsCreate.push(args)
+          return Promise.resolve({
+            client_secret:
+              opts.sessionClientSecret === undefined ? 'cs_secret_1' : opts.sessionClientSecret
+          })
+        }
+      }
+    }
+  } as any
+
+  const deps: Deps = {
+    admin,
+    stripe,
+    getUser: () => Promise.resolve({ id: 'user_1', email: 'a@b.com' })
+  }
+
+  return { deps, calls }
+}
+
+function req(body: unknown, headers: Record<string, string> = { Authorization: 'Bearer x' }) {
+  return new Request('http://localhost/create-subscription', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  })
+}
+
+Deno.test('returns 401 when no Authorization header is present', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req({ planId: 'paid', returnUrl: 'https://app.test' }, {}), deps)
+  assertEquals(res.status, 401)
+})
+
+Deno.test('returns 401 when getUser resolves null', async () => {
+  const { deps } = makeDeps()
+  deps.getUser = () => Promise.resolve(null)
+  const res = await handler(req({ planId: 'paid', returnUrl: 'https://app.test' }), deps)
+  assertEquals(res.status, 401)
+})
+
+Deno.test('returns 400 Missing planId when planId is absent', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req({ returnUrl: 'https://app.test' }), deps)
+  assertEquals(res.status, 400)
+  assertEquals(await res.text(), 'Missing planId')
+})
+
+Deno.test('returns 400 Missing returnUrl when returnUrl is absent', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req({ planId: 'paid' }), deps)
+  assertEquals(res.status, 400)
+  assertEquals(await res.text(), 'Missing returnUrl')
+})
+
+Deno.test('creates the Checkout Session in subscription mode with ui_mode elements', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(req({ planId: 'paid', returnUrl: 'https://app.test' }), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.checkoutSessionsCreate.length, 1)
+  const args = calls.checkoutSessionsCreate[0]
+  assertEquals(args.mode, 'subscription')
+  assertEquals(args.ui_mode, 'elements')
+  assertEquals(args.customer, 'cus_1')
+  assertEquals(args.return_url, 'https://app.test')
+  assertEquals(args.line_items, [{ price: 'price_1', quantity: 1 }])
+})
+
+Deno.test('response body is { clientSecret } only — no subscriptionId', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req({ planId: 'paid', returnUrl: 'https://app.test' }), deps)
+
+  const body = await res.json()
+  assertEquals(body, { clientSecret: 'cs_secret_1' })
+  assertEquals('subscriptionId' in body, false)
+})
+
+Deno.test('creates a new Stripe customer when the member has none, persists the id', async () => {
+  const { deps, calls } = makeDeps({ member: { stripe_customer_id: null } })
+  const res = await handler(req({ planId: 'paid', returnUrl: 'https://app.test' }), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.customersCreate.length, 1)
+  assertEquals(calls.membersUpdate, [{ stripe_customer_id: 'cus_new' }])
+})
+
+Deno.test('reuses an existing Stripe customer found by email instead of creating one', async () => {
+  const { deps, calls } = makeDeps({
+    member: { stripe_customer_id: null },
+    existingCustomers: [{ id: 'cus_existing' }]
+  })
+  const res = await handler(req({ planId: 'paid', returnUrl: 'https://app.test' }), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.customersCreate.length, 0)
+  assertEquals(calls.membersUpdate, [{ stripe_customer_id: 'cus_existing' }])
+})
+
+Deno.test('returns 400 when the plan is not purchasable', async () => {
+  const { deps } = makeDeps({ plan: null })
+  const res = await handler(req({ planId: 'free', returnUrl: 'https://app.test' }), deps)
+
+  assertEquals(res.status, 400)
+  assertEquals(await res.text(), 'Plan not purchasable: free')
+})
+
+Deno.test('returns 500 when the Checkout Session has no client_secret', async () => {
+  const { deps } = makeDeps({ sessionClientSecret: null })
+  const res = await handler(req({ planId: 'paid', returnUrl: 'https://app.test' }), deps)
+
+  assertEquals(res.status, 500)
+})
+
+Deno.test('returns 500 with a generic message when Stripe throws', async () => {
+  const { deps } = makeDeps()
+  deps.stripe.checkout.sessions.create = () => Promise.reject(new Error('stripe down'))
+  const res = await handler(req({ planId: 'paid', returnUrl: 'https://app.test' }), deps)
+
+  assertEquals(res.status, 500)
+  assertEquals(await res.text(), 'Error creating subscription')
+})
+
+Deno.test('responds 204 to OPTIONS preflight', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(
+    new Request('http://localhost/create-subscription', { method: 'OPTIONS' }),
+    deps
+  )
+  assertEquals(res.status, 204)
+})
+
+Deno.test('responds 405 to non-POST methods', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(
+    new Request('http://localhost/create-subscription', { method: 'GET' }),
+    deps
+  )
+  assertEquals(res.status, 405)
+})

--- a/supabase/functions/create-subscription/index.ts
+++ b/supabase/functions/create-subscription/index.ts
@@ -94,6 +94,10 @@ export async function handler(req: Request, deps: Deps): Promise<Response> {
     // object underneath — completing the embedded Payment Element activates
     // it, at which point the webhook fires `customer.subscription.updated`,
     // same as before.
+    //
+    // ui_mode: 'elements' is a preview feature (Stripe-Version 2026-03-25.dahlia)
+    // not yet reflected in this SDK version's published types — cast past the
+    // stable-only UiMode union until stripe-node catches up.
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
       ui_mode: 'elements',
@@ -101,7 +105,7 @@ export async function handler(req: Request, deps: Deps): Promise<Response> {
       line_items: [{ price: plan.stripe_price_id, quantity: 1 }],
       subscription_data: { metadata: { member_id: user.id } },
       return_url: returnUrl
-    })
+    } as unknown as Stripe.Checkout.SessionCreateParams)
 
     if (!session.client_secret) {
       return new Response('No client_secret on Checkout Session', {
@@ -121,7 +125,9 @@ export async function handler(req: Request, deps: Deps): Promise<Response> {
 
 if (import.meta.main) {
   const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
-    apiVersion: '2026-03-25.dahlia',
+    // Preview version (see ui_mode note below) — not yet in this SDK's
+    // LatestApiVersion type.
+    apiVersion: '2026-03-25.dahlia' as Stripe.LatestApiVersion,
     httpClient: Stripe.createFetchHttpClient()
   })
 

--- a/supabase/functions/create-subscription/index.ts
+++ b/supabase/functions/create-subscription/index.ts
@@ -1,16 +1,15 @@
-// Creates an incomplete subscription + PaymentIntent for the caller's plan.
+// Creates a Checkout Session (subscription mode, embedded UI) for the
+// caller's plan.
 //
-// Used with Stripe Elements (Payment Element). The client gets back the
-// PaymentIntent's client_secret and runs `stripe.confirmPayment()` with a
-// Payment Element mounted in our own UI. That's the opposite of Embedded
-// Checkout (which returned a *Session* client_secret and mounted Stripe's
-// pre-built UI). We chose Elements to own the appearance layer.
+// The client mounts our own Payment Element against the Session's
+// client_secret and calls `checkout.confirm()` — appearance stays ours,
+// Stripe owns creating the underlying Subscription + PaymentIntent.
 
 import Stripe from 'npm:stripe@20'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
-  apiVersion: '2024-06-20',
+  apiVersion: '2026-03-25.dahlia',
   httpClient: Stripe.createFetchHttpClient()
 })
 
@@ -52,9 +51,12 @@ Deno.serve(async (req) => {
   )
 
   try {
-    const { planId } = await req.json().catch(() => ({}))
+    const { planId, returnUrl } = await req.json().catch(() => ({}))
     if (!planId) {
       return new Response('Missing planId', { status: 400, headers: cors })
+    }
+    if (!returnUrl) {
+      return new Response('Missing returnUrl', { status: 400, headers: cors })
     }
 
     // Client sends plan id, server resolves to Stripe price id via plans.
@@ -94,39 +96,29 @@ Deno.serve(async (req) => {
       await admin.from('members').update({ stripe_customer_id: customerId }).eq('id', user.id)
     }
 
-    // Create the subscription in "incomplete" state. Stripe generates a
-    // PaymentIntent for the first invoice; we expand it so we can read the
-    // client_secret without a second round-trip.
-    //
-    // `default_incomplete` means the subscription exists but has no active
-    // payment yet — completing the PaymentIntent on the frontend activates
-    // it, at which point the webhook fires `customer.subscription.updated`.
-    const subscription = await stripe.subscriptions.create({
+    // Checkout Session in subscription mode still creates a real Subscription
+    // object underneath — completing the embedded Payment Element activates
+    // it, at which point the webhook fires `customer.subscription.updated`,
+    // same as before.
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      ui_mode: 'elements',
       customer: customerId,
-      items: [{ price: plan.stripe_price_id }],
-      payment_behavior: 'default_incomplete',
-      payment_settings: {
-        save_default_payment_method: 'on_subscription'
-      },
-      expand: ['latest_invoice.payment_intent'],
-      metadata: { member_id: user.id }
+      line_items: [{ price: plan.stripe_price_id, quantity: 1 }],
+      subscription_data: { metadata: { member_id: user.id } },
+      return_url: returnUrl
     })
 
-    const paymentIntent = subscription.latest_invoice?.payment_intent
-    if (!paymentIntent || typeof paymentIntent !== 'object') {
-      return new Response('No PaymentIntent on subscription', {
+    if (!session.client_secret) {
+      return new Response('No client_secret on Checkout Session', {
         status: 500,
         headers: cors
       })
     }
 
-    return new Response(
-      JSON.stringify({
-        clientSecret: paymentIntent.client_secret,
-        subscriptionId: subscription.id
-      }),
-      { headers: { ...cors, 'Content-Type': 'application/json' } }
-    )
+    return new Response(JSON.stringify({ clientSecret: session.client_secret }), {
+      headers: { ...cors, 'Content-Type': 'application/json' }
+    })
   } catch (err) {
     console.error(err)
     return new Response('Error creating subscription', { status: 500, headers: cors })

--- a/supabase/functions/create-subscription/index.ts
+++ b/supabase/functions/create-subscription/index.ts
@@ -6,19 +6,25 @@
 // Stripe owns creating the underlying Subscription + PaymentIntent.
 
 import Stripe from 'npm:stripe@20'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
-  apiVersion: '2026-03-25.dahlia',
-  httpClient: Stripe.createFetchHttpClient()
-})
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 const cors = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type'
 }
 
-Deno.serve(async (req) => {
+export type StripeLike = Pick<Stripe, 'checkout' | 'customers'>
+
+export type AuthedUser = { id: string; email?: string | null }
+
+export type Deps = {
+  admin: SupabaseClient
+  stripe: StripeLike
+  // Resolves the Authorization header to the caller, or null if invalid.
+  getUser: (authHeader: string) => Promise<AuthedUser | null>
+}
+
+export async function handler(req: Request, deps: Deps): Promise<Response> {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: cors })
   }
@@ -31,24 +37,12 @@ Deno.serve(async (req) => {
     return new Response('Unauthorized', { status: 401, headers: cors })
   }
 
-  const userClient = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_ANON_KEY')!,
-    { global: { headers: { Authorization: authHeader } } }
-  )
-
-  const {
-    data: { user },
-    error: authError
-  } = await userClient.auth.getUser()
-  if (authError || !user) {
+  const user = await deps.getUser(authHeader)
+  if (!user) {
     return new Response('Unauthorized', { status: 401, headers: cors })
   }
 
-  const admin = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-  )
+  const { admin, stripe } = deps
 
   try {
     const { planId, returnUrl } = await req.json().catch(() => ({}))
@@ -84,11 +78,11 @@ Deno.serve(async (req) => {
     let customerId = member?.stripe_customer_id ?? null
 
     if (!customerId) {
-      const existing = await stripe.customers.list({ email: user.email, limit: 1 })
+      const existing = await stripe.customers.list({ email: user.email ?? undefined, limit: 1 })
       const customer =
         existing.data[0] ??
         (await stripe.customers.create({
-          email: user.email,
+          email: user.email ?? undefined,
           metadata: { member_id: user.id }
         }))
       customerId = customer.id
@@ -123,4 +117,35 @@ Deno.serve(async (req) => {
     console.error(err)
     return new Response('Error creating subscription', { status: 500, headers: cors })
   }
-})
+}
+
+if (import.meta.main) {
+  const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
+    apiVersion: '2026-03-25.dahlia',
+    httpClient: Stripe.createFetchHttpClient()
+  })
+
+  const admin = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  )
+
+  Deno.serve((req) =>
+    handler(req, {
+      admin,
+      stripe,
+      getUser: async (authHeader) => {
+        const userClient = createClient(
+          Deno.env.get('SUPABASE_URL')!,
+          Deno.env.get('SUPABASE_ANON_KEY')!,
+          { global: { headers: { Authorization: authHeader } } }
+        )
+        const {
+          data: { user },
+          error: authError
+        } = await userClient.auth.getUser()
+        return authError || !user ? null : user
+      }
+    })
+  )
+}

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -4,7 +4,8 @@
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "npm:@supabase/supabase-js@2": "2.105.1",
-    "npm:opencc-js@1.0.5": "1.0.5"
+    "npm:opencc-js@1.0.5": "1.0.5",
+    "npm:stripe@20": "20.4.1"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -82,6 +83,9 @@
     },
     "opencc-js@1.0.5": {
       "integrity": "sha512-LD+1SoNnZdlRwtYTjnQdFrSVCAaYpuDqL5CkmOaHOkKoKh7mFxUicLTRVNLU5C+Jmi1vXQ3QL4jWdgSaa4sKjg=="
+    },
+    "stripe@20.4.1": {
+      "integrity": "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w=="
     },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="

--- a/supabase/functions/manage-subscription/index.test.ts
+++ b/supabase/functions/manage-subscription/index.test.ts
@@ -1,0 +1,282 @@
+import { assertEquals } from '@std/assert'
+import { handler, type Deps } from './index.ts'
+
+type FakeOpts = {
+  member?: { stripe_customer_id: string | null; stripe_subscription_id: string | null } | null
+  subscription?: any
+  upcoming?: any
+  plan?: { stripe_price_id: string } | null
+}
+
+const DEFAULT_MEMBER = { stripe_customer_id: 'cus_1', stripe_subscription_id: 'sub_1' }
+
+function makeDeps(opts: FakeOpts = {}) {
+  const calls = {
+    checkoutSessionsCreate: [] as any[],
+    subscriptionsUpdate: [] as any[],
+    subscriptionsCancel: [] as any[]
+  }
+
+  const member = opts.member === undefined ? DEFAULT_MEMBER : opts.member
+
+  const userClient = {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: member })
+        })
+      })
+    })
+  } as any
+
+  const admin = {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: opts.plan === undefined ? { stripe_price_id: 'price_1' } : opts.plan
+              })
+          })
+        })
+      })
+    })
+  } as any
+
+  const stripe = {
+    subscriptions: {
+      retrieve: () =>
+        Promise.resolve(
+          opts.subscription === undefined
+            ? {
+                status: 'active',
+                cancel_at_period_end: false,
+                items: { data: [{ id: 'si_1', current_period_end: 1700000000, price: null }] }
+              }
+            : opts.subscription
+        ),
+      update: (id: string, args: any) => {
+        calls.subscriptionsUpdate.push({ id, args })
+        return Promise.resolve({ id, ...args })
+      },
+      cancel: (id: string) => {
+        calls.subscriptionsCancel.push(id)
+        return Promise.resolve({ id, status: 'canceled' })
+      }
+    },
+    invoices: {
+      retrieveUpcoming: () =>
+        opts.upcoming === undefined
+          ? Promise.reject(new Error('no upcoming'))
+          : Promise.resolve(opts.upcoming),
+      list: () => Promise.resolve({ data: [] })
+    },
+    paymentMethods: {
+      list: () => Promise.resolve({ data: [] }),
+      detach: (id: string) => Promise.resolve({ id })
+    },
+    customers: {
+      retrieve: () => Promise.resolve({ deleted: false, invoice_settings: {} }),
+      update: (id: string, args: any) => Promise.resolve({ id, ...args })
+    },
+    checkout: {
+      sessions: {
+        create: (args: any) => {
+          calls.checkoutSessionsCreate.push(args)
+          return Promise.resolve({ client_secret: 'cs_secret_setup' })
+        }
+      }
+    }
+  } as any
+
+  const deps: Deps = {
+    stripe,
+    admin,
+    getUserClient: () => userClient,
+    getUser: () => Promise.resolve({ id: 'user_1' })
+  }
+
+  return { deps, calls }
+}
+
+function req(body: unknown, headers: Record<string, string> = { Authorization: 'Bearer x' }) {
+  return new Request('http://localhost/manage-subscription', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  })
+}
+
+Deno.test('returns 401 when no Authorization header is present', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req({ action: 'get-subscription' }, {}), deps)
+  assertEquals(res.status, 401)
+})
+
+Deno.test('returns 401 when getUser resolves null', async () => {
+  const { deps } = makeDeps()
+  deps.getUser = () => Promise.resolve(null)
+  const res = await handler(req({ action: 'get-subscription' }), deps)
+  assertEquals(res.status, 401)
+})
+
+Deno.test('returns 400 when action is missing', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req({}), deps)
+  assertEquals(res.status, 400)
+})
+
+Deno.test('returns 400 when the member has no Stripe customer', async () => {
+  const { deps } = makeDeps({ member: { stripe_customer_id: null, stripe_subscription_id: null } })
+  const res = await handler(req({ action: 'get-subscription' }), deps)
+  assertEquals(res.status, 400)
+  assertEquals(await res.text(), 'No Stripe customer for this member')
+})
+
+Deno.test('get-subscription returns null payload for a free member with no subscription', async () => {
+  const { deps } = makeDeps({
+    member: { stripe_customer_id: 'cus_1', stripe_subscription_id: null }
+  })
+  const res = await handler(req({ action: 'get-subscription' }), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(await res.json(), null)
+})
+
+Deno.test('get-subscription reads currentPeriodEnd off the subscription item, not the top-level object [regression]', async () => {
+  // Mirrors the real API-version-bump bug: top-level subscription has no
+  // current_period_end field at all (it moved to items.data[0]).
+  const { deps } = makeDeps({
+    subscription: {
+      status: 'active',
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            id: 'si_1',
+            current_period_end: 1798765432,
+            price: { unit_amount: 999, currency: 'usd', recurring: { interval: 'month' } }
+          }
+        ]
+      }
+      // intentionally no top-level current_period_end
+    }
+  })
+  const res = await handler(req({ action: 'get-subscription' }), deps)
+
+  assertEquals(res.status, 200)
+  const body = await res.json()
+  assertEquals(body.currentPeriodEnd, 1798765432)
+  assertEquals(body.priceCents, 999)
+  assertEquals(body.currency, 'usd')
+  assertEquals(body.interval, 'month')
+})
+
+Deno.test('get-subscription includes the upcoming invoice when one exists', async () => {
+  const { deps } = makeDeps({ upcoming: { amount_due: 500, currency: 'usd' } })
+  const res = await handler(req({ action: 'get-subscription' }), deps)
+
+  const body = await res.json()
+  assertEquals(body.upcoming, { amountCents: 500, currency: 'usd' })
+})
+
+Deno.test('get-subscription sets upcoming to null when retrieveUpcoming rejects', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req({ action: 'get-subscription' }), deps)
+
+  const body = await res.json()
+  assertEquals(body.upcoming, null)
+})
+
+Deno.test('create-setup-intent requires returnUrl', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req({ action: 'create-setup-intent' }), deps)
+  assertEquals(res.status, 400)
+  assertEquals(await res.text(), 'Missing returnUrl')
+})
+
+Deno.test('create-setup-intent calls checkout.sessions.create with mode setup, ui_mode elements', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(
+    req({ action: 'create-setup-intent', returnUrl: 'https://app.test' }),
+    deps
+  )
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.checkoutSessionsCreate.length, 1)
+  const args = calls.checkoutSessionsCreate[0]
+  assertEquals(args.mode, 'setup')
+  assertEquals(args.ui_mode, 'elements')
+  assertEquals(args.customer, 'cus_1')
+  assertEquals(args.return_url, 'https://app.test')
+  assertEquals(await res.json(), { clientSecret: 'cs_secret_setup' })
+})
+
+Deno.test('change-plan returns 400 when there is no active subscription', async () => {
+  const { deps } = makeDeps({
+    member: { stripe_customer_id: 'cus_1', stripe_subscription_id: null }
+  })
+  const res = await handler(req({ action: 'change-plan', planId: 'paid' }), deps)
+  assertEquals(res.status, 400)
+})
+
+Deno.test('change-plan updates the subscription item with proration always_invoice', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(req({ action: 'change-plan', planId: 'paid' }), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.subscriptionsUpdate.length, 1)
+  assertEquals(calls.subscriptionsUpdate[0].args.proration_behavior, 'always_invoice')
+})
+
+Deno.test('cancel with atPeriodEnd true updates cancel_at_period_end instead of canceling immediately', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(req({ action: 'cancel', atPeriodEnd: true }), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.subscriptionsUpdate.length, 1)
+  assertEquals(calls.subscriptionsUpdate[0].args, { cancel_at_period_end: true })
+  assertEquals(calls.subscriptionsCancel.length, 0)
+})
+
+Deno.test('cancel with atPeriodEnd false cancels the subscription immediately', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(req({ action: 'cancel', atPeriodEnd: false }), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.subscriptionsCancel, ['sub_1'])
+})
+
+Deno.test('resume clears cancel_at_period_end', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(req({ action: 'resume' }), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.subscriptionsUpdate[0].args, { cancel_at_period_end: false })
+})
+
+Deno.test('returns 500 with the Stripe error message when Stripe throws', async () => {
+  const { deps } = makeDeps()
+  deps.stripe.subscriptions.retrieve = () => Promise.reject(new Error('stripe down'))
+  const res = await handler(req({ action: 'get-subscription' }), deps)
+
+  assertEquals(res.status, 500)
+  assertEquals(await res.text(), 'stripe down')
+})
+
+Deno.test('returns 400 Unknown action for an unrecognized action', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req({ action: 'not-a-real-action' }), deps)
+  assertEquals(res.status, 400)
+  assertEquals(await res.text(), 'Unknown action')
+})
+
+Deno.test('responds 204 to OPTIONS preflight', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(
+    new Request('http://localhost/manage-subscription', { method: 'OPTIONS' }),
+    deps
+  )
+  assertEquals(res.status, 204)
+})

--- a/supabase/functions/manage-subscription/index.test.ts
+++ b/supabase/functions/manage-subscription/index.test.ts
@@ -66,7 +66,7 @@ function makeDeps(opts: FakeOpts = {}) {
       }
     },
     invoices: {
-      retrieveUpcoming: () =>
+      createPreview: () =>
         opts.upcoming === undefined
           ? Promise.reject(new Error('no upcoming'))
           : Promise.resolve(opts.upcoming),
@@ -181,7 +181,7 @@ Deno.test('get-subscription includes the upcoming invoice when one exists', asyn
   assertEquals(body.upcoming, { amountCents: 500, currency: 'usd' })
 })
 
-Deno.test('get-subscription sets upcoming to null when retrieveUpcoming rejects', async () => {
+Deno.test('get-subscription sets upcoming to null when createPreview rejects', async () => {
   const { deps } = makeDeps()
   const res = await handler(req({ action: 'get-subscription' }), deps)
 

--- a/supabase/functions/manage-subscription/index.ts
+++ b/supabase/functions/manage-subscription/index.ts
@@ -88,7 +88,7 @@ export async function handler(req: Request, deps: Deps): Promise<Response> {
 
         let upcoming = null
         try {
-          upcoming = await stripe.invoices.retrieveUpcoming({ customer: customerId })
+          upcoming = await stripe.invoices.createPreview({ customer: customerId })
         } catch {
           // No upcoming invoice (e.g. subscription canceled).
         }
@@ -147,12 +147,14 @@ export async function handler(req: Request, deps: Deps): Promise<Response> {
       case 'create-setup-intent': {
         if (!payload.returnUrl) return err('Missing returnUrl')
 
+        // ui_mode: 'elements' is a preview feature not yet in this SDK
+        // version's published types — see create-subscription/index.ts.
         const session = await stripe.checkout.sessions.create({
           mode: 'setup',
           ui_mode: 'elements',
           customer: customerId,
           return_url: payload.returnUrl
-        })
+        } as unknown as Stripe.Checkout.SessionCreateParams)
         return json({ clientSecret: session.client_secret })
       }
 
@@ -209,7 +211,8 @@ export async function handler(req: Request, deps: Deps): Promise<Response> {
 
 if (import.meta.main) {
   const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
-    apiVersion: '2026-03-25.dahlia',
+    // Preview version — not yet in this SDK's LatestApiVersion type.
+    apiVersion: '2026-03-25.dahlia' as Stripe.LatestApiVersion,
     httpClient: Stripe.createFetchHttpClient()
   })
 

--- a/supabase/functions/manage-subscription/index.ts
+++ b/supabase/functions/manage-subscription/index.ts
@@ -5,12 +5,7 @@
 // Plan changes use proration_behavior: 'always_invoice' — diff charged now.
 
 import Stripe from 'npm:stripe@20'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
-  apiVersion: '2026-03-25.dahlia',
-  httpClient: Stripe.createFetchHttpClient()
-})
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 const cors = {
   'Access-Control-Allow-Origin': '*',
@@ -28,6 +23,22 @@ type Payload =
   | { action: 'cancel'; atPeriodEnd: boolean }
   | { action: 'resume' }
 
+export type StripeLike = Pick<
+  Stripe,
+  'subscriptions' | 'invoices' | 'paymentMethods' | 'customers' | 'checkout'
+>
+
+export type AuthedUser = { id: string }
+
+export type Deps = {
+  stripe: StripeLike
+  // Resolves the Authorization header to the caller, or null if invalid.
+  getUser: (authHeader: string) => Promise<AuthedUser | null>
+  // Caller-scoped client (RLS applies) to read the member's Stripe ids.
+  getUserClient: (authHeader: string) => SupabaseClient
+  admin: SupabaseClient
+}
+
 function json(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
@@ -39,28 +50,20 @@ function err(message: string, status = 400) {
   return new Response(message, { status, headers: cors })
 }
 
-Deno.serve(async (req) => {
+export async function handler(req: Request, deps: Deps): Promise<Response> {
   if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors })
   if (req.method !== 'POST') return err('Method Not Allowed', 405)
 
   const authHeader = req.headers.get('Authorization')
   if (!authHeader) return err('Unauthorized', 401)
 
-  const userClient = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_ANON_KEY')!,
-    { global: { headers: { Authorization: authHeader } } }
-  )
-
-  const {
-    data: { user },
-    error: authError
-  } = await userClient.auth.getUser()
-  if (authError || !user) return err('Unauthorized', 401)
+  const user = await deps.getUser(authHeader)
+  if (!user) return err('Unauthorized', 401)
 
   const payload = (await req.json().catch(() => null)) as Payload | null
   if (!payload?.action) return err('Missing action')
 
+  const userClient = deps.getUserClient(authHeader)
   const { data: member } = await userClient
     .from('members')
     .select('stripe_customer_id, stripe_subscription_id')
@@ -69,6 +72,8 @@ Deno.serve(async (req) => {
 
   const customerId = member?.stripe_customer_id
   if (!customerId) return err('No Stripe customer for this member')
+
+  const { stripe, admin } = deps
 
   try {
     switch (payload.action) {
@@ -91,6 +96,9 @@ Deno.serve(async (req) => {
         // Normalize Stripe's nested shape into the flat domain DTO the pill
         // needs. Money stays in minor units, the date stays a UNIX second —
         // the FE owns locale-specific currency/date formatting.
+        //
+        // current_period_end moved off the top-level Subscription object onto
+        // each subscription item as of API version 2026-03-25.dahlia.
         const item = subscription.items.data[0]
         const price = item?.price
         return json({
@@ -137,6 +145,8 @@ Deno.serve(async (req) => {
       }
 
       case 'create-setup-intent': {
+        if (!payload.returnUrl) return err('Missing returnUrl')
+
         const session = await stripe.checkout.sessions.create({
           mode: 'setup',
           ui_mode: 'elements',
@@ -149,10 +159,6 @@ Deno.serve(async (req) => {
       case 'change-plan': {
         if (!member?.stripe_subscription_id) return err('No active subscription')
 
-        const admin = createClient(
-          Deno.env.get('SUPABASE_URL')!,
-          Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-        )
         const { data: plan } = await admin
           .from('plans')
           .select('stripe_price_id')
@@ -199,4 +205,39 @@ Deno.serve(async (req) => {
     console.error(e)
     return err(e instanceof Error ? e.message : 'Stripe error', 500)
   }
-})
+}
+
+if (import.meta.main) {
+  const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
+    apiVersion: '2026-03-25.dahlia',
+    httpClient: Stripe.createFetchHttpClient()
+  })
+
+  const admin = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  )
+
+  Deno.serve((req) =>
+    handler(req, {
+      stripe,
+      admin,
+      getUserClient: (authHeader) =>
+        createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_ANON_KEY')!, {
+          global: { headers: { Authorization: authHeader } }
+        }),
+      getUser: async (authHeader) => {
+        const userClient = createClient(
+          Deno.env.get('SUPABASE_URL')!,
+          Deno.env.get('SUPABASE_ANON_KEY')!,
+          { global: { headers: { Authorization: authHeader } } }
+        )
+        const {
+          data: { user },
+          error: authError
+        } = await userClient.auth.getUser()
+        return authError || !user ? null : user
+      }
+    })
+  )
+}

--- a/supabase/functions/manage-subscription/index.ts
+++ b/supabase/functions/manage-subscription/index.ts
@@ -8,7 +8,7 @@ import Stripe from 'npm:stripe@20'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
-  apiVersion: '2024-06-20',
+  apiVersion: '2026-03-25.dahlia',
   httpClient: Stripe.createFetchHttpClient()
 })
 
@@ -23,7 +23,7 @@ type Payload =
   | { action: 'list-payment-methods' }
   | { action: 'set-default-payment-method'; paymentMethodId: string }
   | { action: 'detach-payment-method'; paymentMethodId: string }
-  | { action: 'create-setup-intent' }
+  | { action: 'create-setup-intent'; returnUrl: string }
   | { action: 'change-plan'; planId: string }
   | { action: 'cancel'; atPeriodEnd: boolean }
   | { action: 'resume' }
@@ -91,13 +91,14 @@ Deno.serve(async (req) => {
         // Normalize Stripe's nested shape into the flat domain DTO the pill
         // needs. Money stays in minor units, the date stays a UNIX second —
         // the FE owns locale-specific currency/date formatting.
-        const price = subscription.items.data[0]?.price
+        const item = subscription.items.data[0]
+        const price = item?.price
         return json({
           priceCents: price?.unit_amount ?? null,
           currency: price?.currency ?? null,
           interval: price?.recurring?.interval ?? null,
           status: subscription.status,
-          currentPeriodEnd: subscription.current_period_end,
+          currentPeriodEnd: item?.current_period_end ?? null,
           cancelAtPeriodEnd: subscription.cancel_at_period_end,
           upcoming: upcoming
             ? { amountCents: upcoming.amount_due, currency: upcoming.currency }
@@ -136,12 +137,13 @@ Deno.serve(async (req) => {
       }
 
       case 'create-setup-intent': {
-        const intent = await stripe.setupIntents.create({
+        const session = await stripe.checkout.sessions.create({
+          mode: 'setup',
+          ui_mode: 'elements',
           customer: customerId,
-          usage: 'off_session',
-          payment_method_types: ['card']
+          return_url: payload.returnUrl
         })
-        return json({ clientSecret: intent.client_secret })
+        return json({ clientSecret: session.client_secret })
       }
 
       case 'change-plan': {

--- a/tests/integration/components/modals/checkout.test.js
+++ b/tests/integration/components/modals/checkout.test.js
@@ -7,26 +7,23 @@ import { defineComponent, h, useAttrs } from 'vue'
 const {
   mockCreateSubscription,
   mockInvalidateQueries,
-  mockConfirmPayment,
+  mockLoadActions,
+  mockConfirm,
   mockElementMount,
   mockElementDestroy,
   elementHandlers,
-  mockLoadStripe,
-  stripeInstance
+  mockLoadStripe
 } = vi.hoisted(() => {
   const handlers = new Map()
   return {
-    mockCreateSubscription: vi.fn().mockResolvedValue({
-      clientSecret: 'pi_secret_x',
-      subscriptionId: 'sub_1'
-    }),
+    mockCreateSubscription: vi.fn().mockResolvedValue({ clientSecret: 'cs_secret_x' }),
     mockInvalidateQueries: vi.fn(),
-    mockConfirmPayment: vi.fn(),
+    mockLoadActions: vi.fn(),
+    mockConfirm: vi.fn(),
     mockElementMount: vi.fn(),
     mockElementDestroy: vi.fn(),
     elementHandlers: handlers,
-    mockLoadStripe: vi.fn(),
-    stripeInstance: null
+    mockLoadStripe: vi.fn()
   }
 })
 
@@ -53,9 +50,17 @@ vi.mock('@/utils/logger', () => ({
 const MobileSheetStub = defineComponent({
   name: 'MobileSheet',
   emits: ['close'],
-  setup(_props, { slots }) {
+  setup(_props, { slots, emit }) {
     return () =>
-      h('div', { 'data-testid': 'mobile-sheet-stub' }, [slots.default?.(), slots.footer?.()])
+      h('div', { 'data-testid': 'mobile-sheet-stub' }, [
+        slots.default?.(),
+        slots.footer?.(),
+        h(
+          'button',
+          { 'data-testid': 'mobile-sheet-stub__close', onClick: () => emit('close') },
+          'close'
+        )
+      ])
   }
 })
 
@@ -69,7 +74,7 @@ const UiButtonStub = defineComponent({
   }
 })
 
-// ── Fake Stripe SDK (configurable per test) ────────────────────────────────────
+// ── Fake Stripe Checkout Elements SDK (configurable per test) ──────────────────
 
 function makeStripe() {
   const fakePaymentElement = {
@@ -77,12 +82,12 @@ function makeStripe() {
     mount: mockElementMount,
     destroy: mockElementDestroy
   }
-  const fakeElements = {
-    create: vi.fn(() => fakePaymentElement)
+  const fakeCheckout = {
+    createPaymentElement: vi.fn(() => fakePaymentElement),
+    loadActions: mockLoadActions
   }
   return {
-    elements: vi.fn(() => fakeElements),
-    confirmPayment: mockConfirmPayment
+    initCheckoutElementsSdk: vi.fn(() => fakeCheckout)
   }
 }
 
@@ -112,12 +117,11 @@ function fireReady() {
 
 beforeEach(() => {
   mockCreateSubscription.mockReset()
-  mockCreateSubscription.mockResolvedValue({
-    clientSecret: 'pi_secret_x',
-    subscriptionId: 'sub_1'
-  })
+  mockCreateSubscription.mockResolvedValue({ clientSecret: 'cs_secret_x' })
   mockInvalidateQueries.mockReset()
-  mockConfirmPayment.mockReset()
+  mockLoadActions.mockReset()
+  mockLoadActions.mockResolvedValue({ type: 'success', actions: { confirm: mockConfirm } })
+  mockConfirm.mockReset()
   mockElementMount.mockReset()
   mockElementDestroy.mockReset()
   elementHandlers.clear()
@@ -142,6 +146,16 @@ describe('checkout modal', () => {
 
     resolveStripe(makeStripe())
     await flushPromises()
+  })
+
+  test('[obligation] requests the Checkout Session with planId "paid" and returnUrl = window.location.origin', async () => {
+    await makeCheckout()
+    await flushPromises()
+
+    expect(mockCreateSubscription).toHaveBeenCalledWith({
+      planId: 'paid',
+      returnUrl: window.location.origin
+    })
   })
 
   test('mounts the Payment Element once Stripe resolves', async () => {
@@ -182,9 +196,10 @@ describe('checkout modal', () => {
     expect(wrapper.find('[data-testid="checkout__error"]').exists()).toBe(true)
   })
 
-  test('on successful payment, invalidates member cache and closes the modal', async () => {
-    mockConfirmPayment.mockResolvedValue({
-      paymentIntent: { status: 'succeeded' }
+  test('on successful confirm, invalidates member cache and closes the modal', async () => {
+    mockConfirm.mockResolvedValue({
+      type: 'success',
+      session: { status: { type: 'complete' } }
     })
     const { wrapper, close } = await makeCheckout()
     await flushPromises()
@@ -198,8 +213,27 @@ describe('checkout modal', () => {
     expect(close).toHaveBeenCalledWith({ upgraded: true })
   })
 
-  test('shows the submit error when confirmPayment returns an error', async () => {
-    mockConfirmPayment.mockResolvedValue({
+  test('[obligation] confirm() is called with only { redirect: "if_required" } — no returnUrl', async () => {
+    mockConfirm.mockResolvedValue({
+      type: 'success',
+      session: { status: { type: 'complete' } }
+    })
+    const { wrapper } = await makeCheckout()
+    await flushPromises()
+    fireReady()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="checkout__submit"]').trigger('click')
+    await flushPromises()
+
+    expect(mockConfirm).toHaveBeenCalledWith({ redirect: 'if_required' })
+    const [args] = mockConfirm.mock.calls[0]
+    expect('returnUrl' in args).toBe(false)
+  })
+
+  test('shows the submit error when confirm() returns an error', async () => {
+    mockConfirm.mockResolvedValue({
+      type: 'error',
       error: { message: 'Your card was declined.' }
     })
     const { wrapper, close } = await makeCheckout()
@@ -216,9 +250,24 @@ describe('checkout modal', () => {
     expect(close).not.toHaveBeenCalled()
   })
 
-  test('falls back to a generic submit error when paymentIntent status is non-success', async () => {
-    mockConfirmPayment.mockResolvedValue({
-      paymentIntent: { status: 'requires_action' }
+  test('shows the submit error when loadActions() returns an error', async () => {
+    mockLoadActions.mockResolvedValue({ type: 'error', error: { message: 'Could not load.' } })
+    const { wrapper, close } = await makeCheckout()
+    await flushPromises()
+    fireReady()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="checkout__submit"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="checkout__submit-error"]').text()).toBe('Could not load.')
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  test('[obligation] treats a success-typed result with a non-complete session as an error, not success', async () => {
+    mockConfirm.mockResolvedValue({
+      type: 'success',
+      session: { status: { type: 'open' } }
     })
     const { wrapper, close } = await makeCheckout()
     await flushPromises()
@@ -238,5 +287,14 @@ describe('checkout modal', () => {
 
     wrapper.unmount()
     expect(mockElementDestroy).toHaveBeenCalledTimes(1)
+  })
+
+  test('emitting close from mobile-sheet calls close() with no argument', async () => {
+    const { wrapper, close } = await makeCheckout()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="mobile-sheet-stub__close"]').trigger('click')
+
+    expect(close).toHaveBeenCalledWith()
   })
 })

--- a/tests/integration/phone/apps/settings/component/tab-subscription/add-credit-card-modal.test.js
+++ b/tests/integration/phone/apps/settings/component/tab-subscription/add-credit-card-modal.test.js
@@ -5,7 +5,8 @@ import { defineComponent, h, useAttrs } from 'vue'
 const {
   mockCreateSetupIntent,
   mockInvalidateQueries,
-  mockConfirmSetup,
+  mockLoadActions,
+  mockConfirm,
   mockElementMount,
   mockElementDestroy,
   elementHandlers,
@@ -13,7 +14,8 @@ const {
 } = vi.hoisted(() => ({
   mockCreateSetupIntent: vi.fn(),
   mockInvalidateQueries: vi.fn(),
-  mockConfirmSetup: vi.fn(),
+  mockLoadActions: vi.fn(),
+  mockConfirm: vi.fn(),
   mockElementMount: vi.fn(),
   mockElementDestroy: vi.fn(),
   elementHandlers: new Map(),
@@ -65,11 +67,11 @@ function makeStripe() {
     mount: mockElementMount,
     destroy: mockElementDestroy
   }
-  const fakeElements = { create: vi.fn(() => fakePaymentElement) }
-  return {
-    elements: vi.fn(() => fakeElements),
-    confirmSetup: mockConfirmSetup
+  const fakeCheckout = {
+    createPaymentElement: vi.fn(() => fakePaymentElement),
+    loadActions: mockLoadActions
   }
+  return { initCheckoutElementsSdk: vi.fn(() => fakeCheckout) }
 }
 
 async function makeAddCreditCardModal({ close = vi.fn() } = {}) {
@@ -95,9 +97,11 @@ function fireReady() {
 
 beforeEach(() => {
   mockCreateSetupIntent.mockReset()
-  mockCreateSetupIntent.mockResolvedValue({ clientSecret: 'seti_secret_x' })
+  mockCreateSetupIntent.mockResolvedValue({ clientSecret: 'cs_secret_x' })
   mockInvalidateQueries.mockReset()
-  mockConfirmSetup.mockReset()
+  mockLoadActions.mockReset()
+  mockLoadActions.mockResolvedValue({ type: 'success', actions: { confirm: mockConfirm } })
+  mockConfirm.mockReset()
   mockElementMount.mockReset()
   mockElementDestroy.mockReset()
   elementHandlers.clear()
@@ -120,7 +124,14 @@ describe('add-credit-card-modal — load states', () => {
     await flushPromises()
   })
 
-  test('mounts the Payment Element once SetupIntent + Stripe resolve', async () => {
+  test('[obligation] requests the setup-intent Checkout Session with returnUrl = window.location.origin', async () => {
+    await makeAddCreditCardModal()
+    await flushPromises()
+
+    expect(mockCreateSetupIntent).toHaveBeenCalledWith(window.location.origin)
+  })
+
+  test('mounts the Payment Element once the Checkout Session + Stripe resolve', async () => {
     const { wrapper } = await makeAddCreditCardModal()
     await flushPromises()
     expect(wrapper.find('[data-testid="add-credit-card-modal__payment-element"]').exists()).toBe(
@@ -158,9 +169,10 @@ describe('add-credit-card-modal — load states', () => {
 })
 
 describe('add-credit-card-modal — submit', () => {
-  test('on succeeded SetupIntent with string payment_method, closes with paymentMethodId string [obligation]', async () => {
-    mockConfirmSetup.mockResolvedValue({
-      setupIntent: { status: 'succeeded', payment_method: 'pm_abc123' }
+  test('[obligation] on a saved payment method, closes with the first saved payment method id', async () => {
+    mockConfirm.mockResolvedValue({
+      type: 'success',
+      session: { status: { type: 'complete' }, savedPaymentMethods: [{ id: 'pm_abc123' }] }
     })
     const { wrapper, close } = await makeAddCreditCardModal()
     await flushPromises()
@@ -174,27 +186,10 @@ describe('add-credit-card-modal — submit', () => {
     expect(close).toHaveBeenCalledWith({ added: true, paymentMethodId: 'pm_abc123' })
   })
 
-  test('on succeeded SetupIntent with PM-object payment_method, extracts id [obligation]', async () => {
-    mockConfirmSetup.mockResolvedValue({
-      setupIntent: {
-        status: 'succeeded',
-        payment_method: { id: 'pm_obj456', object: 'payment_method' }
-      }
-    })
-    const { wrapper, close } = await makeAddCreditCardModal()
-    await flushPromises()
-    fireReady()
-    await flushPromises()
-
-    await wrapper.find('[data-testid="add-credit-card-modal__submit"]').trigger('click')
-    await flushPromises()
-
-    expect(close).toHaveBeenCalledWith({ added: true, paymentMethodId: 'pm_obj456' })
-  })
-
-  test('on succeeded SetupIntent with null payment_method, closes with paymentMethodId null [obligation]', async () => {
-    mockConfirmSetup.mockResolvedValue({
-      setupIntent: { status: 'succeeded', payment_method: null }
+  test('[obligation] closes with paymentMethodId null when savedPaymentMethods is empty', async () => {
+    mockConfirm.mockResolvedValue({
+      type: 'success',
+      session: { status: { type: 'complete' }, savedPaymentMethods: [] }
     })
     const { wrapper, close } = await makeAddCreditCardModal()
     await flushPromises()
@@ -207,8 +202,42 @@ describe('add-credit-card-modal — submit', () => {
     expect(close).toHaveBeenCalledWith({ added: true, paymentMethodId: null })
   })
 
-  test('shows the submit error when confirmSetup returns an error', async () => {
-    mockConfirmSetup.mockResolvedValue({ error: { message: 'Your card was declined.' } })
+  test('[obligation] closes with paymentMethodId null when savedPaymentMethods is absent', async () => {
+    mockConfirm.mockResolvedValue({
+      type: 'success',
+      session: { status: { type: 'complete' } }
+    })
+    const { wrapper, close } = await makeAddCreditCardModal()
+    await flushPromises()
+    fireReady()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="add-credit-card-modal__submit"]').trigger('click')
+    await flushPromises()
+
+    expect(close).toHaveBeenCalledWith({ added: true, paymentMethodId: null })
+  })
+
+  test('confirm() is called with only { redirect: "if_required" } — no returnUrl', async () => {
+    mockConfirm.mockResolvedValue({
+      type: 'success',
+      session: { status: { type: 'complete' }, savedPaymentMethods: [] }
+    })
+    const { wrapper } = await makeAddCreditCardModal()
+    await flushPromises()
+    fireReady()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="add-credit-card-modal__submit"]').trigger('click')
+    await flushPromises()
+
+    expect(mockConfirm).toHaveBeenCalledWith({ redirect: 'if_required' })
+    const [args] = mockConfirm.mock.calls[0]
+    expect('returnUrl' in args).toBe(false)
+  })
+
+  test('shows the submit error when confirm() returns an error', async () => {
+    mockConfirm.mockResolvedValue({ type: 'error', error: { message: 'Your card was declined.' } })
     const { wrapper, close } = await makeAddCreditCardModal()
     await flushPromises()
     fireReady()
@@ -223,8 +252,8 @@ describe('add-credit-card-modal — submit', () => {
     expect(close).not.toHaveBeenCalled()
   })
 
-  test('falls back to a generic submit error when setupIntent status is non-success', async () => {
-    mockConfirmSetup.mockResolvedValue({ setupIntent: { status: 'requires_action' } })
+  test('falls back to a generic submit error when the session is not complete', async () => {
+    mockConfirm.mockResolvedValue({ type: 'success', session: { status: { type: 'open' } } })
     const { wrapper, close } = await makeAddCreditCardModal()
     await flushPromises()
     fireReady()

--- a/tests/unit/api/billing/db.test.js
+++ b/tests/unit/api/billing/db.test.js
@@ -30,27 +30,31 @@ beforeEach(() => {
 })
 
 describe('createSubscription', () => {
-  test('invokes create-subscription edge function with the planId body', async () => {
+  test('invokes create-subscription edge function with the planId + returnUrl body', async () => {
     mocks.invokeMock.mockResolvedValueOnce({
-      data: { clientSecret: 'pi_x', subscriptionId: 'sub_1' },
+      data: { clientSecret: 'cs_x' },
       error: null
     })
-    const result = await createSubscription({ planId: 'paid' })
+    const result = await createSubscription({ planId: 'paid', returnUrl: 'https://app.test' })
     expect(mocks.invokeMock).toHaveBeenCalledWith('create-subscription', {
-      body: { planId: 'paid' }
+      body: { planId: 'paid', returnUrl: 'https://app.test' }
     })
-    expect(result).toEqual({ clientSecret: 'pi_x', subscriptionId: 'sub_1' })
+    expect(result).toEqual({ clientSecret: 'cs_x' })
   })
 
   test('throws when the function returns no clientSecret', async () => {
     mocks.invokeMock.mockResolvedValueOnce({ data: {}, error: null })
-    await expect(createSubscription({ planId: 'paid' })).rejects.toThrow()
+    await expect(
+      createSubscription({ planId: 'paid', returnUrl: 'https://app.test' })
+    ).rejects.toThrow()
   })
 
   test('throws when the edge function returns an error', async () => {
     const err = new Error('boom')
     mocks.invokeMock.mockResolvedValueOnce({ data: null, error: err })
-    await expect(createSubscription({ planId: 'paid' })).rejects.toBe(err)
+    await expect(
+      createSubscription({ planId: 'paid', returnUrl: 'https://app.test' })
+    ).rejects.toBe(err)
   })
 })
 
@@ -106,10 +110,10 @@ describe('manage-subscription wrappers', () => {
     })
   })
 
-  test('createSetupIntent dispatches with action=create-setup-intent', async () => {
-    await createSetupIntent()
+  test('createSetupIntent dispatches with action=create-setup-intent and the returnUrl', async () => {
+    await createSetupIntent('https://app.test')
     expect(mocks.invokeMock).toHaveBeenCalledWith('manage-subscription', {
-      body: { action: 'create-setup-intent' }
+      body: { action: 'create-setup-intent', returnUrl: 'https://app.test' }
     })
   })
 

--- a/tests/unit/api/billing/mutations.test.js
+++ b/tests/unit/api/billing/mutations.test.js
@@ -5,8 +5,7 @@ const { useMutationSpy, useQueryCacheSpy, createSubscriptionMock, manageMocks } 
     useMutationSpy: vi.fn((cfg) => cfg),
     useQueryCacheSpy: vi.fn(() => ({ invalidateQueries: vi.fn() })),
     createSubscriptionMock: vi.fn().mockResolvedValue({
-      clientSecret: 'pi_secret_x',
-      subscriptionId: 'sub_1'
+      clientSecret: 'cs_secret_x'
     }),
     manageMocks: {
       changePlan: vi.fn().mockResolvedValue({ subscription: { id: 'sub_1' } }),
@@ -49,16 +48,19 @@ function configFrom(hook) {
 }
 
 describe('useCreateSubscriptionMutation', () => {
-  test('delegates to createSubscription with the caller args', async () => {
+  test('delegates to createSubscription with the caller args, including returnUrl', async () => {
     const { mutation } = configFrom(useCreateSubscriptionMutation)
-    await mutation({ planId: 'paid' })
-    expect(createSubscriptionMock).toHaveBeenCalledWith({ planId: 'paid' })
+    await mutation({ planId: 'paid', returnUrl: 'https://app.test' })
+    expect(createSubscriptionMock).toHaveBeenCalledWith({
+      planId: 'paid',
+      returnUrl: 'https://app.test'
+    })
   })
 
   test('returns whatever createSubscription resolved with', async () => {
     const { mutation } = configFrom(useCreateSubscriptionMutation)
-    const result = await mutation({ planId: 'paid' })
-    expect(result).toEqual({ clientSecret: 'pi_secret_x', subscriptionId: 'sub_1' })
+    const result = await mutation({ planId: 'paid', returnUrl: 'https://app.test' })
+    expect(result).toEqual({ clientSecret: 'cs_secret_x' })
   })
 })
 
@@ -103,9 +105,19 @@ describe('useDetachPaymentMethodMutation', () => {
 })
 
 describe('useCreateSetupIntentMutation', () => {
-  test('delegates to createSetupIntent', async () => {
+  test('delegates to createSetupIntent with the returnUrl', async () => {
     const { mutation } = configFrom(useCreateSetupIntentMutation)
-    await mutation()
-    expect(manageMocks.createSetupIntent).toHaveBeenCalled()
+    await mutation('https://app.test')
+    expect(manageMocks.createSetupIntent).toHaveBeenCalledWith('https://app.test')
+  })
+
+  test('onSettled invalidates the payment-methods query', () => {
+    const invalidateQueries = vi.fn()
+    useQueryCacheSpy.mockReturnValueOnce({ invalidateQueries })
+    const { onSettled } = configFrom(useCreateSetupIntentMutation)
+
+    onSettled()
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ key: ['billing', 'payment-methods'] })
   })
 })

--- a/tests/unit/composables/billing/use-checkout-elements.test.js
+++ b/tests/unit/composables/billing/use-checkout-elements.test.js
@@ -1,0 +1,252 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { createApp, h } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+const { mockLoadStripe } = vi.hoisted(() => ({ mockLoadStripe: vi.fn() }))
+
+vi.mock('@stripe/stripe-js', () => ({ loadStripe: mockLoadStripe }))
+vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
+
+import { useCheckoutElements } from '@/composables/billing/use-checkout-elements'
+
+let app
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+})
+
+// useTemplateRef needs a real render tree with a matching `ref` element, so
+// mount a host component instead of calling the composable bare.
+function withSetup(options) {
+  let result
+  app = createApp({
+    setup() {
+      result = useCheckoutElements(options)
+      return () => h('div', { ref: 'container' })
+    }
+  })
+  app.mount(document.createElement('div'))
+  return result
+}
+
+function makePaymentElement() {
+  const handlers = new Map()
+  return {
+    on: vi.fn((event, handler) => handlers.set(event, handler)),
+    mount: vi.fn(),
+    destroy: vi.fn(),
+    fireReady: () => handlers.get('ready')?.()
+  }
+}
+
+function makeCheckoutSdk({ paymentElement = makePaymentElement(), loadActions } = {}) {
+  return {
+    createPaymentElement: vi.fn(() => paymentElement),
+    loadActions: loadActions ?? vi.fn()
+  }
+}
+
+function makeStripe({ checkout = makeCheckoutSdk() } = {}) {
+  return { initCheckoutElementsSdk: vi.fn(() => checkout) }
+}
+
+function baseOptions(overrides = {}) {
+  return {
+    publicKey: 'pk_test_x',
+    genericErrorMessage: 'Something went wrong.',
+    getClientSecret: vi.fn().mockResolvedValue('cs_secret_x'),
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  mockLoadStripe.mockReset()
+})
+
+describe('useCheckoutElements — mount lifecycle', () => {
+  test('loads Stripe.js + the client secret in parallel, mounts the Payment Element, flips is_ready', async () => {
+    const paymentElement = makePaymentElement()
+    const checkout = makeCheckoutSdk({ paymentElement })
+    const stripe = makeStripe({ checkout })
+    mockLoadStripe.mockResolvedValue(stripe)
+
+    const result = withSetup(baseOptions())
+    expect(result.is_loading.value).toBe(true)
+    await flushPromises()
+
+    expect(result.is_loading.value).toBe(false)
+    expect(result.load_error.value).toBe(false)
+    expect(paymentElement.mount).toHaveBeenCalledTimes(1)
+    expect(result.is_ready.value).toBe(false)
+
+    paymentElement.fireReady()
+    expect(result.is_ready.value).toBe(true)
+  })
+
+  test('initCheckoutElementsSdk is called with the resolved client secret', async () => {
+    const stripe = makeStripe()
+    mockLoadStripe.mockResolvedValue(stripe)
+    const getClientSecret = vi.fn().mockResolvedValue('cs_specific')
+
+    withSetup(baseOptions({ getClientSecret }))
+    await flushPromises()
+
+    expect(stripe.initCheckoutElementsSdk).toHaveBeenCalledWith(
+      expect.objectContaining({ clientSecret: 'cs_specific' })
+    )
+  })
+
+  test('sets load_error when Stripe.js fails to load (resolves null)', async () => {
+    mockLoadStripe.mockResolvedValue(null)
+
+    const result = withSetup(baseOptions())
+    await flushPromises()
+
+    expect(result.load_error.value).toBe(true)
+    expect(result.is_loading.value).toBe(false)
+  })
+
+  test('sets load_error when getClientSecret rejects', async () => {
+    mockLoadStripe.mockResolvedValue(makeStripe())
+
+    const result = withSetup(
+      baseOptions({ getClientSecret: vi.fn().mockRejectedValue(new Error('network down')) })
+    )
+    await flushPromises()
+
+    expect(result.load_error.value).toBe(true)
+  })
+
+  test('destroys the Payment Element on unmount', async () => {
+    const paymentElement = makePaymentElement()
+    mockLoadStripe.mockResolvedValue(makeStripe({ checkout: makeCheckoutSdk({ paymentElement }) }))
+
+    withSetup(baseOptions())
+    await flushPromises()
+
+    app.unmount()
+    expect(paymentElement.destroy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useCheckoutElements — confirm()', () => {
+  async function setupReady({ loadActions } = {}) {
+    const checkout = makeCheckoutSdk({ loadActions })
+    mockLoadStripe.mockResolvedValue(makeStripe({ checkout }))
+    const result = withSetup(baseOptions())
+    await flushPromises()
+    return { result, checkout }
+  }
+
+  test('[obligation] calls actions.confirm() with only { redirect: "if_required" } — no returnUrl', async () => {
+    const confirmSpy = vi.fn().mockResolvedValue({
+      type: 'success',
+      session: { status: { type: 'complete' } }
+    })
+    const loadActions = vi
+      .fn()
+      .mockResolvedValue({ type: 'success', actions: { confirm: confirmSpy } })
+    const { result } = await setupReady({ loadActions })
+
+    await result.confirm()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(confirmSpy).toHaveBeenCalledWith({ redirect: 'if_required' })
+    const [args] = confirmSpy.mock.calls[0]
+    expect('returnUrl' in args).toBe(false)
+  })
+
+  test('[obligation] does not leave is_submitting stuck when actions.confirm() throws an IntegrationError', async () => {
+    const confirmSpy = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          'You cannot provide `returnUrl` to confirm() when `return_url` was already provided when creating the Checkout Session.'
+        )
+      )
+    const loadActions = vi
+      .fn()
+      .mockResolvedValue({ type: 'success', actions: { confirm: confirmSpy } })
+    const { result } = await setupReady({ loadActions })
+
+    await result.confirm().catch(() => {})
+
+    expect(result.is_submitting.value).toBe(false)
+  })
+
+  test('returns success when confirm resolves a complete session', async () => {
+    const session = { status: { type: 'complete' }, savedPaymentMethods: [] }
+    const loadActions = vi.fn().mockResolvedValue({
+      type: 'success',
+      actions: { confirm: vi.fn().mockResolvedValue({ type: 'success', session }) }
+    })
+    const { result } = await setupReady({ loadActions })
+
+    const outcome = await result.confirm()
+
+    expect(outcome).toEqual({ status: 'success', session })
+    expect(result.is_submitting.value).toBe(false)
+  })
+
+  test('treats a success-typed result with a non-complete session as an error', async () => {
+    const session = { status: { type: 'open' } }
+    const loadActions = vi.fn().mockResolvedValue({
+      type: 'success',
+      actions: { confirm: vi.fn().mockResolvedValue({ type: 'success', session }) }
+    })
+    const { result } = await setupReady({ loadActions })
+
+    const outcome = await result.confirm()
+
+    expect(outcome).toEqual({ status: 'error', message: 'Something went wrong.' })
+    expect(result.submit_error.value).toBe('Something went wrong.')
+  })
+
+  test('surfaces the error and resets is_submitting when loadActions() returns type error', async () => {
+    const loadActions = vi.fn().mockResolvedValue({
+      type: 'error',
+      error: { message: 'Could not load actions.' }
+    })
+    const { result } = await setupReady({ loadActions })
+
+    const outcome = await result.confirm()
+
+    expect(outcome).toEqual({ status: 'error', message: 'Could not load actions.' })
+    expect(result.is_submitting.value).toBe(false)
+    expect(result.submit_error.value).toBe('Could not load actions.')
+  })
+
+  test('surfaces the error and resets is_submitting when actions.confirm() returns type error', async () => {
+    const loadActions = vi.fn().mockResolvedValue({
+      type: 'success',
+      actions: {
+        confirm: vi.fn().mockResolvedValue({ type: 'error', error: { message: 'Card declined.' } })
+      }
+    })
+    const { result } = await setupReady({ loadActions })
+
+    const outcome = await result.confirm()
+
+    expect(outcome).toEqual({ status: 'error', message: 'Card declined.' })
+    expect(result.is_submitting.value).toBe(false)
+  })
+
+  test('falls back to the generic error message when the SDK error has no message', async () => {
+    const loadActions = vi.fn().mockResolvedValue({ type: 'error', error: {} })
+    const { result } = await setupReady({ loadActions })
+
+    const outcome = await result.confirm()
+
+    expect(outcome).toEqual({ status: 'error', message: 'Something went wrong.' })
+  })
+
+  test('returns a generic error immediately when called before the Checkout SDK has initialized', async () => {
+    mockLoadStripe.mockReturnValue(new Promise(() => {})) // never resolves
+    const result = withSetup(baseOptions())
+
+    const outcome = await result.confirm()
+
+    expect(outcome).toEqual({ status: 'error', message: 'Something went wrong.' })
+  })
+})


### PR DESCRIPTION
## Summary

Migrates the subscription checkout and add-credit-card flows from manually-created PaymentIntent/SetupIntent objects to Stripe's embedded Checkout Sessions API (`ui_mode: 'elements'`), per Stripe's deprecation warning on the old integration. The Payment Element still mounts in-app — no redirect to Stripe-hosted Checkout.

## Changes

- `create-subscription` and `manage-subscription`'s `create-setup-intent` action now create Checkout Sessions instead of a raw Subscription/SetupIntent.
- Bumps the pinned Stripe API version to support `ui_mode: 'elements'`, which also moved `current_period_end` off the Subscription object onto each subscription item — fixed the `get-subscription` read site accordingly.
- Extracts the shared Checkout Elements mount/confirm lifecycle into `use-checkout-elements`, used by both `checkout.vue` and `add-credit-card-modal.vue`.
- Fixes a live bug found during manual testing: `confirm()` was passing `returnUrl` a second time even though it's already set on the Checkout Session at creation, which Stripe rejects — left the subscribe button spinning forever. Also hardens `confirm()` against any other unhandled throw doing the same.
- Refactors `create-subscription` and `manage-subscription` to export a pure `handler(deps)` (matching the project's documented edge-function testing convention) so Stripe/Supabase clients can be injected as fakes in tests.
- Adds test coverage for the new Checkout Session flows, the `returnUrl` regression, and the `current_period_end` migration.

## Test plan

- [x] Manually subscribed with a test card through the live UI — confirmed the fix for the infinite-spinner bug.
- [x] Full Vitest suite green (340 files / 4702 tests).
- [x] Deno edge-function tests green (31 tests).
- [ ] Manually exercise the add-credit-card flow through the UI (not yet click-tested this branch).