### PR TITLE
perf(ci): shard test job, add no-coverage fast test script

### DIFF
--- a/.claude/skills/update-tests/SKILL.md
+++ b/.claude/skills/update-tests/SKILL.md
@@ -67,8 +67,10 @@ The subagent works from a cold diff and can mis-scope or over-claim. Cross-check
 Before you commit, run the **entire** suite, not just the touched/mirror files:
 
 ```
-vp test --no-coverage
+pnpm test:fast
 ```
+
+(Unit + Integration, no coverage — the fast full-suite runner. Never add `--coverage` here; this gate only needs pass/fail, not instrumentation.)
 
 This is non-negotiable. The subagent only ever runs touched-file scope, so collateral breakage in **untouched** test files is invisible to it — and that is the single most common reason these PRs fail CI (it happens on nearly every move/barrel/mock-shape change). The mirror-file check in item 3 is necessary but **not sufficient**: a file-move or barrel-widening refactor breaks tests that don't mirror any touched source at all (e.g. a sibling feature whose `vi.mock('@/some/barrel')` is now missing a newly-transitive export). Only a full run catches those.
 
@@ -76,7 +78,7 @@ If the full suite is red:
 
 - Fix the failures yourself when they're mechanical (repoint a moved import, add the missing export to a `vi.mock` factory, mock the barrel the source now imports instead of the old deep path). These are review fixes, not new authoring — keep them in the test commit.
 - Re-dispatch the subagent only if the failures reveal a genuine missing-coverage gap, not just a broken harness.
-- Do **not** commit until `vp test --no-coverage` is fully green. A green touched-file scope with a red full suite is a failed run.
+- Do **not** commit until `pnpm test:fast` is fully green. A green touched-file scope with a red full suite is a failed run.
 
 ### Decide
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,6 @@ jobs:
       - name: Run tests (shard ${{ matrix.shard }}/3)
         run: pnpm exec vp test run --coverage --reporter=blob --reporter=default --project Unit --project Integration --shard=${{ matrix.shard }}/3
 
-      - name: Rename blob to avoid collision with contract blob
-        run: mv .vitest-reports/blob.json .vitest-reports/blob-unit-${{ matrix.shard }}.json
-
       - name: Upload blob report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'vite.config.*'
 
-  lint-and-test:
+  lint:
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -74,19 +74,38 @@ jobs:
       - name: Run type-check
         run: pnpm type-check
 
+  test:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-node
+
       - name: Install Playwright Chromium
         run: pnpm exec playwright install chromium
 
-      - name: Run tests
-        run: pnpm exec vp test run --coverage --reporter=blob --reporter=default --project Unit --project Integration
+      - name: Run tests (shard ${{ matrix.shard }}/3)
+        run: pnpm exec vp test run --coverage --reporter=blob --reporter=default --project Unit --project Integration --shard=${{ matrix.shard }}/3
 
       - name: Rename blob to avoid collision with contract blob
-        run: mv .vitest-reports/blob.json .vitest-reports/blob-unit.json
+        run: mv .vitest-reports/blob.json .vitest-reports/blob-unit-${{ matrix.shard }}.json
 
       - name: Upload blob report
         uses: actions/upload-artifact@v4
         with:
-          name: blob-unit-integration
+          name: blob-unit-integration-${{ matrix.shard }}
           path: .vitest-reports/
           retention-days: 30
           include-hidden-files: true
@@ -184,10 +203,11 @@ jobs:
           include-hidden-files: true
 
   coverage-report:
-    needs: [changes, lint-and-test, test-contract]
+    needs: [changes, lint, test, test-contract]
     if: |
       always() &&
-      needs.lint-and-test.result == 'success' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success' &&
       (needs.test-contract.result == 'success' || needs.test-contract.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
@@ -201,11 +221,12 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      - name: Download unit/integration blob
+      - name: Download unit/integration blobs (all shards)
         uses: actions/download-artifact@v4
         with:
-          name: blob-unit-integration
+          pattern: blob-unit-integration-*
           path: .vitest-reports/
+          merge-multiple: true
 
       - name: Download contract blob (this run)
         if: needs.test-contract.result == 'success'

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vp preview",
     "test": "vp test run --coverage",
+    "test:fast": "vp test run --project Unit --project Integration",
     "test:watch": "vp test",
     "test:ui": "vp test --ui --coverage",
     "build-only": "vp build",


### PR DESCRIPTION
## Summary
- Split CI's `lint-and-test` job into `lint` (lint + type-check, once) and `test` (Unit+Integration sharded 3-way via `--shard=N/3`), so the ~500-file suite runs across more cores instead of serially in one job.
- `coverage-report` now downloads and merges all shard blobs.
- Added `pnpm test:fast` — Unit+Integration without `--coverage`, for a quick local pre-push check without paying v8 instrumentation cost.