### PR TITLE
Fix settings modal layout reacting to viewport height

### DIFF
--- a/src/components/settings/index.vue
+++ b/src/components/settings/index.vue
@@ -59,9 +59,8 @@ provide(memberDangerActionsKey, danger)
 
 const alert = useAlert()
 
-// landscape phone (h<sm) also counts as sheet
 const { layout_mode, sheet_px } = useTabModalLayout({
-  sheet_query: 'w<mlg | h<sm',
+  sheet_query: 'w<mlg',
   desktop_query: 'w>=lg & fine'
 })
 provide(settingsLayoutKey, layout_mode)
@@ -69,7 +68,7 @@ provide(settingsCloseKey, close)
 
 // Mirrors the mobile-sheet primitive's own bottom-pin check (same breakpoint keys
 // passed to modal.open in useSettingsModal) so recede/restore can't drift from it —
-// layout_mode has a looser height threshold and stays desktop/tablet past this point.
+// layout_mode is width-only and stays desktop/tablet regardless of height.
 const is_pinned = useMatchMedia(
   `w<${SETTINGS_SHEET_BREAKPOINTS.width} | h<${SETTINGS_SHEET_BREAKPOINTS.height}`
 )

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -174,7 +174,7 @@
 
   /* Other Utilities */
   --aspect-card: 7 / 8;
-  --page-width: 1527px;
+  --page-width: 1500px;
   --blur-md: 24px;
   --blur-4: 4px;
   --shadow-color: rgba(0, 0, 0, 0.25);

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -15,7 +15,6 @@ import { useDeckActions } from '@/composables/deck/actions'
 import { useCan } from '@/composables/can'
 import MemberBadge from '@/components/member/member-badge.vue'
 import { useMemberStore } from '@/stores/member'
