### PR TITLE
Audio reader term-popover and toolbar polish

### DIFF
--- a/src/components/ui-kit/dropdown-button/index.vue
+++ b/src/components/ui-kit/dropdown-button/index.vue
@@ -12,7 +12,15 @@ export type { DropdownOption } from './types'
 
 type DropdownButtonProps = Pick<
   ButtonProps,
-  'size' | 'variant' | 'inverted' | 'fullWidth' | 'iconLeft' | 'sfx' | 'playOnTap' | 'tapAnimate'
+  | 'size'
+  | 'variant'
+  | 'inverted'
+  | 'fullWidth'
+  | 'iconLeft'
+  | 'iconRight'
+  | 'sfx'
+  | 'playOnTap'
+  | 'tapAnimate'
 > & {
   options?: DropdownOption[]
   position?: Placement
@@ -43,6 +51,7 @@ const {
   inverted,
   fullWidth,
   iconLeft,
+  iconRight,
   sfx,
   // Mirror ui-button's tap defaults: an absent Boolean prop casts to `false`,
   // which would otherwise forward `:play-on-tap="false"` and suppress the
@@ -192,6 +201,7 @@ function onMenuSelect(option: DropdownOption) {
         :inverted="inverted"
         :full-width="fullWidth"
         :icon-left="iconLeft"
+        :icon-right="iconRight"
         :sfx="sfx"
         :play-on-tap="playOnTap"
         :tap-animate="tapAnimate"

--- a/src/composables/audio-reader/reader-highlights.ts
+++ b/src/composables/audio-reader/reader-highlights.ts
@@ -43,6 +43,10 @@ const TAP_SLOP = 10
 // ~500ms native long-press so it feels responsive without firing on a quick tap.
 const LONG_PRESS_MS = 400
 
+// How long follow stays off after the member scrolls by hand before it re-arms
+// itself, so a brief detour to re-read a line doesn't require a manual resume.
+const FOLLOW_RESUME_IDLE_MS = 5000
+
 // On mobile the term sheet rises over roughly the bottom half of the viewport, so a
 // word committed past this fraction of the screen risks being buried by it. Such a
 // word is eased up into view before the sheet covers it.
@@ -196,6 +200,7 @@ export function useReaderHighlights(
   let suppress_gesture_click = false
 
   let follow_timer: ReturnType<typeof setTimeout> | null = null
+  let follow_resume_timer: ReturnType<typeof setTimeout> | null = null
   let resize_observer: ResizeObserver | null = null
 
   // The word element currently flagged as playing. The active-word cue is painted
@@ -230,6 +235,7 @@ export function useReaderHighlights(
     window.removeEventListener('wheel', disableFollow)
     cancelLongPress()
     if (follow_timer !== null) clearTimeout(follow_timer)
+    if (follow_resume_timer !== null) clearTimeout(follow_resume_timer)
   })
 
   // Once a long-press has armed range-select the finger is extending the range,
@@ -439,13 +445,19 @@ export function useReaderHighlights(
 
   // The member started scrolling by hand — a wheel/trackpad on desktop or a touch
   // pan on mobile: let the follow go and kill the live tween so it stops fighting
-  // them. No-op once already off.
+  // them. Re-arms itself after an idle spell even without a manual resume tap.
   function disableFollow() {
-    if (!following.value) return
+    if (following.value) {
+      following.value = false
+      cancelScroll(scrollParentOf(content.value))
+      updateFollowDirection()
+    }
 
-    following.value = false
-    cancelScroll(scrollParentOf(content.value))
-    updateFollowDirection()
+    if (follow_resume_timer !== null) clearTimeout(follow_resume_timer)
+    follow_resume_timer = setTimeout(() => {
+      follow_resume_timer = null
+      resumeFollow()
+    }, FOLLOW_RESUME_IDLE_MS)
   }
 
   // Point the resume control at the playing word: 'up' when its centre sits above
@@ -475,6 +487,11 @@ export function useReaderHighlights(
    * tween is wanted (and welcome) regardless of play state.
    */
   function resumeFollow() {
+    if (follow_resume_timer !== null) {
+      clearTimeout(follow_resume_timer)
+      follow_resume_timer = null
+    }
+
     following.value = true
     const index = toValue(active_word)
     if (index < 0) return

--- a/src/views/audio-reader/lesson/audio-toolbar.vue
+++ b/src/views/audio-reader/lesson/audio-toolbar.vue
@@ -65,10 +65,15 @@ const active_lesson_chapter = computed(() => {
   return index
 })
 
+// Numbered so a chapter's position in the lesson is legible at a glance,
+// independent of its (often non-Latin) title.
 const chapter_options = computed<DropdownOption[]>(() =>
   use_lesson_chapters.value
-    ? lessonChapters.map((chapter) => ({ label: chapter.title, value: chapter.start }))
-    : chapters.map((chapter) => ({ label: chapter.title, value: chapter.id }))
+    ? lessonChapters.map((chapter, i) => ({
+        label: `${i + 1}. ${chapter.title}`,
+        value: chapter.start
+      }))
+    : chapters.map((chapter, i) => ({ label: `${i + 1}. ${chapter.title}`, value: chapter.id }))
 )
 const current_chapter_label = computed(() =>
   use_lesson_chapters.value
@@ -197,11 +202,12 @@ function setMode(next: 'expanded' | 'mini') {
             data-testid="audio-toolbar__chapter-select"
             icon-left="browser-content"
             menu-theme="brown-100"
+            menu-class="border-1 border-brown-300 dark:border-grey-900"
             variant="ghost"
             open-on-trigger
             hide-trigger
             shadow
-            position="top-start"
+            position="top"
             :options="chapter_options"
             @select="onChapter"
           >

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -176,6 +176,13 @@ function resumeFollow() {
   transcript.value?.resumeFollow()
 }
 
+// Seeking to the term's start should rejoin the live scroll too, in case the
+// member had scrolled away before playing from here.
+function onPlayFromHere() {
+  transcript.value?.resumeFollow()
+  playFromHere()
+}
+
 // Tapping outside the term dismisses it with the same cue as its close button.
 function dismissTerm() {
   emitSfx('snappy_button_5')
@@ -291,7 +298,7 @@ onBeforeUnmount(() => {
             show_back
             @back="closeTerm"
             @close="closeTerm"
-            @play-from-here="playFromHere"
+            @play-from-here="onPlayFromHere"
             @play-word="playClip"
           />
         </div>
@@ -398,7 +405,7 @@ onBeforeUnmount(() => {
               show_back
               @back="closeTerm"
               @close="closeTerm"
-              @play-from-here="playFromHere"
+              @play-from-here="onPlayFromHere"
               @play-word="playClip"
             />
           </div>

--- a/src/views/audio-reader/term-popover/add-card-panel.vue
+++ b/src/views/audio-reader/term-popover/add-card-panel.vue
@@ -165,8 +165,10 @@ async function onSave() {
         menu-theme-dark="stone-700"
         variant="ghost"
         size="base"
+        position="bottom"
         open-on-trigger
         hide-trigger
+        icon-right="carat-down"
         :options="deck_options"
         @select="onSelectDeck"
       >

--- a/src/views/audio-reader/term-popover/term-card.vue
+++ b/src/views/audio-reader/term-popover/term-card.vue
@@ -114,8 +114,8 @@ function onAddCard(deck_id: number | null) {
   adding.value = { front: term, back, note: description, deck_id }
 }
 
-// Saving and cancelling both reverse the push so the term card slides back in —
-// a saved card is confirmed by its own toast, so the term stays open to add more.
+// Cancelling reverses the push so the term card slides back in. Saving closes
+// the whole popover instead — the card is confirmed by its own toast.
 function returnToTermCard() {
   slide_direction.value = 'back'
   adding.value = null
@@ -323,7 +323,7 @@ watch(
         :note="adding.note"
         :deck_id="adding.deck_id"
         @cancel="returnToTermCard"
-        @saved="returnToTermCard"
+        @saved="emit('close')"
       />
     </transition>
   </div>

--- a/tests/integration/components/ui-kit/dropdown-button.test.js
+++ b/tests/integration/components/ui-kit/dropdown-button.test.js
@@ -45,7 +45,7 @@ vi.mock('@floating-ui/vue', () => ({
 const UiButtonStub = defineComponent({
   name: 'UiButton',
   inheritAttrs: false,
-  props: ['size', 'variant', 'inverted', 'fullWidth', 'iconLeft', 'sfx', 'style'],
+  props: ['size', 'variant', 'inverted', 'fullWidth', 'iconLeft', 'iconRight', 'sfx', 'style'],
   emits: ['press'],
   setup(props, { slots, attrs, emit }) {
     return () =>
@@ -505,6 +505,13 @@ describe('UiDropdownButton', () => {
     const wrapper = mountDropdown({ shadow: false })
     const popover = wrapper.findComponent(UiPopoverStub)
     expect(popover.props('shadow')).toBe(false)
+  })
+
+  // ── iconRight forwarding [obligation] ─────────────────────────────────────
+
+  test('iconRight prop forwards to the inner UiButton [obligation]', () => {
+    const wrapper = mountDropdown({ iconRight: 'carat-down' })
+    expect(wrapper.findComponent(UiButtonStub).props('iconRight')).toBe('carat-down')
   })
 
   // ── sfx emissions [obligation] ────────────────────────────────────────────

--- a/tests/integration/views/audio-reader/lesson/audio-toolbar.test.js
+++ b/tests/integration/views/audio-reader/lesson/audio-toolbar.test.js
@@ -378,7 +378,7 @@ describe('AudioToolbar', () => {
 
   // ── Dropdown wiring: chapters ──────────────────────────────────────────────
 
-  test('chapter options use bare title (no number prefix) [obligation]', () => {
+  test('collection-level chapter options are numbered with a 1-based prefix [obligation]', () => {
     const wrapper = mountToolbar({
       chapters: [
         { id: 10, title: 'Intro' },
@@ -389,8 +389,23 @@ describe('AudioToolbar', () => {
     const chapterDropdown = wrapper.find('[data-testid="audio-toolbar__chapter-select"]')
     const options = chapterDropdown.findAll('[data-testid="dropdown-button__option"]')
 
-    expect(options[0].text()).toBe('Intro')
-    expect(options[1].text()).toBe('Part Two')
+    expect(options[0].text()).toBe('1. Intro')
+    expect(options[1].text()).toBe('2. Part Two')
+  })
+
+  test('internal lesson-chapter options are numbered with a 1-based prefix [obligation]', () => {
+    const wrapper = mountToolbar({
+      lessonChapters: [
+        { start: 0, title: 'Warm-up' },
+        { start: 30, title: 'Vocabulary' }
+      ]
+    })
+
+    const chapterDropdown = wrapper.find('[data-testid="audio-toolbar__chapter-select"]')
+    const options = chapterDropdown.findAll('[data-testid="dropdown-button__option"]')
+
+    expect(options[0].text()).toBe('1. Warm-up')
+    expect(options[1].text()).toBe('2. Vocabulary')
   })
 
   test('current chapter label is the bare chapter title (no number prefix) [obligation]', () => {
@@ -402,10 +417,11 @@ describe('AudioToolbar', () => {
       currentLessonId: 10
     })
 
-    const chapterDropdown = wrapper.find('[data-testid="audio-toolbar__chapter-select"]')
-    // The default slot of the chapter dropdown renders current_chapter_label
-    expect(chapterDropdown.text()).toContain('Intro')
-    expect(chapterDropdown.text()).not.toMatch(/\d+\.\s/)
+    // Scoped to the label span (not the whole dropdown, which also renders the
+    // numbered options list) — the current-chapter label itself stays bare.
+    const label = wrapper.find('[data-testid="audio-toolbar__chapter-label"]')
+    expect(label.text()).toBe('Intro')
+    expect(label.text()).not.toMatch(/\d+\.\s/)
   })
 
   test('selecting a chapter option emits select-chapter with Number(value) [obligation]', async () => {

--- a/tests/integration/views/audio-reader/lesson/index.test.js
+++ b/tests/integration/views/audio-reader/lesson/index.test.js
@@ -471,6 +471,18 @@ describe('LessonView', () => {
       expect(playFromHereMock).toHaveBeenCalledOnce()
     })
 
+    test('term-card play-from-here event also resumes transcript follow [obligation]', async () => {
+      const wrapper = mountView()
+      selectionRef.value = { term: 'hi', sentence: 'say hi', word_index: 1, rect: {} }
+      popoverOpenRef.value = true
+      await nextTick()
+
+      await wrapper.find('[data-testid="term-card-stub__play-from-here"]').trigger('click')
+
+      expect(transcriptResumeMock).toHaveBeenCalledOnce()
+      expect(playFromHereMock).toHaveBeenCalledOnce()
+    })
+
     test('term-card play-word event calls playClip [obligation]', async () => {
       const wrapper = mountView()
       selectionRef.value = { term: 'hi', sentence: 'say hi', word_index: 1, rect: {} }

--- a/tests/integration/views/audio-reader/term-popover/add-card-panel.test.js
+++ b/tests/integration/views/audio-reader/term-popover/add-card-panel.test.js
@@ -106,7 +106,7 @@ const CardFaceFieldStub = defineComponent({
 const UiDropdownButtonStub = defineComponent({
   name: 'UiDropdownButton',
   inheritAttrs: false,
-  props: ['options'],
+  props: ['options', 'position', 'iconRight'],
   emits: ['select'],
   setup(props, { slots, emit, attrs }) {
     return () =>
@@ -299,6 +299,18 @@ describe('AddCardPanel', () => {
       const dropdown = wrapper.findComponent(UiDropdownButtonStub)
       const options = dropdown.props('options')
       expect(options.every((o) => o.value !== 1)).toBe(true)
+    })
+
+    test('deck dropdown opens centered below the trigger (position="bottom") [obligation]', () => {
+      const wrapper = mountPanel()
+      const dropdown = wrapper.findComponent(UiDropdownButtonStub)
+      expect(dropdown.props('position')).toBe('bottom')
+    })
+
+    test('deck dropdown shows a caret-down trailing icon [obligation]', () => {
+      const wrapper = mountPanel()
+      const dropdown = wrapper.findComponent(UiDropdownButtonStub)
+      expect(dropdown.props('iconRight')).toBe('carat-down')
     })
   })
 

--- a/tests/integration/views/audio-reader/term-popover/term-card.test.js
+++ b/tests/integration/views/audio-reader/term-popover/term-card.test.js
@@ -344,7 +344,7 @@ describe('TermCard', () => {
       expect(panel.attributes('data-back')).toBe('cat')
     })
 
-    test('panel saved slides back to term card and does NOT emit close [obligation]', async () => {
+    test('panel saved emits close and does NOT slide back to the term face [obligation]', async () => {
       mutateAsyncMock.mockResolvedValueOnce(TRANSLATION_RESULT)
       const wrapper = mountCard({ term: '猫', sentence: 'test' })
       await flushPromises()
@@ -354,10 +354,10 @@ describe('TermCard', () => {
       wrapper.findComponent(AddCardPanelStub).vm.$emit('saved')
       await flushPromises()
 
-      // Panel unmounts (term face restored), but close is NOT emitted
-      expect(wrapper.find('[data-testid="add-card-panel-stub"]').exists()).toBe(false)
-      expect(wrapper.find('[data-testid="term-card__face"]').exists()).toBe(true)
-      expect(wrapper.emitted('close')).toBeFalsy()
+      // Saved closes the whole popover instead of reversing the push — the
+      // panel is NOT swapped back for the term face.
+      expect(wrapper.emitted('close')).toHaveLength(1)
+      expect(wrapper.find('[data-testid="term-card__face"]').exists()).toBe(false)
     })
 
     test('panel cancel slides back to term card and does NOT emit close [obligation]', async () => {

--- a/tests/unit/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/unit/composables/audio-reader/use-reader-highlights.test.js
@@ -1340,6 +1340,70 @@ describe('useReaderHighlights', () => {
     })
   })
 
+  describe('disableFollow — idle auto-resume timer [obligation]', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    test('re-arms following after FOLLOW_RESUME_IDLE_MS with no manual resume tap [obligation]', async () => {
+      const { result } = withHighlights()
+      expect(result.following.value).toBe(true)
+
+      window.dispatchEvent(new Event('wheel'))
+      await nextTick()
+      expect(result.following.value).toBe(false)
+
+      vi.advanceTimersByTime(5000)
+      await nextTick()
+
+      expect(result.following.value).toBe(true)
+    })
+
+    test('a second disableFollow call before the timer fires restarts the idle window [obligation]', async () => {
+      const { result } = withHighlights()
+
+      window.dispatchEvent(new Event('wheel'))
+      await nextTick()
+      expect(result.following.value).toBe(false)
+
+      // Most of the window elapses, then the member scrolls again — this must
+      // restart the countdown rather than let the original timer fire.
+      vi.advanceTimersByTime(4000)
+      window.dispatchEvent(new Event('wheel'))
+      await nextTick()
+
+      // Advancing to the original 5000ms mark (1000ms more) must NOT fire yet —
+      // the restarted timer needs its own full 5000ms from the second call.
+      vi.advanceTimersByTime(1000)
+      await nextTick()
+      expect(result.following.value).toBe(false)
+
+      // The restarted timer completes 4000ms later (5000ms after the second call).
+      vi.advanceTimersByTime(4000)
+      await nextTick()
+      expect(result.following.value).toBe(true)
+    })
+
+    test('calling resumeFollow manually cancels the pending auto re-arm [obligation]', async () => {
+      const { result } = withHighlights()
+
+      window.dispatchEvent(new Event('wheel'))
+      await nextTick()
+      expect(result.following.value).toBe(false)
+
+      result.resumeFollow()
+      expect(result.following.value).toBe(true)
+
+      // Force following back off directly (bypassing disableFollow) so that if
+      // the cancelled timer still fired, it would flip it back on and reveal
+      // the bug. Advancing past the original window must cause no change.
+      result.following.value = false
+      vi.advanceTimersByTime(5000)
+      await nextTick()
+
+      expect(result.following.value).toBe(false)
+    })
+  })
+
   describe('follow_direction [obligation]', () => {
     test('follow_direction is "up" when the active word centre is above the viewport centre [obligation]', async () => {
       const active_word = ref(0)


### PR DESCRIPTION
## Summary

Closes the term popover on flashcard save, re-arms transcript auto-scroll on "play from here" and after a 5s idle spell, centers the chapter and deck dropdown menus, adds a caret-down affordance to the deck picker, and numbers chapters in the selector for legibility.

## Changes

- Saving a card from the term popover now closes the popover instead of returning to the term view
- "Play from here" and a 5s idle timeout both re-arm transcript auto-scroll follow
- Chapter dropdown menu is centered under its trigger
- Deck dropdown menu (add-card panel) is centered and shows a caret-down icon
- `UiDropdownButton` gained an `iconRight` passthrough prop
- Chapter options in the toolbar dropdown are numbered (`1. <title>`, `2. <title>`, ...)