### PR TITLE
fix(deploy): stop stale index.html surviving redeploys

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/index.html
+  Cache-Control: no-cache
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,14 @@ import { warmupAnimations } from '@/utils/animations/warmup'
 
 warmupAnimations()
 
+window.addEventListener('vite:preloadError', () => {
+  const reload_key = 'stale-chunk-reload'
+  if (sessionStorage.getItem(reload_key)) return
+
+  sessionStorage.setItem(reload_key, '1')
+  window.location.reload()
+})
+
 const i18n = createI18n({
   locale: 'en-us',
   legacy: false,
@@ -28,3 +36,5 @@ app.use(router)
 app.directive('sfx', vSfx)
 
 app.mount('#app')
+
+sessionStorage.removeItem('stale-chunk-reload')


### PR DESCRIPTION
## Summary
No cache-control headers were configured for the Netlify deploy, so `index.html` could be served stale after a new deploy replaced hashed asset files — clients holding an old `index.html` then 404 on old chunk hashes, breaking module loading (mobile Safari user hit this as `'text/plain' is not a valid JavaScript MIME type'` and CSS preload errors, unable to even open the login sheet). Adds `public/_headers` with `no-cache` on `index.html` and `immutable`/long-cache on `/assets/*`, plus a `vite:preloadError` listener in `src/main.ts` that force-reloads once as defense-in-depth for any client still caught mid-transition.