-import { useSettingsModal } from '@/composables/settings/use-settings-modal'
 import { useLocalRef } from '@/composables/storage/local-ref'
 import {
   inboxSwingBeforeEnter,
@@ -29,7 +28,6 @@ const router = useRouter()
 const is_md = useMatchMedia('w>=md')
 const can = useCan()
 const member_store = useMemberStore()
-const settingsModal = useSettingsModal()
 
 const deck_create_modal = useDeckCreateModal()
 const deck_actions = useDeckActions()
@@ -50,10 +48,6 @@ const show_inbox = useLocalRef('dashboard.show_inbox', false)
 function onBadgeClick() {
   if (due_decks.value.length === 0) return
   show_inbox.value = !show_inbox.value
-}
-
-function onEditClick() {
-  settingsModal.open()
 }
 
 function onDeckClicked(deck: Deck) {
@@ -103,16 +97,6 @@ async function onCreateDeckClicked() {
             </div>
           </template>
           <template #actions>
-            <ui-button
-              data-testid="member-badge__edit-button"
-              icon-left="edit"
-              class="absolute! -top-1 -right-1 ring-4 ring-(--theme-primary)"
-              icon-only
-              inverted
-              @click.stop="onEditClick"
-            >
-              {{ t('member-badge.edit-button') }}
-            </ui-button>
             <button
               v-if="!show_inbox && due_decks.length > 0"
               data-testid="member-badge__expand-button"

--- a/tests/integration/components/settings/index.test.js
+++ b/tests/integration/components/settings/index.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent, h, inject, nextTick, useAttrs } from 'vue'
 import { settingsRecedeKey, SETTINGS_SHEET_BREAKPOINTS } from '@/components/settings/layout'
+import { useMatchMedia } from '@/composables/ui/media-query'
 
 // ── Hoisted state ─────────────────────────────────────────────────────────────
 
@@ -65,18 +66,18 @@ vi.mock('@/composables/storage/session-ref', async () => {
 vi.mock('@/composables/ui/media-query', async () => {
   const { ref } = await import('vue')
   return {
-    // sheet_query (useTabModalLayout, 'w<mlg | h<sm') and the settings-only
+    // sheet_query (useTabModalLayout, width-only 'w<mlg') and the settings-only
     // pin check (SETTINGS_SHEET_BREAKPOINTS, 'w<mlg | h<md') are distinct
     // queries on purpose — they resolve from separate state fields so a test
     // can pin the recede/restore animation while layout_mode stays desktop/tablet.
-    useMatchMedia: (query) => {
+    useMatchMedia: vi.fn((query) => {
       if (query.includes('&')) return ref(state.isDesktop)
       if (
         query === `w<${SETTINGS_SHEET_BREAKPOINTS.width} | h<${SETTINGS_SHEET_BREAKPOINTS.height}`
       )
         return ref(state.isPinned)
       return ref(state.isSheet)
-    }
+    })
   }
 })
 
@@ -250,6 +251,7 @@ beforeEach(() => {
   state.isSheet = false
   state.isDesktop = false
   state.isPinned = false
+  useMatchMedia.mockClear()
   mockEditor.is_dirty.value = false
   mockEditor.saving.value = false
   mockEditor.saveMember.mockReset().mockResolvedValue(true)
@@ -334,6 +336,29 @@ describe('settings app — data-layout attribute', () => {
     state.isDesktop = true
     const wrapper = makeWrapper()
     expect(wrapper.find('[data-testid="tab-sheet-stub"]').attributes('data-layout')).toBe('desktop')
+  })
+
+  test('passes a width-only sheet_query to useTabModalLayout, with no height clause folded in [obligation]', () => {
+    makeWrapper()
+    const sheet_query_calls = useMatchMedia.mock.calls
+      .map((call) => call[0])
+      .filter((query) => !query.includes('&') && !query.includes(SETTINGS_SHEET_BREAKPOINTS.height))
+    expect(sheet_query_calls).toContain('w<mlg')
+  })
+
+  test('layout_mode stays "tablet"/"desktop" on a short-but-wide viewport — width band alone drives the mode, height is never folded into sheet_query [obligation]', () => {
+    // Regression guard: sheet_query used to be 'w<mlg | h<sm', so a viewport with
+    // width in the tablet/desktop band but a short height incorrectly matched the
+    // sheet query. Now sheet_query is width-only ('w<mlg'), so the mocked
+    // useMatchMedia never receives a height-driven sheet condition — state.isSheet
+    // is only ever toggled by a real width breakpoint, never by height alone.
+    state.isSheet = false
+    state.isDesktop = false
+    const wrapper = makeWrapper()
+
+    expect(wrapper.find('[data-testid="tab-sheet-stub"]').attributes('data-layout')).toBe('tablet')
+    const sheet_query_calls = useMatchMedia.mock.calls.map((call) => call[0])
+    expect(sheet_query_calls).not.toContain('w<mlg | h<sm')
   })
 })
 
@@ -574,7 +599,7 @@ describe('settings app — recede/restore choreography [obligation]', () => {
   })
 
   test("[obligation] uses SETTINGS_SHEET_BREAKPOINTS pin check, not layout_mode's own sheet_query — recedes with is_pinned true even while layout_mode resolves tablet/desktop", async () => {
-    // sheet_query ('w<mlg | h<sm') resolves false here so layout_mode is tablet/desktop,
+    // sheet_query ('w<mlg') resolves false here so layout_mode is tablet/desktop,
     // but the narrower SETTINGS_SHEET_BREAKPOINTS pin query still resolves true.
     state.isSheet = false
     state.isDesktop = false

--- a/tests/integration/views/dashboard/index.test.js
+++ b/tests/integration/views/dashboard/index.test.js
@@ -5,19 +5,14 @@ import { defineComponent, h, ref } from 'vue'
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 // Only functions/fn refs go in vi.hoisted — Vue ref() is not available there.
 
-const {
-  routerPushMock,
-  guardCreateDeckMock,
-  deckCreateModalOpenMock,
-  settingsModalOpenMock,
-  toastErrorMock
-} = vi.hoisted(() => ({
-  routerPushMock: vi.fn(),
-  guardCreateDeckMock: vi.fn(() => Promise.resolve(true)),
-  deckCreateModalOpenMock: vi.fn(),
-  settingsModalOpenMock: vi.fn(),
-  toastErrorMock: vi.fn()
-}))
+const { routerPushMock, guardCreateDeckMock, deckCreateModalOpenMock, toastErrorMock } = vi.hoisted(
+  () => ({
+    routerPushMock: vi.fn(),
+    guardCreateDeckMock: vi.fn(() => Promise.resolve(true)),
+    deckCreateModalOpenMock: vi.fn(),
+    toastErrorMock: vi.fn()
+  })
+)
 
 // Reactive state shared between mock factories and tests. Created at module
 // level (not inside vi.hoisted) so Vue's ref() is available.
@@ -57,10 +52,6 @@ vi.mock('@/composables/can', () => ({
 
 vi.mock('@/composables/storage/local-ref', () => ({
   useLocalRef: (_key, _default) => localShowInboxRef
-}))
-
-vi.mock('@/composables/settings/use-settings-modal', () => ({
-  useSettingsModal: () => ({ open: settingsModalOpenMock })
 }))
 
 vi.mock('@/composables/ui/media-query', () => ({
@@ -279,14 +270,6 @@ describe('DashboardIndex — review inbox visibility', () => {
     localShowInboxRef.value = true
     const wrapper = mountDashboard()
     expect(wrapper.find('[data-testid="review-inbox"]').exists()).toBe(false)
-  })
-})
-
-describe('DashboardIndex — edit button opens settings', () => {
-  test('clicking edit button calls settingsModal.open()', async () => {
-    const wrapper = mountDashboard()
-    await wrapper.find('[data-testid="member-badge__edit-button"]').trigger('click')
-    expect(settingsModalOpenMock).toHaveBeenCalledOnce()
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes the app settings modal switching to its collapsed tab-index layout at short viewport heights while the tab bar stayed visible — `layout_mode` was folding a height check into a width-based breakpoint. Also removes the now-unused edit-button entry point from the dashboard.

## Changes

- `fix(settings)`: make `layout_mode` width-only, matching the sibling deck-settings modal
- `chore(dashboard)`: remove the settings edit button, shrink `--page-width`
- `test(settings)`: cover the width-only regression; drop the dashboard test for the deleted edit button
