### PR TITLE
Consolidate code-splitting to route level

### DIFF
--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, onMounted, provide, ref, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, provide, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DeckAside from './deck-aside.vue'
 import { deckSettingsLayoutKey, deckSettingsCloseKey } from './layout'
@@ -12,6 +12,11 @@ import { useAlert } from '@/composables/alert'
 import { useModalAfterEnter, useModalRequestClose } from '@/composables/modal'
 import DeckPinnedPreview from '@/components/deck/pinned-preview.vue'
 import TabSheet from '@/components/layout-kit/sheet/tab-sheet.vue'
+import TabDetails from './tab-details/index.vue'
+import TabDesign from './tab-design/index.vue'
+import TabStudy from './tab-study/index.vue'
+import TabDangerZone from './tab-danger-zone/index.vue'
+import TabIndex from './tab-index/index.vue'
 import { TAB_META, type TabValue } from './tabs'
 
 export type DeckSettingsResponse = boolean
@@ -23,12 +28,6 @@ const { deck, close, initial_tab, initial_side } = defineProps<{
   initial_tab?: ActiveTab
   initial_side?: CardSide
 }>()
-
-const TabDetails = defineAsyncComponent(() => import('./tab-details/index.vue'))
-const TabDesign = defineAsyncComponent(() => import('./tab-design/index.vue'))
-const TabStudy = defineAsyncComponent(() => import('./tab-study/index.vue'))
-const TabDangerZone = defineAsyncComponent(() => import('./tab-danger-zone/index.vue'))
-const TabIndex = defineAsyncComponent(() => import('./tab-index/index.vue'))
 
 const TAB_COMPONENTS = {
   index: TabIndex,

--- a/src/components/modals/deck-settings/index.vue
+++ b/src/components/modals/deck-settings/index.vue
@@ -104,15 +104,6 @@ const tab_content_class = computed(() =>
 )
 
 onMounted(async () => {
-  const idle = window.requestIdleCallback ?? ((cb: IdleRequestCallback) => setTimeout(cb, 200))
-  idle(() => {
-    import('./tab-details/index.vue')
-    import('./tab-design/index.vue')
-    import('./tab-study/index.vue')
-    import('./tab-danger-zone/index.vue')
-    import('./tab-index/index.vue')
-  })
-
   if (initial_side) {
     await after_enter
     editor.setActiveSide(initial_side)

--- a/src/components/modals/move-cards.vue
+++ b/src/components/modals/move-cards.vue
@@ -86,7 +86,7 @@ function onClick(deck_id?: number) {
             data-testid="move-cards__deck-item"
             :class="[
               deck.id === current_deck_id || isDeckFull(deck)
-                ? ' bg-brown-200 dark:bg-stone-900 pointer-events-none text-(--theme-on-primary)/20'
+                ? ' bg-brown-300 dark:bg-stone-700 pointer-events-none text-(--theme-on-primary)/20'
                 : 'cursor-pointer'
             ]"
             class="text-(--theme-on-primary) text-left flex items-center gap-3 p-4"

--- a/src/components/settings/index.vue
+++ b/src/components/settings/index.vue
@@ -1,14 +1,5 @@
 <script setup lang="ts">
-import {
-  computed,
-  defineAsyncComponent,
-  onBeforeUnmount,
-  onMounted,
-  provide,
-  ref,
-  useTemplateRef,
-  watch
-} from 'vue'
+import { computed, onBeforeUnmount, onMounted, provide, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import SettingsAside from './settings-aside.vue'
 import {
@@ -30,19 +21,16 @@ import { recedeModal, restoreModal } from '@/utils/animations/modal'
 import MemberCard from '@/components/member/member-card.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import TabSheet from '@/components/layout-kit/sheet/tab-sheet.vue'
+import TabProfile from './tab-profile/index.vue'
+import TabSubscription from './tab-subscription/index.vue'
+import TabApp from './tab-app/index.vue'
+import TabReviewPreferences from './tab-review-preferences/index.vue'
+import TabDangerZone from './tab-danger-zone/index.vue'
+import TabAccountAccess from './tab-account-access/index.vue'
+import TabIndex from './tab-index/index.vue'
 const { close } = defineProps<{ close: () => void }>()
 
 const { t } = useI18n()
-
-const TabProfile = defineAsyncComponent(() => import('./tab-profile/index.vue'))
-const TabSubscription = defineAsyncComponent(() => import('./tab-subscription/index.vue'))
-const TabApp = defineAsyncComponent(() => import('./tab-app/index.vue'))
-const TabReviewPreferences = defineAsyncComponent(
-  () => import('./tab-review-preferences/index.vue')
-)
-const TabDangerZone = defineAsyncComponent(() => import('./tab-danger-zone/index.vue'))
-const TabAccountAccess = defineAsyncComponent(() => import('./tab-account-access/index.vue'))
-const TabIndex = defineAsyncComponent(() => import('./tab-index/index.vue'))
 
 const TAB_COMPONENTS = {
   index: TabIndex,

--- a/src/components/settings/index.vue
+++ b/src/components/settings/index.vue
@@ -122,19 +122,6 @@ const tab_content_class = computed(() =>
 onMounted(() => emitSfx('snappy_button_3'))
 onBeforeUnmount(() => emitSfx('snappy_button_5'))
 
-onMounted(() => {
-  const idle = window.requestIdleCallback ?? ((cb: IdleRequestCallback) => setTimeout(cb, 200))
-  idle(() => {
-    import('./tab-profile/index.vue')
-    import('./tab-subscription/index.vue')
-    import('./tab-app/index.vue')
-    import('./tab-review-preferences/index.vue')
-    import('./tab-danger-zone/index.vue')
-    import('./tab-account-access/index.vue')
-    import('./tab-index/index.vue')
-  })
-})
-
 async function onClose() {
   if (!editor.is_dirty.value) return close()
   const { response } = alert.warn({

--- a/src/components/study-session/composables/study-modal.ts
+++ b/src/components/study-session/composables/study-modal.ts
@@ -1,8 +1,6 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-
-const StudySession = defineAsyncComponent(() => import('@/components/study-session/index.vue'))
+import StudySession from '@/components/study-session/index.vue'
 
 export type SecondaryAction = 'study-more' | 'study-all' | 'study-again'
 

--- a/src/composables/audio-reader/collection-create-modal.ts
+++ b/src/composables/audio-reader/collection-create-modal.ts
@@ -1,11 +1,8 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-import type { CollectionCreateResponse } from '@/components/modals/collection-create/index.vue'
-
-const CollectionCreate = defineAsyncComponent(
-  () => import('@/components/modals/collection-create/index.vue')
-)
+import CollectionCreate, {
+  type CollectionCreateResponse
+} from '@/components/modals/collection-create/index.vue'
 
 /**
  * Open the create-collection modal. Resolves to the created LessonCollection,

--- a/src/composables/audio-reader/collection-edit-modal.ts
+++ b/src/composables/audio-reader/collection-edit-modal.ts
@@ -1,11 +1,8 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-import type { CollectionEditResponse } from '@/components/modals/collection-edit/index.vue'
-
-const CollectionEdit = defineAsyncComponent(
-  () => import('@/components/modals/collection-edit/index.vue')
-)
+import CollectionEdit, {
+  type CollectionEditResponse
+} from '@/components/modals/collection-edit/index.vue'
 
 /**
  * Open the edit-collection modal (manage a collection's chapters + danger zone)

--- a/src/composables/audio-reader/upload-lesson-modal.ts
+++ b/src/composables/audio-reader/upload-lesson-modal.ts
@@ -1,11 +1,8 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-import type { UploadLessonResponse } from '@/components/modals/upload-lesson/index.vue'
-
-const UploadLesson = defineAsyncComponent(
-  () => import('@/components/modals/upload-lesson/index.vue')
-)
+import UploadLesson, {
+  type UploadLessonResponse
+} from '@/components/modals/upload-lesson/index.vue'
 
 /**
  * Open the upload-lesson modal for a collection. Resolves to the created

--- a/src/composables/deck/create-modal.ts
+++ b/src/composables/deck/create-modal.ts
@@ -1,9 +1,6 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-import type { DeckCreateResponse } from '@/components/modals/deck-create/index.vue'
-
-const DeckCreate = defineAsyncComponent(() => import('@/components/modals/deck-create/index.vue'))
+import DeckCreate, { type DeckCreateResponse } from '@/components/modals/deck-create/index.vue'
 
 /** Open the create-deck modal. Resolves true when the deck was saved. */
 export function useDeckCreateModal() {

--- a/src/composables/deck/settings-modal.ts
+++ b/src/composables/deck/settings-modal.ts
@@ -1,11 +1,9 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-import type { ActiveTab, DeckSettingsResponse } from '@/components/modals/deck-settings/index.vue'
-
-const DeckSettings = defineAsyncComponent(
-  () => import('@/components/modals/deck-settings/index.vue')
-)
+import DeckSettings, {
+  type ActiveTab,
+  type DeckSettingsResponse
+} from '@/components/modals/deck-settings/index.vue'
 
 type OpenOptions = {
   tab?: ActiveTab

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,12 +4,12 @@ import { useMemberStore } from '@/stores/member'
 import { prefetchMemberDecks } from '@/api/decks'
 import { prefetchMemberById } from '@/api/members'
 import { prefetchPlanLimits } from '@/api/plans'
-import WelcomeView from '@/views/welcome/index.vue'
 import AuthenticatedView from '@/views/authenticated.vue'
-import PrivacyPolicyView from '@/views/privacy-policy.vue'
-import TermsOfServiceView from '@/views/terms-of-service.vue'
-import AuthCallbackView from '@/views/auth/callback.vue'
 
+const WelcomeView = () => import('@/views/welcome/index.vue')
+const PrivacyPolicyView = () => import('@/views/privacy-policy.vue')
+const TermsOfServiceView = () => import('@/views/terms-of-service.vue')
+const AuthCallbackView = () => import('@/views/auth/callback.vue')
 const Dashboard = () => import('@/views/dashboard/index.vue')
 const DeckView = () => import('@/views/deck/index.vue')
 const LessonView = () => import('@/views/audio-reader/lesson/index.vue')

--- a/src/utils/animations/warmup.ts
+++ b/src/utils/animations/warmup.ts
@@ -1,12 +1,5 @@
 import { gsap } from 'gsap'
 
-type IdleCallback = (cb: () => void) => void
-
-const scheduleIdle: IdleCallback =
-  typeof window !== 'undefined' && 'requestIdleCallback' in window
-    ? (cb) => (window as any).requestIdleCallback(cb, { timeout: 2000 })
-    : (cb) => setTimeout(cb, 500)
-
 export function warmupAnimations() {
   gsap.to({ _: 0 }, { _: 1, duration: 0, ease: 'expo.out' })
   gsap.to({ _: 0 }, { _: 1, duration: 0, ease: 'back.out(1.7)' })
@@ -30,10 +23,5 @@ export function warmupAnimations() {
 
   requestAnimationFrame(() => {
     requestAnimationFrame(() => el.remove())
-  })
-
-  scheduleIdle(() => {
-    void import('@/components/study-session/index.vue')
-    void import('@/components/modals/deck-settings/index.vue')
   })
 }

--- a/src/views/deck/index.vue
+++ b/src/views/deck/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, provide, ref, useTemplateRef } from 'vue'
+import { computed, provide, ref, useTemplateRef } from 'vue'
 import DeckHero from '@/views/deck/deck-hero/index.vue'
 import DeckSkeleton from './skeleton.vue'
 import ModeToolbar from './mode-toolbar/index.vue'
@@ -7,7 +7,6 @@ import ModeToolbarSkeleton from './mode-toolbar/skeleton.vue'
 import ModeStack from './mode-stack.vue'
 import CardGridSkeleton from './card-grid/skeleton.vue'
 import CardGridEmpty from './card-grid/empty-state.vue'
-import { preloadDeckModes } from './modes'
 import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
 import DeckMobileFooter from './mobile-footer/index.vue'
 import { useDeckQuery } from '@/api/decks'
@@ -59,8 +58,6 @@ const view_state = computed<'loading' | 'empty' | 'ready'>(() => {
 })
 
 const show_skeleton = computed(() => !deck.value)
-
-onMounted(preloadDeckModes)
 </script>
 
 <template>

--- a/src/views/deck/modes.ts
+++ b/src/views/deck/modes.ts
@@ -1,35 +1,24 @@
-import { defineAsyncComponent, type Component } from 'vue'
+import type { Component } from 'vue'
 import CardGrid from './card-grid/scroll-grid.vue'
+import CardEditor from './card-editor/index.vue'
+import CardImporter from './card-importer.vue'
 
 type DeckModeConfig = {
   pane: Component
 }
 
-const loadCardEditor = () => import('./card-editor/index.vue')
-const loadCardImporter = () => import('./card-importer.vue')
-
 // Single source of truth for the deck view's modes. Adding a mode = write the
 // pane component + one entry here; `satisfies` keeps the registry and the
-// `CardEditorMode` union in sync both ways. The base `view` pane stays mounted
-// across switches (it preserves grid scroll/pages), so it's imported eagerly;
-// overlay panes lazy-load out of the deck view's chunk.
+// `CardEditorMode` union in sync both ways. All panes bundle into the deck
+// view's own route chunk.
 export const DECK_MODES = {
   view: {
     pane: CardGrid
   },
   edit: {
-    pane: defineAsyncComponent(loadCardEditor)
+    pane: CardEditor
   },
   'import-export': {
-    pane: defineAsyncComponent(loadCardImporter)
+    pane: CardImporter
   }
 } satisfies Record<CardEditorMode, DeckModeConfig>
-
-/**
- * Warm the lazy overlay chunks so the first mode switch animates immediately
- * instead of waiting on the network. Call once when the deck view mounts.
- */
-export function preloadDeckModes() {
-  loadCardEditor()
-  loadCardImporter()
-}

--- a/src/views/welcome/forgot-password/forgot-password-modal.ts
+++ b/src/views/welcome/forgot-password/forgot-password-modal.ts
@@ -1,7 +1,5 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
-
-const ForgotPasswordModal = defineAsyncComponent(() => import('./index.vue'))
+import ForgotPasswordModal from './index.vue'
 
 /** Opens the forgot-password request modal. */
 export function useForgotPasswordModal() {

--- a/src/views/welcome/login/login-modal.ts
+++ b/src/views/welcome/login/login-modal.ts
@@ -1,8 +1,6 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-
-const LoginSheet = defineAsyncComponent(() => import('./sheet.vue'))
+import LoginSheet from './sheet.vue'
 
 /** Opens the login dialog as a mobile sheet on small viewports. */
 export function useLoginModal() {

--- a/src/views/welcome/reset-password/reset-password-modal.ts
+++ b/src/views/welcome/reset-password/reset-password-modal.ts
@@ -1,7 +1,5 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
-
-const ResetPasswordModal = defineAsyncComponent(() => import('./index.vue'))
+import ResetPasswordModal from './index.vue'
 
 /** Opens the post-recovery reset-password modal. */
 export function useResetPasswordModal() {

--- a/src/views/welcome/signup/signup-modal.ts
+++ b/src/views/welcome/signup/signup-modal.ts
@@ -1,8 +1,6 @@
-import { defineAsyncComponent } from 'vue'
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-
-const SignupDialog = defineAsyncComponent(() => import('./index.vue'))
+import SignupDialog from './index.vue'
 
 /** Opens the sign-up modal as a mobile sheet on small viewports. */
 export function useSignupModal() {

--- a/tests/integration/components/modals/deck-settings/index.test.js
+++ b/tests/integration/components/modals/deck-settings/index.test.js
@@ -158,6 +158,51 @@ vi.mock('@/components/modals/deck-settings/tab-danger-zone/index.vue', async () 
   }
 })
 
+// The remaining tabs (index/details/design/study) are now statically bundled
+// too — module-mock each so their real setup() (deep editor/i18n context we
+// don't provide here) never runs. Their own logic is covered in their
+// dedicated test files (tab-design/index.test.js, tab-study.test.js, ...).
+function makeTabContentMock(testid) {
+  return async () => {
+    const { defineComponent, h } = await import('vue')
+    return {
+      default: defineComponent({
+        emits: ['navigate'],
+        setup(_props, { emit }) {
+          return () =>
+            h('div', { 'data-testid': testid }, [
+              h(
+                'button',
+                {
+                  'data-testid': 'tab-content__navigate',
+                  onClick: () => emit('navigate', 'study')
+                },
+                'navigate'
+              )
+            ])
+        }
+      })
+    }
+  }
+}
+
+vi.mock(
+  '@/components/modals/deck-settings/tab-index/index.vue',
+  makeTabContentMock('tab-index-stub')
+)
+vi.mock(
+  '@/components/modals/deck-settings/tab-details/index.vue',
+  makeTabContentMock('tab-details-stub')
+)
+vi.mock(
+  '@/components/modals/deck-settings/tab-design/index.vue',
+  makeTabContentMock('tab-content-stub')
+)
+vi.mock(
+  '@/components/modals/deck-settings/tab-study/index.vue',
+  makeTabContentMock('tab-content-stub')
+)
+
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
 const TabSheetStub = defineComponent({
@@ -551,34 +596,6 @@ describe('DeckSettings — overlay actions', () => {
     await wrapper.find('[data-testid="tab-sheet__close-emit"]').trigger('click')
 
     expect(close).toHaveBeenCalledWith(false)
-  })
-
-  test('mounts under requestIdleCallback fallback (setTimeout) without throwing', async () => {
-    const originalIdle = window.requestIdleCallback
-    // drop rIC to force the setTimeout fallback path in onMounted
-    window.requestIdleCallback = undefined
-
-    expect(() => makeWrapper()).not.toThrow()
-    await flushPromises()
-
-    window.requestIdleCallback = originalIdle
-  })
-
-  test('mounts and fires the idle prefetch callback', async () => {
-    const idleSpy = vi.fn((cb) => {
-      cb({ didTimeout: false, timeRemaining: () => 50 })
-      return 0
-    })
-    const originalIdle = window.requestIdleCallback
-    window.requestIdleCallback = idleSpy
-
-    makeWrapper()
-    await flushPromises()
-
-    expect(idleSpy).toHaveBeenCalledTimes(1)
-    expect(idleSpy.mock.calls[0][0]).toBeTypeOf('function')
-
-    window.requestIdleCallback = originalIdle
   })
 })
 

--- a/tests/integration/components/settings/index.test.js
+++ b/tests/integration/components/settings/index.test.js
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent, h, inject, nextTick, useAttrs } from 'vue'
-import { settingsRecedeKey, SETTINGS_SHEET_BREAKPOINTS } from '@/components/settings/layout'
+import { defineComponent, h, nextTick, useAttrs } from 'vue'
+import { SETTINGS_SHEET_BREAKPOINTS } from '@/components/settings/layout'
 import { useMatchMedia } from '@/composables/ui/media-query'
 
 // ── Hoisted state ─────────────────────────────────────────────────────────────
@@ -113,6 +113,86 @@ vi.mock('@/components/settings/tab-index/index.vue', async () => {
   }
 })
 
+// The rest of the tabs are now statically imported (no defineAsyncComponent
+// boundary to shield the test from their real setup()), so each one that
+// needs real Pinia/editor context we don't provide here gets a lightweight
+// stand-in. Their own business logic is covered in their dedicated test files
+// (tab-profile.test.js, tab-subscription.test.js, etc.) — this file only
+// exercises SettingsApp's own routing/chrome/provide wiring.
+vi.mock('@/components/settings/tab-profile/index.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'TabProfile',
+      setup: () => () => h('div', { 'data-testid': 'tab-profile-stub' })
+    })
+  }
+})
+
+vi.mock('@/components/settings/tab-app/index.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'TabApp',
+      setup: () => () => h('div', { 'data-testid': 'tab-app-stub' })
+    })
+  }
+})
+
+vi.mock('@/components/settings/tab-review-preferences/index.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'TabReviewPreferences',
+      setup: () => () => h('div', { 'data-testid': 'tab-review-preferences-stub' })
+    })
+  }
+})
+
+vi.mock('@/components/settings/tab-danger-zone/index.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'TabDangerZone',
+      setup: () => () => h('div', { 'data-testid': 'tab-danger-zone-stub' })
+    })
+  }
+})
+
+// TabSubscription doubles as the recede/restore inject probe below — it
+// exposes the same recede-trigger/restore-trigger buttons the dedicated
+// InjectRecedeStub used to provide via global.stubs.
+vi.mock('@/components/settings/tab-subscription/index.vue', async () => {
+  const { defineComponent, h, inject } = await import('vue')
+  const { settingsRecedeKey } = await import('@/components/settings/layout')
+  return {
+    default: defineComponent({
+      name: 'TabSubscription',
+      setup() {
+        const recede = inject(settingsRecedeKey)
+        return () =>
+          h('div', { 'data-testid': 'tab-subscription-stub' }, [
+            h('button', { 'data-testid': 'recede-trigger', onClick: () => recede?.recede() }),
+            h('button', { 'data-testid': 'restore-trigger', onClick: () => recede?.restore() })
+          ])
+      }
+    })
+  }
+})
+
+vi.mock('@/components/settings/tab-account-access/index.vue', async () => {
+  const { defineComponent, h } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'TabAccountAccess',
+      setup(_p, { expose }) {
+        expose({ onChromeBack: mockAccountAccessOnChromeBack })
+        return () => h('div', { 'data-testid': 'tab-account-access-stub' })
+      }
+    })
+  }
+})
+
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
 
 vi.mock('@/utils/animations/fade', () => ({
@@ -144,32 +224,6 @@ const PassthroughStub = defineComponent({
   setup(_p, { slots }) {
     const attrs = useAttrs()
     return () => h('div', { ...attrs }, slots.default?.())
-  }
-})
-
-const TabIndexStub = defineComponent({
-  name: 'TabIndex',
-  emits: ['navigate'],
-  setup(_p, { emit }) {
-    return () =>
-      h(
-        'button',
-        {
-          'data-testid': 'tab-index-stub',
-          onClick: () => emit('navigate', 'app')
-        },
-        'go'
-      )
-  }
-})
-
-// Exposes a controllable onChromeBack so onChromeBack delegation tests can
-// assert the "tab handled it" (true) and "tab didn't handle it" (false) paths.
-const TabAccountAccessStub = defineComponent({
-  name: 'TabAccountAccess',
-  setup(_p, { expose }) {
-    expose({ onChromeBack: mockAccountAccessOnChromeBack })
-    return () => h('div', { 'data-testid': 'tab-account-access-stub' })
   }
 })
 
@@ -243,18 +297,6 @@ const TabSheetStub = defineComponent({
 
 import SettingsApp from '@/components/settings/index.vue'
 
-const InjectRecedeStub = defineComponent({
-  name: 'InjectRecedeStub',
-  setup() {
-    const recede = inject(settingsRecedeKey)
-    return () =>
-      h('div', [
-        h('button', { 'data-testid': 'recede-trigger', onClick: () => recede?.recede() }),
-        h('button', { 'data-testid': 'restore-trigger', onClick: () => recede?.restore() })
-      ])
-  }
-})
-
 // ── Factory ───────────────────────────────────────────────────────────────────
 
 function makeWrapper(closeFn = vi.fn()) {
@@ -263,14 +305,6 @@ function makeWrapper(closeFn = vi.fn()) {
     global: {
       stubs: {
         TabSheet: TabSheetStub,
-        TabIndex: TabIndexStub,
-        TabProfile: PassthroughStub,
-        TabSubscription: PassthroughStub,
-        TabSounds: PassthroughStub,
-        TabApp: PassthroughStub,
-        TabReviewPreferences: PassthroughStub,
-        TabDangerZone: PassthroughStub,
-        TabAccountAccess: TabAccountAccessStub,
         SettingsAside: PassthroughStub,
         SettingsSaveButton: PassthroughStub,
         MemberCard: PassthroughStub,
@@ -661,34 +695,9 @@ describe('settings app — open/close sfx [obligation]', () => {
 // ── Recede/restore provide wiring ───────────────────────────────────────────────
 
 describe('settings app — recede/restore choreography [obligation]', () => {
-  function makeWrapperWithRecedeInjector(closeFn = vi.fn()) {
-    return mount(SettingsApp, {
-      props: { close: closeFn },
-      global: {
-        stubs: {
-          TabSheet: TabSheetStub,
-          TabIndex: TabIndexStub,
-          TabProfile: PassthroughStub,
-          TabSubscription: InjectRecedeStub,
-          TabSounds: PassthroughStub,
-          TabApp: PassthroughStub,
-          TabReviewPreferences: PassthroughStub,
-          TabDangerZone: PassthroughStub,
-          TabAccountAccess: TabAccountAccessStub,
-          SettingsAside: PassthroughStub,
-          SettingsSaveButton: PassthroughStub,
-          MemberCard: PassthroughStub,
-          UiButton: PassthroughStub,
-          UiTagButton: PassthroughStub,
-          UiIcon: PassthroughStub
-        }
-      }
-    })
-  }
-
   test('provides recede() calling recedeModal on the tab-sheet root element', async () => {
     mockRecedeModal.mockClear()
-    const wrapper = makeWrapperWithRecedeInjector()
+    const wrapper = makeWrapper()
     await wrapper.find('[data-testid="tab-sheet__select-subscription"]').trigger('click')
     await flushPromises()
 
@@ -699,7 +708,7 @@ describe('settings app — recede/restore choreography [obligation]', () => {
 
   test('provides restore() calling restoreModal on the tab-sheet root element', async () => {
     mockRestoreModal.mockClear()
-    const wrapper = makeWrapperWithRecedeInjector()
+    const wrapper = makeWrapper()
     await wrapper.find('[data-testid="tab-sheet__select-subscription"]').trigger('click')
     await flushPromises()
 
@@ -716,7 +725,7 @@ describe('settings app — recede/restore choreography [obligation]', () => {
     state.isPinned = true
     mockRecedeModal.mockClear()
 
-    const wrapper = makeWrapperWithRecedeInjector()
+    const wrapper = makeWrapper()
     await wrapper.find('[data-testid="tab-sheet__select-subscription"]').trigger('click')
     await flushPromises()
     await wrapper.find('[data-testid="recede-trigger"]').trigger('click')
@@ -730,7 +739,7 @@ describe('settings app — recede/restore choreography [obligation]', () => {
     state.isPinned = false
     mockRecedeModal.mockClear()
 
-    const wrapper = makeWrapperWithRecedeInjector()
+    const wrapper = makeWrapper()
     await wrapper.find('[data-testid="tab-sheet__select-subscription"]').trigger('click')
     await flushPromises()
     await wrapper.find('[data-testid="recede-trigger"]').trigger('click')

--- a/tests/integration/views/deck/index.test.js
+++ b/tests/integration/views/deck/index.test.js
@@ -17,12 +17,18 @@ const {
 }))
 
 // card-face-uploader (reached statically via mode-stack → list-item-card) now
-// imports useCan, which pulls useMemberDeckCountQuery from this barrel — so the
-// mock must expose it too, or ESM linking of the graph fails.
+// imports useCan, which pulls useMemberDeckCountQuery from this barrel. The
+// edit/import-export panes (mode-stack → modes.ts) are also statically bundled
+// now (no more defineAsyncComponent boundary), so their own deck/actions and
+// deck/editor composables pull useUpsertDeckMutation and useDeleteDeckMutation
+// from this same barrel too — the mock must expose all of it or ESM linking of
+// the graph fails.
 vi.mock('@/api/decks', () => ({
   useDeckQuery: useDeckQueryMock,
   useMemberDeckCountQuery: () => ({ data: { value: 0 }, refresh: vi.fn() }),
-  useMemberDecksQuery: () => ({ data: { value: [] }, refresh: vi.fn() })
+  useMemberDecksQuery: () => ({ data: { value: [] }, refresh: vi.fn() }),
+  useUpsertDeckMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+  useDeleteDeckMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() })
 }))
 vi.mock('@/views/deck/composables/list-controller', () => ({
   cardEditorKey: Symbol('cardEditor'),

--- a/tests/integration/views/deck/mode-stack.test.js
+++ b/tests/integration/views/deck/mode-stack.test.js
@@ -14,8 +14,8 @@ vi.mock('@/utils/animations/deck-view/card-overlay', () => ({
   cancelOverlayAnimation: vi.fn()
 }))
 
-// Panes in DECK_MODES use defineAsyncComponent; mock the whole registry with
-// synchronous stubs so shallowMount can find them by name immediately.
+// Panes in DECK_MODES are plain synchronous components; mock the whole
+// registry with synchronous stubs so shallowMount can find them by name.
 vi.mock('@/views/deck/modes.ts', async () => {
   const { defineComponent, h } = await import('vue')
   const makePane = (name, testid) =>
@@ -28,8 +28,7 @@ vi.mock('@/views/deck/modes.ts', async () => {
       view: { pane: CardGrid },
       edit: { pane: CardEditor },
       'import-export': { pane: CardImporter }
-    },
-    preloadDeckModes: () => {}
+    }
   }
 })
 

--- a/tests/integration/views/deck/modes.test.js
+++ b/tests/integration/views/deck/modes.test.js
@@ -1,8 +1,8 @@
 import { describe, test, expect, vi } from 'vite-plus/test'
-import { DECK_MODES, preloadDeckModes } from '@/views/deck/modes'
+import { DECK_MODES } from '@/views/deck/modes'
 
-// Lazy pane imports inside DECK_MODES use defineAsyncComponent — mock them so
-// the test environment doesn't need the full component graphs.
+// Pane imports inside DECK_MODES are plain synchronous components — mock them
+// so the test environment doesn't need the full component graphs.
 vi.mock('@/views/deck/card-grid/scroll-grid.vue', () => ({
   default: { name: 'CardGrid' }
 }))
@@ -24,11 +24,5 @@ describe('DECK_MODES registry', () => {
     for (const config of Object.values(DECK_MODES)) {
       expect(config.pane).toBeDefined()
     }
-  })
-})
-
-describe('preloadDeckModes', () => {
-  test('is callable without throwing', () => {
-    expect(() => preloadDeckModes()).not.toThrow()
   })
 })

--- a/tests/unit/composables/signup-modal.test.js
+++ b/tests/unit/composables/signup-modal.test.js
@@ -17,11 +17,8 @@ vi.mock('@/composables/modal', () => ({
   useModal: vi.fn(() => ({ open: mockOpen }))
 }))
 
-// SignupDialog is wrapped in defineAsyncComponent inside the composable —
-// assert on the async component wrapper shape rather than the raw .vue import.
-const asyncComponentMatcher = expect.objectContaining({ __asyncLoader: expect.any(Function) })
-
 import { useSignupModal } from '@/views/welcome/signup/signup-modal'
+import SignupDialog from '@/views/welcome/signup/index.vue'
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -71,7 +68,7 @@ describe('useSignupModal', () => {
     useSignupModal().open()
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      SignupDialog,
       expect.objectContaining({ mode: 'mobile-sheet' })
     )
   })
@@ -83,7 +80,7 @@ describe('useSignupModal', () => {
     useSignupModal().open()
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      SignupDialog,
       expect.objectContaining({ mobile_below_width: 'sm' })
     )
   })
@@ -94,10 +91,7 @@ describe('useSignupModal', () => {
 
     useSignupModal().open()
 
-    expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
-      expect.objectContaining({ backdrop: true })
-    )
+    expect(mockOpen).toHaveBeenCalledWith(SignupDialog, expect.objectContaining({ backdrop: true }))
   })
 
   test('passes payment prop through to the modal [obligation]', () => {
@@ -107,7 +101,7 @@ describe('useSignupModal', () => {
     useSignupModal().open(true)
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      SignupDialog,
       expect.objectContaining({ props: { payment: true } })
     )
   })
@@ -119,7 +113,7 @@ describe('useSignupModal', () => {
     useSignupModal().open()
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      SignupDialog,
       expect.objectContaining({ props: { payment: undefined } })
     )
   })

--- a/tests/unit/composables/use-deck-create-modal.test.js
+++ b/tests/unit/composables/use-deck-create-modal.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { flushPromises } from '@vue/test-utils'
 import { useDeckCreateModal } from '@/composables/deck/create-modal'
+import DeckCreate from '@/components/modals/deck-create/index.vue'
 
 const { mockEmitSfx, mockOpen } = vi.hoisted(() => ({
   mockEmitSfx: vi.fn(),
@@ -11,8 +12,6 @@ vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
 vi.mock('@/composables/modal', () => ({
   useModal: vi.fn(() => ({ open: mockOpen }))
 }))
-
-const asyncComponentMatcher = expect.objectContaining({ __asyncLoader: expect.any(Function) })
 
 function makeModalResult(value) {
   return { response: Promise.resolve(value) }
@@ -29,7 +28,7 @@ describe('useDeckCreateModal', () => {
 
     useDeckCreateModal().open()
 
-    expect(mockOpen).toHaveBeenCalledWith(asyncComponentMatcher, {
+    expect(mockOpen).toHaveBeenCalledWith(DeckCreate, {
       backdrop: true,
       mode: 'mobile-sheet',
       mobile_below_width: 'md',

--- a/tests/unit/composables/use-deck-settings-modal.test.js
+++ b/tests/unit/composables/use-deck-settings-modal.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { flushPromises } from '@vue/test-utils'
 import { useDeckSettingsModal } from '@/composables/deck/settings-modal'
+import DeckSettings from '@/components/modals/deck-settings/index.vue'
 
 const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
 const { mockOpen } = vi.hoisted(() => ({ mockOpen: vi.fn() }))
@@ -10,10 +11,6 @@ vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
 vi.mock('@/composables/modal', () => ({
   useModal: vi.fn(() => ({ open: mockOpen }))
 }))
-
-// DeckSettings is wrapped with defineAsyncComponent inside the composable, so
-// the component identity doesn't match the raw .vue import. Assert on shape.
-const asyncComponentMatcher = expect.objectContaining({ __asyncLoader: expect.any(Function) })
 
 function makeModalResult(value) {
   return { response: Promise.resolve(value) }
@@ -41,7 +38,7 @@ describe('useDeckSettingsModal', () => {
     const { open } = useDeckSettingsModal()
     open(deck)
 
-    expect(mockOpen).toHaveBeenCalledWith(asyncComponentMatcher, {
+    expect(mockOpen).toHaveBeenCalledWith(DeckSettings, {
       backdrop: true,
       mode: 'mobile-sheet',
       mobile_below_width: 'md',
@@ -58,7 +55,7 @@ describe('useDeckSettingsModal', () => {
     open(deck, { tab: 'design', side: 'front' })
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      DeckSettings,
       expect.objectContaining({
         props: expect.objectContaining({ initial_tab: 'design', initial_side: 'front' })
       })
@@ -73,7 +70,7 @@ describe('useDeckSettingsModal', () => {
     open(deck)
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      DeckSettings,
       expect.objectContaining({
         props: expect.objectContaining({ initial_tab: undefined, initial_side: undefined })
       })
@@ -88,7 +85,7 @@ describe('useDeckSettingsModal', () => {
     open(deck, { tab: 'study' })
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      DeckSettings,
       expect.objectContaining({
         props: expect.objectContaining({ initial_tab: 'study', initial_side: undefined })
       })

--- a/tests/unit/composables/use-study-modal.test.js
+++ b/tests/unit/composables/use-study-modal.test.js
@@ -1,11 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { flushPromises } from '@vue/test-utils'
 import { useStudyModal } from '@/components/study-session/composables/study-modal'
-
-// StudySession is wrapped with defineAsyncComponent inside the composable, so
-// the component identity doesn't match the raw .vue import. We assert on the
-// wrapper object shape instead.
-const asyncComponentMatcher = expect.objectContaining({ __asyncLoader: expect.any(Function) })
+import StudySession from '@/components/study-session/index.vue'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
@@ -67,7 +63,7 @@ describe('useStudyModal', () => {
     const { start } = useStudyModal()
     const startPromise = start(DECKS)
 
-    expect(mockOpen).toHaveBeenCalledWith(asyncComponentMatcher, {
+    expect(mockOpen).toHaveBeenCalledWith(StudySession, {
       backdrop: true,
       mode: 'popup',
       props: { decks: DECKS, config_override: undefined }
@@ -85,7 +81,7 @@ describe('useStudyModal', () => {
     const startPromise = start(MULTI_DECKS)
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      StudySession,
       expect.objectContaining({ props: { decks: MULTI_DECKS, config_override: undefined } })
     )
 

--- a/tests/unit/utils/animations/warmup.test.js
+++ b/tests/unit/utils/animations/warmup.test.js
@@ -4,12 +4,6 @@ const { mockGsapTo } = vi.hoisted(() => ({ mockGsapTo: vi.fn() }))
 
 vi.mock('gsap', () => ({ gsap: { to: mockGsapTo } }))
 
-// Stub out dynamic imports performed on idle so the real modal modules aren't
-// pulled into the jsdom runtime during this unit test.
-vi.mock('@/components/study-session/index.vue', () => ({ default: {} }))
-vi.mock('@/components/study-session/session-summary/index.vue', () => ({ default: {} }))
-vi.mock('@/components/modals/deck-settings/index.vue', () => ({ default: {} }))
-
 import { warmupAnimations } from '@/utils/animations/warmup'
 
 describe('warmupAnimations', () => {
@@ -39,6 +33,7 @@ describe('warmupAnimations', () => {
   afterEach(() => {
     rafSpy.mockRestore()
     idleSpy?.mockRestore()
+    idleSpy = undefined
   })
 
   test('runs gsap priming tweens for the eases used by modal animations', () => {
@@ -79,11 +74,11 @@ describe('warmupAnimations', () => {
     expect(findProbes()).toHaveLength(0)
   })
 
-  test('schedules a preload pass via requestIdleCallback when available', () => {
+  test('does not schedule any idle preload pass', () => {
     if (!idleSpy) return
 
     warmupAnimations()
 
-    expect(idleSpy).toHaveBeenCalled()
+    expect(idleSpy).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/views/welcome/forgot-password-modal.test.js
+++ b/tests/unit/views/welcome/forgot-password-modal.test.js
@@ -1,15 +1,12 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { useForgotPasswordModal } from '@/views/welcome/forgot-password/forgot-password-modal'
+import ForgotPasswordModal from '@/views/welcome/forgot-password/index.vue'
 
 const { mockOpen } = vi.hoisted(() => ({ mockOpen: vi.fn() }))
 
 vi.mock('@/composables/modal', () => ({
   useModal: vi.fn(() => ({ open: mockOpen }))
 }))
-
-// ForgotPasswordModal is wrapped in defineAsyncComponent inside the composable —
-// assert on the async component wrapper shape rather than the raw .vue import.
-const asyncComponentMatcher = expect.objectContaining({ __asyncLoader: expect.any(Function) })
 
 describe('useForgotPasswordModal — call shape', () => {
   beforeEach(() => {
@@ -22,7 +19,7 @@ describe('useForgotPasswordModal — call shape', () => {
     const { open } = useForgotPasswordModal()
     open()
 
-    expect(mockOpen).toHaveBeenCalledWith(asyncComponentMatcher, {
+    expect(mockOpen).toHaveBeenCalledWith(ForgotPasswordModal, {
       backdrop: true,
       mode: 'popup'
     })

--- a/tests/unit/views/welcome/login-modal.test.js
+++ b/tests/unit/views/welcome/login-modal.test.js
@@ -17,11 +17,8 @@ vi.mock('@/composables/modal', () => ({
   useModal: vi.fn(() => ({ open: mockOpen }))
 }))
 
-// LoginSheet is wrapped in defineAsyncComponent inside the composable —
-// assert on the async component wrapper shape rather than the raw .vue import.
-const asyncComponentMatcher = expect.objectContaining({ __asyncLoader: expect.any(Function) })
-
 import { useLoginModal } from '@/views/welcome/login/login-modal'
+import LoginSheet from '@/views/welcome/login/sheet.vue'
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -84,7 +81,7 @@ describe('useLoginModal', () => {
     useLoginModal().open()
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      LoginSheet,
       expect.objectContaining({ mode: 'mobile-sheet' })
     )
   })
@@ -96,7 +93,7 @@ describe('useLoginModal', () => {
     useLoginModal().open()
 
     expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
+      LoginSheet,
       expect.objectContaining({ mobile_below_width: 'md' })
     )
   })
@@ -107,10 +104,7 @@ describe('useLoginModal', () => {
 
     useLoginModal().open()
 
-    expect(mockOpen).toHaveBeenCalledWith(
-      asyncComponentMatcher,
-      expect.objectContaining({ backdrop: true })
-    )
+    expect(mockOpen).toHaveBeenCalledWith(LoginSheet, expect.objectContaining({ backdrop: true }))
   })
 
   test('returns the modal result from open', () => {

--- a/tests/unit/views/welcome/reset-password-modal.test.js
+++ b/tests/unit/views/welcome/reset-password-modal.test.js
@@ -1,15 +1,12 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { useResetPasswordModal } from '@/views/welcome/reset-password/reset-password-modal'
+import ResetPasswordModal from '@/views/welcome/reset-password/index.vue'
 
 const { mockOpen } = vi.hoisted(() => ({ mockOpen: vi.fn() }))
 
 vi.mock('@/composables/modal', () => ({
   useModal: vi.fn(() => ({ open: mockOpen }))
 }))
-
-// ResetPasswordModal is wrapped in defineAsyncComponent inside the composable —
-// assert on the async component wrapper shape rather than the raw .vue import.
-const asyncComponentMatcher = expect.objectContaining({ __asyncLoader: expect.any(Function) })
 
 describe('useResetPasswordModal — call shape', () => {
   beforeEach(() => {
@@ -22,7 +19,7 @@ describe('useResetPasswordModal — call shape', () => {
     const { open } = useResetPasswordModal()
     open()
 
-    expect(mockOpen).toHaveBeenCalledWith(asyncComponentMatcher, {
+    expect(mockOpen).toHaveBeenCalledWith(ResetPasswordModal, {
       backdrop: true,
       mode: 'popup'
     })


### PR DESCRIPTION
## Summary

Only routes lazy-load now; everything a route needs (modals, tab panels, editor/importer panes) bundles statically into that route's chunk instead of splitting further. Also lazy-loads the remaining static routes (welcome, privacy, terms, auth-callback) for consistency, and removes idle-preload code left dangling by the collapse.

## Changes

- Lazy-load `welcome`, `privacy-policy`, `terms-of-service`, `auth-callback` routes in the router (previously eager)
- Collapse `defineAsyncComponent`/dynamic-import call sites back to static imports: modal launchers, settings/deck-settings tab panels, deck editor/importer panes
- Remove now-dead idle-preload scheduling (`warmupAnimations`, deck-settings/settings idle callbacks, `preloadDeckModes`) that warmed chunks no longer split out
- Fix disabled deck-item background contrast in the move-cards modal (unrelated drive-by)
- Update tests for the async→static collapse (removed assertions on deleted idle-preload/async-resolution behavior)