### PR TITLE
Persist member profile cover appearance, polish member-card

### DIFF
--- a/src/components/member/member-badge.vue
+++ b/src/components/member/member-badge.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{ click: [e: MouseEvent] }>()
 
 const { t } = useI18n()
 
-const body_bindings = computed(() => memberCoverBindings(cover, { patternOpacity: '0.15' }))
+const body_bindings = computed(() => memberCoverBindings(cover))
 </script>
 
 <template>

--- a/src/components/member/member-card.vue
+++ b/src/components/member/member-card.vue
@@ -25,16 +25,16 @@ const body_bindings = computed(() =>
 <template>
   <div
     data-testid="member-card"
-    class="bg-brown-300 dark:bg-stone-900 rounded-8 border-brown-300 dark:border-stone-900 flex w-89 flex-col overflow-hidden border-8"
+    class="bg-brown-300 dark:bg-stone-900 rounded-8 border-brown-300 dark:border-stone-900 flex w-89 flex-col overflow-hidden border-8 shadow-[-1px_-1px_0_0_var(--color-brown-100)] dark:shadow-[-1px_-1px_0_0_var(--color-grey-900)]"
   >
-    <div data-testid="member-card__header" class="flex items-center justify-center px-9 pt-6 pb-2">
-      <h1 class="text-brown-700 dark:text-brown-100 text-5xl">{{ t('member-card.heading') }}</h1>
+    <div data-testid="member-card__header" class="flex items-center justify-center px-9 pt-4 pb-1">
+      <h1 class="text-brown-700 dark:text-brown-100 text-5xl">{{ displayName }}</h1>
     </div>
 
     <div
       data-testid="member-card__body"
       v-bind="body_bindings"
-      class="wave-top-[40px] flex h-full flex-col items-center gap-4.5 bg-(--theme-primary) px-8 pt-9 pb-3"
+      class="wave-top-[40px] flex h-full flex-col items-center gap-4 bg-(--theme-primary) px-8 pt-9 pb-3"
     >
       <div data-testid="member-card__avatar" class="flex h-full flex-col justify-center">
         <div
@@ -46,35 +46,18 @@ const body_bindings = computed(() =>
 
       <div
         data-testid="member-card__comment"
-        class="bg-brown-300 dark:bg-stone-900 text-brown-700 dark:text-brown-100 ring-brown-300 dark:ring-stone-900 rounded-2 w-full ring-8"
+        class="bg-brown-300 dark:bg-stone-900 rounded-4 w-full px-2 py-3"
       >
-        {{ cardComment || t('member-card.description-fallback') }}
-      </div>
-
-      <div data-testid="member-card__fields" class="flex w-full flex-col gap-2">
-        <div data-testid="member-card__name-field" class="flex flex-col">
-          <p class="pb-1 text-xl text-brown-700 dark:text-brown-100">
-            {{ displayName || t('member-card.field.name-placeholder') }}
-          </p>
-          <div class="bg-brown-300 dark:bg-stone-900 h-px w-full"></div>
-          <p class="text-sm text-brown-100 dark:text-grey-900">
-            {{ t('member-card.field.member-label') }}
-          </p>
-        </div>
-        <div data-testid="member-card__title-field" class="flex flex-col">
-          <p class="pb-1 text-xl text-brown-700 dark:text-brown-100">
-            {{ cardTitle || t('member-card.field.title-placeholder') }}
-          </p>
-          <div class="bg-brown-300 dark:bg-stone-900 h-px w-full"></div>
-          <p class="text-sm text-brown-100 dark:text-grey-900">
-            {{ t('member-card.field.title-label') }}
-          </p>
-        </div>
+        <p
+          class="text-brown-700 dark:text-brown-100 flex h-[3lh] items-center justify-center text-center"
+        >
+          <q>{{ cardComment || t('member-card.description-fallback') }}</q>
+        </p>
       </div>
 
       <div
         data-testid="member-card__registration"
-        class="align-center flex w-full justify-between text-sm font-semibold text-brown-700 dark:text-brown-100"
+        class="align-center flex w-full justify-between text-sm font-semibold text-brown-100 mt-2"
       >
         <p>{{ t('member-card.field.registration-label', { date: created_on }) }}</p>
         <p aria-hidden="true">&lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt;</p>

--- a/src/components/settings/index.vue
+++ b/src/components/settings/index.vue
@@ -174,8 +174,8 @@ watch(layout_mode, (mode) => {
     data-theme-dark="blue-650"
     :data-layout="layout_mode"
     :class="[
-      layout_mode === 'desktop' ? 'w-262!' : 'w-full! max-w-224',
-      layout_mode !== 'sheet' && 'h-170',
+      layout_mode === 'desktop' ? 'w-270!' : 'w-full! max-w-224',
+      layout_mode !== 'sheet' && 'h-182',
       layout_mode === 'sheet' ? '[--settings-padding:var(--sheet-px)]' : '[--settings-padding:0px]'
     ]"
     :sheet_px="sheet_px"
@@ -215,7 +215,7 @@ watch(layout_mode, (mode) => {
     <settings-aside
       v-if="layout_mode !== 'sheet'"
       data-testid="settings__aside"
-      class="w-96 shrink-0 self-end"
+      class="w-90 shrink-0 self-end"
       :class="layout_mode === 'tablet' ? 'pt-56' : 'pt-60'"
     />
 

--- a/src/components/settings/tab-profile/index.vue
+++ b/src/components/settings/tab-profile/index.vue
@@ -2,6 +2,7 @@
 import { inject } from 'vue'
 import { useI18n } from 'vue-i18n'
 import UiInput from '@/components/ui-kit/input.vue'
+import UiTextarea from '@/components/ui-kit/textarea.vue'
 import UiThemePicker from '@/components/ui-kit/theme-picker.vue'
 import UiPatternPicker from '@/components/ui-kit/pattern-picker.vue'
 import SectionList from '@/components/layout-kit/section-list.vue'
@@ -37,8 +38,10 @@ const emit = defineEmits<{ back: [] }>()
         :placeholder="t('settings.profile.member-name-placeholder')"
         v-model:value="editor.settings.display_name"
       />
-      <ui-input
+      <ui-textarea
         :placeholder="t('settings.profile.description-placeholder')"
+        :max_chars="100"
+        rows="3"
         v-model:value="editor.settings.description"
       />
     </labeled-section>

--- a/src/composables/member/editor.ts
+++ b/src/composables/member/editor.ts
@@ -1,15 +1,12 @@
 import { computed, reactive, type InjectionKey } from 'vue'
 import { useUpsertMemberMutation } from '@/api/members'
 import { useMemberStore } from '@/stores/member'
-import { MEMBER_CARD_COVER_DEFAULTS } from '@/utils/member/defaults'
 import { buildMemberPayload, hasMemberChanges } from '@/utils/member/payload'
 
 /**
  * Reactive state + mutations for editing the current member's profile.
  * Owns the in-flight `settings` object that the settings tabs bind into,
- * plus a `cover` object the member-card preview consumes. `cover` is
- * client-only today (no member.cover_config column yet) — seeded from
- * MEMBER_CARD_COVER_DEFAULTS each session. Mirrors `useDeckEditor`.
+ * plus a `cover` object the member-card preview consumes. Mirrors `useDeckEditor`.
  */
 export function useMemberEditor() {
   const member_store = useMemberStore()
@@ -21,14 +18,16 @@ export function useMemberEditor() {
 
   const preferences = reactive({ ...member_store.preferences })
 
-  const cover = reactive<DeckCover>({ ...MEMBER_CARD_COVER_DEFAULTS })
+  const cover = reactive<DeckCover>({ ...member_store.cover })
 
   const email = computed(() => member_store.email ?? '')
   const created_at = computed(() => member_store.created_at ?? '')
   const plan = computed(() => member_store.plan ?? 'free')
 
-  const initial_payload = buildMemberPayload({ settings, preferences })
-  const is_dirty = computed(() => hasMemberChanges({ settings, preferences }, initial_payload))
+  const initial_payload = buildMemberPayload({ settings, preferences, cover })
+  const is_dirty = computed(() =>
+    hasMemberChanges({ settings, preferences, cover }, initial_payload)
+  )
 
   const upsert_mutation = useUpsertMemberMutation()
 
@@ -40,7 +39,7 @@ export function useMemberEditor() {
     try {
       await upsert_mutation.mutateAsync({
         id: member_store.id,
-        ...buildMemberPayload({ settings, preferences })
+        ...buildMemberPayload({ settings, preferences, cover })
       })
       return true
     } catch {

--- a/src/stores/member.ts
+++ b/src/stores/member.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed } from 'vue'
 import { useCurrentMemberQuery } from '@/api/members'
 import { withMemberPreferencesDefaults } from '@/utils/member/preferences'
+import { withMemberCardCoverDefaults } from '@/utils/member/defaults'
 import { useSessionStore } from './session'
 
 export const useMemberStore = defineStore('member', () => {
@@ -24,6 +25,7 @@ export const useMemberStore = defineStore('member', () => {
   const plan = computed(() => member.value?.plan)
   const plan_display_name = computed(() => member.value?.plan_display_name)
   const preferences = computed(() => withMemberPreferencesDefaults(member.value?.preferences))
+  const cover = computed(() => withMemberCardCoverDefaults(member.value?.cover_config))
 
   const has_member = computed(() => Boolean(id.value))
 
@@ -39,6 +41,7 @@ export const useMemberStore = defineStore('member', () => {
     role,
     plan,
     plan_display_name,
-    preferences
+    preferences,
+    cover
   }
 })

--- a/src/utils/member/payload.ts
+++ b/src/utils/member/payload.ts
@@ -1,15 +1,17 @@
-import { MEMBER_SETTINGS_DEFAULTS } from './defaults'
+import { MEMBER_SETTINGS_DEFAULTS, withMemberCardCoverDefaults } from './defaults'
 import { withMemberPreferencesDefaults, type ResolvedMemberPreferences } from './preferences'
 
 export type MemberEditorState = {
   settings: { display_name?: string; description?: string }
   preferences: MemberPreferences
+  cover: DeckCover
 }
 
 export type MemberPayload = {
   display_name: string
   description: string
   preferences: ResolvedMemberPreferences
+  cover_config: DeckCover
 }
 
 /**
@@ -21,7 +23,8 @@ export function buildMemberPayload(state: MemberEditorState): MemberPayload {
   return {
     display_name: state.settings.display_name ?? MEMBER_SETTINGS_DEFAULTS.display_name,
     description: state.settings.description ?? MEMBER_SETTINGS_DEFAULTS.description,
-    preferences: withMemberPreferencesDefaults(state.preferences)
+    preferences: withMemberPreferencesDefaults(state.preferences),
+    cover_config: withMemberCardCoverDefaults(state.cover)
   }
 }
 

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -77,6 +77,7 @@ async function onCreateDeckClicked() {
         <member-badge
           :display-name="member_store.display_name"
           :description="member_store.description"
+          :cover="member_store.cover"
           class="z-10"
           :sfx="{
             hover: 'tap_05',

--- a/supabase/migrations/20260702000000_member-cover-config.sql
+++ b/supabase/migrations/20260702000000_member-cover-config.sql
@@ -1,0 +1,18 @@
+-- =============================================================================
+-- members.cover_config: persisted member-card theme + pattern
+-- =============================================================================
+--
+-- Mirrors decks.cover_config — nullable jsonb, no default. Existing rows read
+-- back NULL and the frontend falls back to MEMBER_CARD_COVER_DEFAULTS, same
+-- as it did for the client-only cover before this column existed. Kept
+-- separate from members.preferences (private, behavioral) since cover is
+-- visual identity that may need its own RLS/select boundary if member
+-- profiles ever become viewable by others.
+-- =============================================================================
+
+BEGIN;
+
+ALTER TABLE public.members
+  ADD COLUMN cover_config jsonb;
+
+COMMIT;

--- a/supabase/tests/00022_member_cover_config.sql
+++ b/supabase/tests/00022_member_cover_config.sql
@@ -1,0 +1,50 @@
+-- =============================================================================
+-- members.cover_config: column exists, nullable, and is writable only by the
+-- owning member (same RLS policy as the rest of the members row).
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(3);
+
+-- ── Setup (as postgres superuser) ─────────────────────────────────────────────
+
+SELECT tests.create_user('44444444-4444-4444-4444-444444444444'::uuid, 'carol');
+SELECT tests.create_user('55555555-5555-5555-5555-555555555555'::uuid, 'dave');
+
+-- Test 1: column exists and defaults to NULL for a freshly-created member
+SELECT is(
+  (SELECT cover_config FROM public.members WHERE id = '44444444-4444-4444-4444-444444444444'),
+  NULL,
+  'cover_config defaults to NULL on member creation'
+);
+
+-- ── Act as Carol ──────────────────────────────────────────────────────────────
+
+SELECT tests.set_claims('44444444-4444-4444-4444-444444444444'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 2: Carol can persist her own cover_config
+SELECT lives_ok(
+  $$
+    UPDATE public.members
+    SET cover_config = '{"theme": "red-500", "theme_dark": "red-700", "pattern": "wave"}'::jsonb
+    WHERE id = '44444444-4444-4444-4444-444444444444'
+  $$,
+  'Carol can update her own cover_config'
+);
+
+-- Test 3: Carol cannot update Dave's cover_config (existing members RLS policy)
+UPDATE public.members
+SET cover_config = '{"theme": "hacked"}'::jsonb
+WHERE id = '55555555-5555-5555-5555-555555555555';
+
+SET LOCAL role = 'postgres';
+SELECT is(
+  (SELECT cover_config FROM public.members WHERE id = '55555555-5555-5555-5555-555555555555'),
+  NULL,
+  'Carol cannot update Dave''s cover_config'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/integration/components/member/member-card.test.js
+++ b/tests/integration/components/member/member-card.test.js
@@ -49,14 +49,14 @@ describe('MemberCard', () => {
     expect(body.classes()).toContain('pattern-mask')
   })
 
-  test('renders displayName when provided', () => {
+  test('renders displayName in the header', () => {
     const wrapper = mountCard({ displayName: 'Nina' })
-    expect(wrapper.find('[data-testid="member-card__name-field"]').text()).toContain('Nina')
+    expect(wrapper.find('[data-testid="member-card__header"]').text()).toContain('Nina')
   })
 
-  test('falls back to name-placeholder when displayName omitted', () => {
+  test('header is empty when displayName omitted', () => {
     const wrapper = mountCard()
-    expect(wrapper.find('[data-testid="member-card__name-field"]').text()).toContain('Member Name')
+    expect(wrapper.find('[data-testid="member-card__header"]').text()).toBe('')
   })
 
   test('renders cardComment when provided', () => {
@@ -67,11 +67,6 @@ describe('MemberCard', () => {
   test('falls back to description-fallback when cardComment omitted', () => {
     const wrapper = mountCard()
     expect(wrapper.find('[data-testid="member-card__comment"]').text().length).toBeGreaterThan(0)
-  })
-
-  test('renders cardTitle in the title field', () => {
-    const wrapper = mountCard({ cardTitle: 'Sensei' })
-    expect(wrapper.find('[data-testid="member-card__title-field"]').text()).toContain('Sensei')
   })
 
   test('renders the formatted registration date in the registration row', () => {

--- a/tests/integration/components/settings/tab-profile.test.js
+++ b/tests/integration/components/settings/tab-profile.test.js
@@ -124,10 +124,10 @@ describe('TabProfile', () => {
     expect(editor.settings.display_name).toBe('Nina')
   })
 
-  test('typing into the bio input updates editor.settings.description', async () => {
+  test('typing into the bio textarea updates editor.settings.description', async () => {
     const { wrapper, editor } = makeTab()
-    const input = wrapper.findAll('input')[1]
-    await input.setValue('New bio')
+    const textarea = wrapper.find('textarea')
+    await textarea.setValue('New bio')
     expect(editor.settings.description).toBe('New bio')
   })
 

--- a/tests/integration/views/dashboard/index.test.js
+++ b/tests/integration/views/dashboard/index.test.js
@@ -32,7 +32,11 @@ vi.mock('@/api/decks', () => ({
 }))
 
 vi.mock('@/stores/member', () => ({
-  useMemberStore: () => ({ display_name: 'Test User', description: 'Learner' })
+  useMemberStore: () => ({
+    display_name: 'Test User',
+    description: 'Learner',
+    cover: { theme: 'green-500', theme_dark: 'green-800', pattern: 'bank-note' }
+  })
 }))
 
 vi.mock('vue-router', () => ({
@@ -77,14 +81,19 @@ vi.mock('@/utils/animations/inbox-toggle', () => ({
 
 const MemberBadgeStub = defineComponent({
   name: 'MemberBadge',
-  props: ['displayName', 'description', 'sfx'],
+  props: ['displayName', 'description', 'sfx', 'cover'],
   emits: ['click'],
-  setup(_p, { emit, slots }) {
+  setup(props, { emit, slots }) {
     return () =>
-      h('div', { 'data-testid': 'member-badge', onClick: () => emit('click') }, [
-        slots.description?.(),
-        slots.actions?.()
-      ])
+      h(
+        'div',
+        {
+          'data-testid': 'member-badge',
+          'data-cover-theme': props.cover?.theme,
+          onClick: () => emit('click')
+        },
+        [slots.description?.(), slots.actions?.()]
+      )
   }
 })
 
@@ -185,6 +194,15 @@ beforeEach(() => {
   vi.clearAllMocks()
   guardCreateDeckMock.mockReturnValue(Promise.resolve(true))
   toastErrorMock.mockReset()
+})
+
+describe('DashboardIndex — member-badge cover wiring [obligation]', () => {
+  test('forwards member_store.cover to the member-badge cover prop', () => {
+    const wrapper = mountDashboard()
+    expect(wrapper.find('[data-testid="member-badge"]').attributes('data-cover-theme')).toBe(
+      'green-500'
+    )
+  })
 })
 
 describe('DashboardIndex — deck list', () => {

--- a/tests/unit/composables/member-editor.test.js
+++ b/tests/unit/composables/member-editor.test.js
@@ -13,7 +13,8 @@ const { mockMember } = vi.hoisted(() => ({
     description: 'hello',
     email: 'chris@example.com',
     created_at: '2026-01-01T00:00:00Z',
-    plan: 'pro'
+    plan: 'pro',
+    cover: { theme: 'green-500', theme_dark: 'green-800', pattern: 'bank-note' }
   }
 }))
 
@@ -42,7 +43,8 @@ beforeEach(() => {
       accessibility: { left_hand: false },
       audio: { study_sounds: 5, interface_sounds: 5, hover_sounds: 5 },
       study: { show_all_ratings: true, desired_retention: 90 }
-    }
+    },
+    cover: { theme: 'green-500', theme_dark: 'green-800', pattern: 'bank-note' }
   })
 })
 
@@ -80,13 +82,19 @@ describe('useMemberEditor', () => {
     expect(editor.preferences).toEqual(mockMember.preferences)
   })
 
-  test('seeds cover from MEMBER_CARD_COVER_DEFAULTS', () => {
+  test('seeds cover from member_store.cover (persisted value) [obligation]', () => {
     const editor = useMemberEditor()
     expect(editor.cover).toEqual({
       theme: 'green-500',
       theme_dark: 'green-800',
       pattern: 'bank-note'
     })
+  })
+
+  test('reopening with a previously-saved cover seeds that cover, not hardcoded defaults [obligation]', () => {
+    mockMember.cover = { theme: 'red-500', theme_dark: 'red-700', pattern: 'wave' }
+    const editor = useMemberEditor()
+    expect(editor.cover).toEqual({ theme: 'red-500', theme_dark: 'red-700', pattern: 'wave' })
   })
 
   test('is_dirty is false when nothing has changed', () => {
@@ -103,6 +111,24 @@ describe('useMemberEditor', () => {
   test('is_dirty flips to true when description changes', () => {
     const editor = useMemberEditor()
     editor.settings.description = 'changed'
+    expect(editor.is_dirty.value).toBe(true)
+  })
+
+  test('is_dirty flips to true when only cover.theme changes, settings/preferences untouched [obligation]', () => {
+    const editor = useMemberEditor()
+    editor.cover.theme = 'red-500'
+    expect(editor.is_dirty.value).toBe(true)
+  })
+
+  test('is_dirty flips to true when only cover.theme_dark changes [obligation]', () => {
+    const editor = useMemberEditor()
+    editor.cover.theme_dark = 'red-700'
+    expect(editor.is_dirty.value).toBe(true)
+  })
+
+  test('is_dirty flips to true when only cover.pattern changes [obligation]', () => {
+    const editor = useMemberEditor()
+    editor.cover.pattern = 'wave'
     expect(editor.is_dirty.value).toBe(true)
   })
 
@@ -136,8 +162,22 @@ describe('useMemberEditor', () => {
         accessibility: { left_hand: false },
         audio: { study_sounds: 5, interface_sounds: 5, hover_sounds: 5 },
         study: { show_all_ratings: true, desired_retention: 90 }
-      }
+      },
+      cover_config: { theme: 'green-500', theme_dark: 'green-800', pattern: 'bank-note' }
     })
+  })
+
+  test('saveMember includes cover_config in the upsert payload when only cover changed [obligation]', async () => {
+    const editor = useMemberEditor()
+    editor.cover.theme = 'red-500'
+    const result = await editor.saveMember()
+    expect(result).toBe(true)
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'member-1',
+        cover_config: { theme: 'red-500', theme_dark: 'green-800', pattern: 'bank-note' }
+      })
+    )
   })
 
   test('saveMember returns false when the mutation throws', async () => {

--- a/tests/unit/utils/member/payload.test.js
+++ b/tests/unit/utils/member/payload.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vite-plus/test'
 import { buildMemberPayload, hasMemberChanges } from '@/utils/member/payload'
+import { MEMBER_CARD_COVER_DEFAULTS } from '@/utils/member/defaults'
 
 const DEFAULT_PREFS = {
   accessibility: { left_hand: false },
@@ -12,66 +13,101 @@ describe('member/payload', () => {
     test('returns the settings values when both fields are present', () => {
       const payload = buildMemberPayload({
         settings: { display_name: 'Chris', description: 'hi' },
-        preferences: {}
+        preferences: {},
+        cover: {}
       })
       expect(payload).toEqual({
         display_name: 'Chris',
         description: 'hi',
-        preferences: DEFAULT_PREFS
+        preferences: DEFAULT_PREFS,
+        cover_config: MEMBER_CARD_COVER_DEFAULTS
       })
     })
 
     test('falls back to empty-string defaults when display_name is missing', () => {
       const payload = buildMemberPayload({
         settings: { description: 'hi' },
-        preferences: {}
+        preferences: {},
+        cover: {}
       })
       expect(payload).toEqual({
         display_name: '',
         description: 'hi',
-        preferences: DEFAULT_PREFS
+        preferences: DEFAULT_PREFS,
+        cover_config: MEMBER_CARD_COVER_DEFAULTS
       })
     })
 
     test('falls back to empty-string defaults when description is missing', () => {
       const payload = buildMemberPayload({
         settings: { display_name: 'Chris' },
-        preferences: {}
+        preferences: {},
+        cover: {}
       })
       expect(payload).toEqual({
         display_name: 'Chris',
         description: '',
-        preferences: DEFAULT_PREFS
+        preferences: DEFAULT_PREFS,
+        cover_config: MEMBER_CARD_COVER_DEFAULTS
       })
     })
 
     test('falls back to defaults when both fields are missing', () => {
-      const payload = buildMemberPayload({ settings: {}, preferences: {} })
+      const payload = buildMemberPayload({ settings: {}, preferences: {}, cover: {} })
       expect(payload).toEqual({
         display_name: '',
         description: '',
-        preferences: DEFAULT_PREFS
+        preferences: DEFAULT_PREFS,
+        cover_config: MEMBER_CARD_COVER_DEFAULTS
       })
     })
 
     test('preserves empty strings rather than substituting defaults', () => {
       const payload = buildMemberPayload({
         settings: { display_name: '', description: '' },
-        preferences: {}
+        preferences: {},
+        cover: {}
       })
       expect(payload).toEqual({
         display_name: '',
         description: '',
-        preferences: DEFAULT_PREFS
+        preferences: DEFAULT_PREFS,
+        cover_config: MEMBER_CARD_COVER_DEFAULTS
       })
     })
 
     test('round-trips left_hand preference', () => {
       const payload = buildMemberPayload({
         settings: { display_name: 'Chris', description: 'hi' },
-        preferences: { accessibility: { left_hand: true } }
+        preferences: { accessibility: { left_hand: true } },
+        cover: {}
       })
       expect(payload.preferences.accessibility.left_hand).toBe(true)
+    })
+
+    // ── cover_config resolution [obligation] ──────────────────────────────
+
+    test('resolves a sparse cover to a fully-defaulted cover_config, no undefined fields [obligation]', () => {
+      const payload = buildMemberPayload({
+        settings: { display_name: 'Chris', description: 'hi' },
+        preferences: {},
+        cover: { theme: 'red-500' }
+      })
+      expect(payload.cover_config).toEqual({
+        theme: 'red-500',
+        theme_dark: MEMBER_CARD_COVER_DEFAULTS.theme_dark,
+        pattern: MEMBER_CARD_COVER_DEFAULTS.pattern
+      })
+      expect(Object.values(payload.cover_config)).not.toContain(undefined)
+    })
+
+    test('resolves an empty cover to MEMBER_CARD_COVER_DEFAULTS verbatim', () => {
+      const payload = buildMemberPayload({
+        settings: { display_name: 'Chris', description: 'hi' },
+        preferences: {},
+        cover: {}
+      })
+      expect(payload.cover_config).toEqual(MEMBER_CARD_COVER_DEFAULTS)
     })
   })
 
@@ -79,12 +115,14 @@ describe('member/payload', () => {
     const baseState = (extra = {}) => ({
       settings: { display_name: 'Chris', description: 'hi' },
       preferences: {},
+      cover: {},
       ...extra
     })
     const baseSnapshot = (extra = {}) => ({
       display_name: 'Chris',
       description: 'hi',
       preferences: DEFAULT_PREFS,
+      cover_config: MEMBER_CARD_COVER_DEFAULTS,
       ...extra
     })
 
@@ -93,23 +131,46 @@ describe('member/payload', () => {
     })
 
     test('returns true when display_name diverges', () => {
-      const state = { ...baseState(), settings: { display_name: 'Other', description: 'hi' } }
+      const state = {
+        ...baseState(),
+        settings: { display_name: 'Other', description: 'hi' }
+      }
       expect(hasMemberChanges(state, baseSnapshot())).toBe(true)
     })
 
     test('returns true when description diverges', () => {
-      const state = { ...baseState(), settings: { display_name: 'Chris', description: 'bye' } }
+      const state = {
+        ...baseState(),
+        settings: { display_name: 'Chris', description: 'bye' }
+      }
       expect(hasMemberChanges(state, baseSnapshot())).toBe(true)
     })
 
     test('treats a missing field as the default empty string', () => {
-      const state = { settings: { display_name: 'Chris' }, preferences: {} }
+      const state = { settings: { display_name: 'Chris' }, preferences: {}, cover: {} }
       const snapshot = baseSnapshot({ description: '' })
       expect(hasMemberChanges(state, snapshot)).toBe(false)
     })
 
     test('returns true when left_hand preference diverges', () => {
       const state = { ...baseState(), preferences: { accessibility: { left_hand: true } } }
+      expect(hasMemberChanges(state, baseSnapshot())).toBe(true)
+    })
+
+    // ── cover-only dirty state [obligation] ───────────────────────────────
+
+    test('returns true when only cover.theme diverges, settings/preferences unchanged [obligation]', () => {
+      const state = { ...baseState(), cover: { theme: 'red-500' } }
+      expect(hasMemberChanges(state, baseSnapshot())).toBe(true)
+    })
+
+    test('returns true when only cover.theme_dark diverges [obligation]', () => {
+      const state = { ...baseState(), cover: { theme_dark: 'red-700' } }
+      expect(hasMemberChanges(state, baseSnapshot())).toBe(true)
+    })
+
+    test('returns true when only cover.pattern diverges [obligation]', () => {
+      const state = { ...baseState(), cover: { pattern: 'wave' } }
       expect(hasMemberChanges(state, baseSnapshot())).toBe(true)
     })
   })

--- a/types/member.d.ts
+++ b/types/member.d.ts
@@ -10,6 +10,7 @@ type Member = {
   plan?: MemberPlan
   plan_display_name?: string
   preferences?: MemberPreferences
+  cover_config?: DeckCover
 }
 
 type MemberPreferences = {


### PR DESCRIPTION
## Summary

Member-card theme/pattern (previously client-only, reset every session) now persists via a new `members.cover_config` column. Appearance edits in the profile tab correctly mark the settings modal dirty and are picked up wherever the member's cover is rendered (dashboard badge, card preview). Also fixes a double-rounded-corner border seam on member-card and polishes the profile description field into a bounded textarea.

## Changes

- Add `members.cover_config` (nullable jsonb, mirrors `decks.cover_config`)
- `useMemberEditor` seeds `cover` from the persisted store value; `buildMemberPayload`/`hasMemberChanges` include it so appearance-only edits trigger the dirty-state prompt and save
- Dashboard's `member-badge` now reads the persisted cover instead of defaulting
- `member-card`: replace nested-wrapper border (double-rounds corners, visible seam) with a single-element box-shadow; card comment gets a fixed 3-line-height box wrapped in `<q>`
- Profile tab description input swaps `ui-input` for a 3-row, 100-char `ui-textarea`
- `member-badge` pattern opacity now uses the shared default instead of a one-off override