### PR TITLE
Unify dialog-card sizing, layout, and paging across modals

### DIFF
--- a/src/components/layout-kit/dialog-card/dialog-card-pager.vue
+++ b/src/components/layout-kit/dialog-card/dialog-card-pager.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { sessionPaneEnter, sessionPaneLeave } from '@/utils/animations/session-pane'
 
+export type DialogCardPagerProps = {
+  mode?: 'in-out' | 'out-in'
+}
+
+const { mode } = defineProps<DialogCardPagerProps>()
+
 const emit = defineEmits<{
   (e: 'enter-start'): void
 }>()
@@ -15,7 +21,7 @@ function onEnter(el: Element, done: () => void) {
 </script>
 
 <template>
-  <transition :css="false" mode="out-in" @leave="onLeave" @enter="onEnter">
+  <transition :css="false" :mode="mode" @leave="onLeave" @enter="onEnter">
     <slot></slot>
   </transition>
 </template>

--- a/src/components/layout-kit/dialog-card/dialog-card-pager.vue
+++ b/src/components/layout-kit/dialog-card/dialog-card-pager.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { sessionPaneEnter, sessionPaneLeave } from '@/utils/animations/session-pane'
+
+const emit = defineEmits<{
+  (e: 'enter-start'): void
+}>()
+
+function onLeave(el: Element, done: () => void) {
+  sessionPaneLeave(el, done)
+}
+
+function onEnter(el: Element, done: () => void) {
+  sessionPaneEnter(el, done, () => emit('enter-start'))
+}
+</script>
+
+<template>
+  <transition :css="false" mode="out-in" @leave="onLeave" @enter="onEnter">
+    <slot></slot>
+  </transition>
+</template>

--- a/src/components/layout-kit/dialog-card/dialog-card-viewport.ts
+++ b/src/components/layout-kit/dialog-card/dialog-card-viewport.ts
@@ -6,7 +6,7 @@ export type DialogCardViewport = 'mobile' | 'desktop'
 export const dialogCardViewportKey: InjectionKey<ComputedRef<DialogCardViewport>> =
   Symbol('dialog-card.viewport')
 
-/** Compute and provide the dialog-card's viewport mode from a match-media query string. */
+/** Compute and provide the dialog-card's viewport mode from a full-bleed match-media query string. */
 export function provideDialogCardViewport(query: string) {
   const is_mobile = useMatchMedia(query)
   const viewport = computed<DialogCardViewport>(() => (is_mobile.value ? 'mobile' : 'desktop'))

--- a/src/components/layout-kit/dialog-card/dialog-card.vue
+++ b/src/components/layout-kit/dialog-card/dialog-card.vue
@@ -7,8 +7,10 @@ import UiButton from '@/components/ui-kit/button.vue'
 
 export type DialogCardProps = {
   title?: string
+  show_header?: boolean
   show_close_button?: boolean
   close_label?: string
+  close_disabled?: boolean
   full_bleed_at?: string
   dialog_px?: string
   content_max_width?: string
@@ -17,8 +19,10 @@ export type DialogCardProps = {
 
 const {
   title,
+  show_header = true,
   show_close_button = true,
   close_label,
+  close_disabled = false,
   full_bleed_at = 'w<sm | h<sm',
   dialog_px,
   content_max_width,
@@ -31,6 +35,7 @@ const emit = defineEmits<{
 
 const slots = defineSlots<{
   header(): any
+  'header-start'(): any
   'header-end'(): any
   default(props: { viewport: DialogCardViewport }): any
 }>()
@@ -58,19 +63,27 @@ defineExpose({ viewport })
     :style="card_style"
   >
     <slot name="header">
-      <dialog-card-header v-if="title || show_close_button" :title="title" class="full-width">
-        <template v-if="show_close_button" #start>
-          <ui-button
-            data-testid="dialog-card__close"
-            data-theme="brown-100"
-            data-theme-dark="stone-700"
-            icon-left="close"
-            icon-only
-            rounded-full
-            @press="emit('close')"
-          >
-            {{ close_label ?? t('dialog-card.close-label') }}
-          </ui-button>
+      <dialog-card-header
+        v-if="show_header && (title || show_close_button || slots['header-start'])"
+        :title="title"
+        class="full-width"
+      >
+        <template #start>
+          <slot name="header-start">
+            <ui-button
+              v-if="show_close_button"
+              data-testid="dialog-card__close"
+              data-theme="brown-100"
+              data-theme-dark="stone-700"
+              icon-left="close"
+              icon-only
+              rounded-full
+              :disabled="close_disabled"
+              @press="emit('close')"
+            >
+              {{ close_label ?? t('dialog-card.close-label') }}
+            </ui-button>
+          </slot>
         </template>
 
         <template v-if="slots['header-end']" #end>

--- a/src/components/layout-kit/dialog-card/dialog-card.vue
+++ b/src/components/layout-kit/dialog-card/dialog-card.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DialogCardHeader from './dialog-card-header.vue'
 import { provideDialogCardViewport, type DialogCardViewport } from './dialog-card-viewport'
@@ -10,6 +11,8 @@ export type DialogCardProps = {
   close_label?: string
   full_bleed_at?: string
   dialog_px?: string
+  content_max_width?: string
+  content_breakout_max_width?: string
 }
 
 const {
@@ -17,7 +20,9 @@ const {
   show_close_button = true,
   close_label,
   full_bleed_at = 'w<sm | h<sm',
-  dialog_px
+  dialog_px,
+  content_max_width,
+  content_breakout_max_width
 } = defineProps<DialogCardProps>()
 
 const emit = defineEmits<{
@@ -33,6 +38,15 @@ const slots = defineSlots<{
 const { t } = useI18n()
 const viewport = provideDialogCardViewport(full_bleed_at)
 
+const card_style = computed(() => (dialog_px ? { '--dialog-px': dialog_px } : undefined))
+
+const body_style = computed(() => ({
+  ...(content_max_width && { '--content-grid-max-width': content_max_width }),
+  ...(content_breakout_max_width && {
+    '--content-grid-breakout-max-width': content_breakout_max_width
+  })
+}))
+
 defineExpose({ viewport })
 </script>
 
@@ -41,10 +55,10 @@ defineExpose({ viewport })
     data-testid="dialog-card"
     class="relative flex flex-col gap-4 overflow-hidden [--dialog-px:1.5rem] sm:[--dialog-px:2rem]"
     :class="viewport === 'mobile' ? 'h-full! w-full! rounded-none!' : 'rounded-8 shadow-lg'"
-    :style="dialog_px ? { '--dialog-px': dialog_px } : undefined"
+    :style="card_style"
   >
     <slot name="header">
-      <dialog-card-header v-if="title || show_close_button" :title="title">
+      <dialog-card-header v-if="title || show_close_button" :title="title" class="full-width">
         <template v-if="show_close_button" #start>
           <ui-button
             data-testid="dialog-card__close"
@@ -65,6 +79,12 @@ defineExpose({ viewport })
       </dialog-card-header>
     </slot>
 
-    <slot :viewport="viewport"></slot>
+    <div
+      data-testid="dialog-card__body"
+      class="content-grid content-grid-px-(--dialog-px) min-h-0 flex-1"
+      :style="body_style"
+    >
+      <slot :viewport="viewport"></slot>
+    </div>
   </div>
 </template>

--- a/src/components/layout-kit/dialog-card/dialog-card.vue
+++ b/src/components/layout-kit/dialog-card/dialog-card.vue
@@ -5,12 +5,33 @@ import DialogCardHeader from './dialog-card-header.vue'
 import { provideDialogCardViewport, type DialogCardViewport } from './dialog-card-viewport'
 import UiButton from '@/components/ui-kit/button.vue'
 
+export type DialogCardSize = 'sm' | 'md' | 'lg'
+
+const SIZE_CLASSES: Record<DialogCardSize, string> = {
+  sm: 'w-140 h-110',
+  md: 'w-150 h-160',
+  lg: 'w-full max-w-160 h-170'
+}
+
+const SIZE_FULL_BLEED_AT: Record<DialogCardSize, string> = {
+  sm: 'w<sm | h<sm',
+  md: 'w<sm | h<sm',
+  lg: 'w<sm'
+}
+
+const SIZE_CONTENT_MAX_WIDTH: Record<DialogCardSize, string> = {
+  sm: '25rem',
+  md: '32.5rem',
+  lg: '35rem'
+}
+
 export type DialogCardProps = {
   title?: string
   show_header?: boolean
   show_close_button?: boolean
   close_label?: string
   close_disabled?: boolean
+  size?: DialogCardSize
   full_bleed_at?: string
   dialog_px?: string
   content_max_width?: string
@@ -23,7 +44,8 @@ const {
   show_close_button = true,
   close_label,
   close_disabled = false,
-  full_bleed_at = 'w<sm | h<sm',
+  size = 'md',
+  full_bleed_at,
   dialog_px,
   content_max_width,
   content_breakout_max_width
@@ -41,12 +63,12 @@ const slots = defineSlots<{
 }>()
 
 const { t } = useI18n()
-const viewport = provideDialogCardViewport(full_bleed_at)
+const viewport = provideDialogCardViewport(full_bleed_at ?? SIZE_FULL_BLEED_AT[size])
 
 const card_style = computed(() => (dialog_px ? { '--dialog-px': dialog_px } : undefined))
 
 const body_style = computed(() => ({
-  ...(content_max_width && { '--content-grid-max-width': content_max_width }),
+  '--content-grid-max-width': content_max_width ?? SIZE_CONTENT_MAX_WIDTH[size],
   ...(content_breakout_max_width && {
     '--content-grid-breakout-max-width': content_breakout_max_width
   })
@@ -59,7 +81,12 @@ defineExpose({ viewport })
   <div
     data-testid="dialog-card"
     class="relative flex flex-col gap-4 overflow-hidden [--dialog-px:1.5rem] sm:[--dialog-px:2rem]"
-    :class="viewport === 'mobile' ? 'h-full! w-full! rounded-none!' : 'rounded-8 shadow-lg'"
+    :class="[
+      SIZE_CLASSES[size],
+      viewport === 'mobile'
+        ? 'h-full! w-full! rounded-none!'
+        : 'rounded-8 shadow-lg border-t border-l border-brown-100 dark:border-grey-900'
+    ]"
     :style="card_style"
   >
     <slot name="header">

--- a/src/components/layout-kit/dialog-card/dialog-card.vue
+++ b/src/components/layout-kit/dialog-card/dialog-card.vue
@@ -8,7 +8,7 @@ export type DialogCardProps = {
   title?: string
   show_close_button?: boolean
   close_label?: string
-  viewport_query?: string
+  full_bleed_at?: string
   dialog_px?: string
 }
 
@@ -16,7 +16,7 @@ const {
   title,
   show_close_button = true,
   close_label,
-  viewport_query = 'w<sm | h<sm',
+  full_bleed_at = 'w<sm | h<sm',
   dialog_px
 } = defineProps<DialogCardProps>()
 
@@ -31,7 +31,7 @@ const slots = defineSlots<{
 }>()
 
 const { t } = useI18n()
-const viewport = provideDialogCardViewport(viewport_query)
+const viewport = provideDialogCardViewport(full_bleed_at)
 
 defineExpose({ viewport })
 </script>

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -35,9 +35,30 @@ function onEnter(el: Element, done: () => void) {
     class="h-160 w-150 bg-brown-100 pb-6 dark:bg-grey-800"
     data-theme="brown-300"
     data-theme-dark="stone-700"
-    :show_close_button="false"
     @close="close()"
   >
+    <template #header>
+      <dialog-card-header
+        v-if="status !== 'success'"
+        data-testid="checkout__header"
+        class="full-width"
+        :title="t('billing.checkout.title')"
+      >
+        <template #start>
+          <ui-button
+            data-testid="checkout__close"
+            icon-left="close"
+            icon-only
+            rounded-full
+            :disabled="status === 'confirming'"
+            @press="close()"
+          >
+            {{ t('billing.checkout.close-label') }}
+          </ui-button>
+        </template>
+      </dialog-card-header>
+    </template>
+
     <template #default="{ viewport }">
       <div
         data-testid="checkout__scroll-area"
@@ -48,31 +69,12 @@ function onEnter(el: Element, done: () => void) {
           viewport === 'mobile' ? 'overflow-y-auto scroll-hidden' : ''
         ]"
       >
-        <dialog-card-header
-          v-if="status !== 'success'"
-          data-testid="checkout__header"
-          :title="t('billing.checkout.title')"
-        >
-          <template #start>
-            <ui-button
-              data-testid="checkout__close"
-              icon-left="close"
-              icon-only
-              rounded-full
-              :disabled="status === 'confirming'"
-              @press="close()"
-            >
-              {{ t('billing.checkout.close-label') }}
-            </ui-button>
-          </template>
-        </dialog-card-header>
-
         <transition :css="false" mode="out-in" @leave="onLeave" @enter="onEnter">
           <div
             v-if="status !== 'success'"
             key="form"
             data-testid="checkout__body"
-            class="flex flex-col gap-4 px-(--dialog-px)"
+            class="flex flex-col gap-4"
           >
             <payment-status :status="status" />
             <div ref="container" data-testid="checkout__payment-element"></div>
@@ -83,7 +85,6 @@ function onEnter(el: Element, done: () => void) {
 
         <checkout-footer
           v-if="status !== 'success'"
-          class="px-(--dialog-px)"
           :status="status"
           :is_ready="is_ready"
           @submit="onSubmit"

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import DialogCard from '@/components/layout-kit/dialog-card/dialog-card.vue'
-import DialogCardHeader from '@/components/layout-kit/dialog-card/dialog-card-header.vue'
 import DialogCardPager from '@/components/layout-kit/dialog-card/dialog-card-pager.vue'
-import UiButton from '@/components/ui-kit/button.vue'
 import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
 import PaymentStatus from './payment-status.vue'
 import SuccessView from './success-view.vue'
@@ -26,30 +24,12 @@ const { status, is_ready, onSubmit } = useCheckout(close)
     class="h-160 w-150 bg-brown-100 pb-6 dark:bg-grey-800"
     data-theme="brown-300"
     data-theme-dark="stone-700"
+    :title="t('billing.checkout.title')"
+    :show_header="status !== 'success'"
+    :close_label="t('billing.checkout.close-label')"
+    :close_disabled="status === 'confirming'"
     @close="close()"
   >
-    <template #header>
-      <dialog-card-header
-        v-if="status !== 'success'"
-        data-testid="checkout__header"
-        class="full-width"
-        :title="t('billing.checkout.title')"
-      >
-        <template #start>
-          <ui-button
-            data-testid="checkout__close"
-            icon-left="close"
-            icon-only
-            rounded-full
-            :disabled="status === 'confirming'"
-            @press="close()"
-          >
-            {{ t('billing.checkout.close-label') }}
-          </ui-button>
-        </template>
-      </dialog-card-header>
-    </template>
-
     <template #default="{ viewport }">
       <div
         data-testid="checkout__scroll-area"

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -2,14 +2,13 @@
 import { useI18n } from 'vue-i18n'
 import DialogCard from '@/components/layout-kit/dialog-card/dialog-card.vue'
 import DialogCardHeader from '@/components/layout-kit/dialog-card/dialog-card-header.vue'
+import DialogCardPager from '@/components/layout-kit/dialog-card/dialog-card-pager.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
 import PaymentStatus from './payment-status.vue'
 import SuccessView from './success-view.vue'
 import CheckoutFooter from './checkout-footer.vue'
 import { useCheckout, type CheckoutResponse } from './use-checkout'
-import { fadeLeave } from '@/utils/animations/fade'
-import { springScaleIn } from '@/utils/animations/modal'
 
 export type { CheckoutResponse }
 
@@ -19,14 +18,6 @@ const { close } = defineProps<{
 
 const { t } = useI18n()
 const { status, is_ready, onSubmit } = useCheckout(close)
-
-function onLeave(el: Element, done: () => void) {
-  fadeLeave(el, done)
-}
-
-function onEnter(el: Element, done: () => void) {
-  springScaleIn(el, done)
-}
 </script>
 
 <template>
@@ -69,7 +60,7 @@ function onEnter(el: Element, done: () => void) {
           viewport === 'mobile' ? 'overflow-y-auto scroll-hidden' : ''
         ]"
       >
-        <transition :css="false" mode="out-in" @leave="onLeave" @enter="onEnter">
+        <dialog-card-pager mode="out-in">
           <div
             v-if="status !== 'success'"
             key="form"
@@ -81,7 +72,7 @@ function onEnter(el: Element, done: () => void) {
           </div>
 
           <success-view v-else key="success" />
-        </transition>
+        </dialog-card-pager>
 
         <checkout-footer
           v-if="status !== 'success'"

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -21,7 +21,8 @@ const { status, is_ready, onSubmit } = useCheckout(close)
 <template>
   <dialog-card
     data-testid="checkout"
-    class="h-160 w-150 bg-brown-100 pb-6 dark:bg-grey-800"
+    class="bg-brown-100 pb-6 dark:bg-grey-800"
+    size="md"
     data-theme="brown-300"
     data-theme-dark="stone-700"
     :title="t('billing.checkout.title')"

--- a/src/components/modals/move-cards.vue
+++ b/src/components/modals/move-cards.vue
@@ -72,18 +72,15 @@ function onClick(deck_id?: number) {
 <template>
   <dialog-card
     data-testid="move-cards"
-    class="w-150 h-150 bg-brown-200 dark:bg-stone-900 flex flex-col items-center"
+    class="w-150 h-150 bg-brown-200 dark:bg-stone-900"
     full_bleed_at="w<sm | h<sm"
+    content_max_width="32.5rem"
     :title="title"
     @close="close(false)"
   >
-    <div data-testid="move-cards__body" class="flex h-full min-h-0 w-full sm:w-130 flex-col">
+    <div data-testid="move-cards__body" class="flex h-full min-h-0 flex-col">
       <div data-testid="move-cards__deck-list-wrap" class="relative flex min-h-0 flex-1 flex-col">
-        <grouped-list
-          data-testid="move-cards__deck-list"
-          scrollable
-          class="mx-(--dialog-px) my-4 min-h-0 flex-1"
-        >
+        <grouped-list data-testid="move-cards__deck-list" scrollable class="my-4 min-h-0 flex-1">
           <ui-tappable
             v-for="(deck, index) in decks"
             :key="index"
@@ -129,10 +126,7 @@ function onClick(deck_id?: number) {
         />
       </div>
 
-      <div
-        data-testid="move-cards__actions"
-        class="px-(--dialog-px) pb-6 flex w-full justify-end gap-3"
-      >
+      <div data-testid="move-cards__actions" class="pb-6 flex w-full justify-end gap-3">
         <ui-button
           data-testid="move-cards__move"
           data-theme="blue-500"

--- a/src/components/modals/move-cards.vue
+++ b/src/components/modals/move-cards.vue
@@ -72,9 +72,8 @@ function onClick(deck_id?: number) {
 <template>
   <dialog-card
     data-testid="move-cards"
-    class="w-150 h-150 bg-brown-200 dark:bg-stone-900"
-    full_bleed_at="w<sm | h<sm"
-    content_max_width="32.5rem"
+    class="bg-brown-200 dark:bg-stone-900"
+    size="md"
     :title="title"
     @close="close(false)"
   >

--- a/src/components/modals/move-cards.vue
+++ b/src/components/modals/move-cards.vue
@@ -73,7 +73,7 @@ function onClick(deck_id?: number) {
   <dialog-card
     data-testid="move-cards"
     class="w-150 h-150 bg-brown-200 dark:bg-stone-900 flex flex-col items-center"
-    viewport_query="w<sm | h<sm"
+    full_bleed_at="w<sm | h<sm"
     :title="title"
     @close="close(false)"
   >

--- a/src/components/settings/account-access/account-access-content.vue
+++ b/src/components/settings/account-access/account-access-content.vue
@@ -34,13 +34,11 @@ defineExpose({ title })
 </script>
 
 <template>
-  <div data-testid="account-access-content" class="flex flex-1 flex-col items-center">
-    <div class="w-full max-w-100 flex flex-1 flex-col gap-4">
-      <dialog-card-pager mode="out-in">
-        <account-access-menu v-if="page === 'menu'" key="menu" @navigate="(p) => (page = p)" />
-        <email-section v-else-if="page === 'email'" key="email" :close="onSuccessClose" />
-        <password-section v-else key="password" :close="onSuccessClose" />
-      </dialog-card-pager>
-    </div>
+  <div data-testid="account-access-content">
+    <dialog-card-pager mode="out-in">
+      <account-access-menu v-if="page === 'menu'" key="menu" @navigate="(p) => (page = p)" />
+      <email-section v-else-if="page === 'email'" key="email" :close="onSuccessClose" />
+      <password-section v-else key="password" :close="onSuccessClose" />
+    </dialog-card-pager>
   </div>
 </template>

--- a/src/components/settings/account-access/account-access-content.vue
+++ b/src/components/settings/account-access/account-access-content.vue
@@ -4,9 +4,8 @@ import { useI18n } from 'vue-i18n'
 import AccountAccessMenu, { type AccountAccessPage } from './account-access-menu.vue'
 import EmailSection from './email-section.vue'
 import PasswordSection from './password-section.vue'
+import DialogCardPager from '@/components/layout-kit/dialog-card/dialog-card-pager.vue'
 import { useSessionStore } from '@/stores/session'
-import { fadeLeave } from '@/utils/animations/fade'
-import { springScaleIn } from '@/utils/animations/modal'
 
 export type AccountAccessContentPage = 'menu' | AccountAccessPage
 
@@ -31,25 +30,17 @@ const title = computed(() => {
     : t('account-access-modal.password.heading-set')
 })
 
-function onLeave(el: Element, done: () => void) {
-  fadeLeave(el, done)
-}
-
-function onEnter(el: Element, done: () => void) {
-  springScaleIn(el, done)
-}
-
 defineExpose({ title })
 </script>
 
 <template>
   <div data-testid="account-access-content" class="flex flex-1 flex-col items-center">
     <div class="w-full max-w-100 flex flex-1 flex-col gap-4">
-      <transition :css="false" mode="out-in" @leave="onLeave" @enter="onEnter">
+      <dialog-card-pager mode="out-in">
         <account-access-menu v-if="page === 'menu'" key="menu" @navigate="(p) => (page = p)" />
         <email-section v-else-if="page === 'email'" key="email" :close="onSuccessClose" />
         <password-section v-else key="password" :close="onSuccessClose" />
-      </transition>
+      </dialog-card-pager>
     </div>
   </div>
 </template>

--- a/src/components/settings/account-access/index.vue
+++ b/src/components/settings/account-access/index.vue
@@ -28,7 +28,11 @@ onBeforeUnmount(() => emitSfx('pop_up_close'))
     @close="close()"
   >
     <template #header>
-      <dialog-card-header data-testid="account-access-modal__header" :title="content?.title">
+      <dialog-card-header
+        data-testid="account-access-modal__header"
+        class="full-width"
+        :title="content?.title"
+      >
         <template #start>
           <ui-button
             v-if="page === 'menu'"
@@ -56,11 +60,6 @@ onBeforeUnmount(() => emitSfx('pop_up_close'))
       </dialog-card-header>
     </template>
 
-    <account-access-content
-      ref="content"
-      v-model:page="page"
-      :close="close"
-      class="gap-18 px-(--dialog-px)"
-    />
+    <account-access-content ref="content" v-model:page="page" :close="close" class="gap-18" />
   </dialog-card>
 </template>

--- a/src/components/settings/account-access/index.vue
+++ b/src/components/settings/account-access/index.vue
@@ -2,7 +2,6 @@
 import { onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DialogCard from '@/components/layout-kit/dialog-card/dialog-card.vue'
-import DialogCardHeader from '@/components/layout-kit/dialog-card/dialog-card-header.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import AccountAccessContent, { type AccountAccessContentPage } from './account-access-content.vue'
 import { emitSfx } from '@/sfx/bus'
@@ -27,37 +26,29 @@ onBeforeUnmount(() => emitSfx('pop_up_close'))
     :title="content?.title"
     @close="close()"
   >
-    <template #header>
-      <dialog-card-header
-        data-testid="account-access-modal__header"
-        class="full-width"
-        :title="content?.title"
+    <template #header-start>
+      <ui-button
+        v-if="page === 'menu'"
+        data-testid="dialog-card__close"
+        icon-left="close"
+        icon-only
+        rounded-full
+        @press="close()"
       >
-        <template #start>
-          <ui-button
-            v-if="page === 'menu'"
-            data-testid="dialog-card__close"
-            icon-left="close"
-            icon-only
-            rounded-full
-            @press="close()"
-          >
-            {{ t('dialog-card.close-label') }}
-          </ui-button>
+        {{ t('dialog-card.close-label') }}
+      </ui-button>
 
-          <ui-button
-            v-else
-            data-testid="account-access-modal__back"
-            icon-left="arrow-back"
-            icon-only
-            rounded-full
-            :sfx="{ press: 'snappy_button_5' }"
-            @press="page = 'menu'"
-          >
-            {{ t('account-access-modal.back-label') }}
-          </ui-button>
-        </template>
-      </dialog-card-header>
+      <ui-button
+        v-else
+        data-testid="account-access-modal__back"
+        icon-left="arrow-back"
+        icon-only
+        rounded-full
+        :sfx="{ press: 'snappy_button_5' }"
+        @press="page = 'menu'"
+      >
+        {{ t('account-access-modal.back-label') }}
+      </ui-button>
     </template>
 
     <account-access-content ref="content" v-model:page="page" :close="close" class="gap-18" />

--- a/src/components/settings/account-access/index.vue
+++ b/src/components/settings/account-access/index.vue
@@ -20,7 +20,8 @@ onBeforeUnmount(() => emitSfx('pop_up_close'))
 <template>
   <dialog-card
     data-testid="account-access-modal"
-    class="w-140 h-110 bg-brown-200 dark:bg-grey-800 gap-0!"
+    class="bg-brown-200 dark:bg-grey-800 gap-0!"
+    size="sm"
     data-theme="brown-50"
     data-theme-dark="stone-700"
     :title="content?.title"
@@ -51,6 +52,6 @@ onBeforeUnmount(() => emitSfx('pop_up_close'))
       </ui-button>
     </template>
 
-    <account-access-content ref="content" v-model:page="page" :close="close" class="gap-18" />
+    <account-access-content ref="content" v-model:page="page" :close="close" />
   </dialog-card>
 </template>

--- a/src/components/settings/tab-account-access/index.vue
+++ b/src/components/settings/tab-account-access/index.vue
@@ -21,6 +21,6 @@ defineExpose({ onChromeBack })
     data-testid="tab-account-access"
     class="px-(--settings-padding) pb-(--settings-padding)"
   >
-    <account-access-content v-model:page="page" class="gap-8" />
+    <account-access-content v-model:page="page" />
   </section-list>
 </template>

--- a/src/components/study-session/index.vue
+++ b/src/components/study-session/index.vue
@@ -52,10 +52,13 @@ function onPaneEnterStart() {
     data-testid="study-session"
     class="bg-brown-300 dark:bg-grey-800 bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-brown-500"
     size="lg"
-    :show_close_button="false"
   >
+    <template #header>
+      <div data-testid="study-session__header-target"></div>
+    </template>
+
     <template #default>
-      <div data-testid="study-session__outlet" class="relative w-full h-full overflow-hidden">
+      <div data-testid="study-session__outlet" class="relative w-full h-full">
         <dialog-card-pager @enter-start="onPaneEnterStart">
           <session-flashcard
             v-if="phase === 'studying'"

--- a/src/components/study-session/index.vue
+++ b/src/components/study-session/index.vue
@@ -50,40 +50,31 @@ function onPaneEnterStart() {
 <template>
   <dialog-card
     data-testid="study-session"
-    class="h-170 w-full max-w-160 bg-brown-300 dark:bg-grey-800 bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-brown-500"
-    full_bleed_at="w<sm"
+    class="bg-brown-300 dark:bg-grey-800 bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-brown-500"
+    size="lg"
     :show_close_button="false"
   >
-    <template #default="{ viewport }">
-      <div
-        class="w-full h-full"
-        :class="
-          viewport === 'mobile'
-            ? 'outline-1 outline-brown-100'
-            : 'border-t border-l border-brown-100 dark:border-grey-900'
-        "
-      >
-        <div data-testid="study-session__outlet" class="relative w-full h-full overflow-hidden">
-          <dialog-card-pager @enter-start="onPaneEnterStart">
-            <session-flashcard
-              v-if="phase === 'studying'"
-              key="studying"
-              :decks="decks"
-              :title="title"
-              :config_override="config_override"
-              @closed="onClosed"
-              @finished="onSessionFinished"
-            />
-            <session-summary
-              v-else
-              key="summary"
-              class="absolute inset-0 z-10"
-              :title="title"
-              :results="results"
-              @close="onClosed"
-            />
-          </dialog-card-pager>
-        </div>
+    <template #default>
+      <div data-testid="study-session__outlet" class="relative w-full h-full overflow-hidden">
+        <dialog-card-pager @enter-start="onPaneEnterStart">
+          <session-flashcard
+            v-if="phase === 'studying'"
+            key="studying"
+            :decks="decks"
+            :title="title"
+            :config_override="config_override"
+            @closed="onClosed"
+            @finished="onSessionFinished"
+          />
+          <session-summary
+            v-else
+            key="summary"
+            class="absolute inset-0 z-10"
+            :title="title"
+            :results="results"
+            @close="onClosed"
+          />
+        </dialog-card-pager>
       </div>
     </template>
   </dialog-card>

--- a/src/components/study-session/index.vue
+++ b/src/components/study-session/index.vue
@@ -4,9 +4,9 @@ import SessionSummary from './session-summary/index.vue'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DialogCard from '@/components/layout-kit/dialog-card/dialog-card.vue'
+import DialogCardPager from '@/components/layout-kit/dialog-card/dialog-card-pager.vue'
 import { emitSfx, emitStudySfx } from '@/sfx/bus'
 import { useProvideDeckContext } from './deck-context'
-import { sessionPaneEnter, sessionPaneLeave } from '@/utils/animations/session-pane'
 import { clearPersistedSession } from './composables/session-persistence'
 import type { CardReviewResult } from './composables/session-core'
 import type { SecondaryAction } from './composables/study-modal'
@@ -42,13 +42,8 @@ function onClosed() {
   close()
 }
 
-function onPaneLeave(el: Element, done: () => void) {
-  sessionPaneLeave(el, done)
-}
-
-function onPaneEnter(el: Element, done: () => void) {
-  if (phase.value !== 'summary') return done()
-  sessionPaneEnter(el, done, () => emitStudySfx('music_pizz_duo_hi'))
+function onPaneEnterStart() {
+  emitStudySfx('music_pizz_duo_hi')
 }
 </script>
 
@@ -69,7 +64,7 @@ function onPaneEnter(el: Element, done: () => void) {
         "
       >
         <div data-testid="study-session__outlet" class="relative w-full h-full overflow-hidden">
-          <transition :css="false" @leave="onPaneLeave" @enter="onPaneEnter">
+          <dialog-card-pager @enter-start="onPaneEnterStart">
             <session-flashcard
               v-if="phase === 'studying'"
               key="studying"
@@ -87,7 +82,7 @@ function onPaneEnter(el: Element, done: () => void) {
               :results="results"
               @close="onClosed"
             />
-          </transition>
+          </dialog-card-pager>
         </div>
       </div>
     </template>

--- a/src/components/study-session/index.vue
+++ b/src/components/study-session/index.vue
@@ -56,7 +56,7 @@ function onPaneEnter(el: Element, done: () => void) {
   <dialog-card
     data-testid="study-session"
     class="h-170 w-full max-w-160 bg-brown-300 dark:bg-grey-800 bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-brown-500"
-    viewport_query="w<sm"
+    full_bleed_at="w<sm"
     :show_close_button="false"
   >
     <template #default="{ viewport }">

--- a/src/components/study-session/session-flashcard/index.vue
+++ b/src/components/study-session/session-flashcard/index.vue
@@ -166,6 +166,7 @@ watch(mode, (m) => {
       :class="{ 'opacity-0 pointer-events-none': mode !== 'studying' }"
     >
       <session-header
+        teleport_target="[data-testid='study-session__header-target']"
         :title="title"
         :can_edit="can_edit"
         :is_cover="is_cover"

--- a/src/components/study-session/session-flashcard/session-header.vue
+++ b/src/components/study-session/session-flashcard/session-header.vue
@@ -14,12 +14,14 @@ type SessionHeaderProps = {
   is_cover?: boolean
   show_menu?: boolean
   show_all_ratings?: boolean
+  teleport_target: string
 }
 
 const {
   can_edit = false,
   show_menu = true,
-  show_all_ratings = MEMBER_PREFERENCES_DEFAULTS.study.show_all_ratings
+  show_all_ratings = MEMBER_PREFERENCES_DEFAULTS.study.show_all_ratings,
+  teleport_target
 } = defineProps<SessionHeaderProps>()
 
 const emit = defineEmits<{
@@ -71,47 +73,49 @@ function onSelect(option: DropdownOption) {
 </script>
 
 <template>
-  <dialog-card-header data-testid="session-header" :title="title" :padded="false">
-    <template #start>
-      <ui-button
-        v-if="is_cover"
-        data-testid="session-header__close"
-        data-theme="brown-100"
-        data-theme-dark="stone-700"
-        icon-left="close"
-        icon-only
-        rounded-full
-        @press="emit('stop')"
-      >
-        {{ t('study-session.close-button') }}
-      </ui-button>
-      <ui-button
-        v-else
-        data-testid="session-header__stop"
-        data-theme="brown-100"
-        data-theme-dark="stone-700"
-        icon-left="stop"
-        rounded-full
-        @press="emit('stop')"
-      >
-        {{ t('study-session.stop-button') }}
-      </ui-button>
-    </template>
+  <teleport defer :to="teleport_target">
+    <dialog-card-header data-testid="session-header" :title="title">
+      <template #start>
+        <ui-button
+          v-if="is_cover"
+          data-testid="session-header__close"
+          data-theme="brown-100"
+          data-theme-dark="stone-700"
+          icon-left="close"
+          icon-only
+          rounded-full
+          @press="emit('stop')"
+        >
+          {{ t('study-session.close-button') }}
+        </ui-button>
+        <ui-button
+          v-else
+          data-testid="session-header__stop"
+          data-theme="brown-100"
+          data-theme-dark="stone-700"
+          icon-left="stop"
+          rounded-full
+          @press="emit('stop')"
+        >
+          {{ t('study-session.stop-button') }}
+        </ui-button>
+      </template>
 
-    <template v-if="show_menu" #end>
-      <ui-dropdown-button
-        data-testid="session-header__menu"
-        trigger-only
-        trigger-icon="pencil"
-        variant="ghost"
-        position="bottom-end"
-        trigger-theme="brown-100"
-        trigger-theme-dark="stone-700"
-        menu-theme="brown-100"
-        menu-theme-dark="stone-700"
-        :options="menu_options"
-        @select="onSelect"
-      />
-    </template>
-  </dialog-card-header>
+      <template v-if="show_menu" #end>
+        <ui-dropdown-button
+          data-testid="session-header__menu"
+          trigger-only
+          trigger-icon="pencil"
+          variant="ghost"
+          position="bottom-end"
+          trigger-theme="brown-100"
+          trigger-theme-dark="stone-700"
+          menu-theme="brown-100"
+          menu-theme-dark="stone-700"
+          :options="menu_options"
+          @select="onSelect"
+        />
+      </template>
+    </dialog-card-header>
+  </teleport>
 </template>

--- a/src/components/study-session/session-summary/index.vue
+++ b/src/components/study-session/session-summary/index.vue
@@ -24,7 +24,13 @@ const summary = computed(() => aggregateSession(results))
 
 <template>
   <div data-testid="session-summary" class="h-full w-full flex flex-col gap-6 p-(--dialog-px)">
-    <session-header :title="title" is_cover :show_menu="false" @stop="emit('close')" />
+    <session-header
+      teleport_target="[data-testid='study-session__header-target']"
+      :title="title"
+      is_cover
+      :show_menu="false"
+      @stop="emit('close')"
+    />
 
     <div
       data-testid="session-summary__body"

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -355,6 +355,7 @@
   "dashboard.create-deck-button": "Make a New Deck",
   "dashboard.cards-due.cards-label": "card due across | cards due across",
   "dialog-card.close-label": "Close",
+  "dialog-card.back-label": "Back",
   "dashboard.cards-due.decks-label": "deck | decks",
   "review-inbox.cards-due-heading": "{count} card due | {count} cards due",
   "review-inbox.empty-label": "Nothing due right now!",

--- a/src/styles/content-grid.css
+++ b/src/styles/content-grid.css
@@ -1,0 +1,52 @@
+/* Named-line CSS grid for width-zoned layouts (content / breakout / full-width)
+   without wrapper divs. Override defaults per instance with the
+   content-grid-px-* / content-grid-max-w-* / content-grid-breakout-max-w-*
+   utilities below. */
+
+@utility content-grid {
+  --content-grid-padding: 0px;
+  --content-grid-max-width: 100%;
+  --content-grid-breakout-max-width: var(--content-grid-max-width);
+  --content-grid-breakout-size: calc(
+    (var(--content-grid-breakout-max-width) - var(--content-grid-max-width)) / 2
+  );
+
+  display: grid;
+  grid-template-columns:
+    [full-width-start] minmax(var(--content-grid-padding), 1fr)
+    [breakout-start] minmax(0, var(--content-grid-breakout-size))
+    [content-start] min(100% - var(--content-grid-padding) * 2, var(--content-grid-max-width))
+    [content-end] minmax(0, var(--content-grid-breakout-size))
+    [breakout-end] minmax(var(--content-grid-padding), 1fr)
+    [full-width-end];
+
+  & > * {
+    grid-column: content;
+  }
+}
+
+@utility content-grid-px-* {
+  --content-grid-padding: --value([length]);
+}
+
+@utility content-grid-max-w-* {
+  --content-grid-max-width: --value([length]);
+}
+
+@utility content-grid-breakout-max-w-* {
+  --content-grid-breakout-max-width: --value([length]);
+}
+
+@utility breakout {
+  grid-column: breakout;
+}
+
+@utility full-width {
+  grid-column: full-width;
+  display: grid;
+  grid-template-columns: inherit;
+
+  & > * {
+    grid-column: content;
+  }
+}

--- a/src/styles/content-grid.css
+++ b/src/styles/content-grid.css
@@ -43,10 +43,4 @@
 
 @utility full-width {
   grid-column: full-width;
-  display: grid;
-  grid-template-columns: inherit;
-
-  & > * {
-    grid-column: content;
-  }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6,6 +6,7 @@
 @import '@/styles/custom-variants.css';
 @import '@/styles/mobile-modal-variant.css';
 @import '@/styles/border-utils.css';
+@import '@/styles/content-grid.css';
 @import '@/styles/bg-utils.css';
 @import '@/styles/shimmer.css';
 @import '@/styles/outline-utils.css';

--- a/tests/integration/components/layout-kit/dialog-card/dialog-card-pager.test.js
+++ b/tests/integration/components/layout-kit/dialog-card/dialog-card-pager.test.js
@@ -1,0 +1,140 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import DialogCardPager from '@/components/layout-kit/dialog-card/dialog-card-pager.vue'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+// Mirrors the real session-pane animation hooks' call shape (el, done, onStart?)
+// so dialog-card-pager's own onEnter/onLeave wiring is under direct test —
+// the underlying tween math itself is covered in
+// tests/unit/utils/animations/session-pane.test.js.
+
+// onComplete resolves on a microtask, not synchronously — a real GSAP tween
+// never completes within the same call stack as the leave hook, and calling
+// done() synchronously during a real (unstubbed) unmount transition crashes
+// Vue's internal removal bookkeeping (`afterLeave` reads a detached parentNode).
+const { mockSessionPaneEnter, mockSessionPaneLeave } = vi.hoisted(() => ({
+  mockSessionPaneEnter: vi.fn((_el, done, onStart) => {
+    Promise.resolve().then(() => {
+      onStart?.()
+      done()
+    })
+  }),
+  mockSessionPaneLeave: vi.fn((_el, done) => {
+    Promise.resolve().then(() => done())
+  })
+}))
+
+vi.mock('@/utils/animations/session-pane', () => ({
+  sessionPaneLeave: mockSessionPaneLeave,
+  sessionPaneEnter: mockSessionPaneEnter
+}))
+
+// ── Host component ────────────────────────────────────────────────────────────
+// dialog-card-pager's default slot swaps between two keyed panes; a small host
+// component lets tests flip which pane is active and observe the transition
+// hooks fire against real (mocked) session-pane calls.
+
+function makeHost(mode) {
+  return defineComponent({
+    components: { DialogCardPager },
+    props: { phase: { type: String, default: 'a' } },
+    emits: ['enter-start'],
+    setup(props, { emit }) {
+      return () =>
+        h(DialogCardPager, { mode, onEnterStart: () => emit('enter-start') }, () =>
+          props.phase === 'a'
+            ? h('div', { key: 'a', 'data-testid': 'pane-a' }, 'A')
+            : h('div', { key: 'b', 'data-testid': 'pane-b' }, 'B')
+        )
+    }
+  })
+}
+
+function mountHost(mode) {
+  // Vue Test Utils stubs the built-in <transition> by default (no JS hooks
+  // fire); disable that stub so onLeave/onEnter run for real against the
+  // mocked session-pane calls.
+  return mount(makeHost(mode), {
+    props: { phase: 'a' },
+    global: { stubs: { transition: false } }
+  })
+}
+
+beforeEach(() => {
+  mockSessionPaneEnter.mockClear()
+  mockSessionPaneLeave.mockClear()
+})
+
+describe('DialogCardPager', () => {
+  test('renders the active slot pane', () => {
+    const wrapper = mountHost()
+    expect(wrapper.find('[data-testid="pane-a"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="pane-b"]').exists()).toBe(false)
+  })
+
+  test('switching the active pane calls sessionPaneLeave for the outgoing pane', async () => {
+    const wrapper = mountHost()
+    await wrapper.setProps({ phase: 'b' })
+    await flushPromises()
+
+    expect(mockSessionPaneLeave).toHaveBeenCalledOnce()
+  })
+
+  test('switching the active pane calls sessionPaneEnter for the incoming pane', async () => {
+    const wrapper = mountHost()
+    await wrapper.setProps({ phase: 'b' })
+    await flushPromises()
+
+    expect(mockSessionPaneEnter).toHaveBeenCalledOnce()
+    expect(wrapper.find('[data-testid="pane-b"]').exists()).toBe(true)
+  })
+
+  // ── enter-start emit [obligation] ───────────────────────────────────────────
+
+  test('[obligation] emits enter-start when the entering pane animation begins', async () => {
+    const wrapper = mountHost()
+    expect(wrapper.emitted('enter-start')).toBeFalsy()
+
+    await wrapper.setProps({ phase: 'b' })
+    await flushPromises()
+
+    expect(wrapper.emitted('enter-start')).toHaveLength(1)
+  })
+
+  test('does not emit enter-start on initial mount (no pane is "entering" yet)', () => {
+    const wrapper = mountHost()
+    expect(wrapper.emitted('enter-start')).toBeFalsy()
+  })
+
+  // ── mode prop [obligation] ──────────────────────────────────────────────────
+
+  describe('mode [obligation]', () => {
+    test('mode="out-in" still fires both leave and enter hooks across a swap', async () => {
+      const wrapper = mountHost('out-in')
+      await wrapper.setProps({ phase: 'b' })
+      await flushPromises()
+
+      expect(mockSessionPaneLeave).toHaveBeenCalledOnce()
+      expect(mockSessionPaneEnter).toHaveBeenCalledOnce()
+    })
+
+    test('mode="in-out" still fires both leave and enter hooks across a swap', async () => {
+      const wrapper = mountHost('in-out')
+      await wrapper.setProps({ phase: 'b' })
+      await flushPromises()
+
+      expect(mockSessionPaneLeave).toHaveBeenCalledOnce()
+      expect(mockSessionPaneEnter).toHaveBeenCalledOnce()
+    })
+
+    test('an undefined mode (simultaneous enter/leave) still fires both hooks across a swap', async () => {
+      const wrapper = mountHost(undefined)
+      await wrapper.setProps({ phase: 'b' })
+      await flushPromises()
+
+      expect(mockSessionPaneLeave).toHaveBeenCalledOnce()
+      expect(mockSessionPaneEnter).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/tests/integration/components/layout-kit/dialog-card/dialog-card.test.js
+++ b/tests/integration/components/layout-kit/dialog-card/dialog-card.test.js
@@ -59,23 +59,23 @@ beforeEach(() => {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('DialogCard', () => {
-  // ── viewport_query drives its own provide per-instance [obligation] ────────
+  // ── full_bleed_at drives its own provide per-instance [obligation] ─────────
 
-  describe('viewport_query [obligation]', () => {
+  describe('full_bleed_at [obligation]', () => {
     test('defaults to "w<sm | h<sm" when the prop is omitted', () => {
       mountCard()
       expect(capturedQueries).toContain('w<sm | h<sm')
     })
 
-    test('forwards an explicit viewport_query verbatim, not the default', () => {
-      mountCard({ viewport_query: 'w<sm' })
+    test('forwards an explicit full_bleed_at verbatim, not the default', () => {
+      mountCard({ full_bleed_at: 'w<sm' })
       expect(capturedQueries).toContain('w<sm')
       expect(capturedQueries).not.toContain('w<sm | h<sm')
     })
 
-    test('two instances with different viewport_query props resolve independently', () => {
-      const checkout = mountCard({ viewport_query: 'w<sm | h<sm' })
-      const study_session = mountCard({ viewport_query: 'w<sm' })
+    test('two instances with different full_bleed_at props resolve independently', () => {
+      const checkout = mountCard({ full_bleed_at: 'w<sm | h<sm' })
+      const study_session = mountCard({ full_bleed_at: 'w<sm' })
 
       expect(capturedQueries).toEqual(expect.arrayContaining(['w<sm | h<sm', 'w<sm']))
       checkout.unmount()
@@ -84,23 +84,77 @@ describe('DialogCard', () => {
 
     test('exposed viewport is "mobile" when the resolved query matches', () => {
       matchState.value = true
-      const wrapper = mountCard({ viewport_query: 'w<sm' })
+      const wrapper = mountCard({ full_bleed_at: 'w<sm' })
       expect(wrapper.vm.viewport).toBe('mobile')
     })
 
     test('exposed viewport is "desktop" when the resolved query does not match', () => {
       matchState.value = false
-      const wrapper = mountCard({ viewport_query: 'w<sm' })
+      const wrapper = mountCard({ full_bleed_at: 'w<sm' })
       expect(wrapper.vm.viewport).toBe('desktop')
     })
 
     test('default slot receives the same viewport value that is exposed', () => {
       matchState.value = true
       const wrapper = mountCard(
-        { viewport_query: 'w<sm' },
+        { full_bleed_at: 'w<sm' },
         { default: (props) => h('div', { 'data-testid': 'slot-viewport' }, props.viewport) }
       )
       expect(wrapper.find('[data-testid="slot-viewport"]').text()).toBe('mobile')
+    })
+  })
+
+  // ── size prop bundles width/height + full_bleed_at + content_max_width [obligation]
+
+  describe('size [obligation]', () => {
+    test('defaults to "md" — applies w-150 h-160 and a 32.5rem content max width', () => {
+      const wrapper = mountCard()
+      const classes = wrapper.find('[data-testid="dialog-card"]').classes()
+
+      expect(classes).toContain('w-150')
+      expect(classes).toContain('h-160')
+      expect(wrapper.find('[data-testid="dialog-card__body"]').attributes('style')).toContain(
+        '--content-grid-max-width: 32.5rem'
+      )
+    })
+
+    test('size="sm" applies w-140 h-110, full_bleed_at "w<sm | h<sm", and a 25rem content max width', () => {
+      const wrapper = mountCard({ size: 'sm' })
+      const classes = wrapper.find('[data-testid="dialog-card"]').classes()
+
+      expect(classes).toContain('w-140')
+      expect(classes).toContain('h-110')
+      expect(capturedQueries).toContain('w<sm | h<sm')
+      expect(wrapper.find('[data-testid="dialog-card__body"]').attributes('style')).toContain(
+        '--content-grid-max-width: 25rem'
+      )
+    })
+
+    test('size="lg" applies w-full max-w-160 h-170, full_bleed_at "w<sm", and a 35rem content max width', () => {
+      const wrapper = mountCard({ size: 'lg' })
+      const classes = wrapper.find('[data-testid="dialog-card"]').classes()
+
+      expect(classes).toContain('w-full')
+      expect(classes).toContain('max-w-160')
+      expect(classes).toContain('h-170')
+      expect(capturedQueries).toContain('w<sm')
+      expect(capturedQueries).not.toContain('w<sm | h<sm')
+      expect(wrapper.find('[data-testid="dialog-card__body"]').attributes('style')).toContain(
+        '--content-grid-max-width: 35rem'
+      )
+    })
+
+    test('an explicit full_bleed_at wins over the size default', () => {
+      mountCard({ size: 'sm', full_bleed_at: 'w<sm' })
+      expect(capturedQueries).toContain('w<sm')
+      expect(capturedQueries).not.toContain('w<sm | h<sm')
+    })
+
+    test('an explicit content_max_width wins over the size default', () => {
+      const wrapper = mountCard({ size: 'sm', content_max_width: '50rem' })
+      expect(wrapper.find('[data-testid="dialog-card__body"]').attributes('style')).toContain(
+        '--content-grid-max-width: 50rem'
+      )
     })
   })
 
@@ -129,6 +183,29 @@ describe('DialogCard', () => {
       expect(classes).not.toContain('h-full!')
       expect(classes).not.toContain('w-full!')
       expect(classes).not.toContain('rounded-none!')
+    })
+  })
+
+  // ── desktop-only frame chrome [obligation] ──────────────────────────────────
+
+  describe('desktop frame chrome [obligation]', () => {
+    test('applies the border-t/border-l frame classes on desktop', () => {
+      matchState.value = false
+      const wrapper = mountCard()
+      const classes = wrapper.find('[data-testid="dialog-card"]').classes()
+
+      expect(classes).toContain('border-t')
+      expect(classes).toContain('border-l')
+      expect(classes).toContain('border-brown-100')
+    })
+
+    test('drops the frame classes entirely on mobile (full-bleed, no edge to frame)', () => {
+      matchState.value = true
+      const wrapper = mountCard()
+      const classes = wrapper.find('[data-testid="dialog-card"]').classes()
+
+      expect(classes).not.toContain('border-t')
+      expect(classes).not.toContain('border-l')
     })
   })
 
@@ -171,6 +248,55 @@ describe('DialogCard', () => {
       const close = wrapper.find('[data-testid="dialog-card__close"]')
       expect(close.attributes('data-theme')).toBe('brown-100')
       expect(close.attributes('data-theme-dark')).toBe('stone-700')
+    })
+  })
+
+  // ── show_header [obligation] ────────────────────────────────────────────────
+
+  describe('show_header [obligation]', () => {
+    test('hides the whole header (including the close button) when false', () => {
+      const wrapper = mountCard({ title: 'x', show_header: false })
+      expect(wrapper.findComponent({ name: 'DialogCardHeader' }).exists()).toBe(false)
+      expect(wrapper.find('[data-testid="dialog-card__close"]').exists()).toBe(false)
+    })
+
+    test('renders the header by default (show_header omitted)', () => {
+      const wrapper = mountCard({ title: 'x' })
+      expect(wrapper.findComponent({ name: 'DialogCardHeader' }).exists()).toBe(true)
+    })
+  })
+
+  // ── close_disabled [obligation] ─────────────────────────────────────────────
+
+  describe('close_disabled [obligation]', () => {
+    test('disables the built-in close button when true', () => {
+      const wrapper = mountCard({ title: 'x', close_disabled: true })
+      expect(wrapper.find('[data-testid="dialog-card__close"]').attributes('disabled')).toBe('')
+    })
+
+    test('leaves the close button enabled by default', () => {
+      const wrapper = mountCard({ title: 'x' })
+      expect(wrapper.find('[data-testid="dialog-card__close"]').attributes('disabled')).toBe(
+        undefined
+      )
+    })
+  })
+
+  // ── header-start slot [obligation] ──────────────────────────────────────────
+
+  describe('#header-start slot [obligation]', () => {
+    test('falls back to the built-in close button when not overridden', () => {
+      const wrapper = mountCard({ title: 'x' })
+      expect(wrapper.find('[data-testid="dialog-card__close"]').exists()).toBe(true)
+    })
+
+    test('a custom #header-start slot replaces the built-in close button', () => {
+      const wrapper = mountCard(
+        { title: 'x' },
+        { 'header-start': () => h('div', { 'data-testid': 'custom-header-start' }) }
+      )
+      expect(wrapper.find('[data-testid="custom-header-start"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="dialog-card__close"]').exists()).toBe(false)
     })
   })
 

--- a/tests/integration/components/modals/checkout/index.test.js
+++ b/tests/integration/components/modals/checkout/index.test.js
@@ -48,7 +48,7 @@ import Checkout from '@/components/modals/checkout/index.vue'
 function mountCheckout(close = vi.fn()) {
   return shallowMount(Checkout, {
     props: { close },
-    global: { stubs: { DialogCard: false, DialogCardHeader: false } }
+    global: { stubs: { DialogCard: false, DialogCardHeader: false, DialogCardPager: false } }
   })
 }
 
@@ -65,14 +65,14 @@ beforeEach(() => {
 describe('Checkout — header', () => {
   test('renders while not in the success status', () => {
     const wrapper = mountCheckout()
-    expect(wrapper.find('[data-testid="checkout__header"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="dialog-card-header"]').exists()).toBe(true)
   })
 
   test('[obligation] is absent while status is success', async () => {
     checkoutState.status.value = 'success'
     const wrapper = mountCheckout()
     await flushPromises()
-    expect(wrapper.find('[data-testid="checkout__header"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="dialog-card-header"]').exists()).toBe(false)
   })
 
   test('[obligation] close button is disabled only while confirming', () => {
@@ -116,7 +116,7 @@ describe('Checkout — header', () => {
     const wrapper = shallowMount(Checkout, {
       props: { close: vi.fn() },
       global: {
-        stubs: { DialogCard: false, DialogCardHeader: false },
+        stubs: { DialogCard: false, DialogCardHeader: false, DialogCardPager: false },
         renderStubDefaultSlot: true
       }
     })
@@ -124,15 +124,14 @@ describe('Checkout — header', () => {
   })
 
   // ── exactly one close button [obligation] ──────────────────────────────────
-  // dialog-card's own fallback header would render a second close button if
-  // show_close_button weren't explicitly false, since checkout renders its own
-  // header manually.
+  // checkout passes close_label/close_disabled through to dialog-card's own
+  // fallback header instead of rendering a second close button of its own.
 
   test('[obligation] renders exactly one close button regardless of status', () => {
     ;['loading', 'form', 'error', 'confirming'].forEach((status) => {
       checkoutState.status.value = status
       const wrapper = mountCheckout()
-      expect(wrapper.findAll('[data-testid="checkout__close"]')).toHaveLength(1)
+      expect(wrapper.findAll('[data-testid="dialog-card__close"]')).toHaveLength(1)
       wrapper.unmount()
     })
   })
@@ -222,12 +221,11 @@ describe('Checkout — full-bleed mobile scroll area [obligation]', () => {
     expect(scrollArea.attributes('data-full-bleed')).toBe('false')
   })
 
-  test('[obligation] scroll-area wraps header, body, and footer together, not just the body', () => {
+  test('[obligation] scroll-area wraps the body and footer together, not just the body', () => {
     mediaState.is_mobile.value = true
     const wrapper = mountCheckout()
 
     const scrollArea = wrapper.find('[data-testid="checkout__scroll-area"]')
-    expect(scrollArea.find('[data-testid="checkout__header"]').exists()).toBe(true)
     expect(scrollArea.find('[data-testid="checkout__body"]').exists()).toBe(true)
     expect(scrollArea.findComponent({ name: 'CheckoutFooter' }).exists()).toBe(true)
   })
@@ -245,41 +243,36 @@ describe('Checkout — full-bleed mobile scroll area [obligation]', () => {
   })
 })
 
-// ── dialog-card header stays inside the scroll-area [obligation] ─────────────
+// ── dialog-card's own header sits outside the scroll-area [obligation] ───────
+// checkout delegates the header entirely to dialog-card (via show_header /
+// close_label / close_disabled) instead of building its own — dialog-card
+// always renders the header as a sibling above its body slot, so it's never
+// nested inside checkout's own scroll-area.
 
-describe('Checkout — header lives inside the scroll-area flex context [obligation]', () => {
-  test('[obligation] dialog-card-header is a descendant of checkout__scroll-area, not a structural sibling', () => {
+describe('Checkout — header lives outside the scroll-area, owned by dialog-card [obligation]', () => {
+  test('[obligation] dialog-card-header is a sibling of checkout__scroll-area, not nested inside it', () => {
     const wrapper = mountCheckout()
 
     const scrollArea = wrapper.find('[data-testid="checkout__scroll-area"]')
-    expect(scrollArea.find('[data-testid="checkout__header"]').exists()).toBe(true)
-
-    // The dialog-card root's direct children should be [scroll-area, scroll-bar?] —
-    // the header must not appear as a second, separate top-level child.
-    const root = wrapper.find('[data-testid="checkout"]')
-    const headerOutsideScrollArea = root
-      .findAll('[data-testid="checkout__header"]')
-      .filter((el) => !scrollArea.element.contains(el.element))
-    expect(headerOutsideScrollArea).toHaveLength(0)
+    expect(scrollArea.find('[data-testid="dialog-card-header"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="dialog-card-header"]').exists()).toBe(true)
   })
 })
 
-// ── viewport_query default [obligation] ───────────────────────────────────────
+// ── size prop default full_bleed_at [obligation] ──────────────────────────────
 
-describe('Checkout — dialog-card viewport_query [obligation]', () => {
-  test('[obligation] uses the "w<sm | h<sm" default query, not a hardcoded/shared one', () => {
+describe('Checkout — dialog-card size default full_bleed_at [obligation]', () => {
+  test('[obligation] uses the "w<sm | h<sm" query sourced from size="md", not a hardcoded/shared one', () => {
     mountCheckout()
     expect(capturedQueries).toContain('w<sm | h<sm')
   })
 })
 
-// ── show_close_button=false passed explicitly [obligation] ───────────────────
+// ── show_header/close_label/close_disabled passed through [obligation] ───────
 
-describe('Checkout — show_close_button [obligation]', () => {
-  test('[obligation] passes show_close_button=false to dialog-card so its fallback header never renders', () => {
+describe('Checkout — header props forwarded to dialog-card [obligation]', () => {
+  test('[obligation] does not pass show_close_button=false, so dialog-card renders its own fallback close button', () => {
     const wrapper = mountCheckout()
-    // dialog-card's own fallback close button carries this data-testid; checkout
-    // renders its own via checkout__close instead.
-    expect(wrapper.find('[data-testid="dialog-card__close"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="dialog-card__close"]').exists()).toBe(true)
   })
 })

--- a/tests/integration/components/modals/study-session/index.test.js
+++ b/tests/integration/components/modals/study-session/index.test.js
@@ -231,9 +231,9 @@ describe('StudySession (index.vue)', () => {
     expect(title.length).toBeGreaterThan(0)
   })
 
-  // ── dialog-card viewport_query [obligation] ────────────────────────────────
+  // ── dialog-card size="lg" sources full_bleed_at="w<sm" [obligation] ────────
 
-  test('[obligation] passes viewport_query="w<sm" — explicit, distinct from dialog-card default', () => {
+  test('[obligation] size="lg" resolves full_bleed_at to "w<sm" (not the "md"/"sm" default), since no explicit full_bleed_at is passed', () => {
     makeWrapper()
     expect(capturedQueries).toContain('w<sm')
     expect(capturedQueries).not.toContain('w<sm | h<sm')
@@ -263,5 +263,26 @@ describe('StudySession (index.vue)', () => {
     const { wrapper } = makeWrapper()
     const classes = wrapper.find('[data-testid="study-session"]').classes()
     expect(classes).toContain('h-full!')
+  })
+
+  // ── regression: outlet must not clip the swipe/drag animation [obligation] ─
+  // study-session__outlet used to carry its own overflow-hidden, which clipped
+  // the flashcard swipe/drag animation at the narrower content column instead
+  // of the full card. dialog-card's own root overflow-hidden (clipping at the
+  // true full-card boundary) is now the only clip boundary.
+
+  test('[obligation] study-session__outlet does not carry overflow-hidden', () => {
+    const { wrapper } = makeWrapper()
+    const classes = wrapper.find('[data-testid="study-session__outlet"]').classes()
+    expect(classes).not.toContain('overflow-hidden')
+  })
+
+  // ── header teleport target [obligation] ────────────────────────────────────
+  // session-header teleports itself into study-session__header-target, which
+  // study-session renders via dialog-card's #header slot override.
+
+  test('[obligation] renders a study-session__header-target placeholder via the #header slot', () => {
+    const { wrapper } = makeWrapper()
+    expect(wrapper.find('[data-testid="study-session__header-target"]').exists()).toBe(true)
   })
 })

--- a/tests/integration/components/modals/study-session/session-flashcard.test.js
+++ b/tests/integration/components/modals/study-session/session-flashcard.test.js
@@ -216,6 +216,16 @@ function fireTransitionEnd(wrapper) {
 
 describe('Session', () => {
   beforeEach(() => {
+    // session-header teleports into a `[data-testid="study-session__header-target"]`
+    // placeholder normally rendered by its ancestor (study-session/index.vue). This
+    // suite mounts session-flashcard/index.vue in isolation, so provide the target
+    // ourselves — otherwise the teleport has nowhere to resolve to and crashes.
+    if (!document.body.querySelector('[data-testid="study-session__header-target"]')) {
+      const target = document.createElement('div')
+      target.setAttribute('data-testid', 'study-session__header-target')
+      document.body.appendChild(target)
+    }
+
     // A prior test's reviewCard()/dropCard() writes a persisted-session snapshot
     // to sessionStorage; without clearing it, the next mount's useSessionCards
     // sees a stale snapshot and takes the restore path instead of a fresh seed.

--- a/tests/integration/components/modals/study-session/session-flashcard/session-header.test.js
+++ b/tests/integration/components/modals/study-session/session-flashcard/session-header.test.js
@@ -1,7 +1,13 @@
-import { describe, test, expect, vi } from 'vite-plus/test'
+import { describe, test, expect, beforeEach } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, nextTick } from 'vue'
 import SessionHeader from '@/components/study-session/session-flashcard/session-header.vue'
+
+// session-header teleports into a placeholder rendered by its ancestor
+// (study-session/index.vue via dialog-card's #header slot). Since teleport
+// content lands outside the mounted wrapper's own DOM subtree, tests query
+// `document.body` directly rather than `wrapper.find`.
+const TARGET_SELECTOR = '[data-testid="study-session__header-target"]'
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
@@ -56,12 +62,18 @@ const DropdownButtonStub = defineComponent({
 
 function mountHeader(props = {}) {
   capturedOptions = []
+  const target = document.createElement('div')
+  target.setAttribute('data-testid', 'study-session__header-target')
+  document.body.appendChild(target)
+
   return mount(SessionHeader, {
     props: {
       is_cover: false,
       can_edit: true,
+      teleport_target: TARGET_SELECTOR,
       ...props
     },
+    attachTo: document.body,
     global: {
       stubs: {
         UiDropdownButton: DropdownButtonStub
@@ -70,45 +82,61 @@ function mountHeader(props = {}) {
   })
 }
 
+function findInTarget(selector) {
+  return document.body.querySelector(`${TARGET_SELECTOR} ${selector}`)
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('SessionHeader', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // ── teleport wiring [obligation] ────────────────────────────────────────────
+
+  test('renders inside the teleport_target element, not in-place [obligation]', () => {
+    mountHeader()
+    expect(findInTarget('[data-testid="session-header"]')).not.toBeNull()
+  })
   // ── is_cover: close vs stop button [obligation] ────────────────────────────
 
   test('renders close button when is_cover is true [obligation]', () => {
-    const wrapper = mountHeader({ is_cover: true })
-    expect(wrapper.find('[data-testid="session-header__close"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="session-header__stop"]').exists()).toBe(false)
+    mountHeader({ is_cover: true })
+    expect(findInTarget('[data-testid="session-header__close"]')).not.toBeNull()
+    expect(findInTarget('[data-testid="session-header__stop"]')).toBeNull()
   })
 
   test('renders stop button when is_cover is false [obligation]', () => {
-    const wrapper = mountHeader({ is_cover: false })
-    expect(wrapper.find('[data-testid="session-header__stop"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="session-header__close"]').exists()).toBe(false)
+    mountHeader({ is_cover: false })
+    expect(findInTarget('[data-testid="session-header__stop"]')).not.toBeNull()
+    expect(findInTarget('[data-testid="session-header__close"]')).toBeNull()
   })
 
   test('close button (is_cover=true) emits "stop" on press [obligation]', async () => {
     const wrapper = mountHeader({ is_cover: true })
-    await wrapper.find('[data-testid="session-header__close"]').trigger('click')
+    findInTarget('[data-testid="session-header__close"]').click()
+    await nextTick()
     expect(wrapper.emitted('stop')).toHaveLength(1)
   })
 
   test('stop button (is_cover=false) emits "stop" on press [obligation]', async () => {
     const wrapper = mountHeader({ is_cover: false })
-    await wrapper.find('[data-testid="session-header__stop"]').trigger('click')
+    findInTarget('[data-testid="session-header__stop"]').click()
+    await nextTick()
     expect(wrapper.emitted('stop')).toHaveLength(1)
   })
 
   // ── edit menu is ALWAYS rendered [obligation] ──────────────────────────────
 
   test('edit menu is always rendered when can_edit is true [obligation]', () => {
-    const wrapper = mountHeader({ can_edit: true })
-    expect(wrapper.find('[data-testid="session-header__menu"]').exists()).toBe(true)
+    mountHeader({ can_edit: true })
+    expect(findInTarget('[data-testid="session-header__menu"]')).not.toBeNull()
   })
 
   test('edit menu is always rendered when can_edit is false [obligation]', () => {
-    const wrapper = mountHeader({ can_edit: false })
-    expect(wrapper.find('[data-testid="session-header__menu"]').exists()).toBe(true)
+    mountHeader({ can_edit: false })
+    expect(findInTarget('[data-testid="session-header__menu"]')).not.toBeNull()
   })
 
   // ── menu options carry disabled: !can_edit [obligation] ───────────────────
@@ -136,53 +164,59 @@ describe('SessionHeader', () => {
 
   test('selecting edit option emits "edit" event', async () => {
     const wrapper = mountHeader({ can_edit: true })
-    await wrapper.find('[data-testid="dropdown-select-edit"]').trigger('click')
+    findInTarget('[data-testid="dropdown-select-edit"]').click()
+    await nextTick()
     expect(wrapper.emitted('edit')).toHaveLength(1)
   })
 
   test('selecting move option emits "move" event', async () => {
     const wrapper = mountHeader({ can_edit: true })
-    await wrapper.find('[data-testid="dropdown-select-move"]').trigger('click')
+    findInTarget('[data-testid="dropdown-select-move"]').click()
+    await nextTick()
     expect(wrapper.emitted('move')).toHaveLength(1)
   })
 
   test('selecting delete option emits "delete" event', async () => {
     const wrapper = mountHeader({ can_edit: true })
-    await wrapper.find('[data-testid="dropdown-select-delete"]').trigger('click')
+    findInTarget('[data-testid="dropdown-select-delete"]').click()
+    await nextTick()
     expect(wrapper.emitted('delete')).toHaveLength(1)
   })
 
   // ── show_menu=false suppresses the menu regardless of can_edit [obligation] ─
 
   test('show_menu=false hides dropdown menu even when can_edit is true [obligation]', () => {
-    const wrapper = mountHeader({ show_menu: false, can_edit: true })
-    expect(wrapper.find('[data-testid="session-header__menu"]').exists()).toBe(false)
+    mountHeader({ show_menu: false, can_edit: true })
+    expect(findInTarget('[data-testid="session-header__menu"]')).toBeNull()
   })
 
   test('show_menu=false hides dropdown menu when can_edit is false [obligation]', () => {
-    const wrapper = mountHeader({ show_menu: false, can_edit: false })
-    expect(wrapper.find('[data-testid="session-header__menu"]').exists()).toBe(false)
+    mountHeader({ show_menu: false, can_edit: false })
+    expect(findInTarget('[data-testid="session-header__menu"]')).toBeNull()
   })
 
   test('show_menu=true (default) still renders dropdown menu when can_edit is true [obligation]', () => {
     // Default: show_menu defaults to true
-    const wrapper = mountHeader({ show_menu: true, can_edit: true })
-    expect(wrapper.find('[data-testid="session-header__menu"]').exists()).toBe(true)
+    mountHeader({ show_menu: true, can_edit: true })
+    expect(findInTarget('[data-testid="session-header__menu"]')).not.toBeNull()
   })
 
   // ── title renders ──────────────────────────────────────────────────────────
 
   test('renders title text in header', () => {
-    const wrapper = mountHeader({ title: 'My Deck' })
-    expect(wrapper.find('[data-testid="dialog-card-header__title"]').text()).toBe('My Deck')
+    mountHeader({ title: 'My Deck' })
+    expect(findInTarget('[data-testid="dialog-card-header__title"]').textContent).toBe('My Deck')
   })
 
-  // ── dialog-card-header padded=false [obligation] ───────────────────────────
+  // ── dialog-card-header padded default (no override) [obligation] ───────────
+  // session-header no longer overrides padded=false — its teleported position
+  // has no ancestor padding wrapper (unlike its old in-place position), so it
+  // relies on dialog-card-header's own default (padded=true).
 
-  test('renders dialog-card-header with padded=false so it does not double the parent inset [obligation]', () => {
-    const wrapper = mountHeader()
-    const header = wrapper.find('[data-testid="session-header"]')
-    expect(header.classes()).not.toContain('px-(--dialog-px)')
+  test('renders dialog-card-header without a padded override, so its own default (true) applies [obligation]', () => {
+    mountHeader()
+    const header = findInTarget('[data-testid="session-header"]')
+    expect(header.classList.contains('px-(--dialog-px)')).toBe(true)
   })
 
   // ── toggle-ratings menu copy [obligation] ─────────────────────────────────
@@ -203,7 +237,8 @@ describe('SessionHeader', () => {
 
   test('selecting the toggle-ratings option emits "toggle-ratings" event [obligation]', async () => {
     const wrapper = mountHeader({ can_edit: true })
-    await wrapper.find('[data-testid="dropdown-select-toggle-ratings"]').trigger('click')
+    findInTarget('[data-testid="dropdown-select-toggle-ratings"]').click()
+    await nextTick()
     expect(wrapper.emitted('toggle-ratings')).toHaveLength(1)
   })
 })

--- a/tests/integration/components/settings/account-access/account-access-content.test.js
+++ b/tests/integration/components/settings/account-access/account-access-content.test.js
@@ -128,6 +128,20 @@ describe('AccountAccessContent — title computed [obligation]', () => {
   })
 })
 
+describe('AccountAccessContent — no local max-width/gap constraint [obligation]', () => {
+  test('[obligation] the root carries no max-w class — width is sourced from an ancestor (dialog-card size, or the standalone tab layout)', () => {
+    const wrapper = mountContent('menu')
+    const root = wrapper.find('[data-testid="account-access-content"]')
+    expect(root.classes().some((c) => c.startsWith('max-w'))).toBe(false)
+  })
+
+  test('[obligation] the root carries no gap-* class — the container only ever has one active child at a time via the pager', () => {
+    const wrapper = mountContent('menu')
+    const root = wrapper.find('[data-testid="account-access-content"]')
+    expect(root.classes().some((c) => c.startsWith('gap-'))).toBe(false)
+  })
+})
+
 describe('AccountAccessContent — page routing', () => {
   test('renders the menu by default', () => {
     const wrapper = mountContent('menu')


### PR DESCRIPTION
## Summary

Consolidates the layout-kit `dialog-card` primitive shared by move-cards, checkout, account-access, and study-session. Each callsite previously hand-rolled its own width/height classes, body-content spacing/max-width, page-transition animation, and header instantiation — this collapses all of that into the primitive itself.

## Changes

- Add `content-grid` CSS utilities (named-line grid for content/breakout/full-width zones), replacing one-off `max-w-*` wrapper divs at each callsite
- Rename `viewport_query` → `full_bleed_at` to describe the actual behavior
- Add `dialog-card-pager`, centralizing the fade-out/spring-scale-in page transition previously duplicated across checkout, account-access, and study-session
- Add a `header-start` slot (mirrors the existing `header-end`) plus `show_header`/`close_disabled`, so callsites stop hand-instantiating the whole header just to customize the close button
- Add a `size` prop (`sm`/`md`/`lg`) bundling width/height/`full_bleed_at`/`content_max_width`, replacing each callsite's own hardcoded classes
- Bake a universal desktop-only border accent into the primitive (dropped on mobile, where the dialog goes full-bleed)
- Teleport study-session's nested header into dialog-card's real header slot, and fix a swipe-animation clipping regression introduced along the way by the content-grid change