### PR TITLE
Extract nav-list/grouped-list primitives, fix stale data-active selectors, opt-in hover state

### DIFF
--- a/src/components/layout-kit/grouped-list.vue
+++ b/src/components/layout-kit/grouped-list.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineSlots<{
+  default(): any
+  /** Absolutely positioned over the list; content must opt in with pointer-events-auto. */
+  overlay?(): any
+}>()
+</script>
+
+<template>
+  <div
+    data-testid="grouped-list"
+    class="relative flex flex-col rounded-4 bg-input dark:bg-stone-700 overflow-hidden"
+  >
+    <slot></slot>
+
+    <div
+      v-if="$slots.overlay"
+      data-testid="grouped-list__overlay"
+      class="absolute inset-0 pointer-events-none"
+    >
+      <slot name="overlay"></slot>
+    </div>
+  </div>
+</template>

--- a/src/components/member/member-badge.vue
+++ b/src/components/member/member-badge.vue
@@ -29,7 +29,7 @@ const body_bindings = computed(() => memberCoverBindings(cover))
     data-testid="member-badge"
     v-bind="body_bindings"
     style="--badge-radius: 42px; --badge-padding: 14px"
-    class="card-outline pointer-fine:hover:scale-101 data-[playing=true]:scale-101 pointer-coarse:data-[playing=true]:scale-105 pointer-fine:transition-transform duration-75 cursor-pointer touch-manipulation select-none flex items-center gap-4 rounded-(--badge-radius) p-(--badge-padding) bg-(--theme-primary)"
+    class="card-outline pointer-fine:hover:scale-101 data-[active=true]:scale-101 pointer-coarse:data-[active=true]:scale-105 pointer-fine:transition-transform duration-75 cursor-pointer touch-manipulation select-none flex items-center gap-4 rounded-(--badge-radius) p-(--badge-padding) bg-(--theme-primary)"
     @tap="emit('click', $event)"
   >
     <div

