### PR TITLE
Checkout modal mobile polish and Stripe theming

### DIFF
--- a/src/components/modals/checkout/checkout-footer.vue
+++ b/src/components/modals/checkout/checkout-footer.vue
@@ -24,7 +24,8 @@ const { t } = useI18n()
   >
     <ui-button
       data-testid="checkout__submit"
-      data-theme="green-400"
+      data-theme="blue-500"
+      data-theme-dark="blue-650"
       full-width
       size="lg"
       :loading="status === 'loading' || status === 'confirming'"

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -7,6 +7,7 @@ import CheckoutFooter from './checkout-footer.vue'
 import { useCheckout, type CheckoutResponse } from './use-checkout'
 import { fadeLeave } from '@/utils/animations/fade'
 import { springScaleIn } from '@/utils/animations/modal'
+import { useMatchMedia } from '@/composables/ui/media-query'
 
 export type { CheckoutResponse }
 
@@ -16,6 +17,7 @@ const { close } = defineProps<{
 
 const { t } = useI18n()
 const { status, is_ready, submit_error, onSubmit } = useCheckout(close)
+const is_mobile = useMatchMedia('w<sm')
 
 function onLeave(el: Element, done: () => void) {
   fadeLeave(el, done)
@@ -29,8 +31,11 @@ function onEnter(el: Element, done: () => void) {
 <template>
   <div
     data-testid="checkout"
-    class="h-160 w-150 relative flex flex-col overflow-hidden rounded-8 bg-brown-100 shadow-lg py-6 dark:bg-grey-800"
-    :class="status === 'success' ? 'justify-center' : 'justify-between'"
+    class="relative flex flex-col overflow-hidden bg-brown-100 py-6 dark:bg-grey-800"
+    :class="[
+      is_mobile ? 'h-full w-full rounded-none' : 'h-160 w-150 rounded-8 shadow-lg',
+      status === 'success' ? 'justify-center' : 'justify-between'
+    ]"
   >
     <header
       v-if="status !== 'success'"

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -32,48 +32,47 @@ function onEnter(el: Element, done: () => void) {
 <template>
   <div
     data-testid="checkout"
-    class="relative flex flex-col gap-4 overflow-hidden bg-brown-100 py-6 dark:bg-grey-800"
-    :class="[
-      is_mobile ? 'h-full w-full rounded-none' : 'h-160 w-150 rounded-8 shadow-lg',
-      status === 'success' ? 'justify-center' : 'justify-between'
-    ]"
+    class="relative flex flex-col overflow-hidden bg-brown-100 py-6 dark:bg-grey-800"
+    :class="is_mobile ? 'h-full w-full rounded-none' : 'h-160 w-150 rounded-8 shadow-lg'"
   >
-    <header
-      v-if="status !== 'success'"
-      data-testid="checkout__header"
-      class="w-full shrink-0 grid grid-cols-[1fr_auto_1fr] px-6"
+    <div
+      data-testid="checkout__scroll-area"
+      class="flex min-h-0 flex-1 flex-col gap-4"
+      :class="[
+        status === 'success' ? 'justify-center' : 'justify-between',
+        is_mobile ? 'overflow-y-auto scroll-hidden' : ''
+      ]"
     >
-      <ui-button
-        data-testid="checkout__close"
-        data-theme="brown-300"
-        data-theme-dark="stone-700"
-        icon-left="close"
-        icon-only
-        rounded-full
-        class="justify-self-start"
-        :disabled="status === 'confirming'"
-        @press="close()"
-      >
-        {{ t('billing.checkout.close-label') }}
-      </ui-button>
-
-      <h1 data-testid="checkout__title" class="text-4xl text-brown-700 dark:text-brown-100">
-        {{ t('billing.checkout.title') }}
-      </h1>
-    </header>
-
-    <transition :css="false" mode="out-in" @leave="onLeave" @enter="onEnter">
-      <div
+      <header
         v-if="status !== 'success'"
-        key="form"
-        data-testid="checkout__body-wrap"
-        class="relative flex flex-col"
-        :class="is_mobile ? 'min-h-0 flex-1' : ''"
+        data-testid="checkout__header"
+        class="w-full shrink-0 grid grid-cols-[1fr_auto_1fr] px-6"
       >
+        <ui-button
+          data-testid="checkout__close"
+          data-theme="brown-300"
+          data-theme-dark="stone-700"
+          icon-left="close"
+          icon-only
+          rounded-full
+          class="justify-self-start"
+          :disabled="status === 'confirming'"
+          @press="close()"
+        >
+          {{ t('billing.checkout.close-label') }}
+        </ui-button>
+
+        <h1 data-testid="checkout__title" class="text-4xl text-brown-700 dark:text-brown-100">
+          {{ t('billing.checkout.title') }}
+        </h1>
+      </header>
+
+      <transition :css="false" mode="out-in" @leave="onLeave" @enter="onEnter">
         <div
+          v-if="status !== 'success'"
+          key="form"
           data-testid="checkout__body"
           class="flex flex-col gap-4 px-16"
-          :class="is_mobile ? 'h-full overflow-y-auto scroll-hidden' : ''"
         >
           <payment-status :status="status" />
           <div ref="container" data-testid="checkout__payment-element"></div>
@@ -82,22 +81,22 @@ function onEnter(el: Element, done: () => void) {
           </p>
         </div>
 
-        <scroll-bar
-          v-if="is_mobile"
-          target="[data-testid='checkout__body']"
-          class="absolute right-1 top-0 bottom-0 pointer-fine:block!"
-        />
-      </div>
+        <success-view v-else key="success" />
+      </transition>
 
-      <success-view v-else key="success" />
-    </transition>
+      <checkout-footer
+        v-if="status !== 'success'"
+        class="px-16"
+        :status="status"
+        :is_ready="is_ready"
+        @submit="onSubmit"
+      />
+    </div>
 
-    <checkout-footer
-      v-if="status !== 'success'"
-      class="px-16"
-      :status="status"
-      :is_ready="is_ready"
-      @submit="onSubmit"
+    <scroll-bar
+      v-if="is_mobile"
+      target="[data-testid='checkout__scroll-area']"
+      class="absolute right-8 top-6 bottom-6 pointer-fine:block!"
     />
   </div>
 </template>

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -46,7 +46,7 @@ function onEnter(el: Element, done: () => void) {
       <header
         v-if="status !== 'success'"
         data-testid="checkout__header"
-        class="w-full shrink-0 grid grid-cols-[1fr_auto_1fr] px-6"
+        class="w-full shrink-0 grid grid-cols-[1fr_auto_1fr] px-6 pointer-coarse:px-4"
       >
         <ui-button
           data-testid="checkout__close"
@@ -72,7 +72,7 @@ function onEnter(el: Element, done: () => void) {
           v-if="status !== 'success'"
           key="form"
           data-testid="checkout__body"
-          class="flex flex-col gap-4 px-16"
+          class="flex flex-col gap-4 px-16 pointer-coarse:px-4"
         >
           <payment-status :status="status" />
           <div ref="container" data-testid="checkout__payment-element"></div>
@@ -83,7 +83,7 @@ function onEnter(el: Element, done: () => void) {
 
       <checkout-footer
         v-if="status !== 'success'"
-        class="px-16"
+        class="px-16 pointer-coarse:px-4"
         :status="status"
         :is_ready="is_ready"
         @submit="onSubmit"
@@ -93,7 +93,8 @@ function onEnter(el: Element, done: () => void) {
     <scroll-bar
       v-if="is_mobile"
       target="[data-testid='checkout__scroll-area']"
-      class="absolute right-8 top-6 bottom-6 pointer-fine:block!"
+      min-width="sm"
+      class="absolute right-8 top-6 bottom-6"
     />
   </div>
 </template>

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -32,7 +32,7 @@ function onEnter(el: Element, done: () => void) {
 <template>
   <div
     data-testid="checkout"
-    class="relative flex flex-col overflow-hidden bg-brown-100 py-6 dark:bg-grey-800"
+    class="relative flex flex-col gap-4 overflow-hidden bg-brown-100 py-6 dark:bg-grey-800"
     :class="[
       is_mobile ? 'h-full w-full rounded-none' : 'h-160 w-150 rounded-8 shadow-lg',
       status === 'success' ? 'justify-center' : 'justify-between'

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -73,7 +73,7 @@ function onEnter(el: Element, done: () => void) {
         <div
           data-testid="checkout__body"
           class="flex flex-col gap-4 px-16"
-          :class="is_mobile ? 'h-full overflow-y-auto' : ''"
+          :class="is_mobile ? 'h-full overflow-y-auto scroll-hidden' : ''"
         >
           <payment-status :status="status" />
           <div ref="container" data-testid="checkout__payment-element"></div>
@@ -85,7 +85,7 @@ function onEnter(el: Element, done: () => void) {
         <scroll-bar
           v-if="is_mobile"
           target="[data-testid='checkout__body']"
-          class="absolute right-1 top-0 bottom-0"
+          class="absolute right-1 top-0 bottom-0 pointer-fine:block!"
         />
       </div>
 

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -32,11 +32,13 @@ function onEnter(el: Element, done: () => void) {
 <template>
   <div
     data-testid="checkout"
+    :data-full-bleed="is_mobile"
     class="relative flex flex-col overflow-hidden bg-brown-100 py-6 dark:bg-grey-800"
     :class="is_mobile ? 'h-full w-full rounded-none' : 'h-160 w-150 rounded-8 shadow-lg'"
   >
     <div
       data-testid="checkout__scroll-area"
+      :data-full-bleed="is_mobile"
       class="flex min-h-0 flex-1 flex-col gap-4"
       :class="[
         status === 'success' ? 'justify-center' : 'justify-between',

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import UiButton from '@/components/ui-kit/button.vue'
+import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
 import PaymentStatus from './payment-status.vue'
 import SuccessView from './success-view.vue'
 import CheckoutFooter from './checkout-footer.vue'
@@ -65,14 +66,27 @@ function onEnter(el: Element, done: () => void) {
       <div
         v-if="status !== 'success'"
         key="form"
-        data-testid="checkout__body"
-        class="flex flex-col gap-4 px-16"
+        data-testid="checkout__body-wrap"
+        class="relative flex flex-col"
+        :class="is_mobile ? 'min-h-0 flex-1' : ''"
       >
-        <payment-status :status="status" />
-        <div ref="container" data-testid="checkout__payment-element"></div>
-        <p v-if="submit_error" data-testid="checkout__submit-error" class="text-sm text-red-500">
-          {{ submit_error }}
-        </p>
+        <div
+          data-testid="checkout__body"
+          class="flex flex-col gap-4 px-16"
+          :class="is_mobile ? 'h-full overflow-y-auto' : ''"
+        >
+          <payment-status :status="status" />
+          <div ref="container" data-testid="checkout__payment-element"></div>
+          <p v-if="submit_error" data-testid="checkout__submit-error" class="text-sm text-red-500">
+            {{ submit_error }}
+          </p>
+        </div>
+
+        <scroll-bar
+          v-if="is_mobile"
+          target="[data-testid='checkout__body']"
+          class="absolute right-1 top-0 bottom-0"
+        />
       </div>
 
       <success-view v-else key="success" />

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -17,7 +17,7 @@ const { close } = defineProps<{
 
 const { t } = useI18n()
 const { status, is_ready, submit_error, onSubmit } = useCheckout(close)
-const is_mobile = useMatchMedia('w<sm')
+const is_mobile = useMatchMedia('w<sm | h<sm')
 
 function onLeave(el: Element, done: () => void) {
   fadeLeave(el, done)

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -17,7 +17,7 @@ const { close } = defineProps<{
 }>()
 
 const { t } = useI18n()
-const { status, is_ready, submit_error, onSubmit } = useCheckout(close)
+const { status, is_ready, onSubmit } = useCheckout(close)
 const is_mobile = useMatchMedia('w<sm | h<sm')
 
 function onLeave(el: Element, done: () => void) {
@@ -76,9 +76,6 @@ function onEnter(el: Element, done: () => void) {
         >
           <payment-status :status="status" />
           <div ref="container" data-testid="checkout__payment-element"></div>
-          <p v-if="submit_error" data-testid="checkout__submit-error" class="text-sm text-red-500">
-            {{ submit_error }}
-          </p>
         </div>
 
         <success-view v-else key="success" />

--- a/src/components/modals/checkout/payment-status.vue
+++ b/src/components/modals/checkout/payment-status.vue
@@ -15,14 +15,14 @@ const { t } = useI18n()
   <p
     v-if="status === 'loading'"
     data-testid="checkout__loading"
-    class="text-brown-700 py-10 text-center"
+    class="text-brown-700 dark:text-brown-100 py-10 text-center"
   >
     {{ t('billing.checkout.loading') }}
   </p>
   <p
     v-else-if="status === 'error'"
     data-testid="checkout__error"
-    class="py-10 text-center text-red-500"
+    class="py-10 text-center text-red-500 dark:text-red-600"
   >
     {{ t('billing.checkout.error') }}
   </p>

--- a/src/components/modals/checkout/use-checkout.ts
+++ b/src/components/modals/checkout/use-checkout.ts
@@ -35,18 +35,17 @@ export function useCheckout(close: (response?: CheckoutResponse) => void) {
   const is_success = ref(false)
   const is_confirming = ref(false)
 
-  const { is_loading, is_submitting, is_ready, load_error, submit_error, confirm } =
-    useCheckoutElements({
-      publicKey: import.meta.env.VITE_STRIPE_PUBLIC_KEY,
-      genericErrorMessage: t('billing.checkout.submit-error'),
-      getClientSecret: async () => {
-        const { clientSecret } = await createSubscription({
-          planId: 'paid',
-          returnUrl: window.location.origin
-        })
-        return clientSecret
-      }
-    })
+  const { is_loading, is_submitting, is_ready, load_error, confirm } = useCheckoutElements({
+    publicKey: import.meta.env.VITE_STRIPE_PUBLIC_KEY,
+    genericErrorMessage: t('billing.checkout.submit-error'),
+    getClientSecret: async () => {
+      const { clientSecret } = await createSubscription({
+        planId: 'paid',
+        returnUrl: window.location.origin
+      })
+      return clientSecret
+    }
+  })
 
   const status = computed<CheckoutStatus>(() => {
     if (is_success.value) return 'success'
@@ -94,7 +93,6 @@ export function useCheckout(close: (response?: CheckoutResponse) => void) {
   return {
     status,
     is_ready,
-    submit_error,
     onSubmit
   }
 }

--- a/src/components/settings/index.vue
+++ b/src/components/settings/index.vue
@@ -11,7 +11,13 @@ import {
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 import SettingsAside from './settings-aside.vue'
-import { settingsLayoutKey, settingsCloseKey, settingsRecedeKey } from './layout'
+import {
+  settingsLayoutKey,
+  settingsCloseKey,
+  settingsRecedeKey,
+  SETTINGS_SHEET_BREAKPOINTS
+} from './layout'
+import { useMatchMedia } from '@/composables/ui/media-query'
 import { emitSfx } from '@/sfx/bus'
 import { useMemberEditor, memberEditorKey } from '@/composables/member/editor'
 import { useMemberDangerActions, memberDangerActionsKey } from '@/composables/member/danger-actions'
@@ -61,10 +67,17 @@ const { layout_mode, sheet_px } = useTabModalLayout({
 provide(settingsLayoutKey, layout_mode)
 provide(settingsCloseKey, close)
 
+// Mirrors the mobile-sheet primitive's own bottom-pin check (same breakpoint keys
+// passed to modal.open in useSettingsModal) so recede/restore can't drift from it —
+// layout_mode has a looser height threshold and stays desktop/tablet past this point.
+const is_pinned = useMatchMedia(
+  `w<${SETTINGS_SHEET_BREAKPOINTS.width} | h<${SETTINGS_SHEET_BREAKPOINTS.height}`
+)
+
 const settings_root = useTemplateRef<{ $el: HTMLElement }>('settings_root')
 provide(settingsRecedeKey, {
-  recede: () => settings_root.value?.$el && recedeModal(settings_root.value.$el),
-  restore: () => settings_root.value?.$el && restoreModal(settings_root.value.$el)
+  recede: () => settings_root.value?.$el && recedeModal(settings_root.value.$el, is_pinned.value),
+  restore: () => settings_root.value?.$el && restoreModal(settings_root.value.$el, is_pinned.value)
 })
 
 type ActiveTab = 'profile' | 'subscription' | 'app' | 'review-preferences' | 'danger-zone'

--- a/src/components/settings/layout.ts
+++ b/src/components/settings/layout.ts
@@ -1,7 +1,18 @@
 import type { ComputedRef, InjectionKey } from 'vue'
 import type { TabModalLayout } from '@/composables/ui/tab-modal-layout'
+import type { BreakpointKey } from '@/composables/ui/media-query'
 
 export type SettingsLayout = TabModalLayout
+
+/**
+ * Breakpoint keys where the settings modal pins to the bottom edge as a mobile sheet.
+ * Shared by `useSettingsModal` (passed as `mobile_below_width`/`mobile_below_height` to
+ * `modal.open`) and the settings modal's own recede/restore pin check, so the two can't drift.
+ */
+export const SETTINGS_SHEET_BREAKPOINTS: { width: BreakpointKey; height: BreakpointKey } = {
+  width: 'mlg',
+  height: 'md'
+}
 
 export const settingsLayoutKey: InjectionKey<ComputedRef<SettingsLayout>> =
   Symbol('settings-layout')

--- a/src/components/settings/tab-subscription/add-credit-card-modal.vue
+++ b/src/components/settings/tab-subscription/add-credit-card-modal.vue
@@ -16,7 +16,7 @@ const { t } = useI18n()
 const queryCache = useQueryCache()
 const { mutateAsync: createSetupIntent } = useCreateSetupIntentMutation()
 
-const { container_ref, is_loading, is_submitting, is_ready, load_error, submit_error, confirm } =
+const { container_ref, is_loading, is_submitting, is_ready, load_error, confirm } =
   useCheckoutElements({
     publicKey: import.meta.env.VITE_STRIPE_PUBLIC_KEY,
     genericErrorMessage: t('settings.subscription.add-credit-card.submit-error'),
@@ -63,13 +63,6 @@ async function onSubmit() {
         {{ t('settings.subscription.add-credit-card.error') }}
       </p>
       <div ref="container" data-testid="add-credit-card-modal__payment-element"></div>
-      <p
-        v-if="submit_error"
-        data-testid="add-credit-card-modal__submit-error"
-        class="text-sm text-red-500"
-      >
-        {{ submit_error }}
-      </p>
     </div>
 
     <div

--- a/src/components/settings/tab-subscription/paid-features.vue
+++ b/src/components/settings/tab-subscription/paid-features.vue
@@ -4,6 +4,7 @@ import { PLANS } from '@/config/plans'
 import { useUpgradeClick } from './use-upgrade-click'
 import UiTappable from '@/components/ui-kit/tappable.vue'
 import UiButton from '@/components/ui-kit/button.vue'
+import { TYPE_SFX } from '@/sfx/config'
 
 const { t } = useI18n()
 const { onUpgradeClick } = useUpgradeClick()
@@ -18,11 +19,18 @@ const price = `$${PLANS.paid.monthlyPriceUsd} / mo`
     <ui-tappable
       data-testid="paid-features__body"
       data-theme="brown-100"
+      :sfx="{ hover: TYPE_SFX }"
       class="card-outline w-full flex flex-col gap-3 rounded-4 px-5 py-4 text-(--theme-on-primary) bg-(--theme-primary) pointer-fine:hover:scale-101 data-[active=true]:scale-101 pointer-coarse:data-[active=true]:scale-105 pointer-fine:transition-transform duration-75 cursor-pointer touch-manipulation"
       @tap="onUpgradeClick"
     >
       <div data-testid="paid-features__upgrade" class="absolute -bottom-2 -right-2 z-10 rotate-2">
-        <ui-button data-theme="yellow-500" icon-left="triangle-eye" @press="onUpgradeClick">
+        <ui-button
+          data-theme="yellow-500"
+          icon-left="triangle-eye"
+          class="pointer-events-none"
+          tabindex="-1"
+          aria-hidden="true"
+        >
           {{ t('settings.subscription.free.upgrade') }}
         </ui-button>
       </div>

--- a/src/components/settings/tab-subscription/paid-features.vue
+++ b/src/components/settings/tab-subscription/paid-features.vue
@@ -19,6 +19,7 @@ const price = `$${PLANS.paid.monthlyPriceUsd} / mo`
     <ui-tappable
       data-testid="paid-features__body"
       data-theme="brown-100"
+      data-theme-dark="stone-700"
       :sfx="{ hover: TYPE_SFX }"
       class="card-outline w-full flex flex-col gap-3 rounded-4 px-5 py-4 text-(--theme-on-primary) bg-(--theme-primary) pointer-fine:hover:scale-101 data-[active=true]:scale-101 pointer-coarse:data-[active=true]:scale-105 pointer-fine:transition-transform duration-75 cursor-pointer touch-manipulation"
       @tap="onUpgradeClick"
@@ -26,6 +27,7 @@ const price = `$${PLANS.paid.monthlyPriceUsd} / mo`
       <div data-testid="paid-features__upgrade" class="absolute -bottom-2 -right-2 z-10 rotate-2">
         <ui-button
           data-theme="yellow-500"
+          data-theme-dark="yellow-700"
           icon-left="triangle-eye"
           class="pointer-events-none"
           tabindex="-1"

--- a/src/components/ui-kit/scroll-bar.vue
+++ b/src/components/ui-kit/scroll-bar.vue
@@ -193,12 +193,15 @@ function isPageTarget(el: HTMLElement) {
   <div
     v-show="visible"
     ref="scrollBarRef"
+    data-testid="ui-kit-scroll-bar"
+    :data-min-width="minWidth"
     class="ui-kit-scroll-bar"
     :class="visibilityClass"
     @pointerdown.prevent="onTrackPointerDown"
   >
     <div
       ref="thumbEl"
+      data-testid="ui-kit-scroll-bar__thumb"
       class="ui-kit-scroll-bar__thumb hover:bgx-diagonal-stripes"
       :style="thumbStyle"
       @pointerdown.stop.prevent="onThumbPointerDown"

--- a/src/components/ui-kit/scroll-bar.vue
+++ b/src/components/ui-kit/scroll-bar.vue
@@ -1,9 +1,19 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue'
 
-const { target } = defineProps<{
+type UiScrollBarProps = {
   target?: string | HTMLElement
-}>()
+  // Viewport width above which the bar can show on a fine pointer. Page-level
+  // scroll-bars stay 'md' (avoid a custom bar on a narrow desktop window);
+  // container-local ones can drop to 'sm' to match their own mobile breakpoint.
+  minWidth?: 'sm' | 'md'
+}
+
+const { target, minWidth = 'md' } = defineProps<UiScrollBarProps>()
+
+const visibilityClass = computed(() =>
+  minWidth === 'sm' ? 'hidden pointer-fine:block' : 'hidden pointer-fine:md:block'
+)
 
 const thumbEl = shallowRef<HTMLElement | null>(null)
 
@@ -183,7 +193,8 @@ function isPageTarget(el: HTMLElement) {
   <div
     v-show="visible"
     ref="scrollBarRef"
-    class="ui-kit-scroll-bar hidden pointer-fine:md:block"
+    class="ui-kit-scroll-bar"
+    :class="visibilityClass"
     @pointerdown.prevent="onTrackPointerDown"
   >
     <div

--- a/src/composables/billing/use-checkout-elements.ts
+++ b/src/composables/billing/use-checkout-elements.ts
@@ -1,4 +1,5 @@
-import { onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
+import { onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import {
   loadStripe,
   type Stripe,
@@ -7,6 +8,7 @@ import {
   type StripePaymentElement
 } from '@stripe/stripe-js'
 import { getStripeAppearance, STRIPE_FONTS } from '@/utils/billing/stripe-theme'
+import { useThemeStore } from '@/stores/theme'
 import logger from '@/utils/logger'
 
 type UseCheckoutElementsOptions = {
@@ -28,6 +30,7 @@ export type ConfirmOutcome =
  */
 export function useCheckoutElements(options: UseCheckoutElementsOptions) {
   const container_ref = useTemplateRef<HTMLDivElement>('container')
+  const { is_dark } = storeToRefs(useThemeStore())
 
   const is_loading = ref(true)
   const is_submitting = ref(false)
@@ -50,7 +53,7 @@ export function useCheckoutElements(options: UseCheckoutElementsOptions) {
 
       checkout = stripe.initCheckoutElementsSdk({
         clientSecret,
-        elementsOptions: { appearance: getStripeAppearance(), fonts: STRIPE_FONTS }
+        elementsOptions: { appearance: getStripeAppearance(is_dark.value), fonts: STRIPE_FONTS }
       })
 
       payment_element = checkout.createPaymentElement({ layout: 'tabs' })
@@ -70,6 +73,8 @@ export function useCheckoutElements(options: UseCheckoutElementsOptions) {
   onBeforeUnmount(() => {
     payment_element?.destroy()
   })
+
+  watch(is_dark, (dark) => checkout?.changeAppearance(getStripeAppearance(dark)))
 
   async function confirm(): Promise<ConfirmOutcome> {
     if (!checkout) return { status: 'error', message: options.genericErrorMessage }

--- a/src/composables/billing/use-checkout-elements.ts
+++ b/src/composables/billing/use-checkout-elements.ts
@@ -36,7 +36,6 @@ export function useCheckoutElements(options: UseCheckoutElementsOptions) {
   const is_submitting = ref(false)
   const is_ready = ref(false)
   const load_error = ref(false)
-  const submit_error = ref<string | null>(null)
 
   let stripe: Stripe | null = null
   let checkout: StripeCheckoutElementsSdk | null = null
@@ -79,13 +78,14 @@ export function useCheckoutElements(options: UseCheckoutElementsOptions) {
   async function confirm(): Promise<ConfirmOutcome> {
     if (!checkout) return { status: 'error', message: options.genericErrorMessage }
     is_submitting.value = true
-    submit_error.value = null
 
     try {
       const loadActionsResult = await checkout.loadActions()
       if (loadActionsResult.type === 'error') {
-        submit_error.value = loadActionsResult.error.message ?? options.genericErrorMessage
-        return { status: 'error', message: submit_error.value }
+        return {
+          status: 'error',
+          message: loadActionsResult.error.message ?? options.genericErrorMessage
+        }
       }
 
       // return_url is already set when the Checkout Session was created
@@ -93,24 +93,21 @@ export function useCheckoutElements(options: UseCheckoutElementsOptions) {
       const result = await loadActionsResult.actions.confirm({ redirect: 'if_required' })
 
       if (result.type === 'error') {
-        submit_error.value = result.error.message ?? options.genericErrorMessage
-        return { status: 'error', message: submit_error.value }
+        return { status: 'error', message: result.error.message ?? options.genericErrorMessage }
       }
 
       if (result.session.status.type !== 'complete') {
-        submit_error.value = options.genericErrorMessage
-        return { status: 'error', message: submit_error.value }
+        return { status: 'error', message: options.genericErrorMessage }
       }
 
       return { status: 'success', session: result.session }
     } catch (err) {
       logger.error((err as Error).message)
-      submit_error.value = options.genericErrorMessage
-      return { status: 'error', message: submit_error.value }
+      return { status: 'error', message: options.genericErrorMessage }
     } finally {
       is_submitting.value = false
     }
   }
 
-  return { container_ref, is_loading, is_submitting, is_ready, load_error, submit_error, confirm }
+  return { container_ref, is_loading, is_submitting, is_ready, load_error, confirm }
 }

--- a/src/composables/settings/use-settings-modal.ts
+++ b/src/composables/settings/use-settings-modal.ts
@@ -1,4 +1,5 @@
 import { useModal } from '@/composables/modal'
+import { SETTINGS_SHEET_BREAKPOINTS } from '@/components/settings/layout'
 import SettingsComponent from '@/components/settings/index.vue'
 
 /** Opens the settings modal. Shared by the phone launcher and any other settings entry point. */
@@ -9,8 +10,8 @@ export function useSettingsModal() {
     return modal.open(SettingsComponent, {
       backdrop: true,
       mode: 'mobile-sheet',
-      mobile_below_width: 'mlg',
-      mobile_below_height: 'md'
+      mobile_below_width: SETTINGS_SHEET_BREAKPOINTS.width,
+      mobile_below_height: SETTINGS_SHEET_BREAKPOINTS.height
     })
   }
 

--- a/src/utils/animations/modal.ts
+++ b/src/utils/animations/modal.ts
@@ -56,12 +56,18 @@ export function scaleFadeOut(el: Element, done: () => void) {
 }
 
 const RECEDE_DURATION = 0.4
+const RECEDE_SCALE = 0.9
+const RECEDE_TRANSLATE_Y = '60px'
 
-/** Dials back a modal that a new modal just opened on top of, as if a shadow fell over it. */
-export function recedeModal(el: Element) {
+/**
+ * Dials back a modal that a new modal just opened on top of, as if a shadow fell over it.
+ * Pinned-to-bottom sheets (tablet/sheet mode) nudge down instead of scaling, since scaling
+ * a bottom-anchored modal reads as shrinking off-anchor rather than receding.
+ */
+export function recedeModal(el: Element, is_pinned: boolean) {
   gsap.set(el, { filter: 'brightness(1) blur(0px)' })
   gsap.to(el, {
-    scale: 0.9,
+    ...(is_pinned ? { translateY: RECEDE_TRANSLATE_Y } : { scale: RECEDE_SCALE }),
     filter: 'brightness(0.8) blur(2px)',
     duration: RECEDE_DURATION,
     ease: 'expo.out',
@@ -70,10 +76,10 @@ export function recedeModal(el: Element) {
 }
 
 /** Restores a modal to full prominence once the modal above it has closed. */
-export function restoreModal(el: Element) {
+export function restoreModal(el: Element, is_pinned: boolean) {
   gsap.set(el, { pointerEvents: 'auto' })
   gsap.to(el, {
-    scale: 1,
+    ...(is_pinned ? { translateY: 0 } : { scale: 1 }),
     filter: 'brightness(1) blur(0px)',
     duration: RECEDE_DURATION,
     ease: 'expo.out'

--- a/src/utils/billing/stripe-theme.ts
+++ b/src/utils/billing/stripe-theme.ts
@@ -47,15 +47,21 @@ export function getStripeAppearance(is_dark: boolean): Appearance {
       colorDanger: red600,
       colorTextPlaceholder: placeholder,
       fontFamily: FONT_FAMILY,
+      fontSizeBase: '14px',
       // "condensed" inputs — Stripe's appearance API has no dedicated input-
-      // density flag, so this is expressed as tighter spacing/radius instead.
+      // density flag, and spacingUnit alone doesn't shrink input padding, so
+      // the actual height reduction happens via explicit rules below.
       spacingUnit: '2px',
+      gridRowSpacing: '8px',
+      gridColumnSpacing: '8px',
+      tabSpacing: '8px',
       borderRadius: '8px'
     },
     rules: {
       '.Input': {
         border: `1px solid ${border}`,
-        boxShadow: 'none'
+        boxShadow: 'none',
+        padding: '8px 10px'
       },
       '.Input:focus': {
         border: `1px solid ${green600}`,
@@ -67,7 +73,8 @@ export function getStripeAppearance(is_dark: boolean): Appearance {
       },
       '.Tab': {
         border: `1px solid ${border}`,
-        backgroundColor: background
+        backgroundColor: background,
+        padding: '8px 10px'
       },
       '.Tab:hover': {
         backgroundColor: surfaceHover

--- a/src/utils/billing/stripe-theme.ts
+++ b/src/utils/billing/stripe-theme.ts
@@ -27,8 +27,8 @@ function withAlpha(hex: string, percent: number): string {
  * so the Stripe form always matches the surrounding modal chrome.
  */
 export function getStripeAppearance(is_dark: boolean): Appearance {
-  const green600 = token('--color-green-600')
   const red600 = token('--color-red-600')
+  const accent = token(is_dark ? '--color-blue-650' : '--color-blue-500')
 
   const background = token(is_dark ? '--color-grey-800' : '--color-brown-50')
   const surface = token(is_dark ? '--color-grey-700' : '--color-brown-100')
@@ -40,32 +40,24 @@ export function getStripeAppearance(is_dark: boolean): Appearance {
   return {
     theme: 'flat',
     labels: 'floating',
+    inputs: 'condensed',
     variables: {
-      colorPrimary: green600,
+      colorPrimary: accent,
       colorBackground: background,
       colorText: text,
       colorDanger: red600,
       colorTextPlaceholder: placeholder,
       fontFamily: FONT_FAMILY,
-      fontSizeBase: '14px',
-      // "condensed" inputs — Stripe's appearance API has no dedicated input-
-      // density flag, and spacingUnit alone doesn't shrink input padding, so
-      // the actual height reduction happens via explicit rules below.
-      spacingUnit: '2px',
-      gridRowSpacing: '8px',
-      gridColumnSpacing: '8px',
-      tabSpacing: '8px',
       borderRadius: '8px'
     },
     rules: {
       '.Input': {
         border: `1px solid ${border}`,
-        boxShadow: 'none',
-        padding: '8px 10px'
+        boxShadow: 'none'
       },
       '.Input:focus': {
-        border: `1px solid ${green600}`,
-        boxShadow: `0 0 0 3px ${withAlpha(green600, 25)}`
+        border: `1px solid ${accent}`,
+        boxShadow: `0 0 0 3px ${withAlpha(accent, 25)}`
       },
       '.Label': {
         color: text,
@@ -73,15 +65,22 @@ export function getStripeAppearance(is_dark: boolean): Appearance {
       },
       '.Tab': {
         border: `1px solid ${border}`,
-        backgroundColor: background,
-        padding: '8px 10px'
+        backgroundColor: background
       },
       '.Tab:hover': {
         backgroundColor: surfaceHover
       },
       '.Tab--selected': {
-        borderColor: green600,
+        borderColor: accent,
         backgroundColor: surface
+      },
+      // Selected-tab label/icon default to a primary-tinted color that reads
+      // low-contrast against the surface — pin them back to the base text color.
+      '.TabLabel--selected': {
+        color: text
+      },
+      '.TabIcon--selected': {
+        color: text
       }
     }
   }

--- a/src/utils/billing/stripe-theme.ts
+++ b/src/utils/billing/stripe-theme.ts
@@ -27,7 +27,7 @@ function withAlpha(hex: string, percent: number): string {
  * so the Stripe form always matches the surrounding modal chrome.
  */
 export function getStripeAppearance(is_dark: boolean): Appearance {
-  const red600 = token('--color-red-600')
+  const danger = token(is_dark ? '--color-red-600' : '--color-red-500')
   const accent = token(is_dark ? '--color-blue-650' : '--color-blue-500')
 
   const background = token(is_dark ? '--color-grey-800' : '--color-brown-50')
@@ -39,13 +39,13 @@ export function getStripeAppearance(is_dark: boolean): Appearance {
 
   return {
     theme: 'flat',
-    labels: 'floating',
+    labels: 'above',
     inputs: 'condensed',
     variables: {
       colorPrimary: accent,
       colorBackground: background,
       colorText: text,
-      colorDanger: red600,
+      colorDanger: danger,
       colorTextPlaceholder: placeholder,
       fontFamily: FONT_FAMILY,
       borderRadius: '8px'

--- a/src/utils/billing/stripe-theme.ts
+++ b/src/utils/billing/stripe-theme.ts
@@ -21,31 +21,40 @@ function withAlpha(hex: string, percent: number): string {
   return `#${clean}${alpha}`
 }
 
-export function getStripeAppearance(): Appearance {
+/**
+ * Builds the shared Payment Element appearance, in either light or dark
+ * palette. `is_dark` should mirror the app's own `useThemeStore().is_dark`
+ * so the Stripe form always matches the surrounding modal chrome.
+ */
+export function getStripeAppearance(is_dark: boolean): Appearance {
   const green600 = token('--color-green-600')
-  const brown50 = token('--color-brown-50')
-  const brown100 = token('--color-brown-100')
-  const brown200 = token('--color-brown-200')
-  const brown300 = token('--color-brown-300')
-  const brown500 = token('--color-brown-500')
-  const brown700 = token('--color-brown-700')
   const red600 = token('--color-red-600')
 
+  const background = token(is_dark ? '--color-grey-800' : '--color-brown-50')
+  const surface = token(is_dark ? '--color-grey-700' : '--color-brown-100')
+  const surfaceHover = token(is_dark ? '--color-grey-900' : '--color-brown-200')
+  const border = token(is_dark ? '--color-grey-700' : '--color-brown-300')
+  const text = token(is_dark ? '--color-grey-300' : '--color-brown-700')
+  const placeholder = token(is_dark ? '--color-grey-500' : '--color-brown-500')
+
   return {
-    theme: 'stripe',
+    theme: 'flat',
+    labels: 'floating',
     variables: {
       colorPrimary: green600,
-      colorBackground: brown50,
-      colorText: brown700,
+      colorBackground: background,
+      colorText: text,
       colorDanger: red600,
-      colorTextPlaceholder: brown500,
+      colorTextPlaceholder: placeholder,
       fontFamily: FONT_FAMILY,
-      spacingUnit: '4px',
+      // "condensed" inputs — Stripe's appearance API has no dedicated input-
+      // density flag, so this is expressed as tighter spacing/radius instead.
+      spacingUnit: '2px',
       borderRadius: '8px'
     },
     rules: {
       '.Input': {
-        border: `1px solid ${brown300}`,
+        border: `1px solid ${border}`,
         boxShadow: 'none'
       },
       '.Input:focus': {
@@ -53,19 +62,19 @@ export function getStripeAppearance(): Appearance {
         boxShadow: `0 0 0 3px ${withAlpha(green600, 25)}`
       },
       '.Label': {
-        color: brown700,
+        color: text,
         fontWeight: '500'
       },
       '.Tab': {
-        border: `1px solid ${brown300}`,
-        backgroundColor: brown50
+        border: `1px solid ${border}`,
+        backgroundColor: background
       },
       '.Tab:hover': {
-        backgroundColor: brown200
+        backgroundColor: surfaceHover
       },
       '.Tab--selected': {
         borderColor: green600,
-        backgroundColor: brown100
+        backgroundColor: surface
       }
     }
   }

--- a/src/views/deck/card-grid/scroll-grid.vue
+++ b/src/views/deck/card-grid/scroll-grid.vue
@@ -39,6 +39,9 @@ const grid_el = useTemplateRef<HTMLElement>('grid_el')
 const sentinel = useTemplateRef<HTMLElement>('sentinel')
 const container_width = ref(0)
 const scroll_margin = ref(0)
+// container_width starts at 0, so columns/row_count fall back to a single tall
+// column for one frame — gate the rendered height on this so that never paints.
+const measured = ref(false)
 
 const { card_scale, cell_width, gap, columns, row_count, row_pitch, itemPosition } = useCardGrid(
   grid_size,
@@ -131,6 +134,7 @@ function measureLayout() {
   if (!container) return
   container_width.value = container.clientWidth
   scroll_margin.value = container.getBoundingClientRect().top + window.scrollY
+  measured.value = true
 }
 
 // The drag/gap-shift offset (px) the reorder engine wants applied to the card at
@@ -255,7 +259,7 @@ watch(
       v-else
       data-testid="card-grid"
       class="relative w-full"
-      :style="{ height: `${virtualizer.getTotalSize()}px` }"
+      :style="{ height: measured ? `${virtualizer.getTotalSize()}px` : '0px' }"
     >
       <div
         v-for="item in visible_items"

--- a/tests/integration/components/modals/checkout/index.test.js
+++ b/tests/integration/components/modals/checkout/index.test.js
@@ -10,9 +10,9 @@ import { ref } from 'vue'
 const mockOnSubmit = vi.fn()
 const checkoutState = {
   status: ref('form'),
-  is_ready: ref(true),
-  submit_error: ref(null)
+  is_ready: ref(true)
 }
+const mediaState = { is_mobile: ref(false) }
 
 vi.mock('gsap', () => ({
   gsap: {
@@ -24,9 +24,12 @@ vi.mock('@/components/modals/checkout/use-checkout', () => ({
   useCheckout: () => ({
     status: checkoutState.status,
     is_ready: checkoutState.is_ready,
-    submit_error: checkoutState.submit_error,
     onSubmit: mockOnSubmit
   })
+}))
+
+vi.mock('@/composables/ui/media-query', () => ({
+  useMatchMedia: () => mediaState.is_mobile
 }))
 
 import Checkout from '@/components/modals/checkout/index.vue'
@@ -40,7 +43,7 @@ function mountCheckout(close = vi.fn()) {
 beforeEach(() => {
   checkoutState.status.value = 'form'
   checkoutState.is_ready.value = true
-  checkoutState.submit_error.value = null
+  mediaState.is_mobile.value = false
   mockOnSubmit.mockReset()
 })
 
@@ -139,12 +142,9 @@ describe('Checkout — body', () => {
     expect(wrapper.findComponent({ name: 'SuccessView' }).exists()).toBe(true)
   })
 
-  test('surfaces a submit_error message', () => {
-    checkoutState.submit_error.value = 'Your card was declined.'
+  test('[obligation] no longer renders local submit-error markup — Stripe surfaces its own', () => {
     const wrapper = mountCheckout()
-    expect(wrapper.find('[data-testid="checkout__submit-error"]').text()).toBe(
-      'Your card was declined.'
-    )
+    expect(wrapper.find('[data-testid="checkout__submit-error"]').exists()).toBe(false)
   })
 })
 
@@ -160,5 +160,61 @@ describe('Checkout — body/success transition', () => {
 
     expect(wrapper.find('[data-testid="checkout__body"]').exists()).toBe(false)
     expect(wrapper.findComponent({ name: 'SuccessView' }).exists()).toBe(true)
+  })
+})
+
+// ── Full-bleed mobile scroll area [obligation] ────────────────────────────────
+
+describe('Checkout — full-bleed mobile scroll area [obligation]', () => {
+  test('[obligation] checkout__scroll-area is the overflow container in full-bleed mode', () => {
+    mediaState.is_mobile.value = true
+    const wrapper = mountCheckout()
+
+    const scrollArea = wrapper.find('[data-testid="checkout__scroll-area"]')
+    expect(scrollArea.attributes('data-full-bleed')).toBe('true')
+  })
+
+  test('[obligation] checkout__scroll-area is not the overflow container outside full-bleed mode', () => {
+    mediaState.is_mobile.value = false
+    const wrapper = mountCheckout()
+
+    const scrollArea = wrapper.find('[data-testid="checkout__scroll-area"]')
+    expect(scrollArea.attributes('data-full-bleed')).toBe('false')
+  })
+
+  test('[obligation] scroll-area wraps header, body, and footer together, not just the body', () => {
+    mediaState.is_mobile.value = true
+    const wrapper = mountCheckout()
+
+    const scrollArea = wrapper.find('[data-testid="checkout__scroll-area"]')
+    expect(scrollArea.find('[data-testid="checkout__header"]').exists()).toBe(true)
+    expect(scrollArea.find('[data-testid="checkout__body"]').exists()).toBe(true)
+    expect(scrollArea.findComponent({ name: 'CheckoutFooter' }).exists()).toBe(true)
+  })
+
+  test('renders the ui-kit scroll-bar targeting the scroll-area only in full-bleed mode', () => {
+    mediaState.is_mobile.value = true
+    const wrapper = mountCheckout()
+    expect(wrapper.findComponent({ name: 'ScrollBar' }).exists()).toBe(true)
+  })
+
+  test('does not render the ui-kit scroll-bar outside full-bleed mode', () => {
+    mediaState.is_mobile.value = false
+    const wrapper = mountCheckout()
+    expect(wrapper.findComponent({ name: 'ScrollBar' }).exists()).toBe(false)
+  })
+
+  test('applies full-bleed sizing (h-full w-full, no rounding) when is_mobile is true', () => {
+    mediaState.is_mobile.value = true
+    const wrapper = mountCheckout()
+    const root = wrapper.find('[data-testid="checkout"]')
+    expect(root.attributes('data-full-bleed')).toBe('true')
+  })
+
+  test('applies fixed desktop sizing when is_mobile is false', () => {
+    mediaState.is_mobile.value = false
+    const wrapper = mountCheckout()
+    const root = wrapper.find('[data-testid="checkout"]')
+    expect(root.attributes('data-full-bleed')).toBe('false')
   })
 })

--- a/tests/integration/components/settings/index.test.js
+++ b/tests/integration/components/settings/index.test.js
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent, h, inject, nextTick, useAttrs } from 'vue'
-import { settingsRecedeKey } from '@/components/settings/layout'
+import { settingsRecedeKey, SETTINGS_SHEET_BREAKPOINTS } from '@/components/settings/layout'
 
 // ── Hoisted state ─────────────────────────────────────────────────────────────
 
@@ -20,7 +20,7 @@ const { mockEditor, mockDanger, mockEmitSfx, mockAlertWarn, alertResponse, state
     }
 
     return {
-      state: { isSheet: false, isDesktop: false },
+      state: { isSheet: false, isDesktop: false, isPinned: false },
       mockEditor: {
         settings: { display_name: 'Chris', description: 'hi' },
         preferences: { accessibility: { left_hand: false } },
@@ -65,9 +65,16 @@ vi.mock('@/composables/storage/session-ref', async () => {
 vi.mock('@/composables/ui/media-query', async () => {
   const { ref } = await import('vue')
   return {
-    // sheet_query contains '|' or 'w<'; desktop_query contains '&'
+    // sheet_query (useTabModalLayout, 'w<mlg | h<sm') and the settings-only
+    // pin check (SETTINGS_SHEET_BREAKPOINTS, 'w<mlg | h<md') are distinct
+    // queries on purpose — they resolve from separate state fields so a test
+    // can pin the recede/restore animation while layout_mode stays desktop/tablet.
     useMatchMedia: (query) => {
       if (query.includes('&')) return ref(state.isDesktop)
+      if (
+        query === `w<${SETTINGS_SHEET_BREAKPOINTS.width} | h<${SETTINGS_SHEET_BREAKPOINTS.height}`
+      )
+        return ref(state.isPinned)
       return ref(state.isSheet)
     }
   }
@@ -242,6 +249,7 @@ function makeWrapper(closeFn = vi.fn()) {
 beforeEach(() => {
   state.isSheet = false
   state.isDesktop = false
+  state.isPinned = false
   mockEditor.is_dirty.value = false
   mockEditor.saving.value = false
   mockEditor.saveMember.mockReset().mockResolvedValue(true)
@@ -563,5 +571,35 @@ describe('settings app — recede/restore choreography [obligation]', () => {
     await wrapper.find('[data-testid="restore-trigger"]').trigger('click')
 
     expect(mockRestoreModal).toHaveBeenCalledOnce()
+  })
+
+  test("[obligation] uses SETTINGS_SHEET_BREAKPOINTS pin check, not layout_mode's own sheet_query — recedes with is_pinned true even while layout_mode resolves tablet/desktop", async () => {
+    // sheet_query ('w<mlg | h<sm') resolves false here so layout_mode is tablet/desktop,
+    // but the narrower SETTINGS_SHEET_BREAKPOINTS pin query still resolves true.
+    state.isSheet = false
+    state.isDesktop = false
+    state.isPinned = true
+    mockRecedeModal.mockClear()
+
+    const wrapper = makeWrapperWithRecedeInjector()
+    await wrapper.find('[data-testid="tab-sheet__select-subscription"]').trigger('click')
+    await flushPromises()
+    await wrapper.find('[data-testid="recede-trigger"]').trigger('click')
+
+    expect(mockRecedeModal).toHaveBeenCalledWith(expect.anything(), true)
+  })
+
+  test('[obligation] recedes with is_pinned false when below the narrower SETTINGS_SHEET_BREAKPOINTS threshold', async () => {
+    state.isSheet = false
+    state.isDesktop = false
+    state.isPinned = false
+    mockRecedeModal.mockClear()
+
+    const wrapper = makeWrapperWithRecedeInjector()
+    await wrapper.find('[data-testid="tab-sheet__select-subscription"]').trigger('click')
+    await flushPromises()
+    await wrapper.find('[data-testid="recede-trigger"]').trigger('click')
+
+    expect(mockRecedeModal).toHaveBeenCalledWith(expect.anything(), false)
   })
 })

--- a/tests/integration/components/settings/tab-subscription/add-credit-card-modal.test.js
+++ b/tests/integration/components/settings/tab-subscription/add-credit-card-modal.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount, flushPromises } from '@vue/test-utils'
 import { defineComponent, h, useAttrs } from 'vue'
+import { createTestingPinia } from '@pinia/testing'
 
 const {
   mockCreateSetupIntent,
@@ -82,6 +83,7 @@ async function makeAddCreditCardModal({ close = vi.fn() } = {}) {
   const wrapper = shallowMount(AddCreditCardModal, {
     props: { close },
     global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn })],
       stubs: {
         MobileSheet: MobileSheetStub,
         UiButton: UiButtonStub
@@ -236,7 +238,7 @@ describe('add-credit-card-modal — submit', () => {
     expect('returnUrl' in args).toBe(false)
   })
 
-  test('shows the submit error when confirm() returns an error', async () => {
+  test('[obligation] does not close and renders no local error markup when confirm() returns an error', async () => {
     mockConfirm.mockResolvedValue({ type: 'error', error: { message: 'Your card was declined.' } })
     const { wrapper, close } = await makeAddCreditCardModal()
     await flushPromises()
@@ -246,13 +248,11 @@ describe('add-credit-card-modal — submit', () => {
     await wrapper.find('[data-testid="add-credit-card-modal__submit"]').trigger('click')
     await flushPromises()
 
-    const err = wrapper.find('[data-testid="add-credit-card-modal__submit-error"]')
-    expect(err.exists()).toBe(true)
-    expect(err.text()).toBe('Your card was declined.')
+    expect(wrapper.find('[data-testid="add-credit-card-modal__submit-error"]').exists()).toBe(false)
     expect(close).not.toHaveBeenCalled()
   })
 
-  test('falls back to a generic submit error when the session is not complete', async () => {
+  test('does not close when the session is not complete', async () => {
     mockConfirm.mockResolvedValue({ type: 'success', session: { status: { type: 'open' } } })
     const { wrapper, close } = await makeAddCreditCardModal()
     await flushPromises()
@@ -262,7 +262,6 @@ describe('add-credit-card-modal — submit', () => {
     await wrapper.find('[data-testid="add-credit-card-modal__submit"]').trigger('click')
     await flushPromises()
 
-    expect(wrapper.find('[data-testid="add-credit-card-modal__submit-error"]').exists()).toBe(true)
     expect(close).not.toHaveBeenCalled()
   })
 })

--- a/tests/integration/components/settings/tab-subscription/paid-features.test.js
+++ b/tests/integration/components/settings/tab-subscription/paid-features.test.js
@@ -152,9 +152,22 @@ describe('paid-features — upgrade actions [obligation]', () => {
     expect(mockOnUpgrade).toHaveBeenCalledOnce()
   })
 
-  test('pressing the upgrade UiButton (@press) calls onUpgrade [obligation]', async () => {
+  test('[obligation] the nested upgrade pill has no click/press handler of its own — it is inert', async () => {
     const wrapper = mountPaidFeatures()
     await wrapper.find('[data-testid="upgrade-button"]').trigger('click')
-    expect(mockOnUpgrade).toHaveBeenCalledOnce()
+    expect(mockOnUpgrade).not.toHaveBeenCalled()
+  })
+
+  test('[obligation] the nested upgrade pill is marked inert (tabindex -1, aria-hidden)', () => {
+    const wrapper = mountPaidFeatures()
+    const pill = wrapper.find('[data-testid="upgrade-button"]')
+    expect(pill.attributes('tabindex')).toBe('-1')
+    expect(pill.attributes('aria-hidden')).toBe('true')
+  })
+
+  test('[obligation] tapping the card body calls onUpgrade exactly once, not twice via the nested pill', async () => {
+    const wrapper = mountPaidFeatures()
+    await wrapper.findComponent({ name: 'UiTappable' }).vm.$emit('tap')
+    expect(mockOnUpgrade).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/integration/components/ui-kit/scroll-bar.test.js
+++ b/tests/integration/components/ui-kit/scroll-bar.test.js
@@ -1,0 +1,239 @@
+import { describe, test, expect, afterEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import UiScrollBar from '@/components/ui-kit/scroll-bar.vue'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+let _activeWrappers = []
+let _activeContainers = []
+
+afterEach(() => {
+  for (const w of _activeWrappers) w.unmount()
+  _activeWrappers = []
+  for (const c of _activeContainers) c.remove()
+  _activeContainers = []
+})
+
+/** Builds a real scrollable container attached to document.body, addressable by id. */
+function makeScrollTarget({ contentHeight = 400, containerHeight = 100 } = {}) {
+  const container = document.createElement('div')
+  container.id = `scroll-target-${_activeContainers.length}`
+  container.style.height = `${containerHeight}px`
+  container.style.overflow = 'auto'
+
+  const inner = document.createElement('div')
+  inner.style.height = `${contentHeight}px`
+  container.appendChild(inner)
+
+  document.body.appendChild(container)
+  _activeContainers.push(container)
+  return container
+}
+
+async function waitForUpdate() {
+  await new Promise((resolve) => requestAnimationFrame(resolve))
+  await new Promise((resolve) => requestAnimationFrame(resolve))
+}
+
+/**
+ * The very first measurement can land while the bar itself is still
+ * `display:none` (v-show hasn't flushed to the DOM yet), which reads the
+ * track as 0px tall and locks the thumb at the MIN_THUMB_PX fallback with
+ * nothing left to trigger a re-measure. Nudging the target's height forces a
+ * fresh ResizeObserver firing against the now-visible bar, giving drag tests
+ * a real (not fallback) geometry to assert against.
+ */
+async function forceRemeasure(target, containerHeight) {
+  target.style.height = `${containerHeight + 1}px`
+  await waitForUpdate()
+  target.style.height = `${containerHeight}px`
+  await waitForUpdate()
+}
+
+// Consumers position/size the bar themselves (e.g. `fixed ... top-x bottom-y`);
+// give it a real height here so the track/thumb geometry math has something to work with.
+function mountScrollBar(props = {}, { trackHeight = 100 } = {}) {
+  const wrapper = mount(UiScrollBar, {
+    attachTo: document.body,
+    props,
+    attrs: { style: `height: ${trackHeight}px` }
+  })
+  _activeWrappers.push(wrapper)
+  return wrapper
+}
+
+function root(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-scroll-bar"]')
+}
+
+function thumb(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-scroll-bar__thumb"]')
+}
+
+// ── Overflow-based visibility ─────────────────────────────────────────────────
+
+describe('UiScrollBar — overflow-based visibility [obligation]', () => {
+  test('hides when the target has no overflow, regardless of minWidth', async () => {
+    const target = makeScrollTarget({ contentHeight: 50, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target: `#${target.id}`, minWidth: 'sm' })
+    await waitForUpdate()
+
+    expect(root(wrapper).isVisible()).toBe(false)
+  })
+
+  test('shows when the target overflows, with minWidth="sm"', async () => {
+    const target = makeScrollTarget({ contentHeight: 400, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target: `#${target.id}`, minWidth: 'sm' })
+    await waitForUpdate()
+
+    expect(root(wrapper).isVisible()).toBe(true)
+  })
+
+  test('shows when the target overflows, with the default minWidth ("md")', async () => {
+    const target = makeScrollTarget({ contentHeight: 400, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target: `#${target.id}` })
+    await waitForUpdate()
+
+    expect(root(wrapper).isVisible()).toBe(true)
+  })
+
+  test('hides again once overflow is resolved (content shrinks below the container height)', async () => {
+    const target = makeScrollTarget({ contentHeight: 400, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target: `#${target.id}` })
+    await waitForUpdate()
+    expect(root(wrapper).isVisible()).toBe(true)
+
+    target.firstElementChild.style.height = '50px'
+    target.dispatchEvent(new Event('scroll'))
+    await waitForUpdate()
+
+    expect(root(wrapper).isVisible()).toBe(false)
+  })
+})
+
+// ── minWidth gates only the pointer/width class, never overflow ────────────────
+
+describe('UiScrollBar — minWidth gate', () => {
+  test('minWidth="sm" is reflected on the root element', () => {
+    const wrapper = mountScrollBar({ minWidth: 'sm' })
+    expect(root(wrapper).attributes('data-min-width')).toBe('sm')
+  })
+
+  test('default minWidth ("md") is reflected on the root element', () => {
+    const wrapper = mountScrollBar()
+    expect(root(wrapper).attributes('data-min-width')).toBe('md')
+  })
+})
+
+// ── Thumb geometry ──────────────────────────────────────────────────────────────
+
+describe('UiScrollBar — thumb geometry', () => {
+  test('sizes the thumb proportionally to the visible/scrollable ratio', async () => {
+    const target = makeScrollTarget({ contentHeight: 400, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target: `#${target.id}` })
+    await waitForUpdate()
+
+    const height = Number.parseFloat(
+      thumb(wrapper)
+        .attributes('style')
+        .match(/height:\s*(\d+)/)[1]
+    )
+    expect(height).toBeGreaterThan(0)
+  })
+
+  test('moves the thumb down as the target is scrolled', async () => {
+    const target = makeScrollTarget({ contentHeight: 400, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target: `#${target.id}` })
+    await waitForUpdate()
+    const before = thumb(wrapper).attributes('style')
+
+    target.scrollTop = 200
+    target.dispatchEvent(new Event('scroll'))
+    await waitForUpdate()
+    const after = thumb(wrapper).attributes('style')
+
+    expect(after).not.toBe(before)
+  })
+})
+
+// ── Target resolution ─────────────────────────────────────────────────────────
+
+describe('UiScrollBar — target resolution', () => {
+  test('falls back to the window/page target when no target prop is given', async () => {
+    const wrapper = mountScrollBar()
+    await waitForUpdate()
+
+    expect(root(wrapper).exists()).toBe(true)
+  })
+
+  test('resolves "body" to document.body as a page target', async () => {
+    const wrapper = mountScrollBar({ target: 'body' })
+    await waitForUpdate()
+
+    expect(root(wrapper).exists()).toBe(true)
+  })
+
+  test('accepts a direct HTMLElement as the target', async () => {
+    const target = makeScrollTarget({ contentHeight: 400, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target })
+    await waitForUpdate()
+
+    expect(root(wrapper).isVisible()).toBe(true)
+  })
+})
+
+// ── Cleanup ───────────────────────────────────────────────────────────────────
+
+describe('UiScrollBar — cleanup', () => {
+  test('unmounting a container-targeted bar does not throw', async () => {
+    const target = makeScrollTarget({ contentHeight: 400, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target: `#${target.id}` })
+    await waitForUpdate()
+
+    expect(() => wrapper.unmount()).not.toThrow()
+  })
+
+  test('unmounting a window-targeted bar does not throw', async () => {
+    const wrapper = mountScrollBar()
+    await waitForUpdate()
+
+    expect(() => wrapper.unmount()).not.toThrow()
+  })
+})
+
+// ── Drag interaction ──────────────────────────────────────────────────────────
+
+describe('UiScrollBar — thumb drag', () => {
+  test('dragging the thumb scrolls the target', async () => {
+    const target = makeScrollTarget({ contentHeight: 400, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target: `#${target.id}` })
+    await waitForUpdate()
+    await forceRemeasure(target, 100)
+
+    const thumbEl = thumb(wrapper).element
+    thumbEl.setPointerCapture = () => {}
+    thumbEl.dispatchEvent(
+      new PointerEvent('pointerdown', { clientY: 0, pointerId: 1, bubbles: true })
+    )
+    window.dispatchEvent(new PointerEvent('pointermove', { clientY: 40, pointerId: 1 }))
+    window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1 }))
+    await waitForUpdate()
+
+    expect(target.scrollTop).toBeGreaterThan(0)
+  })
+
+  test('clicking the track (not the thumb) jumps the scroll position', async () => {
+    const target = makeScrollTarget({ contentHeight: 400, containerHeight: 100 })
+    const wrapper = mountScrollBar({ target: `#${target.id}` })
+    await waitForUpdate()
+    await forceRemeasure(target, 100)
+
+    const rect = root(wrapper).element.getBoundingClientRect()
+    root(wrapper).element.dispatchEvent(
+      new PointerEvent('pointerdown', { clientY: rect.top + 80, bubbles: true })
+    )
+    await waitForUpdate()
+
+    expect(target.scrollTop).toBeGreaterThan(0)
+  })
+})

--- a/tests/integration/views/deck/card-grid/scroll-grid.test.js
+++ b/tests/integration/views/deck/card-grid/scroll-grid.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
-import { defineComponent, h, ref } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 
 const GridItemStub = defineComponent({
   name: 'GridItem',
@@ -82,6 +82,28 @@ describe('card-grid/scroll-grid', () => {
     const wrapper = mountScrollGrid()
     expect(wrapper.find('[data-testid="card-grid-container"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="card-grid"]').exists()).toBe(true)
+  })
+
+  test('[obligation] the initial synchronous render is height 0px, not an inflated single-column fallback', async () => {
+    const search = makeSearch({
+      displayed_cards: [
+        { id: 1, client_id: 'c1', front_text: 'q1', back_text: 'a1' },
+        { id: 2, client_id: 'c2', front_text: 'q2', back_text: 'a2' },
+        { id: 3, client_id: 'c3', front_text: 'q3', back_text: 'a3' }
+      ]
+    })
+    const wrapper = mountScrollGrid(makeEditor(), makeShell(), search)
+
+    // measureLayout() runs in onMounted, but its reactive DOM patch is flushed
+    // on the next microtask — inspect before that flush to catch the true
+    // first-paint state.
+    expect(wrapper.find('[data-testid="card-grid"]').attributes('style')).toContain('height: 0px')
+
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="card-grid"]').attributes('style')).not.toContain(
+      'height: 0px'
+    )
   })
 
   // ── displayed_cards (from cardSearchKey) drives the grid ─────────────────

--- a/tests/unit/components/modals/checkout/use-checkout.test.js
+++ b/tests/unit/components/modals/checkout/use-checkout.test.js
@@ -23,8 +23,7 @@ const {
     is_loading: { value: false },
     is_submitting: { value: false },
     is_ready: { value: true },
-    load_error: { value: false },
-    submit_error: { value: null }
+    load_error: { value: false }
   }
 }))
 
@@ -86,7 +85,6 @@ beforeEach(() => {
   elementsState.is_submitting.value = false
   elementsState.is_ready.value = true
   elementsState.load_error.value = false
-  elementsState.submit_error.value = null
   request_close_handlers.clear()
 })
 

--- a/tests/unit/composables/billing/use-checkout-elements.test.js
+++ b/tests/unit/composables/billing/use-checkout-elements.test.js
@@ -6,8 +6,15 @@ const { mockLoadStripe } = vi.hoisted(() => ({ mockLoadStripe: vi.fn() }))
 
 vi.mock('@stripe/stripe-js', () => ({ loadStripe: mockLoadStripe }))
 vi.mock('@/utils/logger', () => ({ default: { error: vi.fn() } }))
+vi.mock('@/stores/theme', async () => {
+  const { ref } = await import('vue')
+  const is_dark = ref(false)
+  return { useThemeStore: () => ({ is_dark }) }
+})
 
 import { useCheckoutElements } from '@/composables/billing/use-checkout-elements'
+import { useThemeStore } from '@/stores/theme'
+import { getStripeAppearance, STRIPE_FONTS } from '@/utils/billing/stripe-theme'
 
 let app
 
@@ -40,10 +47,15 @@ function makePaymentElement() {
   }
 }
 
-function makeCheckoutSdk({ paymentElement = makePaymentElement(), loadActions } = {}) {
+function makeCheckoutSdk({
+  paymentElement = makePaymentElement(),
+  loadActions,
+  changeAppearance
+} = {}) {
   return {
     createPaymentElement: vi.fn(() => paymentElement),
-    loadActions: loadActions ?? vi.fn()
+    loadActions: loadActions ?? vi.fn(),
+    changeAppearance: changeAppearance ?? vi.fn()
   }
 }
 
@@ -62,6 +74,7 @@ function baseOptions(overrides = {}) {
 
 beforeEach(() => {
   mockLoadStripe.mockReset()
+  useThemeStore().is_dark.value = false
 })
 
 describe('useCheckoutElements — mount lifecycle', () => {
@@ -82,6 +95,15 @@ describe('useCheckoutElements — mount lifecycle', () => {
 
     paymentElement.fireReady()
     expect(result.is_ready.value).toBe(true)
+  })
+
+  test('[obligation] does not return a submit_error field — Stripe surfaces inline errors itself', async () => {
+    mockLoadStripe.mockResolvedValue(makeStripe())
+
+    const result = withSetup(baseOptions())
+    await flushPromises()
+
+    expect('submit_error' in result).toBe(false)
   })
 
   test('initCheckoutElementsSdk is called with the resolved client secret', async () => {
@@ -200,7 +222,6 @@ describe('useCheckoutElements — confirm()', () => {
     const outcome = await result.confirm()
 
     expect(outcome).toEqual({ status: 'error', message: 'Something went wrong.' })
-    expect(result.submit_error.value).toBe('Something went wrong.')
   })
 
   test('surfaces the error and resets is_submitting when loadActions() returns type error', async () => {
@@ -214,7 +235,6 @@ describe('useCheckoutElements — confirm()', () => {
 
     expect(outcome).toEqual({ status: 'error', message: 'Could not load actions.' })
     expect(result.is_submitting.value).toBe(false)
-    expect(result.submit_error.value).toBe('Could not load actions.')
   })
 
   test('surfaces the error and resets is_submitting when actions.confirm() returns type error', async () => {
@@ -248,5 +268,36 @@ describe('useCheckoutElements — confirm()', () => {
     const outcome = await result.confirm()
 
     expect(outcome).toEqual({ status: 'error', message: 'Something went wrong.' })
+  })
+})
+
+describe('useCheckoutElements — dark-mode reactivity', () => {
+  test('[obligation] initializes the Checkout SDK with the light appearance when is_dark starts false', async () => {
+    const stripe = makeStripe()
+    mockLoadStripe.mockResolvedValue(stripe)
+
+    withSetup(baseOptions())
+    await flushPromises()
+
+    expect(stripe.initCheckoutElementsSdk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        elementsOptions: { appearance: getStripeAppearance(false), fonts: STRIPE_FONTS }
+      })
+    )
+  })
+
+  test('[obligation] calls checkout.changeAppearance when is_dark toggles after mount, not just at init', async () => {
+    const changeAppearance = vi.fn()
+    const checkout = makeCheckoutSdk({ changeAppearance })
+    mockLoadStripe.mockResolvedValue(makeStripe({ checkout }))
+
+    withSetup(baseOptions())
+    await flushPromises()
+    expect(changeAppearance).not.toHaveBeenCalled()
+
+    useThemeStore().is_dark.value = true
+    await flushPromises()
+
+    expect(changeAppearance).toHaveBeenCalledWith(getStripeAppearance(true))
   })
 })

--- a/tests/unit/composables/settings/use-settings-modal.test.js
+++ b/tests/unit/composables/settings/use-settings-modal.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { useSettingsModal } from '@/composables/settings/use-settings-modal'
+import { SETTINGS_SHEET_BREAKPOINTS } from '@/components/settings/layout'
 
 const { mockOpen } = vi.hoisted(() => ({ mockOpen: vi.fn() }))
 
@@ -28,6 +29,17 @@ describe('useSettingsModal — call shape [obligation]', () => {
       mobile_below_width: 'mlg',
       mobile_below_height: 'md'
     })
+  })
+
+  test('[obligation] sources the mobile thresholds from SETTINGS_SHEET_BREAKPOINTS, shared with the recede/restore pin check', () => {
+    mockOpen.mockReturnValueOnce({ response: Promise.resolve(undefined) })
+
+    const { open } = useSettingsModal()
+    open()
+
+    const [, opts] = mockOpen.mock.calls[0]
+    expect(opts.mobile_below_width).toBe(SETTINGS_SHEET_BREAKPOINTS.width)
+    expect(opts.mobile_below_height).toBe(SETTINGS_SHEET_BREAKPOINTS.height)
   })
 
   test('returns the result of modal.open unchanged', () => {

--- a/tests/unit/utils/animations/modal.test.js
+++ b/tests/unit/utils/animations/modal.test.js
@@ -182,30 +182,37 @@ describe('modal animations', () => {
 
   describe('recedeModal', () => {
     test('[obligation] seeds filter to brightness(1) blur(0px) before tweening', () => {
-      recedeModal(el)
+      recedeModal(el, false)
 
       expect(mockSet).toHaveBeenCalledWith(el, { filter: 'brightness(1) blur(0px)' })
     })
 
     test('[obligation] seeding happens before the tween is issued', () => {
-      recedeModal(el)
+      recedeModal(el, false)
 
       const setOrder = mockSet.mock.invocationCallOrder[0]
       const toOrder = mockTo.mock.invocationCallOrder[0]
       expect(setOrder).toBeLessThan(toOrder)
     })
 
-    test('tweens scale down and dims/blurs via filter', () => {
-      recedeModal(el)
+    test('[obligation] tweens scale down (not translateY) and dims/blurs via filter when not pinned', () => {
+      recedeModal(el, false)
 
-      expect(mockTo).toHaveBeenCalledWith(
-        el,
-        expect.objectContaining({ scale: 0.9, filter: 'brightness(0.8) blur(2px)' })
-      )
+      const [, vars] = mockTo.mock.calls[0]
+      expect(vars).toMatchObject({ scale: 0.9, filter: 'brightness(0.8) blur(2px)' })
+      expect(vars).not.toHaveProperty('translateY')
+    })
+
+    test('[obligation] tweens translateY (not scale) and still dims/blurs via filter when pinned', () => {
+      recedeModal(el, true)
+
+      const [, vars] = mockTo.mock.calls[0]
+      expect(vars).toMatchObject({ translateY: '60px', filter: 'brightness(0.8) blur(2px)' })
+      expect(vars).not.toHaveProperty('scale')
     })
 
     test('disables pointer events while receded', () => {
-      recedeModal(el)
+      recedeModal(el, false)
 
       expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ pointerEvents: 'none' }))
     })
@@ -213,18 +220,25 @@ describe('modal animations', () => {
 
   describe('restoreModal', () => {
     test('[obligation] seeds pointerEvents to auto before tweening', () => {
-      restoreModal(el)
+      restoreModal(el, false)
 
       expect(mockSet).toHaveBeenCalledWith(el, { pointerEvents: 'auto' })
     })
 
-    test('tweens scale and filter back to full prominence', () => {
-      restoreModal(el)
+    test('[obligation] tweens scale (not translateY) back to full prominence when not pinned', () => {
+      restoreModal(el, false)
 
-      expect(mockTo).toHaveBeenCalledWith(
-        el,
-        expect.objectContaining({ scale: 1, filter: 'brightness(1) blur(0px)' })
-      )
+      const [, vars] = mockTo.mock.calls[0]
+      expect(vars).toMatchObject({ scale: 1, filter: 'brightness(1) blur(0px)' })
+      expect(vars).not.toHaveProperty('translateY')
+    })
+
+    test('[obligation] tweens translateY (not scale) back to full prominence when pinned', () => {
+      restoreModal(el, true)
+
+      const [, vars] = mockTo.mock.calls[0]
+      expect(vars).toMatchObject({ translateY: 0, filter: 'brightness(1) blur(0px)' })
+      expect(vars).not.toHaveProperty('scale')
     })
   })
 })

--- a/tests/unit/utils/billing/stripe-theme.test.js
+++ b/tests/unit/utils/billing/stripe-theme.test.js
@@ -1,0 +1,80 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vite-plus/test'
+import { getStripeAppearance, STRIPE_FONTS } from '@/utils/billing/stripe-theme'
+
+const TOKENS = {
+  '--color-red-500': '#e11d48',
+  '--color-red-600': '#be123c',
+  '--color-blue-500': '#3b82f6',
+  '--color-blue-650': '#1d4ed8',
+  '--color-grey-800': '#1f2937',
+  '--color-grey-700': '#374151',
+  '--color-grey-900': '#111827',
+  '--color-grey-300': '#d1d5db',
+  '--color-grey-500': '#6b7280',
+  '--color-brown-50': '#fdf6ec',
+  '--color-brown-100': '#f5e9d6',
+  '--color-brown-200': '#ecd9bc',
+  '--color-brown-300': '#e0c49a',
+  '--color-brown-700': '#5c4530',
+  '--color-brown-500': '#9c7b52'
+}
+
+beforeEach(() => {
+  Object.entries(TOKENS).forEach(([name, value]) => {
+    document.documentElement.style.setProperty(name, value)
+  })
+})
+
+afterEach(() => {
+  Object.keys(TOKENS).forEach((name) => document.documentElement.style.removeProperty(name))
+})
+
+describe('getStripeAppearance — light/dark token selection', () => {
+  test('resolves the light-mode danger and accent colors when is_dark is false', () => {
+    const appearance = getStripeAppearance(false)
+
+    expect(appearance.variables.colorDanger).toBe(TOKENS['--color-red-500'])
+    expect(appearance.variables.colorPrimary).toBe(TOKENS['--color-blue-500'])
+    expect(appearance.variables.colorBackground).toBe(TOKENS['--color-brown-50'])
+    expect(appearance.variables.colorText).toBe(TOKENS['--color-brown-700'])
+  })
+
+  test('resolves the dark-mode danger and accent colors when is_dark is true', () => {
+    const appearance = getStripeAppearance(true)
+
+    expect(appearance.variables.colorDanger).toBe(TOKENS['--color-red-600'])
+    expect(appearance.variables.colorPrimary).toBe(TOKENS['--color-blue-650'])
+    expect(appearance.variables.colorBackground).toBe(TOKENS['--color-grey-800'])
+    expect(appearance.variables.colorText).toBe(TOKENS['--color-grey-300'])
+  })
+})
+
+describe('getStripeAppearance — static shape', () => {
+  test('always returns the flat theme, above labels, and condensed inputs', () => {
+    const appearance = getStripeAppearance(false)
+
+    expect(appearance.theme).toBe('flat')
+    expect(appearance.labels).toBe('above')
+    expect(appearance.inputs).toBe('condensed')
+  })
+
+  test('builds an 8-digit alpha hex for the focused Input box-shadow', () => {
+    const appearance = getStripeAppearance(false)
+
+    expect(appearance.rules['.Input:focus'].boxShadow).toContain(`${TOKENS['--color-blue-500']}40`)
+  })
+
+  test('pins selected-tab label/icon color back to the base text color', () => {
+    const appearance = getStripeAppearance(false)
+
+    expect(appearance.rules['.TabLabel--selected'].color).toBe(TOKENS['--color-brown-700'])
+    expect(appearance.rules['.TabIcon--selected'].color).toBe(TOKENS['--color-brown-700'])
+  })
+})
+
+describe('STRIPE_FONTS', () => {
+  test('exports a single custom font source entry', () => {
+    expect(STRIPE_FONTS).toHaveLength(1)
+    expect(STRIPE_FONTS[0]).toHaveProperty('cssSrc')
+  })
+})


### PR DESCRIPTION
## Summary

- Checkout modal goes full-bleed and scrolls as one unit (header, body, footer together) on mobile/short viewports, with a themed ui-kit scrollbar overlay
- Settings modal's recede animation translates instead of scales when pinned to the bottom of the screen, using a pin-detection breakpoint shared with the mobile-sheet's own threshold so the two can't drift apart
- Fixes a bug where the paid-features "Upgrade" pill double-opened checkout (nested interactive elements both firing)
- Stripe Elements now use the flat theme, floating labels, condensed inputs, and a blue accent that adapts to dark mode; the redundant custom submit-error message is removed since Stripe's Payment Element already surfaces it inline
- Fixes a scroll-bar bug where forcing visibility with `!important` also defeated its real overflow-based hide (added a `minWidth` prop instead)
- Fixes a deck-view bug where the card grid briefly flashed a tall single-column layout before its first width measurement