### PR TITLE
Fix negative and inconsistent study review preview times

### DIFF
--- a/src/components/study-session/composables/session-core.ts
+++ b/src/components/study-session/composables/session-core.ts
@@ -13,7 +13,7 @@ import { withDeckConfigDefaults } from '@/utils/deck/defaults'
 import { useMemberStore } from '@/stores/member'
 import { usePersistedSession, type PersistedSession } from './session-persistence'
 
-export type StudyCard = Card & { preview?: RecordLog; state: ReviewState }
+export type StudyCard = Card & { state: ReviewState }
 
 type ReviewState = 'failed' | 'passed' | 'unreviewed'
 
@@ -89,6 +89,20 @@ export function useStudySessionCore(_config?: Partial<DeckConfig>) {
   const current_index = computed(() => {
     if (!active_card.value) return cards.value.length
     return cards.value.findIndex((c) => c.id === active_card.value!.id)
+  })
+
+  /**
+   * FSRS scheduling preview for the active card only, computed fresh against
+   * `new Date()` whenever `active_card` changes identity. Previews used to be
+   * precomputed in bulk for the whole queue at session start, so a card
+   * reached late in a long session showed due-dates already in the past
+   * (negative "X minutes/seconds" labels). Computing lazily per active card
+   * keeps the "now" baseline close to when the preview is actually shown.
+   */
+  const active_card_preview = computed<RecordLog | undefined>(() => {
+    if (!active_card.value) return undefined
+    const review = active_card.value.review ?? (createEmptyCard(new Date()) as Review)
+    return _FSRS_INSTANCE.repeat(review, new Date())
   })
 
   /**
@@ -259,8 +273,7 @@ export function useStudySessionCore(_config?: Partial<DeckConfig>) {
 
   function _setupCard(card: Card): StudyCard {
     const review = card.review ?? (createEmptyCard(new Date()) as Review)
-    const preview = _FSRS_INSTANCE.repeat(review, new Date())
-    return { ...card, review, preview, state: 'unreviewed' }
+    return { ...card, review, state: 'unreviewed' }
   }
 
   function _markCurrentCardStudied(grade: Grade) {
@@ -298,6 +311,7 @@ export function useStudySessionCore(_config?: Partial<DeckConfig>) {
   return {
     mode,
     active_card,
+    active_card_preview,
     results,
     cards,
     num_correct,

--- a/src/components/study-session/session-flashcard/card-stage.vue
+++ b/src/components/study-session/session-flashcard/card-stage.vue
@@ -4,7 +4,7 @@ import StudyCard from './study-card.vue'
 import StudyCardEdit from './study-card-edit.vue'
 import { computed, onUnmounted, useTemplateRef, type StyleValue } from 'vue'
 import type { gsap } from 'gsap'
-import { type Grade } from 'ts-fsrs'
+import { type Grade, type RecordLog } from 'ts-fsrs'
 import { coverCardBeforeEnter, coverCardEnter } from '@/utils/animations/session-intro'
 import { useDeckContext } from '../deck-context'
 import { useCoverCarousel } from '@/components/study-session/composables/cover-carousel'
@@ -14,6 +14,7 @@ type CardStageProps = {
   loading: boolean
   editing: boolean
   active_card?: StudyCardType
+  active_card_preview?: RecordLog
   current_card_side: CardSide
   next_card?: StudyCardType
   next_card_side: CardSide
@@ -25,6 +26,7 @@ const {
   loading,
   editing,
   active_card,
+  active_card_preview,
   current_card_side,
   next_card,
   next_card_side,
@@ -126,7 +128,7 @@ onUnmounted(() => cover_tween?.kill())
         :key="active_card?.id"
         :card="active_card"
         :side="current_card_side"
-        :options="active_card?.preview"
+        :options="active_card_preview"
         :show_all_ratings="show_all_ratings"
         :cover_override="current_cover"
         @started="emit('started')"

--- a/src/components/study-session/session-flashcard/index.vue
+++ b/src/components/study-session/session-flashcard/index.vue
@@ -40,6 +40,7 @@ const {
   current_card_side,
   current_index,
   active_card,
+  active_card_preview,
   reviewed_count,
   remaining_due_count,
   is_starting_side,
@@ -193,6 +194,7 @@ watch(mode, (m) => {
           :loading="loading"
           :editing="editing"
           :active_card="active_card"
+          :active_card_preview="active_card_preview"
           :current_card_side="current_card_side"
           :show_all_ratings="show_all_ratings"
           :next_card="next_card"
@@ -210,7 +212,7 @@ watch(mode, (m) => {
         <rating-buttons
           v-if="!editing"
           class="z-10 w-full"
-          :options="active_card?.preview"
+          :options="active_card_preview"
           :side="current_card_side"
           :show_all_ratings="show_all_ratings"
           :loading="loading"

--- a/src/components/study-session/session-flashcard/study-card.vue
+++ b/src/components/study-session/session-flashcard/study-card.vue
@@ -16,6 +16,8 @@ const DRAG_RATING_CONFIG = {
   [Rating.Easy]: { icon: 'smiley-very-happy', label_key: 'study.flashcard.rating.easy-button' }
 } as const
 
+const ALL_GRADES: Grade[] = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy]
+
 defineExpose({ rate, el: () => card_ref.value?.$el as HTMLElement | undefined })
 
 type StudyCardProps = {
@@ -71,6 +73,20 @@ const failVisible = computed(() => card_offset.value < -SWIPE_DISTANCE_THRESHOLD
 const drag_rating_config = computed(
   () => DRAG_RATING_CONFIG[drag_rating.value as keyof typeof DRAG_RATING_CONFIG]
 )
+
+/**
+ * Formatted once per card, not per render. `getRatingTimeFormat` diffs the
+ * FSRS due-date against `Date.now()`, so calling it directly from the
+ * template re-evaluates (and drifts, eventually going negative) on every
+ * unrelated re-render — drag updates, the sitting-idle ticks, etc. Keying
+ * this off `options` alone means it recomputes once when a new card's
+ * preview arrives and stays frozen for that card's whole life.
+ */
+const rating_time_labels = computed<Record<Grade, string>>(() => {
+  const labels = {} as Record<Grade, string>
+  for (const grade of ALL_GRADES) labels[grade] = getRatingTimeFormat(grade, options)
+  return labels
+})
 
 onMounted(() => {
   const el = card_ref.value?.$el as HTMLElement | null
@@ -292,7 +308,7 @@ function toSwipeZone(offset: number) {
         >
           <ui-icon src="dislike" class="size-14" />
           {{ $t('study.flashcard.rating.fail-feedback') }}
-          <p class="text-sm">{{ getRatingTimeFormat(Rating.Again, options) }}</p>
+          <p class="text-sm">{{ rating_time_labels[Rating.Again] }}</p>
         </div>
         <div
           data-testid="review-label--pass"
@@ -302,12 +318,12 @@ function toSwipeZone(offset: number) {
           <template v-if="show_all_ratings">
             <ui-icon :src="drag_rating_config.icon" class="size-14" />
             {{ t(drag_rating_config.label_key) }}
-            <p class="text-sm">{{ getRatingTimeFormat(drag_rating, options) }}</p>
+            <p class="text-sm">{{ rating_time_labels[drag_rating] }}</p>
           </template>
           <template v-else>
             <ui-icon src="like" class="size-14" />
             {{ $t('study.flashcard.rating.pass-feedback') }}
-            <p class="text-sm">{{ getRatingTimeFormat(Rating.Good, options) }}</p>
+            <p class="text-sm">{{ rating_time_labels[Rating.Good] }}</p>
           </template>
         </div>
       </div>

--- a/src/composables/fsrs.ts
+++ b/src/composables/fsrs.ts
@@ -1,8 +1,12 @@
 import { Rating, type Grade, type RecordLog } from 'ts-fsrs'
 import { useI18n } from 'vue-i18n'
-import { toRelativeDistinct } from '@/utils/date'
+import { toRelative, toRelativeDistinct } from '@/utils/date'
 
-const GRADES: Grade[] = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy]
+// Again (fail) always previews the short learning-step interval — it never
+// clashes with the pass grades in a way that should bump its own
+// granularity, so it's formatted on its own rather than joining their
+// collision group.
+const PASS_GRADES: Grade[] = [Rating.Hard, Rating.Good, Rating.Easy]
 
 export function useRatingFormat() {
   const { t, locale } = useI18n()
@@ -14,9 +18,14 @@ export function useRatingFormat() {
   ) {
     if (!options?.[grade].card.due) return ''
 
-    const dates = GRADES.map((g) => options[g].card.due)
-    const labels = toRelativeDistinct(dates, { style, locale: locale.value })
-    const timeString = labels[GRADES.indexOf(grade)]
+    const timeString =
+      grade === Rating.Again
+        ? toRelative(options[Rating.Again].card.due, { style, locale: locale.value })
+        : toRelativeDistinct(
+            PASS_GRADES.map((g) => options[g].card.due),
+            { style, locale: locale.value }
+          )[PASS_GRADES.indexOf(grade)]
+
     return t('study.idle.next-session-cta', { time: timeString })
   }
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -74,14 +74,17 @@ function toRelativeAtUnit(
 
 /**
  * Formats a batch of dates that are displayed together (e.g. one per FSRS
- * rating). Any dates that would otherwise render identical text collapse to
- * day-level granularity instead, so "1 week" / "1 week" becomes "8 days" /
- * "9 days".
+ * rating). If any two would otherwise render identical text, every date in
+ * the batch collapses to day-level granularity instead, so "1 week" / "1
+ * week" / "9 days" becomes "8 days" / "8 days" / "9 days" — one clash bumps
+ * the whole group, keeping their granularity consistent with each other.
  */
 export function toRelativeDistinct(inputs: DateInput[], options: RelativeOptions = {}): string[] {
   const labels = inputs.map((d) => toRelative(d, options))
-  return labels.map((label, i) => {
-    const collides = labels.some((other, j) => j !== i && other === label)
-    return collides ? toRelativeAtUnit(inputs[i]!, 'day', options) : label
-  })
+  const has_collision = labels.some((label, i) =>
+    labels.some((other, j) => j !== i && other === label)
+  )
+  if (!has_collision) return labels
+
+  return inputs.map((input) => toRelativeAtUnit(input, 'day', options))
 }

--- a/tests/integration/components/modals/study-session/session-flashcard/card-stage.test.js
+++ b/tests/integration/components/modals/study-session/session-flashcard/card-stage.test.js
@@ -85,7 +85,7 @@ const CardStub = defineComponent({
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeCard(id = 1) {
-  return { id, front: 'Q', back: 'A', state: 'unreviewed', preview: null }
+  return { id, front: 'Q', back: 'A', state: 'unreviewed' }
 }
 
 function mountCardStage(props = {}) {
@@ -114,6 +114,8 @@ function mountCardStage(props = {}) {
 describe('CardStage', () => {
   beforeEach(() => {
     mockRegister.mockClear()
+    mockCoverCardBeforeEnter.mockClear()
+    mockCoverCardEnter.mockClear()
   })
 
   // ── card_view computed [obligation] ────────────────────────────────────────
@@ -187,6 +189,27 @@ describe('CardStage', () => {
     })
 
     expect(wrapper.find('[data-testid="study-card__preview"]').exists()).toBe(false)
+  })
+
+  // ── active_card_preview forwarding [obligation] ───────────────────────────
+  // CardStage forwards active_card_preview (not active_card.preview, which no
+  // longer exists) to the active StudyCard's `options` prop.
+
+  test('forwards active_card_preview prop as options on the active study-card [obligation]', async () => {
+    const preview = { some: 'record-log' }
+    const wrapper = mountCardStage({
+      loading: false,
+      active_card: makeCard(),
+      active_card_preview: preview
+    })
+
+    expect(wrapper.findComponent(StudyCardStub).props('options')).toEqual(preview)
+  })
+
+  test('options is undefined on the active study-card when active_card_preview is not passed [obligation]', async () => {
+    const wrapper = mountCardStage({ loading: false, active_card: makeCard() })
+
+    expect(wrapper.findComponent(StudyCardStub).props('options')).toBeUndefined()
   })
 
   // ── event forwarding ───────────────────────────────────────────────────────

--- a/tests/integration/components/modals/study-session/study-card.test.js
+++ b/tests/integration/components/modals/study-session/study-card.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent, h, useAttrs } from 'vue'
 import { FSRS, generatorParameters, createEmptyCard, Rating } from 'ts-fsrs'
@@ -71,6 +71,16 @@ function makeOptions() {
   return fsrs.repeat(createEmptyCard(new Date()), new Date())
 }
 
+/** Builds a RecordLog-shaped options object with every grade due at the same date. */
+function makeOptionsWithDue(due) {
+  return {
+    [Rating.Again]: { card: { due } },
+    [Rating.Hard]: { card: { due } },
+    [Rating.Good]: { card: { due } },
+    [Rating.Easy]: { card: { due } }
+  }
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function mountStudyCard(props = {}) {
@@ -124,6 +134,10 @@ describe('StudyCard', () => {
     // Clear captured shortcut handlers between tests
     for (const key of Object.keys(capturedShortcuts)) delete capturedShortcuts[key]
     options = makeOptions()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   // ── Fling direction per grade [obligation] ────────────────────────────────
@@ -1136,6 +1150,36 @@ describe('StudyCard', () => {
 
     expect(wrapper.emitted('reviewed')).toHaveLength(1)
     expect(wrapper.emitted('reviewed')[0][0]).toBe(Rating.Hard)
+  })
+
+  // ── rating_time_labels memoization [obligation] ───────────────────────────
+  // rating_time_labels is a computed keyed off `options` alone — it should not
+  // recompute (and drift, eventually going negative) on unrelated re-renders
+  // like drag state changes or wall-clock time passing.
+
+  test('rating_time_labels stays frozen across unrelated re-renders while options is unchanged [obligation]', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    const due = new Date(Date.now() + 1000 * 60 * 60) // +1 hour
+    const opts = makeOptionsWithDue(due)
+
+    const wrapper = mountStudyCard({ side: 'back', options: opts })
+    await flushPromises()
+
+    const before = wrapper.find('[data-testid="review-label--fail"] p').text()
+
+    // Advance wall-clock time significantly and trigger unrelated reactivity
+    // (a drag move) without changing the `options` prop.
+    vi.setSystemTime(new Date('2026-01-01T05:00:00.000Z'))
+    const { callbacks } = getCallbacks()
+    callbacks.onMove({ dx: 20, dy: 0 })
+    await flushPromises()
+
+    const after = wrapper.find('[data-testid="review-label--fail"] p').text()
+
+    expect(after).toBe(before)
+    expect(after).not.toMatch(/-|ago/)
   })
 
   test('endDrag always uses Rating.Good for right flings when show_all_ratings=false [obligation]', async () => {

--- a/tests/unit/composables/study-session/session-core.test.js
+++ b/tests/unit/composables/study-session/session-core.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { nextTick } from 'vue'
 import { Rating } from 'ts-fsrs'
 import { useStudySessionCore } from '@/components/study-session/composables/session-core'
@@ -780,6 +780,91 @@ describe('session-core — persistence [obligation]', () => {
     await nextTick()
 
     expect(readPersistedSession()?.card_ids).toEqual([c2.id])
+  })
+})
+
+// ── active_card_preview [obligation] ─────────────────────────────────────────
+// Previews used to be precomputed in bulk for the whole queue at session
+// start, so a card reached late in a long session showed FSRS due-dates
+// already in the past. active_card_preview computes lazily against `now`
+// whenever active_card changes identity, so late-session cards never show a
+// stale/negative preview.
+
+describe('session-core — active_card_preview [obligation]', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('is undefined when there is no active card [obligation]', () => {
+    const session = useStudySessionCore({ study_all_cards: true })
+    expect(session.active_card_preview.value).toBeUndefined()
+  })
+
+  test('is defined once a card is active [obligation]', () => {
+    const session = useStudySessionCore({ study_all_cards: true })
+    session.setCards([makeNewCard()])
+
+    expect(session.active_card_preview.value).toBeDefined()
+    expect(session.active_card_preview.value?.[Rating.Good].card.due).toBeInstanceOf(Date)
+  })
+
+  test('recomputes against the current time after reviewCard() advances to the next card, even once wall-clock time has moved on [obligation]', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    const session = useStudySessionCore({ study_all_cards: true })
+    const [c1, c2] = [makeNewCard(), makeNewCard()]
+    session.setCards([c1, c2])
+
+    // Simulate a long session: a lot of wall-clock time passes before the
+    // user gets to the second card.
+    vi.setSystemTime(new Date('2026-01-05T00:00:00.000Z'))
+    session.reviewCard(Rating.Good)
+    expect(session.active_card.value?.id).toBe(c2.id)
+
+    const preview = session.active_card_preview.value
+    expect(preview).toBeDefined()
+    // The regression this guards: previews computed once at session start
+    // (against the old `now`) would show due-dates already in the past by
+    // the time a late card became active. Recomputing fresh keeps every
+    // grade's due date in the future relative to the current (advanced) time.
+    for (const grade of [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy]) {
+      expect(preview[grade].card.due.getTime()).toBeGreaterThan(Date.now())
+    }
+  })
+
+  test('recomputes fresh when setCards seeds a new active card [obligation]', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    const session = useStudySessionCore({ study_all_cards: true })
+    session.setCards([makeNewCard()])
+    const first_preview = session.active_card_preview.value
+
+    vi.setSystemTime(new Date('2026-01-10T00:00:00.000Z'))
+    session.setCards([makeNewCard()])
+    const second_preview = session.active_card_preview.value
+
+    expect(second_preview?.[Rating.Good].card.due.getTime()).not.toBe(
+      first_preview?.[Rating.Good].card.due.getTime()
+    )
+  })
+
+  test('recomputes fresh when restoreCards seeds a new active card [obligation]', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    const c1 = makeNewCard()
+    const persisted = { deck_ids: [1], card_ids: [c1.id], results: [], mode: 'studying' }
+
+    const session = useStudySessionCore({ study_all_cards: true })
+
+    vi.setSystemTime(new Date('2026-02-01T00:00:00.000Z'))
+    session.restoreCards([c1], persisted)
+
+    const preview = session.active_card_preview.value
+    expect(preview).toBeDefined()
+    expect(preview?.[Rating.Good].card.due.getTime()).toBeGreaterThan(Date.now())
   })
 })
 

--- a/tests/unit/composables/use-fsrs.test.js
+++ b/tests/unit/composables/use-fsrs.test.js
@@ -112,4 +112,37 @@ describe('useRatingFormat', () => {
     // Non-colliding grade keeps its natural sub-day unit.
     expect(again_result).toMatch(/minute|second/)
   })
+
+  // ── Rating.Again is isolated from the Hard/Good/Easy collision group [obligation] ──
+  // Again previews the short learning-step interval and always formats via a
+  // plain `toRelative` call, independent of whatever granularity bump the
+  // pass grades force on each other.
+
+  test('Again keeps its own hour-level label even when Hard/Good/Easy collide and bump to day-granularity [obligation]', () => {
+    const { getRatingTimeFormat } = useRatingFormat()
+    const day = 24 * 60 * 60 * 1000
+    // Hard/Good/Easy all round to "in 1 week" — forces their collision group
+    // to day-granularity. Again sits a few hours out, unrelated to the group.
+    const options = {
+      [Rating.Again]: { card: { due: new Date(Date.now() + 1000 * 60 * 60 * 3) } }, // +3 hours
+      [Rating.Hard]: { card: { due: new Date(Date.now() + 7.2 * day) } },
+      [Rating.Good]: { card: { due: new Date(Date.now() + 7.6 * day) } },
+      [Rating.Easy]: { card: { due: new Date(Date.now() + 8.6 * day) } }
+    }
+
+    const again_result = getRatingTimeFormat(Rating.Again, options)
+    const hard_result = getRatingTimeFormat(Rating.Hard, options)
+    const good_result = getRatingTimeFormat(Rating.Good, options)
+    const easy_result = getRatingTimeFormat(Rating.Easy, options)
+
+    // Again never gets bumped to day-granularity by the pass-grade collision.
+    expect(again_result).toMatch(/hour/)
+    expect(again_result).not.toMatch(/day/)
+
+    // Hard/Good/Easy all bump together to day-granularity, and stay distinct.
+    expect(hard_result).toMatch(/day/)
+    expect(good_result).toMatch(/day/)
+    expect(easy_result).toMatch(/day/)
+    expect(new Set([hard_result, good_result, easy_result]).size).toBe(3)
+  })
 })

--- a/tests/unit/utils/date.test.js
+++ b/tests/unit/utils/date.test.js
@@ -187,15 +187,32 @@ describe('toRelativeDistinct [obligation]', () => {
     expect(labelB).toBe('in 3 hours')
   })
 
-  test('only demotes the colliding pair when a third date is distinct [obligation]', () => {
+  test('a collision between two dates bumps every date in the batch to day granularity [obligation]', () => {
+    // Regression: this used to demote only the colliding pair (a, b) and leave
+    // the third, non-colliding date at its natural unit. Now one collision
+    // anywhere in the batch bumps the whole group together.
     const a = new Date(Date.now() + 7.6 * day)
     const b = new Date(Date.now() + 8.6 * day)
-    const distinct = new Date(Date.now() + 2 * 60 * 1000) // in 2 minutes, no collision
+    const distinct = new Date(Date.now() + 2 * 60 * 1000) // in 2 minutes, no collision with a/b
 
     const [labelA, labelB, labelC] = toRelativeDistinct([a, b, distinct], { locale: 'en-US' })
 
     expect(labelA).toBe('in 8 days')
     expect(labelB).toBe('in 9 days')
-    expect(labelC).toBe('in 2 minutes')
+    expect(labelC).toBe('in 0 days')
+  })
+
+  test('preserves each date at its natural granularity when no two labels collide [obligation]', () => {
+    const inTwoMinutes = new Date(Date.now() + 2 * 60 * 1000)
+    const inThreeHours = new Date(Date.now() + 3 * 60 * 60 * 1000)
+    const inTwoDays = new Date(Date.now() + 2 * day)
+
+    const [labelA, labelB, labelC] = toRelativeDistinct([inTwoMinutes, inThreeHours, inTwoDays], {
+      locale: 'en-US'
+    })
+
+    expect(labelA).toBe('in 2 minutes')
+    expect(labelB).toBe('in 3 hours')
+    expect(labelC).toBe('in 2 days')
   })
 })


### PR DESCRIPTION
## Summary

Rating-button previews on the study card could show negative times ("-1 minute") for cards reached late in a session, and the fail/pass granularity (minutes vs. days) could be inconsistent or nonsensical ("in 0 days").

## Changes

- Compute the FSRS preview lazily for only the active card instead of precomputing it in bulk for the whole queue at session start, so due-dates no longer go stale by the time a later card is shown.
- Memoize the formatted rating labels once per card (`rating_time_labels` in `study-card.vue`) so they don't re-evaluate against a drifting `Date.now()` on unrelated re-renders.
- When two pass-grade (Hard/Good/Easy) preview labels collide, bump all of them to day-granularity together instead of just the colliding pair.
- Isolate the Again (fail) label from that collision group so it always reflects its own short learning-step interval, instead of getting force-bumped to day-granularity and rounding to nonsense like "in 0 days".

## Test plan

- [x] Full suite green (`pnpm test:fast`: 377 files / 5107 tests)
- [x] `vp lint` / `pnpm type-check` clean
- [ ] Manually study a deck with several cards and confirm rating preview times stay positive and consistent after leaving a card idle