--- a/src/components/modals/deck-settings/tab-index/index.vue
+++ b/src/components/modals/deck-settings/tab-index/index.vue
@@ -1,14 +1,11 @@
 <script setup lang="ts">
 import { computed, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
-import UiIcon from '@/components/ui-kit/icon.vue'
-import UiTappable from '@/components/ui-kit/tappable.vue'
+import UiNavList from '@/components/ui-kit/nav-list.vue'
 import SectionList from '@/components/layout-kit/section-list.vue'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
 import DangerResetButton from '../danger-reset-button.vue'
 import DangerDeleteButton from '../danger-delete-button.vue'
-import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 import { deckSettingsLayoutKey } from '../layout'
 import DeckSaveButton from '../deck-save-button.vue'
 
@@ -43,9 +40,8 @@ const emit = defineEmits<{
   navigate: [value: TabIndexNavValue]
 }>()
 
-function onNavigate(value: TabIndexNavValue) {
-  emitSfx('snappy_button_5')
-  emit('navigate', value)
+function onNavigate(value: string) {
+  emit('navigate', value as TabIndexNavValue)
 }
 </script>
 
@@ -60,27 +56,16 @@ function onNavigate(value: TabIndexNavValue) {
       :data-testid="`tab-index__nav-group--${group.key}`"
       :label="group.heading"
     >
-      <div
-        data-testid="tab-index__nav-list"
-        class="flex flex-col rounded-4 bg-input dark:bg-stone-700 overflow-hidden"
-      >
-        <ui-tappable
-          v-for="entry in group.entries"
-          :key="entry.value"
-          as="button"
-          type="button"
-          data-testid="tab-index__nav-card"
-          :data-value="entry.value"
-          class="flex items-center gap-3 p-4 text-brown-700 dark:text-brown-100 hover:bg-(--theme-neutral) hover:text-(--theme-on-neutral) cursor-pointer text-left"
-          bgx_color="var(--color-brown-500)"
-          v-sfx="{ hover: TYPE_SFX }"
-          @tap="onNavigate(entry.value)"
-        >
-          <ui-icon :src="entry.icon" class="w-6 h-6" />
-          <span class="flex-1">{{ t(`deck.settings-modal.tab.${entry.value}`) }}</span>
-          <ui-icon src="line-arrow-right" class="size-4" />
-        </ui-tappable>
-      </div>
+      <ui-nav-list
+        :entries="
+          group.entries.map((entry) => ({
+            value: entry.value,
+            icon: entry.icon,
+            label: t(`deck.settings-modal.tab.${entry.value}`)
+          }))
+        "
+        @navigate="onNavigate"
+      />
     </labeled-section>
 
     <deck-save-button v-if="layout_mode === 'sheet'" />

--- a/src/components/settings/tab-index/index.vue
+++ b/src/components/settings/tab-index/index.vue
@@ -1,14 +1,11 @@
 <script setup lang="ts">
 import { computed, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
-import UiIcon from '@/components/ui-kit/icon.vue'
-import UiTappable from '@/components/ui-kit/tappable.vue'
+import UiNavList from '@/components/ui-kit/nav-list.vue'
 import SectionList from '@/components/layout-kit/section-list.vue'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
 import DangerDeleteAccountButton from '../danger-delete-account-button.vue'
 import SettingsSaveButton from '../settings-save-button.vue'
-import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 import { settingsLayoutKey } from '../layout'
 
 export type TabIndexNavValue = 'profile' | 'subscription' | 'app' | 'review-preferences'
@@ -42,9 +39,8 @@ const emit = defineEmits<{
   navigate: [value: TabIndexNavValue]
 }>()
 
-function onNavigate(value: TabIndexNavValue) {
-  emitSfx('snappy_button_5')
-  emit('navigate', value)
+function onNavigate(value: string) {
+  emit('navigate', value as TabIndexNavValue)
 }
 </script>
 
@@ -56,27 +52,16 @@ function onNavigate(value: TabIndexNavValue) {
       :data-testid="`tab-index__nav-group--${group.key}`"
       :label="group.heading"
     >
-      <div
-        data-testid="tab-index__nav-list"
-        class="flex flex-col rounded-4 bg-input dark:bg-stone-700 overflow-hidden"
-      >
-        <ui-tappable
-          v-for="entry in group.entries"
-          :key="entry.value"
-          as="button"
-          type="button"
-          data-testid="tab-index__nav-card"
-          :data-value="entry.value"
-          class="flex items-center gap-3 p-4 text-brown-700 dark:text-brown-100 hover:bg-(--theme-neutral) hover:text-(--theme-on-neutral) cursor-pointer text-left"
-          bgx_color="var(--color-brown-500)"
-          v-sfx="{ hover: TYPE_SFX }"
-          @tap="onNavigate(entry.value)"
-        >
-          <ui-icon :src="entry.icon" class="w-6 h-6" />
-          <span class="flex-1">{{ t(`settings.tab.${entry.value}`) }}</span>
-          <ui-icon src="line-arrow-right" class="size-4" />
-        </ui-tappable>
-      </div>
+      <ui-nav-list
+        :entries="
+          group.entries.map((entry) => ({
+            value: entry.value,
+            icon: entry.icon,
+            label: t(`settings.tab.${entry.value}`)
+          }))
+        "
+        @navigate="onNavigate"
+      />
     </labeled-section>
 
     <settings-save-button v-if="layout_mode === 'sheet'" />

--- a/src/components/taro-phone/app-shell.vue
+++ b/src/components/taro-phone/app-shell.vue
@@ -64,13 +64,13 @@ function spawnBurst() {
             :src="iconSrc"
             class="pointer-events-none"
             :class="{
-              'group-hover:hidden group-focus:hidden group-data-[playing=true]:hidden': hoverIconSrc
+              'group-hover:hidden group-focus:hidden group-data-[active=true]:hidden': hoverIconSrc
             }"
           />
           <ui-image
             v-if="hoverIconSrc"
             :src="hoverIconSrc"
-            class="hidden group-hover:block group-focus:block group-data-[playing=true]:block pointer-events-none"
+            class="hidden group-hover:block group-focus:block group-data-[active=true]:block pointer-events-none"
           />
         </slot>
       </button>

--- a/src/components/ui-kit/dropdown-button/menu.vue
+++ b/src/components/ui-kit/dropdown-button/menu.vue
@@ -70,7 +70,7 @@ function onOptionTap(option: DropdownOption, e: MouseEvent) {
       >
         <div
           aria-hidden="true"
-          class="pointer-events-none absolute inset-0 hidden bgx-diagonal-stripes bgx-color-[var(--theme-neutral)] animation-safe:bgx-slide group-hover/option:block group-data-[playing=true]/option:block"
+          class="pointer-events-none absolute inset-0 hidden bgx-diagonal-stripes bgx-color-[var(--theme-neutral)] animation-safe:bgx-slide group-hover/option:block group-data-[active=true]/option:block"
         ></div>
         <ui-icon
           v-if="option.icon"

--- a/src/components/ui-kit/nav-list.vue
+++ b/src/components/ui-kit/nav-list.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import UiIcon from './icon.vue'
+import UiTappable from './tappable.vue'
+import GroupedList from '@/components/layout-kit/grouped-list.vue'
+import { emitSfx } from '@/sfx/bus'
+import { TYPE_SFX } from '@/sfx/config'
+
+export type NavListEntry = { value: string; icon: string; label: string }
+
+type NavListProps = {
+  entries: NavListEntry[]
+}
+
+defineProps<NavListProps>()
+
+const emit = defineEmits<{
+  navigate: [value: string]
+}>()
+
+function onNavigate(value: string) {
+  emitSfx('snappy_button_5')
+  emit('navigate', value)
+}
+</script>
+
+<template>
+  <grouped-list data-testid="nav-list">
+    <ui-tappable
+      v-for="entry in entries"
+      :key="entry.value"
+      as="button"
+      type="button"
+      data-testid="nav-list__card"
+      :data-value="entry.value"
+      class="flex items-center gap-3 p-4 text-brown-700 dark:text-brown-100 hover:bg-(--theme-neutral) hover:text-(--theme-on-neutral) cursor-pointer text-left"
+      bgx_color="var(--color-brown-500)"
+      v-sfx="{ hover: TYPE_SFX }"
+      @tap="onNavigate(entry.value)"
+    >
+      <ui-icon :src="entry.icon" class="w-6 h-6" />
+      <span class="flex-1">{{ entry.label }}</span>
+      <ui-icon src="line-arrow-right" class="size-4" />
+    </ui-tappable>
+  </grouped-list>
+</template>

--- a/src/components/ui-kit/nav-list.vue
+++ b/src/components/ui-kit/nav-list.vue
@@ -34,7 +34,8 @@ function onNavigate(value: string) {
       :data-value="entry.value"
       class="flex items-center gap-3 p-4 text-brown-700 dark:text-brown-100 hover:bg-(--theme-neutral) hover:text-(--theme-on-neutral) cursor-pointer text-left"
       bgx_color="var(--color-brown-500)"
-      v-sfx="{ hover: TYPE_SFX }"
+      active_on_hover
+      :sfx="{ hover: TYPE_SFX }"
       @tap="onNavigate(entry.value)"
     >
       <ui-icon :src="entry.icon" class="w-6 h-6" />

--- a/src/components/ui-kit/tappable.vue
+++ b/src/components/ui-kit/tappable.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import {
   type StagedTapAnimate,
   type StagedTapPhase,
   useStagedTap
 } from '@/composables/ui/staged-tap'
+import { useMatchMedia } from '@/composables/ui/media-query'
 import type { SfxOptions } from '@/sfx/directive'
 
 type UiTappableProps = {
@@ -12,6 +14,7 @@ type UiTappableProps = {
   sfx?: SfxOptions
   triggerAt?: StagedTapPhase
   bgx_color?: string
+  active_on_hover?: boolean
 }
 
 const {
@@ -19,7 +22,8 @@ const {
   animate = 'quiet',
   sfx = {},
   triggerAt,
-  bgx_color = 'var(--theme-neutral)'
+  bgx_color = 'var(--theme-neutral)',
+  active_on_hover = false
 } = defineProps<UiTappableProps>()
 
 const emit = defineEmits<{
@@ -27,6 +31,8 @@ const emit = defineEmits<{
 }>()
 
 const { playing, tap } = useStagedTap({ animate, triggerAt })
+const is_fine = useMatchMedia('fine')
+const hovering = ref(false)
 
 function onClick(e: MouseEvent) {
   tap((ev) => emit('tap', ev), {
@@ -36,14 +42,24 @@ function onClick(e: MouseEvent) {
     postAudio: sfx.tap_post
   })(e)
 }
+
+function onPointerEnter() {
+  if (active_on_hover && is_fine.value) hovering.value = true
+}
+
+function onPointerLeave() {
+  hovering.value = false
+}
 </script>
 
 <template>
   <component
     :is="as"
-    :data-active="playing || null"
+    :data-active="playing || hovering || null"
     class="group/tappable relative"
     v-sfx="{ hover: sfx.hover, focus: sfx.focus, blur: sfx.blur, debounce: sfx.debounce }"
+    @pointerenter="onPointerEnter"
+    @pointerleave="onPointerLeave"
     @click="onClick"
   >
     <slot />

--- a/src/components/ui-kit/tappable.vue
+++ b/src/components/ui-kit/tappable.vue
@@ -48,7 +48,7 @@ function onClick(e: MouseEvent) {
   >
     <slot />
     <div
-      class="absolute inset-0 rounded-[inherit] bgx-diagonal-stripes animation-safe:group-data-[playing=true]/tappable:bgx-slide pointer-events-none hidden group-data-[playing=true]/tappable:block"
+      class="absolute inset-0 rounded-[inherit] bgx-diagonal-stripes animation-safe:group-data-[active=true]/tappable:bgx-slide pointer-events-none hidden group-data-[active=true]/tappable:block"
       :style="{ '--bgx-fill': bgx_color }"
     />
   </component>

--- a/src/composables/ui/staged-tap.ts
+++ b/src/composables/ui/staged-tap.ts
@@ -68,7 +68,7 @@ export interface TapCallOptions {
  * @example
  * const { playing, tap } = useStagedTap({ animate: 'pop', yoyo: true })
  * const handler = tap((e) => doThing(e), { audio: 'snappy_button_5' })
- * // <button @click="handler" :data-playing="playing || null">
+ * // <button @click="handler" :data-active="playing || null">
  */
 export function useStagedTap(options: StagedTapOptions = {}) {
   const {

--- a/tests/integration/components/layout-kit/grouped-list.test.js
+++ b/tests/integration/components/layout-kit/grouped-list.test.js
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+
+import GroupedList from '@/components/layout-kit/grouped-list.vue'
+
+describe('GroupedList', () => {
+  test('always renders the default slot content inside the container', () => {
+    const wrapper = mount(GroupedList, {
+      slots: { default: () => h('span', { 'data-testid': 'default-content' }, 'rows') }
+    })
+    expect(wrapper.find('[data-testid="grouped-list"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="default-content"]').exists()).toBe(true)
+  })
+
+  test('does not render the overlay wrapper when no overlay slot is provided', () => {
+    const wrapper = mount(GroupedList, {
+      slots: { default: () => h('span', 'rows') }
+    })
+    expect(wrapper.find('[data-testid="grouped-list__overlay"]').exists()).toBe(false)
+  })
+
+  test('renders the overlay wrapper and its content when the overlay slot is provided', () => {
+    const wrapper = mount(GroupedList, {
+      slots: {
+        default: () => h('span', 'rows'),
+        overlay: () => h('div', { 'data-testid': 'overlay-content' }, 'overlay')
+      }
+    })
+    expect(wrapper.find('[data-testid="grouped-list__overlay"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="overlay-content"]').exists()).toBe(true)
+  })
+})

--- a/tests/integration/components/modals/deck-settings/tab-index.test.js
+++ b/tests/integration/components/modals/deck-settings/tab-index.test.js
@@ -41,18 +41,6 @@ const IconStub = defineComponent({
   }
 })
 
-// Renders slot content + forwards attrs; emits tap on click so nav card
-// @tap="onNavigate(entry.value)" fires correctly.
-const UiTappableStub = defineComponent({
-  name: 'UiTappable',
-  inheritAttrs: false,
-  emits: ['tap'],
-  setup(_props, { slots, emit, attrs }) {
-    return () =>
-      h('button', { type: 'button', ...attrs, onClick: () => emit('tap') }, slots.default?.())
-  }
-})
-
 function makeTab(layout = 'desktop') {
   const onDelete = vi.fn()
   const onResetReviews = vi.fn()
@@ -73,8 +61,9 @@ function makeTab(layout = 'desktop') {
         [deckEditorKey]: editor,
         [deckSettingsLayoutKey]: computed(() => layout)
       },
-      stubs: { UiButton: ButtonStub, UiIcon: IconStub, UiTappable: UiTappableStub },
-      mocks: { $t: (k) => k }
+      stubs: { UiButton: ButtonStub, UiIcon: IconStub },
+      mocks: { $t: (k) => k },
+      directives: { sfx: {} }
     }
   })
   return { wrapper, onDelete, onResetReviews }
@@ -83,22 +72,24 @@ function makeTab(layout = 'desktop') {
 describe('TabIndex', () => {
   beforeEach(() => mockEmitSfx.mockClear())
 
-  test('renders both nav groups with two nav cards on desktop (design + study)', () => {
+  test('renders both nav groups with two nav cards on desktop (design + study), labeled from deck.settings-modal.tab.*', () => {
     const { wrapper } = makeTab('desktop')
     expect(wrapper.find('[data-testid="tab-index"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="tab-index__nav-group--appearance"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="tab-index__nav-group--study"]').exists()).toBe(true)
 
-    const cards = wrapper.findAll('[data-testid="tab-index__nav-card"]')
+    const cards = wrapper.findAll('[data-testid="nav-list__card"]')
     expect(cards).toHaveLength(2)
     expect(cards.map((c) => c.attributes('data-value'))).toEqual(['design', 'study'])
+    expect(cards[0].text()).toContain('Appearance')
+    expect(cards[1].text()).toContain('Study Preferences')
   })
 
   test('appearance group lists only "design" in tablet mode', () => {
     const { wrapper } = makeTab('tablet')
     const appearanceCards = wrapper
       .find('[data-testid="tab-index__nav-group--appearance"]')
-      .findAll('[data-testid="tab-index__nav-card"]')
+      .findAll('[data-testid="nav-list__card"]')
     expect(appearanceCards).toHaveLength(1)
     expect(appearanceCards[0].attributes('data-value')).toBe('design')
   })
@@ -107,7 +98,7 @@ describe('TabIndex', () => {
     const { wrapper } = makeTab('sheet')
     const appearanceCards = wrapper
       .find('[data-testid="tab-index__nav-group--appearance"]')
-      .findAll('[data-testid="tab-index__nav-card"]')
+      .findAll('[data-testid="nav-list__card"]')
     expect(appearanceCards).toHaveLength(2)
     expect(appearanceCards[0].attributes('data-value')).toBe('details')
     expect(appearanceCards[1].attributes('data-value')).toBe('design')
@@ -116,31 +107,25 @@ describe('TabIndex', () => {
   test('"details" nav entry absent in tablet/desktop (sheet-only) [obligation]', () => {
     const { wrapper: tabletWrapper } = makeTab('tablet')
     expect(
-      tabletWrapper.find('[data-testid="tab-index__nav-card"][data-value="details"]').exists()
+      tabletWrapper.find('[data-testid="nav-list__card"][data-value="details"]').exists()
     ).toBe(false)
     const { wrapper: desktopWrapper } = makeTab('desktop')
     expect(
-      desktopWrapper.find('[data-testid="tab-index__nav-card"][data-value="details"]').exists()
+      desktopWrapper.find('[data-testid="nav-list__card"][data-value="details"]').exists()
     ).toBe(false)
   })
 
   test('emits navigate with the clicked entry value', async () => {
     const { wrapper } = makeTab('desktop')
-    const designCard = wrapper.find('[data-testid="tab-index__nav-card"][data-value="design"]')
+    const designCard = wrapper.find('[data-testid="nav-list__card"][data-value="design"]')
     await designCard.trigger('click')
     expect(wrapper.emitted('navigate')).toEqual([['design']])
   })
 
   test('emits navigate("details") when details card clicked in sheet mode [obligation]', async () => {
     const { wrapper } = makeTab('sheet')
-    await wrapper.find('[data-testid="tab-index__nav-card"][data-value="details"]').trigger('click')
+    await wrapper.find('[data-testid="nav-list__card"][data-value="details"]').trigger('click')
     expect(wrapper.emitted('navigate')).toEqual([['details']])
-  })
-
-  test('plays snappy_button_5 sfx on nav click', async () => {
-    const { wrapper } = makeTab('desktop')
-    await wrapper.find('[data-testid="tab-index__nav-card"][data-value="design"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
   })
 
   test('renders inlined danger reset + delete buttons', () => {

--- a/tests/integration/components/settings/tab-index.test.js
+++ b/tests/integration/components/settings/tab-index.test.js
@@ -45,7 +45,8 @@ function makeTab() {
     global: {
       provide: { [memberDangerActionsKey]: danger },
       stubs: { UiButton: ButtonStub, UiIcon: IconStub },
-      mocks: { $t: (k) => k }
+      mocks: { $t: (k) => k },
+      directives: { sfx: {} }
     }
   })
   return { wrapper, onDeleteAccount }
@@ -54,13 +55,13 @@ function makeTab() {
 describe('TabIndex', () => {
   beforeEach(() => mockEmitSfx.mockClear())
 
-  test('renders both nav groups with all three nav cards', () => {
+  test('renders both nav groups with all four nav cards, labeled from settings.tab.*', () => {
     const { wrapper } = makeTab()
     expect(wrapper.find('[data-testid="tab-index"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="tab-index__nav-group--account"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="tab-index__nav-group--app"]').exists()).toBe(true)
 
-    const cards = wrapper.findAll('[data-testid="tab-index__nav-card"]')
+    const cards = wrapper.findAll('[data-testid="nav-list__card"]')
     expect(cards).toHaveLength(4)
     expect(cards.map((c) => c.attributes('data-value'))).toEqual([
       'profile',
@@ -68,20 +69,16 @@ describe('TabIndex', () => {
       'app',
       'review-preferences'
     ])
+    expect(cards[0].text()).toContain('Profile')
+    expect(cards[1].text()).toContain('Subscription')
+    expect(cards[2].text()).toContain('App Preferences')
+    expect(cards[3].text()).toContain('Review Preferences')
   })
 
   test('emits navigate with the clicked entry value', async () => {
     const { wrapper } = makeTab()
-    await wrapper
-      .find('[data-testid="tab-index__nav-card"][data-value="subscription"]')
-      .trigger('click')
+    await wrapper.find('[data-testid="nav-list__card"][data-value="subscription"]').trigger('click')
     expect(wrapper.emitted('navigate')).toEqual([['subscription']])
-  })
-
-  test('plays the select sfx on nav click', async () => {
-    const { wrapper } = makeTab()
-    await wrapper.find('[data-testid="tab-index__nav-card"][data-value="profile"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
   })
 
   test('renders the inlined delete-account button', () => {

--- a/tests/integration/components/ui-kit/nav-list.test.js
+++ b/tests/integration/components/ui-kit/nav-list.test.js
@@ -56,4 +56,27 @@ describe('NavList', () => {
     await wrapper.find('[data-testid="nav-list__card"][data-value="profile"]').trigger('click')
     expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
   })
+
+  test("opts every row into tappable's hover-active state [obligation]", () => {
+    const TappableStub = defineComponent({
+      name: 'UiTappable',
+      props: { active_on_hover: { type: Boolean, default: false } },
+      setup(props, { slots, attrs }) {
+        return () =>
+          h(
+            'button',
+            { ...attrs, 'data-active-on-hover': props.active_on_hover },
+            slots.default?.()
+          )
+      }
+    })
+    const wrapper = mount(NavList, {
+      props: { entries: ENTRIES },
+      global: { stubs: { UiIcon: IconStub, UiTappable: TappableStub }, directives: { sfx: {} } }
+    })
+
+    const cards = wrapper.findAll('[data-testid="nav-list__card"]')
+    expect(cards).toHaveLength(2)
+    cards.forEach((card) => expect(card.attributes('data-active-on-hover')).toBe('true'))
+  })
 })

--- a/tests/integration/components/ui-kit/nav-list.test.js
+++ b/tests/integration/components/ui-kit/nav-list.test.js
@@ -1,0 +1,59 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: vi.fn() }))
+
+import NavList from '@/components/ui-kit/nav-list.vue'
+
+const IconStub = defineComponent({
+  name: 'UiIcon',
+  props: { src: { type: String, required: true } },
+  setup(props) {
+    return () => h('span', { 'data-testid': 'ui-icon', 'data-src': props.src })
+  }
+})
+
+const ENTRIES = [
+  { value: 'profile', icon: 'user-sticker-square', label: 'Profile' },
+  { value: 'subscription', icon: 'piggy-bank', label: 'Subscription' }
+]
+
+function makeList(entries = ENTRIES) {
+  return mount(NavList, {
+    props: { entries },
+    global: { stubs: { UiIcon: IconStub }, directives: { sfx: {} } }
+  })
+}
+
+describe('NavList', () => {
+  beforeEach(() => mockEmitSfx.mockClear())
+
+  test('renders one row per entry with its icon, label, and a trailing chevron', () => {
+    const wrapper = makeList()
+    const cards = wrapper.findAll('[data-testid="nav-list__card"]')
+    expect(cards).toHaveLength(2)
+
+    cards.forEach((card, i) => {
+      expect(card.attributes('data-value')).toBe(ENTRIES[i].value)
+      expect(card.text()).toContain(ENTRIES[i].label)
+
+      const icons = card.findAll('[data-testid="ui-icon"]')
+      expect(icons[0].attributes('data-src')).toBe(ENTRIES[i].icon)
+      expect(icons[1].attributes('data-src')).toBe('line-arrow-right')
+    })
+  })
+
+  test('emits navigate with the tapped entry value, not the whole entry object', async () => {
+    const wrapper = makeList()
+    await wrapper.find('[data-testid="nav-list__card"][data-value="subscription"]').trigger('click')
+    expect(wrapper.emitted('navigate')).toEqual([['subscription']])
+  })
+
+  test('plays the select sfx when a row is tapped', async () => {
+    const wrapper = makeList()
+    await wrapper.find('[data-testid="nav-list__card"][data-value="profile"]').trigger('click')
+    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+  })
+})

--- a/tests/integration/components/ui-kit/tappable.test.js
+++ b/tests/integration/components/ui-kit/tappable.test.js
@@ -3,10 +3,12 @@ import { mount, flushPromises } from '@vue/test-utils'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { mockEmitSfx, mockEmitHoverSfx, coarseRef, mockPlayButtonTap } = vi.hoisted(() => {
+const { mockEmitSfx, mockEmitHoverSfx, coarseRef, fineRef, mockPlayButtonTap } = vi.hoisted(() => {
   const coarseRef = { value: true }
+  const fineRef = { value: false }
   return {
     coarseRef,
+    fineRef,
     mockEmitSfx: vi.fn(),
     mockEmitHoverSfx: vi.fn(),
     mockPlayButtonTap: vi.fn(() => ({ peak: Promise.resolve(), done: Promise.resolve() }))
@@ -19,7 +21,7 @@ vi.mock('@/sfx/bus', () => ({
 }))
 
 vi.mock('@/composables/ui/media-query', () => ({
-  useMatchMedia: () => coarseRef
+  useMatchMedia: (query) => (query === 'fine' ? fineRef : coarseRef)
 }))
 
 vi.mock('@/utils/animations/button-tap', () => ({
@@ -45,6 +47,7 @@ function mountTappable(props = {}) {
 beforeEach(() => {
   vi.clearAllMocks()
   coarseRef.value = true
+  fineRef.value = false
   mockPlayButtonTap.mockReturnValue({ peak: Promise.resolve(), done: Promise.resolve() })
 })
 
@@ -133,5 +136,37 @@ describe('UiTappable — data-active state', () => {
     resolvePeak()
     await p
     await flushPromises()
+  })
+})
+
+describe('UiTappable — active_on_hover [obligation]', () => {
+  test('hover does not set data-active when active_on_hover is unset (default off)', async () => {
+    fineRef.value = true
+    const wrapper = mountTappable()
+    await wrapper.trigger('pointerenter')
+    expect(wrapper.attributes('data-active')).toBeUndefined()
+  })
+
+  test('hover sets data-active to "true" when active_on_hover is set on a fine pointer', async () => {
+    fineRef.value = true
+    const wrapper = mountTappable({ active_on_hover: true })
+    await wrapper.trigger('pointerenter')
+    expect(wrapper.attributes('data-active')).toBe('true')
+  })
+
+  test('pointerleave clears the hover-driven data-active', async () => {
+    fineRef.value = true
+    const wrapper = mountTappable({ active_on_hover: true })
+    await wrapper.trigger('pointerenter')
+    expect(wrapper.attributes('data-active')).toBe('true')
+    await wrapper.trigger('pointerleave')
+    expect(wrapper.attributes('data-active')).toBeUndefined()
+  })
+
+  test('hover does not set data-active on a coarse pointer even when active_on_hover is set', async () => {
+    fineRef.value = false
+    const wrapper = mountTappable({ active_on_hover: true })
+    await wrapper.trigger('pointerenter')
+    expect(wrapper.attributes('data-active')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- Extracts the duplicated tab-index nav markup (app settings + deck settings) into two primitives: `layout-kit/grouped-list.vue` (container styling + overlay slot) and `ui-kit/nav-list.vue` (clickable icon/label/chevron rows).
- Fixes a stale-selector bug from an earlier `data-playing` → `data-active` rename: `tappable.vue`, `dropdown-button/menu.vue`, `taro-phone/app-shell.vue`, and `member-badge.vue` still targeted the old attribute name, so their "playing" bgx-sweep/scale animations never fired.
- Adds an opt-in `active_on_hover` prop to `UiTappable` (fine-pointer only, off by default) and enables it on `nav-list` rows only.