### PR TITLE
fix(auth): allow-list /welcome and /auth/callback redirects

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -344,11 +344,19 @@ project_id = "kjxijaowaogiepqteqjk"
 
 [remotes.stage.auth]
 site_url = "https://stage.taro-flash.com"
-additional_redirect_urls = ["https://stage.taro-flash.com"]
+additional_redirect_urls = [
+  "https://stage.taro-flash.com",
+  "https://stage.taro-flash.com/auth/callback",
+  "https://stage.taro-flash.com/welcome"
+]
 
 [remotes.prod]
 project_id = "pwdqswbdiyahmftergyk"
 
 [remotes.prod.auth]
 site_url = "https://taro-flash.com"
-additional_redirect_urls = ["https://taro-flash.com"]
+additional_redirect_urls = [
+  "https://taro-flash.com",
+  "https://taro-flash.com/auth/callback",
+  "https://taro-flash.com/welcome"
+]


### PR DESCRIPTION
## Summary
Password recovery emails were sending users to the bare origin instead of `/welcome`, because GoTrue rejects any `redirectTo` not present in `additional_redirect_urls` and silently falls back to `site_url`. That landed recovery links on `/dashboard`, where Supabase's client auto-detects the recovery token and fully authenticates the user instead of showing the reset-password modal. Adds `/welcome` and `/auth/callback` to the stage/prod redirect allow-lists.