### PR TITLE
Virtualize the audio-reader transcript and fix follow-scroll bugs

### DIFF
--- a/src/components/ui-kit/dropdown-button/menu.vue
+++ b/src/components/ui-kit/dropdown-button/menu.vue
@@ -63,7 +63,7 @@ function onOptionTap(option: DropdownOption, e: MouseEvent) {
         type="button"
         :disabled="option.disabled"
         class="group/option relative flex w-full cursor-pointer items-center gap-(--btn-gap) overflow-hidden rounded-[calc(var(--btn-border-radius)-6px)] py-(--btn-padding-y) px-[calc(var(--btn-padding-x)-6px)] text-start whitespace-nowrap disabled:cursor-default disabled:opacity-40"
-        :data-active="playing_value === option.value || null"
+        :data-active="playing_value === option.value || option.selected || null"
         data-testid="dropdown-button__option"
         v-sfx="option.disabled ? {} : { hover: TYPE_SFX }"
         @click="onOptionTap(option, $event)"

--- a/src/components/ui-kit/dropdown-button/types.ts
+++ b/src/components/ui-kit/dropdown-button/types.ts
@@ -3,4 +3,7 @@ export type DropdownOption = {
   value: string | number
   icon?: string
   disabled?: boolean
+  // Marks the option matching the consumer's current state (e.g. the active
+  // chapter). Renders with the same data-active affordance as a live tap.
+  selected?: boolean
 }

--- a/src/composables/audio-reader/reader-highlights.ts
+++ b/src/composables/audio-reader/reader-highlights.ts
@@ -126,9 +126,6 @@ export const readerMatchesKey = Symbol('readerMatches') as InjectionKey<
  * @param matchRangeAt - resolves the card-match range covering a word, or null
  *   when none. A tap/click on a matched word selects the whole matched phrase;
  *   a drag (or long-press range select) still commits exactly what was swept.
- * @param is_playing - whether the audio is playing; the active-line follow
- *   animates while it's true and jumps instantly otherwise (a resume seek or a
- *   scrub mustn't leave a scroll tween running — it locks up iOS Safari).
  * @param virtualizer - the transcript's window virtualizer, used to bring the
  *   active word's row into the DOM when a seek/resume lands outside the
  *   currently rendered range.
@@ -143,7 +140,6 @@ export function useReaderHighlights(
   popover_open: MaybeRefOrGetter<boolean>,
   onDismiss: () => void,
   matchRangeAt: (index: number) => WordRange | null = () => null,
-  is_playing: MaybeRefOrGetter<boolean> = false,
   virtualizer: WordVirtualizer,
   rowIndexOfWord: (word_index: number) => number
 ) {
@@ -438,7 +434,6 @@ export function useReaderHighlights(
   // (many words per frame) settles into a single scroll instead of a jittery
   // chain. 100 ms is short enough to feel responsive during normal playback
   // (~200–300 ms per word) but swallows bursts from fast scrubs.
-  // Paused jumps must be instant (iOS Safari lock on rAF-driven tweens).
   function followActiveWord() {
     if (!following.value) return
     if (follow_timer !== null) clearTimeout(follow_timer)
@@ -448,7 +443,7 @@ export function useReaderHighlights(
       if (index < 0) return
       const el = await ensureWordMounted(index)
       if (!el) return
-      scrollWordIntoDeadzone(el, toValue(is_playing))
+      scrollWordIntoDeadzone(el)
     }, 100)
   }
 
@@ -516,9 +511,7 @@ export function useReaderHighlights(
     if (!el) return
     if (el.getBoundingClientRect().bottom <= window.innerHeight * SHEET_COVER_RATIO) return
 
-    // Jump instantly — opening a term always pauses the audio, so a rAF-driven
-    // window.scrollTo tween would starve rAF on iOS Safari for 600ms.
-    scrollLineIntoView(el, false)
+    scrollLineIntoView(el)
   }
 
   async function positionInteraction() {

--- a/src/composables/audio-reader/reader-highlights.ts
+++ b/src/composables/audio-reader/reader-highlights.ts
@@ -130,6 +130,10 @@ export const readerMatchesKey = Symbol('readerMatches') as InjectionKey<
  *   active word's row into the DOM when a seek/resume lands outside the
  *   currently rendered range.
  * @param rowIndexOfWord - resolves a word index to its virtualizer row index.
+ * @param is_playing - whether the audio is playing; gates the idle auto-resume
+ *   timer, which only makes sense while the active word is advancing. Paused,
+ *   there's nothing to fall behind, so a manual scroll (e.g. to read a term
+ *   popover) stays put instead of snapping back a few seconds later.
  * @example
  * const { onPointerDown, onPointerMove, onPointerUp, onPointerLeave, onPointerCancel } =
  *   useReaderHighlights(() => active_word, commitSelection, () => popover_open, dismiss)
@@ -141,7 +145,8 @@ export function useReaderHighlights(
   onDismiss: () => void,
   matchRangeAt: (index: number) => WordRange | null = () => null,
   virtualizer: WordVirtualizer,
-  rowIndexOfWord: (word_index: number) => number
+  rowIndexOfWord: (word_index: number) => number,
+  is_playing: MaybeRefOrGetter<boolean> = false
 ) {
   const content = useTemplateRef<HTMLElement>('content')
 
@@ -439,17 +444,35 @@ export function useReaderHighlights(
     if (follow_timer !== null) clearTimeout(follow_timer)
     follow_timer = setTimeout(async () => {
       follow_timer = null
+      // Re-check: a manual scroll can turn follow off during this debounce (or
+      // during the mount await below) — a scroll issued after that must not
+      // fight the member's own, still-in-flight one.
+      if (!following.value) return
       const index = toValue(active_word)
       if (index < 0) return
       const el = await ensureWordMounted(index)
-      if (!el) return
+      if (!el || !following.value) return
       scrollWordIntoDeadzone(el)
     }, 100)
   }
 
+  // Idle-resume only fires while playing — paused, the active word isn't
+  // advancing, so there's nothing to fall behind and auto-resuming would just
+  // yank the view out from under a member reading something (e.g. a term
+  // popover) at the scrolled-away position. A lapse while paused leaves no
+  // timer pending; the watcher below re-arms one if play starts before the
+  // member manually resumes or scrolls again.
+  function armFollowResumeTimer() {
+    if (follow_resume_timer !== null) clearTimeout(follow_resume_timer)
+    follow_resume_timer = setTimeout(() => {
+      follow_resume_timer = null
+      if (toValue(is_playing)) resumeFollow()
+    }, FOLLOW_RESUME_IDLE_MS)
+  }
+
   // The member started scrolling by hand — a wheel/trackpad on desktop or a touch
   // pan on mobile: let the follow go and kill the live tween so it stops fighting
-  // them. Re-arms itself after an idle spell even without a manual resume tap.
+  // them.
   function disableFollow() {
     if (following.value) {
       following.value = false
@@ -457,11 +480,12 @@ export function useReaderHighlights(
       updateFollowDirection()
     }
 
-    if (follow_resume_timer !== null) clearTimeout(follow_resume_timer)
-    follow_resume_timer = setTimeout(() => {
-      follow_resume_timer = null
-      resumeFollow()
-    }, FOLLOW_RESUME_IDLE_MS)
+    if (follow_timer !== null) {
+      clearTimeout(follow_timer)
+      follow_timer = null
+    }
+
+    armFollowResumeTimer()
   }
 
   // Point the resume control at the playing word: 'up' when its centre sits above
@@ -826,6 +850,14 @@ export function useReaderHighlights(
         committed.value = null
         paintWords(null)
       }
+    }
+  )
+  // Play resuming after the idle timer already lapsed while paused (no-op'd)
+  // leaves follow off with nothing scheduled to bring it back — re-arm.
+  watch(
+    () => toValue(is_playing),
+    (playing) => {
+      if (playing && !following.value && follow_resume_timer === null) armFollowResumeTimer()
     }
   )
 

--- a/src/composables/audio-reader/reader-highlights.ts
+++ b/src/composables/audio-reader/reader-highlights.ts
@@ -8,7 +8,7 @@ import {
   useTemplateRef,
   watch
 } from 'vue'
-import type { ComputedRef, InjectionKey, MaybeRefOrGetter } from 'vue'
+import type { ComputedRef, InjectionKey, MaybeRefOrGetter, Ref } from 'vue'
 import { useStagedTap } from '@/composables/ui/staged-tap'
 import { emitSfx } from '@/sfx/bus'
 import { cleanTerm } from '@/utils/transcript'
@@ -65,6 +65,12 @@ type ReaderSelection = {
 }
 
 export type WordRange = { lo: number; hi: number }
+
+// Minimal shape of the window virtualizer this composable needs — just enough
+// to scroll an unmounted row into view before locating its word.
+type WordVirtualizer = Ref<{
+  scrollToIndex: (index: number, options?: { align?: 'start' | 'center' | 'end' | 'auto' }) => void
+}>
 
 // The live selection range (drag, standing selection, or hover) shared down to the
 // words so each can tint itself when it falls under the blue interaction pill.
@@ -123,6 +129,10 @@ export const readerMatchesKey = Symbol('readerMatches') as InjectionKey<
  * @param is_playing - whether the audio is playing; the active-line follow
  *   animates while it's true and jumps instantly otherwise (a resume seek or a
  *   scrub mustn't leave a scroll tween running — it locks up iOS Safari).
+ * @param virtualizer - the transcript's window virtualizer, used to bring the
+ *   active word's row into the DOM when a seek/resume lands outside the
+ *   currently rendered range.
+ * @param rowIndexOfWord - resolves a word index to its virtualizer row index.
  * @example
  * const { onPointerDown, onPointerMove, onPointerUp, onPointerLeave, onPointerCancel } =
  *   useReaderHighlights(() => active_word, commitSelection, () => popover_open, dismiss)
@@ -133,7 +143,9 @@ export function useReaderHighlights(
   popover_open: MaybeRefOrGetter<boolean>,
   onDismiss: () => void,
   matchRangeAt: (index: number) => WordRange | null = () => null,
-  is_playing: MaybeRefOrGetter<boolean> = false
+  is_playing: MaybeRefOrGetter<boolean> = false,
+  virtualizer: WordVirtualizer,
+  rowIndexOfWord: (word_index: number) => number
 ) {
   const content = useTemplateRef<HTMLElement>('content')
 
@@ -276,8 +288,8 @@ export function useReaderHighlights(
 
   // Move the `data-playing` flag from the previous active word to the current one
   // (CSS keys the blue tint + scale off it). A no-op when neither moved.
-  function paintActiveWord() {
-    const next = wordEl(toValue(active_word))
+  async function paintActiveWord() {
+    const next = await ensureWordMounted(toValue(active_word))
     if (next === active_el) return
 
     active_el?.removeAttribute('data-playing')
@@ -410,19 +422,16 @@ export function useReaderHighlights(
     return []
   }
 
-  // The nearest ancestor that actually scrolls — the reader column on desktop.
-  // On mobile the column isn't bounded so nothing overflows; fall back to the
-  // window, which is the real scroller there. Requiring real overflow (not just
-  // an `overflow-y: auto` style) is what makes that fallback kick in.
-  function scrollParentOf(el: HTMLElement | null): HTMLElement | Window {
-    let node = el?.parentElement ?? null
-    while (node) {
-      const overflow_y = getComputedStyle(node).overflowY
-      const scrollable = overflow_y === 'auto' || overflow_y === 'scroll'
-      if (scrollable && node.scrollHeight > node.clientHeight) return node
-      node = node.parentElement
-    }
-    return window
+  // The active word is audio-driven and can legitimately sit outside the
+  // currently virtualized range (after a seek, a scrub, or a resumed lesson).
+  // Every other word lookup in this file targets a word the member is
+  // currently touching on screen, so it's already mounted and doesn't need this.
+  async function ensureWordMounted(index: number): Promise<HTMLElement | null> {
+    const existing = wordEl(index)
+    if (existing) return existing
+    virtualizer.value.scrollToIndex(rowIndexOfWord(index), { align: 'center' })
+    await nextTick()
+    return wordEl(index)
   }
 
   // Follow the active word into the deadzone. Debounced so rapid scrubbing
@@ -433,13 +442,13 @@ export function useReaderHighlights(
   function followActiveWord() {
     if (!following.value) return
     if (follow_timer !== null) clearTimeout(follow_timer)
-    follow_timer = setTimeout(() => {
+    follow_timer = setTimeout(async () => {
       follow_timer = null
       const index = toValue(active_word)
       if (index < 0) return
-      const el = wordEl(index)
+      const el = await ensureWordMounted(index)
       if (!el) return
-      scrollWordIntoDeadzone(scrollParentOf(content.value), el, toValue(is_playing))
+      scrollWordIntoDeadzone(el, toValue(is_playing))
     }, 100)
   }
 
@@ -449,7 +458,7 @@ export function useReaderHighlights(
   function disableFollow() {
     if (following.value) {
       following.value = false
-      cancelScroll(scrollParentOf(content.value))
+      cancelScroll()
       updateFollowDirection()
     }
 
@@ -486,7 +495,7 @@ export function useReaderHighlights(
    * animates — this is a deliberate tap, not a paused-state seek, so the smooth
    * tween is wanted (and welcome) regardless of play state.
    */
-  function resumeFollow() {
+  async function resumeFollow() {
     if (follow_resume_timer !== null) {
       clearTimeout(follow_resume_timer)
       follow_resume_timer = null
@@ -495,25 +504,21 @@ export function useReaderHighlights(
     following.value = true
     const index = toValue(active_word)
     if (index < 0) return
-    const el = wordEl(index)
-    if (el) scrollLineIntoView(scrollParentOf(content.value), el, true)
+    const el = await ensureWordMounted(index)
+    if (el) scrollLineIntoView(el, true)
   }
 
-  // Keep a just-committed word clear of the term sheet. Only on mobile — where the
-  // page itself scrolls and the sheet rises from the bottom — and only when the
-  // word sits low enough to be covered; otherwise leave the view put. Desktop
-  // scrolls the bounded column and anchors a popover that flips clear on its own.
+  // Keep a just-committed word clear of the term sheet, on mobile where the
+  // page itself scrolls and the sheet rises from the bottom, and only when the
+  // word sits low enough to be covered; otherwise leave the view put.
   function revealCommitted(range: WordRange) {
-    const scroller = scrollParentOf(content.value)
-    if (scroller !== window) return
-
     const el = wordEl(range.lo)
     if (!el) return
     if (el.getBoundingClientRect().bottom <= window.innerHeight * SHEET_COVER_RATIO) return
 
     // Jump instantly — opening a term always pauses the audio, so a rAF-driven
     // window.scrollTo tween would starve rAF on iOS Safari for 600ms.
-    scrollLineIntoView(window, el, false)
+    scrollLineIntoView(el, false)
   }
 
   async function positionInteraction() {

--- a/src/utils/animations/transcript-scroll.ts
+++ b/src/utils/animations/transcript-scroll.ts
@@ -12,80 +12,36 @@ const DEADZONE_TOP = 0.15
 const DEADZONE_BOTTOM = 0.35
 const SCROLL_ANCHOR = 0.2
 
-// The scroller is the transcript column on desktop, but the whole page (window)
-// on mobile, where the column isn't bounded and the document scrolls instead.
-type Scroller = HTMLElement | Window
+// The transcript always scrolls the page itself — there's no bounded internal
+// column on any breakpoint. One proxy tween is enough; a fresh call retargets
+// it (and animates from the real current scroll position) instead of fighting
+// a stale one.
+const state = { y: 0 }
 
-// Per-scroller state so a new call retargets the live tween (and animates from
-// the real current scroll position) instead of fighting a stale one.
-const stateByScroller = new WeakMap<Scroller, { y: number }>()
-
-function isWindow(scroller: Scroller): scroller is Window {
-  return scroller === window
-}
-
-// Current scroll offset, viewport height, and max scroll — read from the element
-// or from the document when the page itself is the scroller.
-function metrics(scroller: Scroller) {
-  if (isWindow(scroller)) {
-    const doc = document.documentElement
-    return {
-      current: window.scrollY,
-      viewport: window.innerHeight,
-      max: doc.scrollHeight - doc.clientHeight,
-      top: 0
-    }
-  }
+function metrics() {
+  const doc = document.documentElement
   return {
-    current: scroller.scrollTop,
-    viewport: scroller.clientHeight,
-    max: scroller.scrollHeight - scroller.clientHeight,
-    top: scroller.getBoundingClientRect().top
+    current: window.scrollY,
+    viewport: window.innerHeight,
+    max: doc.scrollHeight - doc.clientHeight
   }
 }
 
 /**
- * Stop any in-flight scroll tween on `scroller`. Used when the member takes the
- * scroll over by hand, so the active-word follow lets go instead of fighting them.
+ * Stop any in-flight scroll tween. Used when the member takes the scroll over
+ * by hand, so the active-word follow lets go instead of fighting them.
  */
-export function cancelScroll(scroller: Scroller) {
-  const state = stateByScroller.get(scroller)
-  if (state) gsap.killTweensOf(state)
+export function cancelScroll() {
+  gsap.killTweensOf(state)
 }
 
-/**
- * Lift `el` clear above `limit_bottom` (a viewport Y, e.g. a fixed footer's top
- * edge) by scrolling `scroller` up just enough. No-op when `el` already sits
- * above the limit. Used to re-clear a selected word after the term footer grows.
- *
- * Pass `animate = false` to jump instantly — same iOS Safari rAF-starvation
- * caveat as `scrollLineIntoView` applies here.
- */
-export function scrollClearOf(
-  scroller: Scroller,
-  el: HTMLElement,
-  limit_bottom: number,
-  animate = true
-) {
-  const overshoot = el.getBoundingClientRect().bottom - limit_bottom
-  if (overshoot <= 0) return
-
-  const { current, max } = metrics(scroller)
-  const target = Math.max(0, Math.min(max, current + overshoot))
-
-  let state = stateByScroller.get(scroller)
-  if (!state) {
-    state = { y: current }
-    stateByScroller.set(scroller, state)
-  }
-
+function runTween(target: number, current: number, animate: boolean) {
   state.y = current
   gsap.killTweensOf(state)
 
   if (!animate) {
     state.y = target
-    if (isWindow(scroller)) window.scrollTo(0, target)
-    else scroller.scrollTop = target
+    window.scrollTo(0, target)
     return
   }
 
@@ -93,17 +49,30 @@ export function scrollClearOf(
     y: target,
     duration: DURATION,
     ease: 'power3.out',
-    onUpdate: () => {
-      if (isWindow(scroller)) window.scrollTo(0, state.y)
-      else scroller.scrollTop = state.y
-    }
+    onUpdate: () => window.scrollTo(0, state.y)
   })
 }
 
 /**
- * Scroll `scroller` so `el` rests ~40% down the viewport, clamped to the
+ * Lift `el` clear above `limit_bottom` (a viewport Y, e.g. a fixed footer's top
+ * edge) by scrolling the page up just enough. No-op when `el` already sits
+ * above the limit. Used to re-clear a selected word after the term footer grows.
+ *
+ * Pass `animate = false` to jump instantly — same iOS Safari rAF-starvation
+ * caveat as `scrollLineIntoView` applies here.
+ */
+export function scrollClearOf(el: HTMLElement, limit_bottom: number, animate = true) {
+  const overshoot = el.getBoundingClientRect().bottom - limit_bottom
+  if (overshoot <= 0) return
+
+  const { current, max } = metrics()
+  const target = Math.max(0, Math.min(max, current + overshoot))
+  runTween(target, current, animate)
+}
+
+/**
+ * Scroll the page so `el` rests ~40% down the viewport, clamped to the
  * scrollable range. Used to follow the active transcript line as audio plays.
- * `scroller` is the transcript column on desktop and the window on mobile.
  * ScrollToPlugin isn't registered, so we tween a proxy and write the scroll
  * offset in onUpdate.
  *
@@ -112,84 +81,34 @@ export function scrollClearOf(
  * paused-state repositioning — a resume seek, a scrub, a skip — must jump rather
  * than tween, or the audio tick and page lock up the moment playback starts.
  */
-export function scrollLineIntoView(scroller: Scroller, el: HTMLElement, animate = true) {
+export function scrollLineIntoView(el: HTMLElement, animate = true) {
   const el_rect = el.getBoundingClientRect()
-  const { current, viewport, max, top } = metrics(scroller)
+  const { current, viewport, max } = metrics()
 
-  const el_top_within = el_rect.top - top + current
+  const el_top_within = el_rect.top + current
   const desired = el_top_within - viewport * ANCHOR_RATIO + el_rect.height / 2
   const target = Math.max(0, Math.min(max, desired))
-
-  let state = stateByScroller.get(scroller)
-  if (!state) {
-    state = { y: current }
-    stateByScroller.set(scroller, state)
-  }
-
-  state.y = current
-  gsap.killTweensOf(state)
-
-  if (!animate) {
-    state.y = target
-    if (isWindow(scroller)) window.scrollTo(0, target)
-    else scroller.scrollTop = target
-    return
-  }
-
-  gsap.to(state, {
-    y: target,
-    duration: DURATION,
-    ease: 'power3.out',
-    onUpdate: () => {
-      if (isWindow(scroller)) window.scrollTo(0, state.y)
-      else scroller.scrollTop = state.y
-    }
-  })
+  runTween(target, current, animate)
 }
 
 /**
- * Scroll `scroller` only when `el` has drifted outside the deadzone band
- * (15%–80% of the viewport). When outside, snaps it to the top of the band.
+ * Scroll the page only when `el` has drifted outside the deadzone band
+ * (15%–35% of the viewport). When outside, snaps it to the top of the band.
  * No-ops when the word is already visible inside the band, so mid-sentence
  * words don't cause jitter. Same iOS Safari rules as `scrollLineIntoView`.
  */
-export function scrollWordIntoDeadzone(scroller: Scroller, el: HTMLElement, animate = true) {
+export function scrollWordIntoDeadzone(el: HTMLElement, animate = true) {
   const el_rect = el.getBoundingClientRect()
-  const { current, viewport, max, top } = metrics(scroller)
+  const { current, viewport, max } = metrics()
 
-  const el_top_in_vp = el_rect.top - top
-  const el_bottom_in_vp = el_rect.bottom - top
+  const el_top_in_vp = el_rect.top
+  const el_bottom_in_vp = el_rect.bottom
   const dz_top = viewport * DEADZONE_TOP
   const dz_bottom = viewport * DEADZONE_BOTTOM
 
   if (el_top_in_vp >= dz_top && el_bottom_in_vp <= dz_bottom) return
 
-  const el_top_within = el_rect.top - top + current
+  const el_top_within = el_rect.top + current
   const target = Math.max(0, Math.min(max, el_top_within - viewport * SCROLL_ANCHOR))
-
-  let state = stateByScroller.get(scroller)
-  if (!state) {
-    state = { y: current }
-    stateByScroller.set(scroller, state)
-  }
-
-  state.y = current
-  gsap.killTweensOf(state)
-
-  if (!animate) {
-    state.y = target
-    if (isWindow(scroller)) window.scrollTo(0, target)
-    else scroller.scrollTop = target
-    return
-  }
-
-  gsap.to(state, {
-    y: target,
-    duration: DURATION,
-    ease: 'power3.out',
-    onUpdate: () => {
-      if (isWindow(scroller)) window.scrollTo(0, state.y)
-      else scroller.scrollTop = state.y
-    }
-  })
+  runTween(target, current, animate)
 }

--- a/src/utils/animations/transcript-scroll.ts
+++ b/src/utils/animations/transcript-scroll.ts
@@ -1,10 +1,7 @@
-import { gsap } from 'gsap'
-
 // Where the active line rests in the scroll viewport (0 = top, 1 = bottom). A
 // little above centre keeps the upcoming lines visible while never letting the
 // current line jam against the top or bottom edge.
 const ANCHOR_RATIO = 0.4
-const DURATION = 0.6
 
 // Deadzone boundaries for word-level scroll. Words inside this band don't
 // trigger a scroll; words outside snap to SCROLL_ANCHOR.
@@ -13,11 +10,7 @@ const DEADZONE_BOTTOM = 0.35
 const SCROLL_ANCHOR = 0.2
 
 // The transcript always scrolls the page itself — there's no bounded internal
-// column on any breakpoint. One proxy tween is enough; a fresh call retargets
-// it (and animates from the real current scroll position) instead of fighting
-// a stale one.
-const state = { y: 0 }
-
+// column on any breakpoint.
 function metrics() {
   const doc = document.documentElement
   return {
@@ -27,39 +20,24 @@ function metrics() {
   }
 }
 
-/**
- * Stop any in-flight scroll tween. Used when the member takes the scroll over
- * by hand, so the active-word follow lets go instead of fighting them.
- */
-export function cancelScroll() {
-  gsap.killTweensOf(state)
+function scrollTo(target: number, animate: boolean) {
+  window.scrollTo({ top: target, behavior: animate ? 'smooth' : 'auto' })
 }
 
-function runTween(target: number, current: number, animate: boolean) {
-  state.y = current
-  gsap.killTweensOf(state)
-
-  if (!animate) {
-    state.y = target
-    window.scrollTo(0, target)
-    return
-  }
-
-  gsap.to(state, {
-    y: target,
-    duration: DURATION,
-    ease: 'power3.out',
-    onUpdate: () => window.scrollTo(0, state.y)
-  })
+/**
+ * Stop any in-flight smooth scroll. Used when the member takes the scroll over
+ * by hand, so the active-word follow lets go instead of fighting them. Issuing
+ * a fresh `scrollTo` at the current position interrupts the browser's own
+ * smooth-scroll animation immediately.
+ */
+export function cancelScroll() {
+  window.scrollTo({ top: window.scrollY, behavior: 'auto' })
 }
 
 /**
  * Lift `el` clear above `limit_bottom` (a viewport Y, e.g. a fixed footer's top
  * edge) by scrolling the page up just enough. No-op when `el` already sits
  * above the limit. Used to re-clear a selected word after the term footer grows.
- *
- * Pass `animate = false` to jump instantly — same iOS Safari rAF-starvation
- * caveat as `scrollLineIntoView` applies here.
  */
 export function scrollClearOf(el: HTMLElement, limit_bottom: number, animate = true) {
   const overshoot = el.getBoundingClientRect().bottom - limit_bottom
@@ -67,19 +45,12 @@ export function scrollClearOf(el: HTMLElement, limit_bottom: number, animate = t
 
   const { current, max } = metrics()
   const target = Math.max(0, Math.min(max, current + overshoot))
-  runTween(target, current, animate)
+  scrollTo(target, animate)
 }
 
 /**
  * Scroll the page so `el` rests ~40% down the viewport, clamped to the
  * scrollable range. Used to follow the active transcript line as audio plays.
- * ScrollToPlugin isn't registered, so we tween a proxy and write the scroll
- * offset in onUpdate.
- *
- * Pass `animate = false` to jump instantly. A rAF-driven `window.scrollTo` tween
- * starves rAF on iOS Safari (it suspends rAF mid programmatic scroll), so the
- * paused-state repositioning — a resume seek, a scrub, a skip — must jump rather
- * than tween, or the audio tick and page lock up the moment playback starts.
  */
 export function scrollLineIntoView(el: HTMLElement, animate = true) {
   const el_rect = el.getBoundingClientRect()
@@ -88,14 +59,14 @@ export function scrollLineIntoView(el: HTMLElement, animate = true) {
   const el_top_within = el_rect.top + current
   const desired = el_top_within - viewport * ANCHOR_RATIO + el_rect.height / 2
   const target = Math.max(0, Math.min(max, desired))
-  runTween(target, current, animate)
+  scrollTo(target, animate)
 }
 
 /**
  * Scroll the page only when `el` has drifted outside the deadzone band
  * (15%–35% of the viewport). When outside, snaps it to the top of the band.
  * No-ops when the word is already visible inside the band, so mid-sentence
- * words don't cause jitter. Same iOS Safari rules as `scrollLineIntoView`.
+ * words don't cause jitter.
  */
 export function scrollWordIntoDeadzone(el: HTMLElement, animate = true) {
   const el_rect = el.getBoundingClientRect()
@@ -110,5 +81,5 @@ export function scrollWordIntoDeadzone(el: HTMLElement, animate = true) {
 
   const el_top_within = el_rect.top + current
   const target = Math.max(0, Math.min(max, el_top_within - viewport * SCROLL_ANCHOR))
-  runTween(target, current, animate)
+  scrollTo(target, animate)
 }

--- a/src/utils/audio-reader/duration.ts
+++ b/src/utils/audio-reader/duration.ts
@@ -1,0 +1,10 @@
+/** Format a seconds count as a clock label — `M:SS` under an hour, `H:MM:SS` at or past it. */
+export function formatDuration(seconds: number): string {
+  const total = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+
+  if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
+  return `${m}:${s.toString().padStart(2, '0')}`
+}

--- a/src/views/audio-reader/lesson/audio-toolbar.vue
+++ b/src/views/audio-reader/lesson/audio-toolbar.vue
@@ -71,9 +71,14 @@ const chapter_options = computed<DropdownOption[]>(() =>
   use_lesson_chapters.value
     ? lessonChapters.map((chapter, i) => ({
         label: `${i + 1}. ${chapter.title}`,
-        value: chapter.start
+        value: chapter.start,
+        selected: i === active_lesson_chapter.value
       }))
-    : chapters.map((chapter, i) => ({ label: `${i + 1}. ${chapter.title}`, value: chapter.id }))
+    : chapters.map((chapter, i) => ({
+        label: `${i + 1}. ${chapter.title}`,
+        value: chapter.id,
+        selected: chapter.id === currentLessonId
+      }))
 )
 const current_chapter_label = computed(() =>
   use_lesson_chapters.value

--- a/src/views/audio-reader/lesson/chapter-list.vue
+++ b/src/views/audio-reader/lesson/chapter-list.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, toValue, type MaybeRef } from 'vue'
+import { formatDuration } from '@/utils/audio-reader/duration'
 
 // Intra-lesson chapter navigation: the auto-detected chapters of THIS lesson's
 // audio (transcript.chapters), each jumping playback to its start by seeking the
@@ -25,13 +26,6 @@ const active_index = computed(() => {
   })
   return index
 })
-
-function formatClock(seconds: number): string {
-  const total = Math.max(0, Math.floor(seconds))
-  const m = Math.floor(total / 60)
-  const s = total % 60
-  return `${m}:${s.toString().padStart(2, '0')}`
-}
 </script>
 
 <template>
@@ -49,7 +43,7 @@ function formatClock(seconds: number): string {
       @click="emit('seek', chapter.start)"
     >
       <span data-testid="chapter-list__time" class="shrink-0 text-base tabular-nums opacity-70">
-        {{ formatClock(chapter.start) }}
+        {{ formatDuration(chapter.start) }}
       </span>
       <span data-testid="chapter-list__title" class="line-clamp-1 text-base">
         {{ chapter.title }}

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -324,7 +324,6 @@ onBeforeUnmount(() => {
           :matches="matches"
           :active_word="active_word"
           :popover_open="popover_open"
-          :is_playing="player.is_playing.value"
           @select="openTerm"
           @dismiss="dismissTerm"
         />

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { emitSfx } from '@/sfx/bus'
@@ -34,7 +34,6 @@ const lesson_id = computed(() => Number(lessonId))
 
 const {
   lesson,
-  words,
   paragraphs,
   matches,
   audio_url,
@@ -93,49 +92,6 @@ const chapter_of = computed(() => ({
 // nav stays the fallback for multi-lesson books with no internal split.
 const lesson_chapters = computed(() => lesson.value?.transcript?.chapters ?? [])
 const has_lesson_chapters = computed(() => lesson_chapters.value.length > 1)
-
-// The last chapter whose start time the active word has reached. Derived from
-// active_word (word-boundary frequency) rather than player.current_time (60fps)
-// so lesson/index.vue does not re-render on every animation frame.
-const active_chapter_index = computed(() => {
-  const chapters = lesson_chapters.value
-  if (chapters.length <= 1) return 0
-  const time = words.value[active_word.value]?.start ?? 0
-  let idx = 0
-  for (let i = 0; i < chapters.length; i++) {
-    if (chapters[i].start <= time + 0.001) idx = i
-  }
-  return idx
-})
-
-// Mount only the current chapter's paragraphs plus one buffer chapter on each
-// side for smooth scrolling. Falls back to the full list when the lesson has no
-// internal chapters.
-//
-// The filter always returns a new array reference, so we stabilize via a
-// shallowRef that only propagates when the paragraph set actually changes. Without
-// this, transcript-view re-renders on every word boundary (~5x/sec during
-// playback) because active_chapter_index is dirty → raw_windowed runs filter →
-// new reference → new prop → re-render, even when the chapter hasn't changed.
-const raw_windowed = computed(() => {
-  if (!has_lesson_chapters.value) return paragraphs.value
-  const chapters = lesson_chapters.value
-  const ci = active_chapter_index.value
-  const lo = Math.max(0, ci - 1)
-  const hi = Math.min(chapters.length - 1, ci + 1)
-  const start_time = chapters[lo].start
-  const end_time = chapters[hi + 1]?.start ?? Infinity
-  return paragraphs.value.filter((p) => p.start >= start_time && p.start < end_time)
-})
-
-const windowed_paragraphs = shallowRef(raw_windowed.value)
-
-watch(raw_windowed, (next) => {
-  const prev = windowed_paragraphs.value
-  if (next === prev) return
-  if (next.length === prev.length && next.every((p, i) => p === prev[i])) return
-  windowed_paragraphs.value = next
-})
 
 const show_term = computed(() => popover_open.value && !!selection.value)
 
@@ -199,7 +155,7 @@ function reclearSelection() {
   const word = document.querySelector<HTMLElement>(`[data-word-index="${sel.word_index}"]`)
   if (!word) return
 
-  scrollClearOf(window, word, dock_el.value.getBoundingClientRect().top - FOOTER_CLEARANCE, false)
+  scrollClearOf(word, dock_el.value.getBoundingClientRect().top - FOOTER_CLEARANCE, false)
 }
 
 // The crossfade owns the footer height while a pane swap is in flight, so the
@@ -363,7 +319,7 @@ onBeforeUnmount(() => {
       >
         <transcript-view
           ref="transcript"
-          :paragraphs="windowed_paragraphs"
+          :paragraphs="paragraphs"
           :chapters="lesson_chapters"
           :matches="matches"
           :active_word="active_word"

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -324,6 +324,7 @@ onBeforeUnmount(() => {
           :matches="matches"
           :active_word="active_word"
           :popover_open="popover_open"
+          :is_playing="player.is_playing.value"
           @select="openTerm"
           @dismiss="dismissTerm"
         />

--- a/src/views/audio-reader/lesson/scrubber.vue
+++ b/src/views/audio-reader/lesson/scrubber.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, useTemplateRef } from 'vue'
 import type { AudioPlayer } from '@/composables/audio-reader/audio-player'
+import { formatDuration } from '@/utils/audio-reader/duration'
 
 type ScrubberProps = {
   player: AudioPlayer
@@ -20,22 +21,14 @@ const progress = computed(() => {
   const total = player.duration.value
   return total > 0 ? (player.current_time.value / total) * 100 : 0
 })
-const current_label = computed(() => formatTime(player.current_time.value))
-const duration_label = computed(() => formatTime(player.duration.value))
+const current_label = computed(() => formatDuration(player.current_time.value))
+const duration_label = computed(() => formatDuration(player.duration.value))
 // Reach the thumb's center, not the progress point, so the thumb always
 // overlaps the fill's rounded cap — no seam between the two rounded shapes.
 const fill_width = computed(() => {
   const center_offset = THUMB_SIZE / 2 - (progress.value / 100) * THUMB_SIZE
   return `calc(${progress.value}% + ${center_offset}px)`
 })
-
-function formatTime(seconds: number) {
-  if (!Number.isFinite(seconds) || seconds < 0) return '0:00'
-
-  const mins = Math.floor(seconds / 60)
-  const secs = Math.floor(seconds % 60)
-  return `${mins}:${secs.toString().padStart(2, '0')}`
-}
 
 function seekToClientX(client_x: number) {
   const el = track.value

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useWindowVirtualizer } from '@tanstack/vue-virtual'
 import type { SentenceWords } from '@/utils/transcript'
 import { markTermInSentence } from '@/utils/transcript'
 import type { CardMatch } from '@/utils/transcript-match'
@@ -16,6 +17,8 @@ type TranscriptViewProps = {
   is_playing?: boolean
 }
 
+type TranscriptRow = { paragraph: SentenceWords; chapter_title?: string }
+
 const {
   paragraphs,
   chapters = [],
@@ -29,6 +32,61 @@ const emit = defineEmits<{
   (e: 'select', selection: TermSelection): void
   (e: 'dismiss'): void
 }>()
+
+// Leading / trailing punctuation edges — strip these from the first/last word of
+// a match so the underline hugs the term's own characters and never bridges a
+// comma or bracket to a neighbouring card.
+const LEADING_EDGE = /^[\p{P}\s]+/u
+const TRAILING_EDGE = /[\p{P}\s]+$/u
+
+// Estimated row height before it's actually measured — deliberately generous
+// since an undershoot causes more visible re-layout than an overshoot. Real
+// height is corrected per-row via virtualizer.measureElement once mounted.
+const BASE_ROW_HEIGHT = 170
+const TRANSLATION_EXTRA = 40
+const HEADING_EXTRA = 170
+const OVERSCAN = 5
+
+const scroll_margin = ref(0)
+
+// One row per paragraph; a row also carries its chapter's heading title when
+// it's the first paragraph of that chapter, so the heading's height is part of
+// the virtualized item instead of a sibling flow element.
+const rows = computed<TranscriptRow[]>(() => {
+  const heading_at = new Map<number, string>()
+  for (const chapter of chapters) {
+    const first = paragraphs.find((p) => p.start >= chapter.start)
+    if (first) heading_at.set(first.index, chapter.title)
+  }
+  return paragraphs.map((paragraph) => ({
+    paragraph,
+    chapter_title: heading_at.get(paragraph.index)
+  }))
+})
+
+// word index -> row index, so the audio-driven active word (which may be
+// unmounted after a seek) can be resolved to a row for scrollToIndex.
+const word_row_index = computed(() => {
+  const map = new Map<number, number>()
+  rows.value.forEach((row, i) => {
+    for (const word of row.paragraph.words) map.set(word.index, i)
+  })
+  return map
+})
+
+const virtualizer = useWindowVirtualizer(
+  computed(() => ({
+    count: rows.value.length,
+    estimateSize: (i: number) => estimateRowSize(rows.value[i]),
+    overscan: OVERSCAN,
+    scrollMargin: scroll_margin.value,
+    getItemKey: (i: number) => rows.value[i].paragraph.index
+  }))
+)
+
+function rowIndexOfWord(word_index: number): number {
+  return word_row_index.value.get(word_index) ?? 0
+}
 
 const {
   content,
@@ -50,18 +108,38 @@ const {
   () => popover_open,
   () => emit('dismiss'),
   matchRangeAt,
-  () => is_playing
+  () => is_playing,
+  virtualizer,
+  rowIndexOfWord
 )
 
 // The follow state + resume action surface to the lesson view, which renders the
 // "jump to current line" control in the mobile dock above the transcript.
 defineExpose({ following, follow_direction, resumeFollow })
 
-// Leading / trailing punctuation edges — strip these from the first/last word of
-// a match so the underline hugs the term's own characters and never bridges a
-// comma or bracket to a neighbouring card.
-const LEADING_EDGE = /^[\p{P}\s]+/u
-const TRAILING_EDGE = /[\p{P}\s]+$/u
+let resize_observer: ResizeObserver | undefined
+
+onMounted(() => {
+  measureScrollMargin()
+  resize_observer = new ResizeObserver(measureScrollMargin)
+  resize_observer.observe(document.body)
+})
+
+onBeforeUnmount(() => resize_observer?.disconnect())
+
+function estimateRowSize(row: TranscriptRow): number {
+  let size = BASE_ROW_HEIGHT
+  if (row.paragraph.translation) size += TRANSLATION_EXTRA
+  if (row.chapter_title) size += HEADING_EXTRA
+  return size
+}
+
+// The transcript always scrolls the page itself, so its document offset is
+// what maps page scroll onto row positions.
+function measureScrollMargin() {
+  if (!content.value) return
+  scroll_margin.value = content.value.getBoundingClientRect().top + window.scrollY
+}
 
 // Paint card-match highlights onto word elements imperatively rather than via
 // reactive inject. With large transcripts (1000+ words) the inject chain caused
@@ -116,16 +194,6 @@ function paintMatchedWords(m: Map<number, CardMatch>) {
   }
 }
 
-// Maps paragraph.index → chapter title for the first paragraph of each chapter.
-const chapter_headings = computed(() => {
-  const map = new Map<number, string>()
-  for (const chapter of chapters) {
-    const first = paragraphs.find((p) => p.start >= chapter.start)
-    if (first) map.set(first.index, chapter.title)
-  }
-  return map
-})
-
 // A tap/click on a word inside a card match selects the whole matched phrase;
 // null for an unmatched word, so the caller falls back to single-word select.
 function matchRangeAt(index: number): WordRange | null {
@@ -164,6 +232,16 @@ function commitSelection({
 }
 
 watch(() => matches, paintMatchedWords, { immediate: true, flush: 'post' })
+
+// Newly-mounted rows (scrolled into view) need their matches painted too — the
+// watch above only fires when the `matches` map itself changes.
+watch(
+  () => virtualizer.value.getVirtualItems(),
+  () => paintMatchedWords(matches),
+  {
+    flush: 'post'
+  }
+)
 </script>
 
 <template>
@@ -171,7 +249,8 @@ watch(() => matches, paintMatchedWords, { immediate: true, flush: 'post' })
     <div
       ref="content"
       data-testid="transcript-view__content"
-      class="relative isolate flex select-none flex-col gap-7 text-4xl leading-[2.5] text-brown-700 dark:text-brown-200"
+      class="relative isolate select-none text-4xl leading-[2.5] text-brown-700 dark:text-brown-200"
+      :style="{ height: `${virtualizer.getTotalSize()}px` }"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"
@@ -192,19 +271,33 @@ watch(() => matches, paintMatchedWords, { immediate: true, flush: 'post' })
           class="absolute inset-0 hidden rounded-2 bgx-diagonal-stripes animation-safe:bgx-slide bgx-color-[currentColor] group-data-[playing=true]/pill:block"
         />
       </div>
-      <template v-for="paragraph in paragraphs" :key="paragraph.index">
+
+      <div
+        v-for="vrow in virtualizer.getVirtualItems()"
+        :key="vrow.key as number"
+        :data-index="vrow.index"
+        :ref="(el) => virtualizer.measureElement(el as Element)"
+        data-testid="transcript-view__row"
+        class="absolute top-0 left-0 w-full pb-7"
+        :style="{ transform: `translateY(${vrow.start - scroll_margin}px)` }"
+      >
         <div
-          v-if="chapter_headings.get(paragraph.index)"
+          v-if="rows[vrow.index].chapter_title"
           data-testid="transcript-view__chapter-heading"
-          class="mt-32 flex flex-col items-center gap-3 first:mt-0"
+          class="flex flex-col items-center gap-3"
+          :class="vrow.index === 0 ? 'mt-0' : 'mt-32'"
         >
           <h2 class="text-xl font-medium text-brown-500 dark:text-brown-400">
-            {{ chapter_headings.get(paragraph.index) }}
+            {{ rows[vrow.index].chapter_title }}
           </h2>
           <hr class="w-16 border-brown-700 dark:border-brown-700" />
         </div>
-        <transcript-segment :group="paragraph" :index="paragraph.index" />
-      </template>
+
+        <transcript-segment
+          :group="rows[vrow.index].paragraph"
+          :index="rows[vrow.index].paragraph.index"
+        />
+      </div>
     </div>
 
     <selection-preview :preview="selection_preview" />

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -14,7 +14,6 @@ type TranscriptViewProps = {
   matches?: Map<number, CardMatch>
   active_word: number
   popover_open?: boolean
-  is_playing?: boolean
 }
 
 type TranscriptRow = { paragraph: SentenceWords; chapter_title?: string }
@@ -24,8 +23,7 @@ const {
   chapters = [],
   matches = new Map(),
   active_word,
-  popover_open = false,
-  is_playing = false
+  popover_open = false
 } = defineProps<TranscriptViewProps>()
 
 const emit = defineEmits<{
@@ -108,7 +106,6 @@ const {
   () => popover_open,
   () => emit('dismiss'),
   matchRangeAt,
-  () => is_playing,
   virtualizer,
   rowIndexOfWord
 )

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -14,6 +14,7 @@ type TranscriptViewProps = {
   matches?: Map<number, CardMatch>
   active_word: number
   popover_open?: boolean
+  is_playing?: boolean
 }
 
 type TranscriptRow = { paragraph: SentenceWords; chapter_title?: string }
@@ -23,7 +24,8 @@ const {
   chapters = [],
   matches = new Map(),
   active_word,
-  popover_open = false
+  popover_open = false,
+  is_playing = false
 } = defineProps<TranscriptViewProps>()
 
 const emit = defineEmits<{
@@ -107,7 +109,8 @@ const {
   () => emit('dismiss'),
   matchRangeAt,
   virtualizer,
-  rowIndexOfWord
+  rowIndexOfWord,
+  () => is_playing
 )
 
 // The follow state + resume action surface to the lesson view, which renders the

--- a/src/views/audio-reader/transcript/segment.vue
+++ b/src/views/audio-reader/transcript/segment.vue
@@ -8,11 +8,7 @@ const { group, index } = defineProps<{
 </script>
 
 <template>
-  <div
-    data-testid="transcript-segment"
-    :data-index="index"
-    class="[content-visibility:auto] [contain-intrinsic-size:auto_12rem] [contain:layout]"
-  >
+  <div data-testid="transcript-segment" :data-index="index">
     <span data-testid="transcript-segment__source"
       ><ruby
         v-for="word in group.words"

--- a/tests/integration/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/integration/composables/audio-reader/use-reader-highlights.test.js
@@ -45,7 +45,13 @@ const Host = defineComponent({
       () => props.activeWord,
       props.onSelect,
       () => props.open,
-      props.onDismiss
+      props.onDismiss,
+      undefined,
+      // A minimal stand-in for the transcript's window virtualizer — the host's
+      // words are always already in the DOM, so ensureWordMounted's fast path
+      // wins and scrollToIndex is never actually exercised here.
+      { value: { scrollToIndex: vi.fn() } },
+      (index) => index
     )
   },
   render() {

--- a/tests/integration/views/audio-reader/transcript/index.test.js
+++ b/tests/integration/views/audio-reader/transcript/index.test.js
@@ -1,7 +1,6 @@
 import { describe, test, expect, vi, afterEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
 import TranscriptView from '@/views/audio-reader/transcript/index.vue'
-import { readerActiveWordKey } from '@/composables/audio-reader/reader-highlights'
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -339,6 +338,9 @@ describe('TranscriptView', () => {
   describe('readerActiveWordKey provide [obligation]', () => {
     test('provides readerActiveWordKey to child words reflecting active_word prop [obligation]', async () => {
       const wrapper = mountView({ active_word: 3 })
+      // paintActiveWord awaits ensureWordMounted (a microtask, even when the
+      // word is already mounted) — let it settle before inspecting the DOM.
+      await flushPromises()
       // The provided value is a ComputedRef<number>. We can inspect it via
       // the component's provides (internal). Drive it via a child word instead:
       // a word at index 3 should have data-playing=true when active_word=3.
@@ -349,6 +351,7 @@ describe('TranscriptView', () => {
 
     test('words that are not the active word have data-playing absent [obligation]', async () => {
       const wrapper = mountView({ active_word: 3 })
+      await flushPromises()
       const words = wrapper.findAll('[data-testid="transcript-word"]')
       // word 0 is not the active word — paintActiveWord removes the attribute entirely
       // (rather than setting it to 'false'), so non-active words carry no data-playing attr

--- a/tests/unit/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/unit/composables/audio-reader/use-reader-highlights.test.js
@@ -117,6 +117,12 @@ function withHighlights({
   const onSelect = vi.fn()
   const onDismiss = vi.fn()
 
+  // A minimal stand-in for the transcript's window virtualizer — real tests add
+  // their words directly to contentEl, so ensureWordMounted's fast (already
+  // mounted) path always wins and scrollToIndex is never actually exercised.
+  const virtualizer = { value: { scrollToIndex: vi.fn() } }
+  const rowIndexOfWord = (index) => index
+
   const HostComponent = defineComponent({
     setup() {
       // matchRangeAt left undefined → the composable's own `() => null` default
@@ -127,6 +133,8 @@ function withHighlights({
         () => popover_open.value,
         onDismiss,
         matchRangeAt,
+        virtualizer,
+        rowIndexOfWord,
         () => is_playing.value
       )
       return () =>
@@ -942,8 +950,10 @@ describe('useReaderHighlights', () => {
       // Nothing should have fired yet — still inside the debounce window.
       expect(mockScrollWordIntoDeadzone).not.toHaveBeenCalled()
 
-      // Advance past debounce.
+      // Advance past debounce. The fired callback awaits ensureWordMounted (a
+      // microtask) before scrolling, so let that settle before asserting.
       vi.advanceTimersByTime(110)
+      await nextTick()
 
       expect(mockScrollWordIntoDeadzone).toHaveBeenCalledTimes(1)
     })
@@ -1065,7 +1075,10 @@ describe('useReaderHighlights', () => {
             () => -1,
             onSelect,
             () => false,
-            onDismiss
+            onDismiss,
+            undefined,
+            { value: { scrollToIndex: vi.fn() } },
+            (index) => index
           )
           // Render WITHOUT ref="content" — so content.value stays null.
           return () => vueH('div', {})
@@ -1314,11 +1327,11 @@ describe('useReaderHighlights', () => {
       result.following.value = false
       mockScrollLineIntoView.mockClear()
 
-      result.resumeFollow()
+      await result.resumeFollow()
 
       expect(mockScrollLineIntoView).toHaveBeenCalledTimes(1)
-      // Third arg: animate (true while playing).
-      const [, , animate] = mockScrollLineIntoView.mock.calls[0]
+      // Second arg: animate (true while playing).
+      const [, animate] = mockScrollLineIntoView.mock.calls[0]
       expect(animate).toBe(true)
     })
 
@@ -1331,11 +1344,11 @@ describe('useReaderHighlights', () => {
       result.following.value = false
       mockScrollLineIntoView.mockClear()
 
-      result.resumeFollow()
+      await result.resumeFollow()
 
       expect(mockScrollLineIntoView).toHaveBeenCalledTimes(1)
       // The resume tap always smooth-scrolls, regardless of play state.
-      const [, , animate] = mockScrollLineIntoView.mock.calls[0]
+      const [, animate] = mockScrollLineIntoView.mock.calls[0]
       expect(animate).toBe(true)
     })
   })
@@ -1344,8 +1357,9 @@ describe('useReaderHighlights', () => {
     beforeEach(() => vi.useFakeTimers())
     afterEach(() => vi.useRealTimers())
 
-    test('re-arms following after FOLLOW_RESUME_IDLE_MS with no manual resume tap [obligation]', async () => {
-      const { result } = withHighlights()
+    test('re-arms following after FOLLOW_RESUME_IDLE_MS while playing, with no manual resume tap [obligation]', async () => {
+      const is_playing = ref(true)
+      const { result } = withHighlights({ is_playing })
       expect(result.following.value).toBe(true)
 
       window.dispatchEvent(new Event('wheel'))
@@ -1358,8 +1372,46 @@ describe('useReaderHighlights', () => {
       expect(result.following.value).toBe(true)
     })
 
+    // [obligation] Paused, the active word isn't advancing — there's nothing to
+    // fall behind, so the idle timer must not yank the view back (e.g. away from
+    // a term popover the member scrolled to read).
+    test('does NOT re-arm following after the idle window while paused [obligation]', async () => {
+      const is_playing = ref(false)
+      const { result } = withHighlights({ is_playing })
+
+      window.dispatchEvent(new Event('wheel'))
+      await nextTick()
+      expect(result.following.value).toBe(false)
+
+      vi.advanceTimersByTime(5000)
+      await nextTick()
+
+      expect(result.following.value).toBe(false)
+    })
+
+    // [obligation] A paused lapse leaves no timer pending; play starting later
+    // must re-arm one rather than leaving follow off forever.
+    test('re-arms once play starts after an idle window lapsed while paused [obligation]', async () => {
+      const is_playing = ref(false)
+      const { result } = withHighlights({ is_playing })
+
+      window.dispatchEvent(new Event('wheel'))
+      await nextTick()
+      vi.advanceTimersByTime(5000)
+      await nextTick()
+      expect(result.following.value).toBe(false)
+
+      is_playing.value = true
+      await nextTick()
+      vi.advanceTimersByTime(5000)
+      await nextTick()
+
+      expect(result.following.value).toBe(true)
+    })
+
     test('a second disableFollow call before the timer fires restarts the idle window [obligation]', async () => {
-      const { result } = withHighlights()
+      const is_playing = ref(true)
+      const { result } = withHighlights({ is_playing })
 
       window.dispatchEvent(new Event('wheel'))
       await nextTick()
@@ -1384,7 +1436,8 @@ describe('useReaderHighlights', () => {
     })
 
     test('calling resumeFollow manually cancels the pending auto re-arm [obligation]', async () => {
-      const { result } = withHighlights()
+      const is_playing = ref(true)
+      const { result } = withHighlights({ is_playing })
 
       window.dispatchEvent(new Event('wheel'))
       await nextTick()

--- a/tests/unit/utils/animations/transcript-scroll.test.js
+++ b/tests/unit/utils/animations/transcript-scroll.test.js
@@ -1,15 +1,25 @@
-import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
-
-const { toMock, killMock } = vi.hoisted(() => ({ toMock: vi.fn(), killMock: vi.fn() }))
-
-vi.mock('gsap', () => ({ gsap: { to: toMock, killTweensOf: killMock } }))
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 
 const { scrollLineIntoView, scrollWordIntoDeadzone, cancelScroll } =
   await import('@/utils/animations/transcript-scroll')
 
-// A minimal element scroller (not `window`, so it's treated as an HTMLElement).
-function makeScroller({ scrollTop = 0, clientHeight = 100, scrollHeight = 1000, top = 0 } = {}) {
-  return { scrollTop, clientHeight, scrollHeight, getBoundingClientRect: () => ({ top }) }
+// The transcript always scrolls the page itself — stub window/document metrics per test.
+function stubViewport({
+  scrollY = 0,
+  innerHeight = 100,
+  scrollHeight = 1000,
+  clientHeight = 100
+} = {}) {
+  vi.stubGlobal('scrollY', scrollY)
+  vi.stubGlobal('innerHeight', innerHeight)
+  Object.defineProperty(document.documentElement, 'scrollHeight', {
+    value: scrollHeight,
+    configurable: true
+  })
+  Object.defineProperty(document.documentElement, 'clientHeight', {
+    value: clientHeight,
+    configurable: true
+  })
 }
 
 function makeLine({ top = 500, height = 20 } = {}) {
@@ -23,139 +33,106 @@ function makeWord({ top = 0, bottom } = {}) {
   return { getBoundingClientRect: () => ({ top, bottom: b }) }
 }
 
+let scrollToMock
+
 beforeEach(() => {
-  toMock.mockClear()
-  killMock.mockClear()
+  scrollToMock = vi.fn()
+  vi.stubGlobal('scrollTo', scrollToMock)
+  stubViewport()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
 })
 
 describe('scrollLineIntoView', () => {
-  test('animate=false jumps the scroll instantly and runs no tween', () => {
-    const scroller = makeScroller()
+  test('animate=false jumps the scroll instantly (behavior: auto)', () => {
+    scrollLineIntoView(makeLine(), false)
 
-    scrollLineIntoView(scroller, makeLine(), false)
-
-    expect(toMock).not.toHaveBeenCalled()
     // 500 − 100*0.4 + 20/2 = 470, clamped into [0, 900].
-    expect(scroller.scrollTop).toBe(470)
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 470, behavior: 'auto' })
   })
 
-  test('animate=true (default) drives a gsap tween instead of a hard jump', () => {
-    const scroller = makeScroller()
+  test('animate=true (default) scrolls smoothly (behavior: smooth)', () => {
+    scrollLineIntoView(makeLine())
 
-    scrollLineIntoView(scroller, makeLine())
-
-    expect(toMock).toHaveBeenCalledTimes(1)
-    expect(scroller.scrollTop).toBe(0) // the tween owns scrollTop, not a sync write
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 470, behavior: 'smooth' })
   })
 })
 
 // Deadzone constants from the source: DEADZONE_TOP=0.15, DEADZONE_BOTTOM=0.35,
-// SCROLL_ANCHOR=0.2. Tests use a 100px-tall scroller to keep arithmetic readable.
-// Deadzone band: 15px–35px. Scroll anchor: 20px from top of scroller.
+// SCROLL_ANCHOR=0.2. Tests use a 100px-tall viewport to keep arithmetic readable.
+// Deadzone band: 15px–35px. Scroll anchor: 20px from top of viewport.
 
 describe('scrollWordIntoDeadzone', () => {
   // [obligation] word fully inside the deadzone band: no scroll fires.
   test('no-op when word top ≥ 15% and bottom ≤ 35% of viewport', () => {
-    // Scroller: scrollTop=0, clientHeight=100, scrollHeight=1000, top=0.
-    // Word sits at viewport y=16 (top) to y=30 (bottom) — inside 15%–35%.
-    const scroller = makeScroller({ scrollTop: 0, clientHeight: 100, scrollHeight: 1000, top: 0 })
     const word = makeWord({ top: 16, bottom: 30 })
 
-    scrollWordIntoDeadzone(scroller, word, false)
+    scrollWordIntoDeadzone(word, false)
 
-    expect(scroller.scrollTop).toBe(0)
-    expect(toMock).not.toHaveBeenCalled()
+    expect(scrollToMock).not.toHaveBeenCalled()
   })
 
   // [obligation] word bottom exceeds the deadzone bottom → scroll fires.
   test('scrolls when word exits bottom of deadzone (bottom > 35%)', () => {
-    // Scroller: scrollTop=0, clientHeight=100, scrollHeight=1000, top=0.
-    // Word sits at top=50px, bottom=60px — below DEADZONE_BOTTOM (35px).
-    const scroller = makeScroller({ scrollTop: 0, clientHeight: 100, scrollHeight: 1000, top: 0 })
     const word = makeWord({ top: 50, bottom: 60 })
 
-    scrollWordIntoDeadzone(scroller, word, false)
+    scrollWordIntoDeadzone(word, false)
 
     // target = el_top_within − viewport * SCROLL_ANCHOR = 50 − 100*0.2 = 30, clamped [0,900].
-    expect(scroller.scrollTop).toBe(30)
-    expect(toMock).not.toHaveBeenCalled()
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 30, behavior: 'auto' })
   })
 
   // [obligation] word above deadzone top → scroll fires.
   test('scrolls when word is above deadzone top (top < 15%)', () => {
-    // Word sits at top=5px, bottom=15px — above DEADZONE_TOP (15px).
-    const scroller = makeScroller({ scrollTop: 0, clientHeight: 100, scrollHeight: 1000, top: 0 })
     const word = makeWord({ top: 5, bottom: 15 })
 
-    scrollWordIntoDeadzone(scroller, word, false)
+    scrollWordIntoDeadzone(word, false)
 
     // target = 5 − 100*0.2 = −15, clamped to 0.
-    expect(scroller.scrollTop).toBe(0)
-    expect(toMock).not.toHaveBeenCalled()
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 0, behavior: 'auto' })
   })
 
-  test('animate=true drives a gsap tween and does not hard-set scrollTop', () => {
-    const scroller = makeScroller({ scrollTop: 0, clientHeight: 100, scrollHeight: 1000, top: 0 })
+  test('animate=true drives a smooth scroll', () => {
     const word = makeWord({ top: 50, bottom: 60 })
 
-    scrollWordIntoDeadzone(scroller, word, true)
+    scrollWordIntoDeadzone(word, true)
 
-    expect(toMock).toHaveBeenCalledTimes(1)
-    expect(scroller.scrollTop).toBe(0) // tween owns it, no sync write
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 30, behavior: 'smooth' })
   })
 
   test('target is clamped to 0 when computed target would be negative', () => {
     // Word near the top: el_top_within − anchor would go negative.
-    const scroller = makeScroller({ scrollTop: 0, clientHeight: 100, scrollHeight: 1000, top: 0 })
     const word = makeWord({ top: 10, bottom: 50 }) // bottom > deadzone_bottom (35), triggers scroll
 
-    scrollWordIntoDeadzone(scroller, word, false)
+    scrollWordIntoDeadzone(word, false)
 
     // target = 10 − 20 = −10, clamped to 0.
-    expect(scroller.scrollTop).toBe(0)
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 0, behavior: 'auto' })
   })
 
   test('target is clamped to max scroll when computed target would overshoot', () => {
-    // Scroller near the bottom: scrollHeight=1000, clientHeight=100 → max=900.
-    // Word at top=990 (would want target = 990 − 20 = 970, > max 900).
-    // But scroller top=0 and scrollTop must be set to show word at the bottom of content.
-    const scroller = makeScroller({
-      scrollTop: 850,
-      clientHeight: 100,
-      scrollHeight: 1000,
-      top: 0
-    })
-    // In viewport: el.top = 990 − 850 = 140 (off screen) > deadzone_bottom (35px) → triggers.
+    // scrollY=850, viewport=100, scrollHeight=1000 → max=900.
+    stubViewport({ scrollY: 850, innerHeight: 100, scrollHeight: 1000, clientHeight: 100 })
+    // In viewport: el.top = 990 − (scroll offset baked into getBoundingClientRect) = 990.
     const word = makeWord({ top: 990, bottom: 1010 })
 
-    scrollWordIntoDeadzone(scroller, word, false)
+    scrollWordIntoDeadzone(word, false)
 
-    // el_top_within = 990 − 0 + 850 = 1840, target = 1840 − 20 = 1820, clamped to max=900.
-    expect(scroller.scrollTop).toBe(900)
+    // el_top_within = 990 + 850 = 1840, target = 1840 − 20 = 1820, clamped to max=900.
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 900, behavior: 'auto' })
   })
 })
 
 describe('cancelScroll', () => {
-  // [obligation] No tween has ever run for this scroller, so there's no per-scroller
-  // state to kill — the WeakMap lookup misses and killTweensOf is never touched.
-  test('is a no-op when the scroller has no tween state', () => {
-    const scroller = makeScroller()
+  // [obligation] Re-issuing scrollTo at the current position interrupts any
+  // in-flight native smooth scroll so it stops fighting a manual scroll.
+  test('scrolls to the current position with behavior "auto" to interrupt any smooth scroll', () => {
+    stubViewport({ scrollY: 234 })
 
-    cancelScroll(scroller)
+    cancelScroll()
 
-    expect(killMock).not.toHaveBeenCalled()
-  })
-
-  // [obligation] Once a scroll has tweened (creating the per-scroller proxy state),
-  // cancelScroll kills the live tween so it stops fighting a manual scroll.
-  test('kills the live tween once a scroll has created state for the scroller', () => {
-    const scroller = makeScroller()
-    // animate=true populates stateByScroller and itself calls killTweensOf once.
-    scrollLineIntoView(scroller, makeLine())
-    killMock.mockClear()
-
-    cancelScroll(scroller)
-
-    expect(killMock).toHaveBeenCalledTimes(1)
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 234, behavior: 'auto' })
   })
 })


### PR DESCRIPTION
## Summary

Replaces the audio-reader transcript's coarse chapter-level DOM windowing with proper segment-level virtualization, fixing both the rendering lag and the auto-scroll jank on long (audiobook-length) lessons. Also fixes several follow-scroll bugs surfaced/clarified during that work, and squeezes in two small related UX fixes.

## Changes

- Virtualize the transcript at the paragraph/segment level via `@tanstack/vue-virtual` (already used elsewhere in the codebase), replacing the old "mount the active chapter ± 1" windowing that caused both the lag and the scroll bugs.
- Replace the GSAP scroll-proxy tween with native `window.scrollTo({ behavior: 'smooth' })` for all transcript auto-scrolling — fixes inconsistent smooth scrolling on chapter seeks and term-popover reveals (a play/pause race and a hardcoded instant-jump respectively).
- Gate the idle follow-resume timer to playback state, so scrolling away to read a term popover while paused no longer gets yanked back a few seconds later; re-arms automatically if playback resumes after a paused lapse.
- Fix a race where a debounced follow-scroll could still fire after a manual scroll had already disabled follow, fighting the member's own scroll input.
- Highlight the current chapter in the toolbar's chapter dropdown.
- Format chapter/scrubber time labels as `H:MM:SS` once past an hour instead of raw minutes (e.g. `270:36` → `4:30:36`).

## Test plan

- [x] Long multi-chapter lesson: only a small, bounded number of transcript rows are mounted regardless of book length; scrolling fast doesn't jump or flicker at chapter boundaries.
- [x] Playback follow-scroll tracks the active word smoothly; scrolling manually mid-follow takes precedence with no fighting.
- [x] Seeking via the chapter dropdown or scrubbing jumps to unmounted content correctly and settles smoothly.
- [x] Word selection, highlight pills, and the term popover position correctly under virtualization.
- [x] Term popover reveal-scroll and idle-resume behave correctly while paused vs. playing.
- [x] Chapter dropdown highlights the current chapter; long durations render as `H:MM:SS`.
- [x] Mobile viewport layout unaffected.
- [x] `vp lint`, `pnpm type-check`, and full test suite (`vp test`) all clean.
