### PR TITLE
Contain layout between audio-reader transcript and mobile dock

### DIFF
--- a/src/components/mobile-dock/mobile-dock-host.vue
+++ b/src/components/mobile-dock/mobile-dock-host.vue
@@ -37,7 +37,7 @@ onBeforeUnmount(() => {
     v-show="fills > 0"
     ref="bar"
     data-testid="mobile-dock-host"
-    class="fixed bottom-0 left-0 z-30 w-full rounded-t-6 bg-brown-300 transform-[translateZ(0)] dark:bg-stone-900 sm:bottom-3 sm:left-auto sm:right-3 sm:w-96 sm:rounded-6 xl:hidden [--dock-px:1.25rem] [--dock-pt:1rem] [--dock-pb:0.5rem] ring-1 ring-brown-100 dark:ring-grey-900"
+    class="fixed bottom-0 left-0 z-30 w-full rounded-t-6 bg-brown-300 contain-[layout_style] transform-[translateZ(0)] dark:bg-stone-900 sm:bottom-3 sm:left-auto sm:right-3 sm:w-96 sm:rounded-6 xl:hidden [--dock-px:1.25rem] [--dock-pt:1rem] [--dock-pb:0.5rem] ring-1 ring-brown-100 dark:ring-grey-900"
   >
     <div
       mobile-dock-above

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -357,7 +357,10 @@ onBeforeUnmount(() => {
         </h1>
       </header>
 
-      <div data-testid="lesson-view__transcript" class="px-0 pt-6 pb-2 sm:px-6">
+      <div
+        data-testid="lesson-view__transcript"
+        class="px-0 pt-6 pb-2 contain-[layout_style] sm:px-6"
+      >
         <transcript-view
           ref="transcript"
           :paragraphs="windowed_paragraphs"


### PR DESCRIPTION
## Summary

Opening the term-popover on the audio-reader's mobile view (`mobile-dock`) causes framerate drops while the dock's height-snap animation runs. The dock's height code (`useAnimatedHeight`, `crossfade-resize`) does forced-synchronous-layout reads (`offsetHeight`/`scrollHeight`), which normally have to flush any pending layout invalidation in the whole document — expensive given the reader's large transcript DOM (`active_word` highlighting ticks several times a second during playback).

This adds CSS `contain: layout style` to the transcript container and the mobile-dock's fixed footer, scoping each one's layout invalidation so a forced read in one doesn't need to flush the other's pending reflow.

## Changes

- `contain-[layout_style]` on `lesson-view__transcript` in `lesson/index.vue`
- `contain-[layout_style]` on `mobile-dock-host`'s footer, alongside its existing `translateZ(0)` compositor pin

## Test plan

- [ ] Open a lesson on mobile width, tap a term while audio is playing, confirm the popover open/resize feels smoother than before