### PR TITLE
Pad mobile dock clear of the screen edge when running as an installed PWA

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -38,6 +38,13 @@ const scheduleIdle =
     : (cb: () => void) => setTimeout(cb, 0)
 
 onMounted(() => {
+  // navigator.standalone is iOS Safari's legacy fallback — display-mode alone misses
+  // older iOS versions that never adopted the media-feature check.
+  const is_standalone =
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (window.navigator as any).standalone === true
+  document.documentElement.setAttribute('data-standalone', String(is_standalone))
+
   try {
     theme.load()
     session.startLoading()

--- a/src/components/mobile-dock/mobile-dock-host.vue
+++ b/src/components/mobile-dock/mobile-dock-host.vue
@@ -37,7 +37,7 @@ onBeforeUnmount(() => {
     v-show="fills > 0"
     ref="bar"
     data-testid="mobile-dock-host"
-    class="fixed bottom-0 left-0 z-30 w-full rounded-t-6 bg-brown-300 contain-[layout_style] transform-[translateZ(0)] dark:bg-stone-900 sm:bottom-3 sm:left-auto sm:right-3 sm:w-96 sm:rounded-6 xl:hidden [--dock-px:1.25rem] [--dock-pt:1rem] [--dock-pb:0.5rem] ring-1 ring-brown-100 dark:ring-grey-900"
+    class="fixed bottom-0 left-0 z-30 w-full rounded-t-6 bg-brown-300 contain-[layout_style] transform-[translateZ(0)] dark:bg-stone-900 sm:bottom-3 sm:left-auto sm:right-3 sm:w-96 sm:rounded-6 xl:hidden [--dock-px:1.25rem] [--dock-pt:1rem] [--dock-pb:0.5rem] standalone:max-sm:[--dock-pb:3rem] ring-1 ring-brown-100 dark:ring-grey-900"
   >
     <div
       mobile-dock-above

--- a/src/styles/custom-variants.css
+++ b/src/styles/custom-variants.css
@@ -28,3 +28,9 @@
     @slot;
   }
 }
+
+@custom-variant standalone {
+  &:where([data-standalone='true'] *, [data-standalone='true']) {
+    @slot;
+  }
+}

--- a/tests/integration/app.test.js
+++ b/tests/integration/app.test.js
@@ -1,0 +1,109 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import App from '@/App.vue'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+// App.vue's onMounted pulls in theme/session/member stores (which themselves
+// pull in vue-router + the member query), plus the audio player and its
+// lifecycle wiring. None of that is relevant to the standalone-detection
+// logic under test, so every dependency is mocked to keep the mount cheap and
+// deterministic.
+
+const { mockLoad, mockStartLoading, mockStopLoading, mockSetup, mockInstallAudioLifecycle } =
+  vi.hoisted(() => ({
+    mockLoad: vi.fn(),
+    mockStartLoading: vi.fn(),
+    mockStopLoading: vi.fn(),
+    mockSetup: vi.fn(() => Promise.resolve()),
+    mockInstallAudioLifecycle: vi.fn(() => vi.fn())
+  }))
+
+vi.mock('@/stores/theme', () => ({
+  useThemeStore: () => ({ load: mockLoad })
+}))
+
+vi.mock('@/stores/session', () => ({
+  useSessionStore: () => ({ startLoading: mockStartLoading, stopLoading: mockStopLoading })
+}))
+
+vi.mock('@/stores/member', () => ({
+  useMemberStore: () => ({ preferences: {} })
+}))
+
+vi.mock('@/sfx/player', () => ({
+  default: { setup: mockSetup, setVolumeConfig: vi.fn() }
+}))
+
+vi.mock('@/sfx/lifecycle', () => ({
+  installAudioLifecycle: mockInstallAudioLifecycle
+}))
+
+// ── Mount helper ──────────────────────────────────────────────────────────────
+
+function mountApp() {
+  return shallowMount(App, {
+    global: {
+      stubs: {
+        RouterView: true
+      }
+    }
+  })
+}
+
+// ── State reset ───────────────────────────────────────────────────────────────
+
+let original_matchMedia
+let original_navigator_standalone
+
+beforeEach(() => {
+  original_matchMedia = window.matchMedia
+  original_navigator_standalone = window.navigator.standalone
+  document.documentElement.removeAttribute('data-standalone')
+})
+
+afterEach(() => {
+  window.matchMedia = original_matchMedia
+  if (original_navigator_standalone === undefined) {
+    delete window.navigator.standalone
+  } else {
+    window.navigator.standalone = original_navigator_standalone
+  }
+  document.documentElement.removeAttribute('data-standalone')
+})
+
+function stubMatchMedia(matches) {
+  window.matchMedia = vi.fn().mockReturnValue({ matches })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('App', () => {
+  describe('data-standalone detection [obligation]', () => {
+    test('sets data-standalone="true" on <html> when display-mode: standalone matches [obligation]', () => {
+      stubMatchMedia(true)
+      delete window.navigator.standalone
+
+      mountApp()
+
+      expect(document.documentElement.getAttribute('data-standalone')).toBe('true')
+    })
+
+    test('sets data-standalone="true" via the navigator.standalone iOS fallback when display-mode does not match [obligation]', () => {
+      stubMatchMedia(false)
+      window.navigator.standalone = true
+
+      mountApp()
+
+      expect(document.documentElement.getAttribute('data-standalone')).toBe('true')
+    })
+
+    test('sets data-standalone="false" when neither display-mode nor navigator.standalone match [obligation]', () => {
+      stubMatchMedia(false)
+      delete window.navigator.standalone
+
+      mountApp()
+
+      expect(document.documentElement.getAttribute('data-standalone')).toBe('false')
+    })
+  })
+})

--- a/tests/integration/components/mobile-dock/mobile-dock-host.test.js
+++ b/tests/integration/components/mobile-dock/mobile-dock-host.test.js
@@ -100,6 +100,17 @@ describe('MobileDockHost', () => {
     })
   })
 
+  describe('standalone PWA padding [obligation]', () => {
+    test('footer carries the standalone:max-sm:[--dock-pb:3rem] class alongside the base --dock-pb [obligation]', () => {
+      mountHost()
+
+      const footer = document.querySelector('[data-testid="mobile-dock-host"]')
+      expect(footer).not.toBeNull()
+      expect(footer?.className).toContain('standalone:max-sm:[--dock-pb:3rem]')
+      expect(footer?.className).toContain('[--dock-pb:0.5rem]')
+    })
+  })
+
   describe('content slot target', () => {
     test('renders the inner content div with [mobile-dock-content] attribute', async () => {
       mountHost()


### PR DESCRIPTION
## Summary

When TaroFlash runs as an installed/standalone PWA, the mobile dock sits flush against the bottom of the physical screen with no browser chrome to buffer it. This adds a `standalone` display-mode detection and bumps the dock's bottom padding on mobile widths when running in that mode.

## Changes

- `App.vue` sets `data-standalone` on `<html>` once on mount, via `matchMedia('(display-mode: standalone)')` with an `navigator.standalone` fallback for older iOS Safari.
- New Tailwind `standalone:` custom-variant in `custom-variants.css`, keyed off `[data-standalone='true']` (mirrors the existing `left-hand` variant).
- `mobile-dock-host.vue` applies extra `--dock-pb` on mobile widths (`max-sm:`) when `standalone` is active; unaffected at `sm:`+ where the dock already floats clear of the edge.