### PR TITLE
Fix study-session review-flow bugs

### DIFF
--- a/src/components/study-session/composables/card-edit.ts
+++ b/src/components/study-session/composables/card-edit.ts
@@ -5,13 +5,17 @@ import type { StudyCard } from './session-core'
 /**
  * Owns the editing/saving UI state for the active study card. Card writes go
  * through the card domain's `useCardMutations` seam so the FSRS queue and
- * rendered card stay in sync without a second persistence path.
+ * rendered card stay in sync without a second persistence path. The saved
+ * text is also patched into the session's own card copy via `updateCard` —
+ * the query-cache patch from `useCardMutations` only touches the deck-list
+ * cache, which the session doesn't read from once seeded.
  *
  * @param deck_id - Reactive id of the deck under study, forwarded to the seam.
  */
 export function useCardEdit(
   active_card: Ref<StudyCard | undefined>,
-  deck_id: MaybeRefOrGetter<number | undefined>
+  deck_id: MaybeRefOrGetter<number | undefined>,
+  updateCard: (card_id: number, values: Partial<Card>) => void
 ) {
   const editing = ref(false)
   const saving = ref(false)
@@ -35,9 +39,11 @@ export function useCardEdit(
 
   async function update(side: 'front' | 'back', text: string) {
     const card = active_card.value
-    if (!card) return
+    if (!card?.id) return
     saving.value = true
-    await mutations.saveCard(card, { [`${side}_text`]: text })
+    const values = { [`${side}_text`]: text }
+    await mutations.saveCard(card, values)
+    updateCard(card.id, values)
     saving.value = false
   }
 

--- a/src/components/study-session/composables/flashcard-session.ts
+++ b/src/components/study-session/composables/flashcard-session.ts
@@ -44,6 +44,13 @@ export function useFlashcardSession(_config?: Partial<DeckConfig>) {
     current_card_side.value = current_card_side.value === 'front' ? 'back' : 'front'
   }
 
+  function dropCard(card_id: number) {
+    core.dropCard(card_id)
+    if (core.mode.value === 'studying' && core.active_card.value) {
+      current_card_side.value = starting_side.value
+    }
+  }
+
   function reviewCard(grade?: Grade) {
     const promise = core.reviewCard(grade)
     // Reset to the starting side for the incoming card.
@@ -63,6 +70,7 @@ export function useFlashcardSession(_config?: Partial<DeckConfig>) {
     is_cover,
     startSession,
     flipCurrentCard,
-    reviewCard
+    reviewCard,
+    dropCard
   }
 }

--- a/src/components/study-session/composables/session-core.ts
+++ b/src/components/study-session/composables/session-core.ts
@@ -131,6 +131,21 @@ export function useStudySessionCore(_config?: Partial<DeckConfig>) {
     if (!active_card.value) mode.value = 'completed'
   }
 
+  /**
+   * Patches a card's fields in the local session queue (and active_card, if
+   * it's the one showing). The session keeps its own copy of cards separate
+   * from the deck-list query cache, so an edit made mid-session needs its own
+   * patch path rather than relying on cache invalidation.
+   */
+  function updateCard(card_id: number, values: Partial<Card>) {
+    _cards_in_deck.value = _cards_in_deck.value.map((c) =>
+      c.id === card_id ? { ...c, ...values } : c
+    )
+    if (active_card.value?.id === card_id) {
+      active_card.value = { ...active_card.value, ...values }
+    }
+  }
+
   function reviewCard(grade?: Grade) {
     if (!active_card.value) return
 
@@ -210,6 +225,7 @@ export function useStudySessionCore(_config?: Partial<DeckConfig>) {
     setCards,
     updateConfig,
     reviewCard,
-    dropCard
+    dropCard,
+    updateCard
   }
 }

--- a/src/components/study-session/session-flashcard/index.vue
+++ b/src/components/study-session/session-flashcard/index.vue
@@ -50,7 +50,8 @@ const {
   setCards,
   startSession,
   flipCurrentCard,
-  dropCard
+  dropCard,
+  updateCard
 } = useFlashcardSession({ ...decks[0]?.study_config, ...config_override })
 
 const { next_card_side, preview_style, onDragProgress, onNextCardFlipped, awaitFlip } =
@@ -62,7 +63,7 @@ const {
   start: startEdit,
   stop: stopEdit,
   update: onEditUpdate
-} = useCardEdit(active_card, () => active_card.value?.deck_id)
+} = useCardEdit(active_card, () => active_card.value?.deck_id, updateCard)
 
 const { onMove, onDelete } = useActiveCardActions({
   active_card,

--- a/src/components/study-session/session-flashcard/study-card.vue
+++ b/src/components/study-session/session-flashcard/study-card.vue
@@ -84,6 +84,7 @@ onMounted(() => {
     onEnd: (result) => endDrag(el, result),
     onCancel: () => snapBack(el)
   })
+  el.addEventListener('mousedown', onCardMouseDown)
 
   shortcuts.register({ combo: 'arrowright', handler: () => swipe(el, 1) })
   shortcuts.register({ combo: 'arrowleft', handler: () => swipe(el, -1) })
@@ -199,6 +200,12 @@ function endDrag(el: HTMLElement, { dx, dy }: { dx: number; dy: number }) {
   if (is_animating.value) return
 
   if (isTap(dx, dy)) {
+    // A tap that ends a drag-selection of the card's text shouldn't also flip.
+    // A plain tap collapses the selection on mousedown, so this only catches
+    // the release of a real selection.
+    const sel = window.getSelection()
+    if (sel && !sel.isCollapsed) return
+
     triggerCardFlip()
     return
   }
@@ -213,6 +220,14 @@ function endDrag(el: HTMLElement, { dx, dy }: { dx: number; dy: number }) {
 /** A gesture that barely moved in either axis — a tap, not a drag. */
 function isTap(dx: number, dy: number) {
   return Math.abs(dx) < FLIP_THRESHOLD && Math.abs(dy) < FLIP_THRESHOLD
+}
+
+// Spamming the flip racks up the browser's click counter, whose double/triple
+// clicks word- and line-select the card content. Suppress the default selection
+// on those multi-clicks only — a single click (and a deliberate click-drag to
+// select) keeps `detail === 1`, so manual selection still works.
+function onCardMouseDown(e: MouseEvent) {
+  if (e.detail > 1) e.preventDefault()
 }
 
 /** Flings the card in a direction (keyboard shortcut entry point). */

--- a/src/composables/fsrs.ts
+++ b/src/composables/fsrs.ts
@@ -12,7 +12,7 @@ export function useRatingFormat() {
     options?: RecordLog,
     style: 'long' | 'short' = 'long'
   ) {
-    if (!options) return ''
+    if (!options?.[grade].card.due) return ''
 
     const dates = GRADES.map((g) => options[g].card.due)
     const labels = toRelativeDistinct(dates, { style, locale: locale.value })

--- a/src/composables/fsrs.ts
+++ b/src/composables/fsrs.ts
@@ -1,6 +1,8 @@
-import { type Grade, type RecordLog } from 'ts-fsrs'
+import { Rating, type Grade, type RecordLog } from 'ts-fsrs'
 import { useI18n } from 'vue-i18n'
-import { toRelative } from '@/utils/date'
+import { toRelativeDistinct } from '@/utils/date'
+
+const GRADES: Grade[] = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy]
 
 export function useRatingFormat() {
   const { t, locale } = useI18n()
@@ -10,10 +12,11 @@ export function useRatingFormat() {
     options?: RecordLog,
     style: 'long' | 'short' = 'long'
   ) {
-    const date = options?.[grade].card.due
-    if (!date) return ''
+    if (!options) return ''
 
-    const timeString = toRelative(date, { style, locale: locale.value })
+    const dates = GRADES.map((g) => options[g].card.due)
+    const labels = toRelativeDistinct(dates, { style, locale: locale.value })
+    const timeString = labels[GRADES.indexOf(grade)]
     return t('study.idle.next-session-cta', { time: timeString })
   }
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -68,6 +68,7 @@ function toRelativeAtUnit(
   const diffSeconds = (toDate(input).getTime() - Date.now()) / 1000
   const perUnit = RELATIVE_UNITS.find(([u]) => u === unit)![1]
   const formatter = new Intl.RelativeTimeFormat(locale, { style })
+  if (!Number.isFinite(diffSeconds)) return formatter.format(0, 'second')
   return formatter.format(Math.round(diffSeconds / perUnit), unit)
 }
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -58,3 +58,29 @@ export function toRelative(input: DateInput, options: RelativeOptions = {}): str
 
   return formatter.format(0, 'second')
 }
+
+function toRelativeAtUnit(
+  input: DateInput,
+  unit: Intl.RelativeTimeFormatUnit,
+  options: RelativeOptions = {}
+): string {
+  const { style = 'long', locale } = options
+  const diffSeconds = (toDate(input).getTime() - Date.now()) / 1000
+  const perUnit = RELATIVE_UNITS.find(([u]) => u === unit)![1]
+  const formatter = new Intl.RelativeTimeFormat(locale, { style })
+  return formatter.format(Math.round(diffSeconds / perUnit), unit)
+}
+
+/**
+ * Formats a batch of dates that are displayed together (e.g. one per FSRS
+ * rating). Any dates that would otherwise render identical text collapse to
+ * day-level granularity instead, so "1 week" / "1 week" becomes "8 days" /
+ * "9 days".
+ */
+export function toRelativeDistinct(inputs: DateInput[], options: RelativeOptions = {}): string[] {
+  const labels = inputs.map((d) => toRelative(d, options))
+  return labels.map((label, i) => {
+    const collides = labels.some((other, j) => j !== i && other === label)
+    return collides ? toRelativeAtUnit(inputs[i]!, 'day', options) : label
+  })
+}

--- a/tests/integration/components/modals/study-session/study-card.test.js
+++ b/tests/integration/components/modals/study-session/study-card.test.js
@@ -328,6 +328,84 @@ describe('StudyCard', () => {
     expect(wrapper.emitted('side-changed')).toBeFalsy()
   })
 
+  // ── Tap release of a text selection must not flip [obligation] ─────────────
+  // Mirrors the same guard in grid-item.vue's onCardClick.
+
+  test('tap that releases a non-collapsed selection does NOT flip [obligation]', async () => {
+    const origGetSelection = window.getSelection
+    window.getSelection = () => ({ isCollapsed: false })
+
+    const wrapper = mountStudyCard({ side: 'front', options })
+    await flushPromises()
+
+    const { callbacks } = getCallbacks()
+    callbacks.onEnd({ dx: 0, dy: 0 })
+    await flushPromises()
+
+    expect(wrapper.emitted('side-changed')).toBeFalsy()
+    expect(wrapper.emitted('started')).toBeFalsy()
+
+    window.getSelection = origGetSelection
+  })
+
+  test('plain tap with a collapsed selection still flips [obligation]', async () => {
+    const origGetSelection = window.getSelection
+    window.getSelection = () => ({ isCollapsed: true })
+
+    const wrapper = mountStudyCard({ side: 'front', options })
+    await flushPromises()
+
+    const { callbacks } = getCallbacks()
+    callbacks.onEnd({ dx: 0, dy: 0 })
+    await flushPromises()
+
+    expect(wrapper.emitted('side-changed')).toHaveLength(1)
+
+    window.getSelection = origGetSelection
+  })
+
+  test('plain tap with no selection (getSelection returns null) still flips [obligation]', async () => {
+    const origGetSelection = window.getSelection
+    window.getSelection = () => null
+
+    const wrapper = mountStudyCard({ side: 'front', options })
+    await flushPromises()
+
+    const { callbacks } = getCallbacks()
+    callbacks.onEnd({ dx: 0, dy: 0 })
+    await flushPromises()
+
+    expect(wrapper.emitted('side-changed')).toHaveLength(1)
+
+    window.getSelection = origGetSelection
+  })
+
+  // ── onCardMouseDown suppresses multi-click selection [obligation] ──────────
+
+  test('onCardMouseDown calls preventDefault on a multi-click (detail > 1) [obligation]', async () => {
+    mountStudyCard({ side: 'front', options })
+    await flushPromises()
+
+    const { el } = getCallbacks()
+    const event = new MouseEvent('mousedown', { detail: 2, bubbles: true })
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+    el.dispatchEvent(event)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+  })
+
+  test('onCardMouseDown does NOT call preventDefault on a single click (detail === 1) [obligation]', async () => {
+    mountStudyCard({ side: 'front', options })
+    await flushPromises()
+
+    const { el } = getCallbacks()
+    const event = new MouseEvent('mousedown', { detail: 1, bubbles: true })
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+    el.dispatchEvent(event)
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled()
+  })
+
   test('long horizontal swipe (|dx| > 50) on back side flings and does NOT flip [obligation]', async () => {
     const wrapper = mountStudyCard({ side: 'back', options })
     await flushPromises()

--- a/tests/unit/composables/study-session/card-edit.test.js
+++ b/tests/unit/composables/study-session/card-edit.test.js
@@ -25,10 +25,10 @@ function makeCard(overrides = {}) {
   return { id: 1, deck_id: 10, front_text: 'Q', back_text: 'A', ...overrides }
 }
 
-function makeSetup({ card = makeCard(), deck_id = () => 10 } = {}) {
+function makeSetup({ card = makeCard(), deck_id = () => 10, updateCard = vi.fn() } = {}) {
   const active_card = ref(card ? { ...card, state: 'unreviewed', preview: undefined } : undefined)
-  const result = useCardEdit(active_card, deck_id)
-  return { result, active_card }
+  const result = useCardEdit(active_card, deck_id, updateCard)
+  return { result, active_card, updateCard }
 }
 
 beforeEach(() => {
@@ -51,7 +51,7 @@ describe('useCardEdit — editing flag', () => {
 
   test('start() is a no-op when active_card is undefined', () => {
     const active_card = ref(undefined)
-    const result = useCardEdit(active_card, () => 10)
+    const result = useCardEdit(active_card, () => 10, vi.fn())
     result.start()
     expect(result.editing.value).toBe(false)
   })
@@ -149,10 +149,41 @@ describe('useCardEdit — update() calls saveCard [obligation]', () => {
 
   test('update() is a no-op when active_card is undefined', async () => {
     const active_card = ref(undefined)
-    const result = useCardEdit(active_card, () => 10)
+    const result = useCardEdit(active_card, () => 10, vi.fn())
 
     await result.update('front', 'noop')
 
     expect(saveCardMock).not.toHaveBeenCalled()
+  })
+
+  test('update() is a no-op when active_card has no id [obligation]', async () => {
+    const { result, updateCard } = makeSetup({ card: { ...makeCard(), id: undefined } })
+
+    await result.update('front', 'noop')
+
+    expect(saveCardMock).not.toHaveBeenCalled()
+    expect(updateCard).not.toHaveBeenCalled()
+  })
+})
+
+// ── update() patches the session's own card copy via updateCard ───────────────
+
+describe('useCardEdit — update() patches the session card via updateCard [obligation]', () => {
+  test('calls updateCard with the card id and patched values after saveCard resolves [obligation]', async () => {
+    const card = makeCard({ id: 42 })
+    const { result, updateCard } = makeSetup({ card })
+
+    await result.update('front', 'Hello')
+
+    expect(updateCard).toHaveBeenCalledWith(42, { front_text: 'Hello' })
+  })
+
+  test('calls updateCard with back_text values [obligation]', async () => {
+    const card = makeCard({ id: 42 })
+    const { result, updateCard } = makeSetup({ card })
+
+    await result.update('back', 'World')
+
+    expect(updateCard).toHaveBeenCalledWith(42, { back_text: 'World' })
   })
 })

--- a/tests/unit/composables/study-session/flashcard-session.test.js
+++ b/tests/unit/composables/study-session/flashcard-session.test.js
@@ -571,6 +571,54 @@ describe('useFlashcardSession', () => {
     expect(session.next_card.value?.id).toBe(cards[2].id)
   })
 
+  // ── dropCard [obligation] ──────────────────────────────────────────────────
+  // Deleting/moving a card mid-session must reset the next active card back to
+  // its starting side — otherwise a flipped card left the next card back-side-up.
+
+  test('dropCard resets current_card_side to the starting side when a card remains [obligation]', () => {
+    const session = useFlashcardSession({ study_all_cards: true, retry_failed_cards: false })
+    const cards = [makeDueCard({ review: null }), makeDueCard({ review: null })]
+    session.setCards(cards)
+    session.startSession() // 'front'
+    session.flipCurrentCard() // now 'back'
+
+    session.dropCard(cards[0].id)
+
+    expect(session.mode.value).toBe('studying')
+    expect(session.active_card.value).toBeDefined()
+    expect(session.current_card_side.value).toBe('front')
+  })
+
+  test('dropCard resets to "back" as the starting side when flip_cards is true [obligation]', () => {
+    const session = useFlashcardSession({
+      study_all_cards: true,
+      retry_failed_cards: false,
+      flip_cards: true
+    })
+    const cards = [makeDueCard({ review: null }), makeDueCard({ review: null })]
+    session.setCards(cards)
+    session.startSession() // 'back' — starting side when flipped
+    session.flipCurrentCard() // now 'front'
+
+    session.dropCard(cards[0].id)
+
+    expect(session.current_card_side.value).toBe('back')
+  })
+
+  test('dropCard does not force a side change when no cards remain [obligation]', () => {
+    const session = useFlashcardSession({ study_all_cards: true, retry_failed_cards: false })
+    const cards = [makeDueCard({ review: null })]
+    session.setCards(cards)
+    session.startSession() // 'front'
+    session.flipCurrentCard() // now 'back'
+
+    session.dropCard(cards[0].id)
+
+    expect(session.mode.value).toBe('completed')
+    expect(session.active_card.value).toBeUndefined()
+    expect(session.current_card_side.value).toBe('back')
+  })
+
   // ── is_cover ───────────────────────────────────────────────────────────────
 
   test('is_cover is true before startSession', () => {

--- a/tests/unit/composables/study-session/session-core.test.js
+++ b/tests/unit/composables/study-session/session-core.test.js
@@ -557,3 +557,63 @@ describe('session-core — dropCard [obligation]', () => {
     expect(session.cards.value.map((c) => c.id)).toEqual([c1.id, c3.id])
   })
 })
+
+// ── updateCard [obligation] ─────────────────────────────────────────────────────
+
+describe('session-core — updateCard [obligation]', () => {
+  test('patches the matching card in cards [obligation]', () => {
+    const session = useStudySessionCore({ study_all_cards: true })
+    const [c1, c2] = [makeNewCard(), makeNewCard()]
+    session.setCards([c1, c2])
+
+    session.updateCard(c1.id, { front_text: 'Updated front' })
+
+    expect(session.cards.value.find((c) => c.id === c1.id)?.front_text).toBe('Updated front')
+  })
+
+  test('reassigns the cards array reference (shallowRef immutability) [obligation]', () => {
+    const session = useStudySessionCore({ study_all_cards: true })
+    const [c1, c2] = [makeNewCard(), makeNewCard()]
+    session.setCards([c1, c2])
+    const before = session.cards.value
+
+    session.updateCard(c1.id, { front_text: 'Updated front' })
+
+    expect(session.cards.value).not.toBe(before)
+  })
+
+  test('leaves non-matching cards untouched (value and reference) [obligation]', () => {
+    const session = useStudySessionCore({ study_all_cards: true })
+    const [c1, c2] = [makeNewCard(), makeNewCard()]
+    session.setCards([c1, c2])
+    const c2_before = session.cards.value.find((c) => c.id === c2.id)
+
+    session.updateCard(c1.id, { front_text: 'Updated front' })
+
+    const c2_after = session.cards.value.find((c) => c.id === c2.id)
+    expect(c2_after).toBe(c2_before)
+  })
+
+  test('patches active_card when the patched card is the active one [obligation]', () => {
+    const session = useStudySessionCore({ study_all_cards: true })
+    const [c1, c2] = [makeNewCard(), makeNewCard()]
+    session.setCards([c1, c2])
+
+    expect(session.active_card.value?.id).toBe(c1.id)
+
+    session.updateCard(c1.id, { front_text: 'Updated front' })
+
+    expect(session.active_card.value?.front_text).toBe('Updated front')
+  })
+
+  test('does not touch active_card when the patched card is not the active one [obligation]', () => {
+    const session = useStudySessionCore({ study_all_cards: true })
+    const [c1, c2] = [makeNewCard(), makeNewCard()]
+    session.setCards([c1, c2])
+    const active_before = session.active_card.value
+
+    session.updateCard(c2.id, { front_text: 'Updated front' })
+
+    expect(session.active_card.value).toBe(active_before)
+  })
+})

--- a/tests/unit/composables/use-fsrs.test.js
+++ b/tests/unit/composables/use-fsrs.test.js
@@ -64,17 +64,52 @@ describe('useRatingFormat', () => {
 
   test('selects the due date corresponding to the given grade', () => {
     const { getRatingTimeFormat } = useRatingFormat()
+    // getRatingTimeFormat resolves all 4 grades together, so the RecordLog
+    // stub must carry a due date for every grade (mirrors the real ts-fsrs
+    // RecordLog shape) — not just the two grades under test. Each grade gets
+    // a distinct due date so none of them collide and force day-granularity.
     const good_due = new Date(Date.now() + 1000 * 60 * 60 * 24)
     const again_due = new Date(Date.now() + 1000 * 60) // +1 minute
     const options = {
       [Rating.Again]: { card: { due: again_due } },
-      [Rating.Good]: { card: { due: good_due } }
+      [Rating.Hard]: { card: { due: new Date(Date.now() + 1000 * 60 * 60 * 2) } }, // +2 hours
+      [Rating.Good]: { card: { due: good_due } },
+      [Rating.Easy]: { card: { due: new Date(Date.now() + 1000 * 60 * 60 * 24 * 3) } } // +3 days
     }
 
     const good_result = getRatingTimeFormat(Rating.Good, options)
     const again_result = getRatingTimeFormat(Rating.Again, options)
 
     expect(good_result).toMatch(/day|hour/)
+    expect(again_result).toMatch(/minute|second/)
+  })
+
+  // ── toRelativeDistinct wiring [obligation] ─────────────────────────────────
+  // getRatingTimeFormat now resolves all 4 grades together via toRelativeDistinct
+  // before picking the requested one, so two grades whose due dates collide at
+  // week-level never render identical preview text.
+
+  test('returns distinct strings for two grades whose due dates collide at week-level [obligation]', () => {
+    const { getRatingTimeFormat } = useRatingFormat()
+    const day = 24 * 60 * 60 * 1000
+    // 7.6 and 8.6 days out both naturally round to "in 1 week" — only these two collide.
+    const good_due = new Date(Date.now() + 7.6 * day)
+    const easy_due = new Date(Date.now() + 8.6 * day)
+    const options = {
+      [Rating.Again]: { card: { due: new Date(Date.now() + 1000 * 60) } }, // +1 minute, distinct
+      [Rating.Hard]: { card: { due: new Date(Date.now() + 2 * day) } }, // +2 days, distinct
+      [Rating.Good]: { card: { due: good_due } },
+      [Rating.Easy]: { card: { due: easy_due } }
+    }
+
+    const good_result = getRatingTimeFormat(Rating.Good, options)
+    const easy_result = getRatingTimeFormat(Rating.Easy, options)
+    const again_result = getRatingTimeFormat(Rating.Again, options)
+
+    expect(good_result).not.toBe(easy_result)
+    expect(good_result).toMatch(/day/)
+    expect(easy_result).toMatch(/day/)
+    // Non-colliding grade keeps its natural sub-day unit.
     expect(again_result).toMatch(/minute|second/)
   })
 })

--- a/tests/unit/utils/date.test.js
+++ b/tests/unit/utils/date.test.js
@@ -1,5 +1,11 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
-import { isoNow, localDayStart, formatShortDate, toRelative } from '@/utils/date'
+import {
+  isoNow,
+  localDayStart,
+  formatShortDate,
+  toRelative,
+  toRelativeDistinct
+} from '@/utils/date'
 
 describe('isoNow', () => {
   afterEach(() => {
@@ -151,5 +157,45 @@ describe('toRelative', () => {
 
     expect(toRelative(twentyEightDays, { locale: 'en-US' })).toBe('in 1 month')
     expect(toRelative(thirtyDays, { locale: 'en-US' })).toBe('in 1 month')
+  })
+})
+
+// ── toRelativeDistinct [obligation] ─────────────────────────────────────────
+
+describe('toRelativeDistinct [obligation]', () => {
+  const day = 86_400 * 1000
+
+  test('demotes two colliding dates to distinct day-level labels [obligation]', () => {
+    // 7.6 and 8.6 days out both naturally round to "in 1 week".
+    const a = new Date(Date.now() + 7.6 * day)
+    const b = new Date(Date.now() + 8.6 * day)
+
+    const [labelA, labelB] = toRelativeDistinct([a, b], { locale: 'en-US' })
+
+    expect(labelA).not.toBe(labelB)
+    expect(labelA).toBe('in 8 days')
+    expect(labelB).toBe('in 9 days')
+  })
+
+  test('leaves non-colliding dates at their natural unit, including sub-day granularity [obligation]', () => {
+    const inTwoMinutes = new Date(Date.now() + 2 * 60 * 1000)
+    const inThreeHours = new Date(Date.now() + 3 * 60 * 60 * 1000)
+
+    const [labelA, labelB] = toRelativeDistinct([inTwoMinutes, inThreeHours], { locale: 'en-US' })
+
+    expect(labelA).toBe('in 2 minutes')
+    expect(labelB).toBe('in 3 hours')
+  })
+
+  test('only demotes the colliding pair when a third date is distinct [obligation]', () => {
+    const a = new Date(Date.now() + 7.6 * day)
+    const b = new Date(Date.now() + 8.6 * day)
+    const distinct = new Date(Date.now() + 2 * 60 * 1000) // in 2 minutes, no collision
+
+    const [labelA, labelB, labelC] = toRelativeDistinct([a, b, distinct], { locale: 'en-US' })
+
+    expect(labelA).toBe('in 8 days')
+    expect(labelB).toBe('in 9 days')
+    expect(labelC).toBe('in 2 minutes')
   })
 })


### PR DESCRIPTION
## Summary

Fixes 5 bugs found while using the study session feature in the field: a flip-state leak after deleting a card, a text-selection/flip conflict, an edit-then-revert bug, and colliding rating-interval previews. Also fixes an edge-case crash surfaced while writing tests for the interval-collision fix.

## Changes

- Reset the card's flip side after dropping (deleting/moving) a card mid-session, so the next card no longer inherits the previous card's flipped state.
- Guard the card-flip gesture against an active text selection, mirroring the existing guard on the deck view.
- Patch the study session's own in-memory card copy after a mid-session edit saves, so the card no longer reverts to stale text.
- When two FSRS rating previews would render an identical interval (e.g. two grades both showing "1 week"), break the tie by demoting the colliding entries to day-level granularity.
- Guard the new day-level formatter against invalid/NaN dates instead of throwing.

## Test plan

- [x] `vp lint` and `pnpm type-check` clean
- [x] Full `study-session` test tree green (21 files, 428 tests)