### PR TITLE
Fix sound effects going silent after iOS app-switch

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,7 +78,9 @@ onMounted(() => {
     audio_player
       .setup()
       .then(() => {
-        teardownAudioLifecycle = installAudioLifecycle()
+        teardownAudioLifecycle = installAudioLifecycle(() => {
+          notice.warn(t('sfx.background-desync-warning'))
+        })
       })
       .catch((e: any) => logger.error(e.message, e))
   })

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -32,6 +32,7 @@
   "login-dialog.errors.generic": "Something went wrong. Please try again",
   "session.logout-error": "Couldn't log out. Please try again.",
   "member.load-error": "Couldn't load your account",
+  "sfx.background-desync-warning": "Sound effects may have gone quiet after switching apps",
   "member.load-error-sub": "Something went wrong loading your profile.",
   "login-dialog.forgot-password-link": "Forgot password?",
   "forgot-password-modal.heading": "Reset Password",

--- a/src/sfx/engine.ts
+++ b/src/sfx/engine.ts
@@ -14,6 +14,7 @@
 type AudioContextCtor = new () => AudioContext
 
 const RESUME_TIMEOUT_MS = 2000
+const LIVENESS_PROBE_MS = 150
 
 let ctx: AudioContext | undefined
 let unlocked = false
@@ -149,11 +150,16 @@ async function resume(): Promise<boolean> {
 
 // Synchronous unlock for the user gesture. Everything here runs inside the
 // gesture's synchronous turn — iOS ignores audio work that happens after an await.
-function unlock(): void {
+//
+// `force` bypasses the running-state shortcut. iOS can report the context as
+// 'running' after an app-switch while the audio hardware is actually dead —
+// state alone isn't trustworthy on the way back from background, so
+// lifecycle.ts asks for a forced rebuild there regardless of what state claims.
+function unlock(force = false): void {
   const current = ensureContext()
   if (!current) return
 
-  if (current.state === 'running') {
+  if (current.state === 'running' && !force) {
     markUnlocked()
     return
   }
@@ -194,4 +200,29 @@ function state(): AudioContextState | undefined {
   return ctx?.state
 }
 
-export default { decode, play, resume, unlock, onStateChange, onUnlock, isUnlocked, state }
+// Diagnostic only — never gates the unlock decision (lifecycle.ts forces a
+// rebuild unconditionally on background-return regardless of this result).
+// Samples currentTime twice: a context that's actually dead despite reporting
+// 'running' leaves it frozen. Tells us whether iOS's state-lie is still
+// happening after the forced-rebuild fix, since the bug is too intermittent to
+// reproduce on demand.
+async function probeLiveness(): Promise<boolean> {
+  const context = ctx
+  if (!context || context.state !== 'running') return true
+
+  const before = context.currentTime
+  await new Promise((resolve) => setTimeout(resolve, LIVENESS_PROBE_MS))
+  return context.currentTime !== before
+}
+
+export default {
+  decode,
+  play,
+  resume,
+  unlock,
+  onStateChange,
+  onUnlock,
+  isUnlocked,
+  state,
+  probeLiveness
+}

--- a/src/sfx/lifecycle.ts
+++ b/src/sfx/lifecycle.ts
@@ -20,19 +20,42 @@ let gesture_armed = false
 // iOS ignores, so audio stays muted.
 const GESTURE_EVENTS = ['touchend', 'click', 'keydown'] as const
 
+// Calling context.resume() before any user gesture has happened is exactly what
+// autoplay-blocking browsers reject — and Chrome logs a console warning about it
+// natively, even though we handle the rejection. Skip the speculative call
+// until a real gesture is on record; the gesture-armed listener still unlocks
+// on first tap regardless. Unsupported in Safari, where resume() before a
+// gesture was already unreliable — this only removes a call that wasn't doing
+// anything useful there either.
+function hasUserActivation(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    (navigator as unknown as { userActivation?: { hasBeenActive: boolean } }).userActivation
+      ?.hasBeenActive === true
+  )
+}
+
 /**
  * Wires `visibilitychange`, `pageshow`, `focus`, and context `statechange`
  * listeners that resume the engine, plus a one-shot `touchend`/`click`/`keydown`
  * listener that unlocks (and, if needed, rebuilds) the context on the next
  * interaction.
  *
+ * `onSuspectedDesync` fires when a hidden→visible return finds the context
+ * reporting 'running' with a frozen `currentTime` — the state-lie this module
+ * works around. Diagnostic only, so a caller (App.vue) can surface it to a
+ * toast; the recovery itself doesn't wait on or need this.
+ *
  * Returns a teardown function that removes every listener it registered.
  * Calling `installAudioLifecycle` while already installed is a no-op and returns
  * a no-op teardown — the original teardown remains the only way to uninstall.
  */
-export function installAudioLifecycle(): () => void {
+export function installAudioLifecycle(onSuspectedDesync?: () => void): () => void {
   if (installed || typeof window === 'undefined') return () => {}
   installed = true
+
+  let forced_unlock = false
+  let was_hidden = false
 
   // Arm the gesture retry up front whenever the context isn't running, then try
   // an opportunistic resume. Crucially we do NOT gate arming on the resume
@@ -42,8 +65,23 @@ export function installAudioLifecycle(): () => void {
   // armed. The resume is fire-and-forget; the gesture is what we rely on.
   const recover = () => {
     if (engine.state() === 'running') return
-    armGestureRetry()
-    void engine.resume()
+    armGestureRetry(false)
+    if (hasUserActivation()) void engine.resume()
+  }
+
+  // iOS can report the context as 'running' after an app-switch even though the
+  // audio hardware is actually dead — state can't be trusted on the way back
+  // from background. Skip the `state === 'running'` short-circuit entirely: arm
+  // the gesture retry unconditionally and force a full rebuild on the next tap.
+  const recoverFromBackground = () => {
+    armGestureRetry(true)
+    if (hasUserActivation()) void engine.resume()
+    void diagnoseLiveness()
+  }
+
+  const diagnoseLiveness = async () => {
+    const alive = await engine.probeLiveness()
+    if (!alive) onSuspectedDesync?.()
   }
 
   // Synchronous so the unlock's priming source + resume() fire inside the
@@ -52,14 +90,16 @@ export function installAudioLifecycle(): () => void {
   const gestureRecover = () => {
     removeGestureListeners()
     gesture_armed = false
-    engine.unlock()
+    engine.unlock(forced_unlock)
+    forced_unlock = false
   }
 
   // Capture phase, not bubble: handlers like the dropdown caret's `@click.stop`
   // swallow propagation before the event reaches `window` in the bubble phase,
   // so a bubble-phase listener would miss those gestures and leave audio locked.
   // Capture runs window→target first, ahead of any descendant's stopPropagation.
-  const armGestureRetry = () => {
+  const armGestureRetry = (force: boolean) => {
+    if (force) forced_unlock = true
     if (gesture_armed) return
     gesture_armed = true
     for (const ev of GESTURE_EVENTS) {
@@ -74,7 +114,29 @@ export function installAudioLifecycle(): () => void {
   }
 
   const onVisibility = () => {
-    if (document.visibilityState === 'visible') recover()
+    if (document.visibilityState === 'hidden') {
+      was_hidden = true
+      return
+    }
+
+    if (was_hidden) {
+      was_hidden = false
+      recoverFromBackground()
+    } else {
+      recover()
+    }
+  }
+
+  // `persisted` marks a bfcache restore — Safari can serve one after an
+  // app-switch instead of a fresh load, which is the same state-lie risk as
+  // the visibilitychange path above.
+  const onPageShow = (e: PageTransitionEvent) => {
+    if (e.persisted || was_hidden) {
+      was_hidden = false
+      recoverFromBackground()
+    } else {
+      recover()
+    }
   }
 
   // statechange fires the moment iOS interrupts the context — a more direct
@@ -84,7 +146,7 @@ export function installAudioLifecycle(): () => void {
   }
 
   document.addEventListener('visibilitychange', onVisibility)
-  window.addEventListener('pageshow', recover)
+  window.addEventListener('pageshow', onPageShow)
   window.addEventListener('focus', recover)
   const offStateChange = engine.onStateChange(onStateChange)
   const offPointerActivity = trackPointerActivity()
@@ -95,7 +157,7 @@ export function installAudioLifecycle(): () => void {
 
   return () => {
     document.removeEventListener('visibilitychange', onVisibility)
-    window.removeEventListener('pageshow', recover)
+    window.removeEventListener('pageshow', onPageShow)
     window.removeEventListener('focus', recover)
     offStateChange()
     offPointerActivity()

--- a/tests/unit/sfx/engine.test.js
+++ b/tests/unit/sfx/engine.test.js
@@ -166,6 +166,35 @@ describe('unlock() when context is already running', () => {
   })
 })
 
+// ─── unlock(force) — bypasses the running-state shortcut [obligation] ────────
+
+describe('unlock(force) when context is already running [obligation]', () => {
+  let engine
+  let contexts
+
+  beforeEach(async () => {
+    contexts = []
+    // Both calls to the ctor return 'running' — the original + the forced rebuild.
+    installCtor(makeCtorWithContexts(contexts, ['running', 'running']))
+    engine = await loadFreshEngine()
+  })
+
+  test('unlock(true) closes and rebuilds even though state is running', () => {
+    engine.unlock(true)
+
+    const old_ctx = contexts[0]
+    expect(old_ctx.close).toHaveBeenCalledTimes(1)
+    expect(contexts.length).toBe(2)
+  })
+
+  test('unlock(false) (default) does not close or rebuild when running', () => {
+    engine.unlock(false)
+
+    expect(contexts.length).toBe(1)
+    expect(contexts[0].close).not.toHaveBeenCalled()
+  })
+})
+
 // ─── unlock() — rebuild path (context suspended) ─────────────────────────────
 
 describe('unlock() when context is suspended — rebuild path', () => {
@@ -680,6 +709,61 @@ describe('resume() — timeout & clearTimeout [obligation]', () => {
     // context.resume().finally(() => clearTimeout(id)) must have run
     expect(clearTimeoutSpy).toHaveBeenCalled()
     clearTimeoutSpy.mockRestore()
+  })
+})
+
+// ─── probeLiveness() [obligation] ─────────────────────────────────────────────
+
+describe('probeLiveness() [obligation]', () => {
+  test('resolves true immediately when no context exists', async () => {
+    delete window.AudioContext
+    delete window.webkitAudioContext
+    const engine = await loadFreshEngine()
+
+    await expect(engine.probeLiveness()).resolves.toBe(true)
+  })
+
+  test('resolves true immediately when context state is not running', async () => {
+    const contexts = []
+    installCtor(makeCtorWithContexts(contexts, ['suspended', 'suspended']))
+    const engine = await loadFreshEngine()
+    engine.unlock() // ensureContext() creates a suspended context, no rebuild reached running
+
+    await expect(engine.probeLiveness()).resolves.toBe(true)
+  })
+
+  test('resolves false when currentTime is frozen despite state reporting running', async () => {
+    vi.useFakeTimers()
+    const contexts = []
+    installCtor(makeCtorWithContexts(contexts, ['running']))
+    const engine = await loadFreshEngine()
+    engine.unlock() // context already running, no rebuild
+
+    contexts[0].currentTime = 5 // frozen — never advances
+
+    const result = engine.probeLiveness()
+    await vi.advanceTimersByTimeAsync(150)
+
+    await expect(result).resolves.toBe(false)
+    vi.useRealTimers()
+  })
+
+  test('resolves true when currentTime advances during the probe window', async () => {
+    vi.useFakeTimers()
+    const contexts = []
+    installCtor(makeCtorWithContexts(contexts, ['running']))
+    const engine = await loadFreshEngine()
+    engine.unlock()
+
+    let time = 5
+    Object.defineProperty(contexts[0], 'currentTime', { get: () => time })
+
+    const result = engine.probeLiveness()
+    time = 5.5 // hardware advanced during the wait
+    await vi.advanceTimersByTimeAsync(150)
+
+    await expect(result).resolves.toBe(true)
+    vi.useRealTimers()
   })
 })
 

--- a/tests/unit/sfx/lifecycle.test.js
+++ b/tests/unit/sfx/lifecycle.test.js
@@ -13,7 +13,8 @@ const engineMock = {
   }),
   play: vi.fn(),
   decode: vi.fn(),
-  onUnlock: vi.fn()
+  onUnlock: vi.fn(),
+  probeLiveness: vi.fn().mockResolvedValue(true)
 }
 
 vi.mock('@/sfx/engine', () => ({ default: engineMock }))
@@ -31,6 +32,22 @@ function fireVisibility(state) {
   document.dispatchEvent(new Event('visibilitychange'))
 }
 
+function firePageShow(persisted = false) {
+  const event = new Event('pageshow')
+  Object.defineProperty(event, 'persisted', { value: persisted })
+  window.dispatchEvent(event)
+}
+
+// Controls navigator.userActivation.hasBeenActive, the gate on speculative
+// resume() calls. `undefined` simulates a browser/state where no gesture has
+// been recorded yet (or the API is unsupported).
+function setUserActivation(hasBeenActive) {
+  Object.defineProperty(navigator, 'userActivation', {
+    configurable: true,
+    value: hasBeenActive === undefined ? undefined : { hasBeenActive }
+  })
+}
+
 function flushMicrotasks() {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
@@ -46,6 +63,15 @@ describe('installAudioLifecycle', () => {
     engineMock.unlock.mockClear()
     engineMock.state.mockReset().mockReturnValue('suspended')
     engineMock.onStateChange.mockClear()
+    engineMock.probeLiveness.mockReset().mockResolvedValue(true)
+    // Existing tests below assert on the opportunistic resume() call itself,
+    // not the userActivation gate — default to "gesture already happened" so
+    // that behavior is unchanged. The gate gets its own describe block.
+    setUserActivation(true)
+  })
+
+  afterEach(() => {
+    setUserActivation(undefined)
   })
 
   afterEach(() => {
@@ -223,5 +249,171 @@ describe('installAudioLifecycle', () => {
     expect(engineMock.resume).toHaveBeenCalledTimes(1)
     expect(typeof noopTeardown).toBe('function')
     noopTeardown()
+  })
+
+  describe('background recovery (hidden→visible) — unconditional forced unlock [obligation]', () => {
+    test('arms a forced gesture retry even when the engine reports running', async () => {
+      engineMock.state.mockReturnValue('running')
+      const install = await loadLifecycle()
+      teardown = install()
+      await flushMicrotasks()
+
+      fireVisibility('hidden')
+      fireVisibility('visible')
+      await flushMicrotasks()
+
+      window.dispatchEvent(new Event('click'))
+      await flushMicrotasks()
+
+      expect(engineMock.unlock).toHaveBeenCalledWith(true)
+    })
+
+    test('a plain focus event (no prior hide) still takes the old running short-circuit', async () => {
+      engineMock.state.mockReturnValue('running')
+      const install = await loadLifecycle()
+      teardown = install()
+      await flushMicrotasks()
+
+      window.dispatchEvent(new Event('focus'))
+      await flushMicrotasks()
+
+      window.dispatchEvent(new Event('click'))
+      await flushMicrotasks()
+
+      expect(engineMock.unlock).not.toHaveBeenCalled()
+    })
+
+    test('pageshow with event.persisted true triggers the same unconditional forced recovery', async () => {
+      engineMock.state.mockReturnValue('running')
+      const install = await loadLifecycle()
+      teardown = install()
+      await flushMicrotasks()
+
+      firePageShow(true)
+      await flushMicrotasks()
+
+      window.dispatchEvent(new Event('click'))
+      await flushMicrotasks()
+
+      expect(engineMock.unlock).toHaveBeenCalledWith(true)
+    })
+
+    test('the forced flag resets after firing once — the next gesture-armed cycle unlocks unforced', async () => {
+      engineMock.state.mockReturnValue('running')
+      const install = await loadLifecycle()
+      teardown = install()
+      await flushMicrotasks()
+
+      fireVisibility('hidden')
+      fireVisibility('visible')
+      await flushMicrotasks()
+      window.dispatchEvent(new Event('click'))
+      await flushMicrotasks()
+
+      expect(engineMock.unlock).toHaveBeenCalledWith(true)
+      engineMock.unlock.mockClear()
+
+      // A later recovery cycle where the engine is genuinely not running arms
+      // the gesture retry unforced — the consumed flag must not leak forward.
+      engineMock.state.mockReturnValue('suspended')
+      window.dispatchEvent(new Event('focus'))
+      await flushMicrotasks()
+      window.dispatchEvent(new Event('click'))
+      await flushMicrotasks()
+
+      expect(engineMock.unlock).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('navigator.userActivation gate on opportunistic resume() [obligation]', () => {
+    test('does not call resume() when hasBeenActive is false', async () => {
+      setUserActivation(false)
+      const install = await loadLifecycle()
+      teardown = install()
+      await flushMicrotasks()
+
+      expect(engineMock.resume).not.toHaveBeenCalled()
+    })
+
+    test('does not call resume() when userActivation is unsupported (undefined)', async () => {
+      setUserActivation(undefined)
+      const install = await loadLifecycle()
+      teardown = install()
+      await flushMicrotasks()
+
+      expect(engineMock.resume).not.toHaveBeenCalled()
+    })
+
+    test('still calls resume() when hasBeenActive is true', async () => {
+      setUserActivation(true)
+      const install = await loadLifecycle()
+      teardown = install()
+      await flushMicrotasks()
+
+      expect(engineMock.resume).toHaveBeenCalledTimes(1)
+    })
+
+    test('background recovery also skips resume() when hasBeenActive is false', async () => {
+      setUserActivation(false)
+      engineMock.state.mockReturnValue('running')
+      const install = await loadLifecycle()
+      teardown = install()
+      await flushMicrotasks()
+
+      fireVisibility('hidden')
+      fireVisibility('visible')
+      await flushMicrotasks()
+
+      expect(engineMock.resume).not.toHaveBeenCalled()
+    })
+
+    test('background recovery calls resume() when hasBeenActive is true', async () => {
+      setUserActivation(true)
+      engineMock.state.mockReturnValue('running')
+      const install = await loadLifecycle()
+      teardown = install()
+      await flushMicrotasks()
+      engineMock.resume.mockClear()
+
+      fireVisibility('hidden')
+      fireVisibility('visible')
+      await flushMicrotasks()
+
+      expect(engineMock.resume).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('background recovery — probeLiveness diagnostic hook [obligation]', () => {
+    test('fires onSuspectedDesync when probeLiveness resolves false', async () => {
+      engineMock.probeLiveness.mockResolvedValue(false)
+      engineMock.state.mockReturnValue('running')
+      const onSuspectedDesync = vi.fn()
+      const install = await loadLifecycle()
+      teardown = install(onSuspectedDesync)
+      await flushMicrotasks()
+
+      fireVisibility('hidden')
+      fireVisibility('visible')
+      await flushMicrotasks()
+
+      expect(engineMock.probeLiveness).toHaveBeenCalledTimes(1)
+      expect(onSuspectedDesync).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not fire onSuspectedDesync when probeLiveness resolves true', async () => {
+      engineMock.probeLiveness.mockResolvedValue(true)
+      engineMock.state.mockReturnValue('running')
+      const onSuspectedDesync = vi.fn()
+      const install = await loadLifecycle()
+      teardown = install(onSuspectedDesync)
+      await flushMicrotasks()
+
+      fireVisibility('hidden')
+      fireVisibility('visible')
+      await flushMicrotasks()
+
+      expect(engineMock.probeLiveness).toHaveBeenCalledTimes(1)
+      expect(onSuspectedDesync).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
## Summary

iOS Safari can report `AudioContext.state` as `'running'` after backgrounding the PWA and switching back, even though the audio hardware is actually dead — every recovery path trusted that lie and skipped rebuilding, so SFX stayed silently broken until something else forced a fix. This also fixes a recurring "AudioContext was not allowed to start" console warning that fired on every page load.

## Changes

- `src/sfx/engine.ts`: `unlock()` takes a `force` flag that bypasses the `state === 'running'` shortcut and always rebuilds the context; adds a diagnostic `probeLiveness()` that detects a frozen `currentTime` despite a `'running'` state.
- `src/sfx/lifecycle.ts`: a hidden→visible transition or bfcache `pageshow` restore now unconditionally arms a forced rebuild on the next gesture, instead of trusting the reported state. `resume()` is only called opportunistically once `navigator.userActivation.hasBeenActive` is true, which stops the autoplay warning from firing before any user gesture.
- `src/App.vue` / locale: wires an optional diagnostic toast (`sfx.background-desync-warning`) so if the state-lie still occurs in the wild after this fix, it surfaces instead of failing silently.
- Tests covering the forced-rebuild path, the userActivation gate, and the liveness-probe diagnostic (100% line coverage on both touched sfx files).

## Test plan

- [ ] On iPhone (Safari and Chrome), background the PWA, switch to another app, return, and confirm SFX still play on the next tap.
- [ ] Confirm no "AudioContext was not allowed to start" warning on a fresh page load.