### PR TITLE
fix(media-query): self-correct stale initial matchMedia read

### DIFF
--- a/src/composables/ui/media-query.ts
+++ b/src/composables/ui/media-query.ts
@@ -114,6 +114,14 @@ function matchCached(media: string): Ref<boolean> {
   mq.addEventListener('change', () => (r!.value = mq.matches))
   cache.set(media, r)
 
+  // iOS Safari's viewport can still be settling (zoom/safe-area renegotiation)
+  // at the instant a fresh page's first script runs, making this initial
+  // synchronous read unreliable. Re-check once after first paint and
+  // self-correct if it drifted.
+  requestAnimationFrame(() => {
+    if (r!.value !== mq.matches) r!.value = mq.matches
+  })
+
   return r
 }
 


### PR DESCRIPTION
## Summary
\`useMatchMedia\` caches a media query's first \`matchMedia().matches\` read for the whole session, with no re-check outside a genuine \`change\` event. On iOS Safari, the viewport can still be settling (zoom/safe-area renegotiation) at the instant a freshly-loaded page's first script runs, so that initial read is sometimes stale — surfacing as desktop layout (splash header, "see more" button, study-session modal desktop mode) rendering on a mobile viewport, non-deterministically across reloads.

Adds a single \`requestAnimationFrame\`-deferred re-check after seeding each cached ref, self-correcting only if the value actually drifted — no visible flash for the common (already-correct) case.