### PR TITLE
Mobile card editor opens as a dialog-card modal

### DIFF
--- a/src/components/layout-kit/dialog-card/index.vue
+++ b/src/components/layout-kit/dialog-card/index.vue
@@ -41,6 +41,11 @@ export type DialogCardProps = {
   // that full height, not the space left over after the header. The header
   // then visually floats over the top of the body instead of pushing it down.
   float_header?: boolean
+  // Background utility classes. A dedicated prop rather than a `class`
+  // override so a caller's value replaces the default outright instead of
+  // both landing in the same Tailwind layer, where two conflicting bg-*
+  // utilities race unpredictably.
+  bg_class?: string
 }
 
 const {
@@ -54,7 +59,8 @@ const {
   dialog_px,
   content_max_width,
   content_breakout_max_width,
-  float_header = false
+  float_header = false,
+  bg_class = 'bg-brown-200 dark:bg-grey-800'
 } = defineProps<DialogCardProps>()
 
 const emit = defineEmits<{
@@ -89,6 +95,7 @@ defineExpose({ viewport })
     class="relative flex flex-col gap-4 overflow-hidden [--dialog-px:1.5rem] sm:[--dialog-px:2rem]"
     :class="[
       SIZE_CLASSES[size],
+      bg_class,
       viewport === 'mobile'
         ? 'h-full! w-full! rounded-none!'
         : 'rounded-8 shadow-lg border-t border-l border-brown-100 dark:border-grey-900'

--- a/src/components/modals/change-card/index.vue
+++ b/src/components/modals/change-card/index.vue
@@ -32,7 +32,8 @@ const submit_label = computed(() =>
 <template>
   <dialog-card
     data-testid="change-card-modal"
-    class="bg-brown-100 pb-6 dark:bg-grey-800"
+    class="pb-6"
+    bg_class="bg-brown-100 dark:bg-grey-800"
     size="lg"
     data-theme="brown-300"
     data-theme-dark="stone-700"

--- a/src/components/modals/checkout/index.vue
+++ b/src/components/modals/checkout/index.vue
@@ -21,7 +21,8 @@ const { status, is_ready, onSubmit } = useCheckout(close)
 <template>
   <dialog-card
     data-testid="checkout"
-    class="bg-brown-100 pb-6 dark:bg-grey-800"
+    class="pb-6"
+    bg_class="bg-brown-100 dark:bg-grey-800"
     size="md"
     data-theme="brown-300"
     data-theme-dark="stone-700"

--- a/src/components/modals/move-cards.vue
+++ b/src/components/modals/move-cards.vue
@@ -83,13 +83,7 @@ function onClick(deck_id?: number) {
 </script>
 
 <template>
-  <dialog-card
-    data-testid="move-cards"
-    class="bg-brown-200 dark:bg-stone-900"
-    size="md"
-    :title="title"
-    @close="close(false)"
-  >
+  <dialog-card data-testid="move-cards" size="md" :title="title" @close="close(false)">
     <div data-testid="move-cards__body" class="flex h-full min-h-0 flex-col">
       <div data-testid="move-cards__deck-list-wrap" class="relative flex min-h-0 flex-1 flex-col">
         <grouped-list data-testid="move-cards__deck-list" scrollable class="my-4 min-h-0 flex-1">

--- a/src/components/settings/account-access/index.vue
+++ b/src/components/settings/account-access/index.vue
@@ -20,7 +20,7 @@ onBeforeUnmount(() => emitSfx('pop_up_close'))
 <template>
   <dialog-card
     data-testid="account-access-modal"
-    class="bg-brown-200 dark:bg-grey-800 gap-0!"
+    class="gap-0!"
     size="sm"
     float_header
     data-theme="brown-50"

--- a/src/components/study-session/index.vue
+++ b/src/components/study-session/index.vue
@@ -50,7 +50,8 @@ function onPaneEnterStart() {
 <template>
   <dialog-card
     data-testid="study-session"
-    class="bg-brown-300 dark:bg-grey-800 bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-brown-500"
+    class="bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-brown-500"
+    bg_class="bg-brown-300 dark:bg-grey-800"
     size="lg"
   >
     <template #header>

--- a/src/composables/modal.ts
+++ b/src/composables/modal.ts
@@ -105,7 +105,10 @@ export function useModal() {
         close: closeFunc
       },
       resolve: resolveFn,
-      context: args?.context,
+      context: args?.context && {
+        key: args.context.key,
+        value: markRaw(args.context.value as object)
+      },
       mobile_below_width: args?.mobile_below_width,
       mobile_below_height: args?.mobile_below_height
     }

--- a/src/views/deck/mobile-editor/editor-header.vue
+++ b/src/views/deck/mobile-editor/editor-header.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
-import UiButton from '@/components/ui-kit/button.vue'
 import UiDropdownButton, {
   type DropdownOption
 } from '@/components/ui-kit/dropdown-button/index.vue'
@@ -9,10 +8,7 @@ import { mobileCardEditorKey } from './use-mobile-card-editor'
 
 const { t } = useI18n()
 
-const { index, cards, saving, has_image, image_controls, close, moveCard, deleteCard } =
-  inject(mobileCardEditorKey)!
-
-const position = computed(() => ({ index: index.value + 1, total: cards.value.length }))
+const { saving, has_image, image_controls, moveCard, deleteCard } = inject(mobileCardEditorKey)!
 
 const menu_options = computed<DropdownOption[]>(() => {
   const image: DropdownOption[] = !image_controls.value
@@ -48,48 +44,24 @@ function onMenuSelect(option: DropdownOption) {
 </script>
 
 <template>
-  <header
-    data-testid="mobile-card-editor__header"
-    class="grid w-full grid-cols-[1fr_auto_1fr] items-center text-base text-brown-500 dark:text-brown-100"
-  >
-    <ui-button
-      data-testid="mobile-card-editor__done"
-      icon-only
-      icon-left="close"
-      data-theme="brown-100"
-      data-theme-dark="stone-700"
-      class="justify-self-start"
-      @press="close"
-    >
-      {{ t('deck-view.mobile-editor.done-button') }}
-    </ui-button>
-
-    <span data-testid="mobile-card-editor__position" class="justify-self-center">
-      {{ t('deck-view.mobile-editor.position', position) }}
+  <div data-testid="mobile-card-editor__header-end" class="flex items-center gap-2">
+    <span v-if="saving" data-testid="mobile-card-editor__saving">
+      {{ t('deck-view.mobile-editor.saving') }}
     </span>
 
-    <div
-      data-testid="mobile-card-editor__header-end"
-      class="flex items-center gap-2 justify-self-end"
-    >
-      <span v-if="saving" data-testid="mobile-card-editor__saving">
-        {{ t('deck-view.mobile-editor.saving') }}
-      </span>
-
-      <ui-dropdown-button
-        data-testid="mobile-card-editor__menu"
-        trigger-only
-        trigger-icon="pencil"
-        variant="ghost"
-        position="bottom-end"
-        trigger-theme="brown-100"
-        trigger-theme-dark="stone-700"
-        menu-theme="brown-100"
-        menu-theme-dark="stone-700"
-        menu-class="dark:outline-1 dark:outline-stone-900"
-        :options="menu_options"
-        @select="onMenuSelect"
-      />
-    </div>
-  </header>
+    <ui-dropdown-button
+      data-testid="mobile-card-editor__menu"
+      trigger-only
+      trigger-icon="pencil"
+      variant="ghost"
+      position="bottom-end"
+      trigger-theme="brown-100"
+      trigger-theme-dark="stone-700"
+      menu-theme="brown-100"
+      menu-theme-dark="stone-700"
+      menu-class="dark:outline-1 dark:outline-stone-900"
+      :options="menu_options"
+      @select="onMenuSelect"
+    />
+  </div>
 </template>

--- a/src/views/deck/mobile-editor/index.vue
+++ b/src/views/deck/mobile-editor/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { inject, onUnmounted } from 'vue'
+import { computed, inject, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import DialogCard from '@/components/layout-kit/dialog-card/index.vue'
 import EditorHeader from './editor-header.vue'
 import EditorStage from './editor-stage.vue'
@@ -12,21 +13,28 @@ type MobileEditorProps = {
 
 const { close } = defineProps<MobileEditorProps>()
 
-const editor = inject(mobileCardEditorKey)!
+const { t } = useI18n()
+const { index, cards, onClosed } = inject(mobileCardEditorKey)!
 
-onUnmounted(() => editor.onClosed())
+const position = computed(() => ({ index: index.value + 1, total: cards.value.length }))
+const title = computed(() => t('deck-view.mobile-editor.position', position.value))
+
+onUnmounted(() => onClosed())
 </script>
 
 <template>
   <dialog-card
     data-testid="mobile-card-editor"
-    bg_class="bg-brown-300 dark:bg-grey-800"
-    :show_header="false"
+    :title="title"
+    :close_label="t('deck-view.mobile-editor.done-button')"
     size="lg"
     @close="close"
   >
-    <div class="flex w-full flex-col gap-4 pt-4 pb-6">
+    <template #header-end>
       <editor-header />
+    </template>
+
+    <div class="flex w-full h-full flex-col justify-between gap-4 pt-4 pb-6">
       <editor-stage />
       <editor-controls />
     </div>

--- a/src/views/deck/mobile-editor/index.vue
+++ b/src/views/deck/mobile-editor/index.vue
@@ -1,16 +1,34 @@
 <script setup lang="ts">
+import { inject, onUnmounted } from 'vue'
+import DialogCard from '@/components/layout-kit/dialog-card/index.vue'
 import EditorHeader from './editor-header.vue'
 import EditorStage from './editor-stage.vue'
 import EditorControls from './editor-controls.vue'
+import { mobileCardEditorKey } from './mobile-card-editor-key'
+
+type MobileEditorProps = {
+  close: () => void
+}
+
+const { close } = defineProps<MobileEditorProps>()
+
+const editor = inject(mobileCardEditorKey)!
+
+onUnmounted(() => editor.onClosed())
 </script>
 
 <template>
-  <div
+  <dialog-card
     data-testid="mobile-card-editor"
-    class="flex w-full flex-col gap-4 px-(--dock-px) pt-(--dock-pt) pb-(--dock-pb)"
+    bg_class="bg-brown-300 dark:bg-grey-800"
+    :show_header="false"
+    size="lg"
+    @close="close"
   >
-    <editor-header />
-    <editor-stage />
-    <editor-controls />
-  </div>
+    <div class="flex w-full flex-col gap-4 pt-4 pb-6">
+      <editor-header />
+      <editor-stage />
+      <editor-controls />
+    </div>
+  </dialog-card>
 </template>

--- a/src/views/deck/mobile-editor/mobile-card-editor-key.ts
+++ b/src/views/deck/mobile-editor/mobile-card-editor-key.ts
@@ -1,0 +1,4 @@
+import type { InjectionKey } from 'vue'
+import type { MobileCardEditor } from './use-mobile-card-editor'
+
+export const mobileCardEditorKey = Symbol('mobileCardEditor') as InjectionKey<MobileCardEditor>

--- a/src/views/deck/mobile-editor/use-mobile-card-editor.ts
+++ b/src/views/deck/mobile-editor/use-mobile-card-editor.ts
@@ -61,7 +61,7 @@ export function useMobileCardEditor(controller: CardListController) {
     if (close_modal) return
 
     close_modal = modal.open(MobileEditor, {
-      mode: 'mobile-sheet',
+      mode: 'popup',
       context: { key: mobileCardEditorKey, value: api }
     }).close
   }

--- a/src/views/deck/mobile-editor/use-mobile-card-editor.ts
+++ b/src/views/deck/mobile-editor/use-mobile-card-editor.ts
@@ -1,10 +1,13 @@
-import { computed, ref, shallowRef, type InjectionKey } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 import { emitSfx } from '@/sfx/bus'
+import { useModal } from '@/composables/modal'
 import type { CardListController } from '@/views/deck/composables'
+import { mobileCardEditorKey } from './mobile-card-editor-key'
+import MobileEditor from './index.vue'
 
 export type MobileCardEditor = ReturnType<typeof useMobileCardEditor>
 
-export const mobileCardEditorKey = Symbol('mobileCardEditor') as InjectionKey<MobileCardEditor>
+export { mobileCardEditorKey }
 
 type CardSide = 'front' | 'back'
 
@@ -28,7 +31,9 @@ export type ImageControls = { openPicker: () => void; onRemove: () => void }
 export function useMobileCardEditor(controller: CardListController) {
   const cards = controller.list.all_cards
 
-  const open = ref(false)
+  const modal = useModal()
+  let close_modal: (() => void) | null = null
+
   const cursor_client_id = ref<string | null>(null)
   const side = ref<CardSide>('front')
   const image_controls = shallowRef<ImageControls | null>(null)
@@ -51,12 +56,24 @@ export function useMobileCardEditor(controller: CardListController) {
 
     cursor_client_id.value = target
     side.value = 'front'
-    open.value = true
     emitSfx('snappy_button_3')
+
+    if (close_modal) return
+
+    close_modal = modal.open(MobileEditor, {
+      mode: 'mobile-sheet',
+      context: { key: mobileCardEditorKey, value: api }
+    }).close
   }
 
   function close() {
-    open.value = false
+    close_modal?.()
+  }
+
+  // Called by the modal wrapper's onUnmounted so state stays in sync no matter
+  // how the modal actually closed (done button, esc, background tap).
+  function onClosed() {
+    close_modal = null
     emitSfx('snappy_button_5')
   }
 
@@ -123,8 +140,7 @@ export function useMobileCardEditor(controller: CardListController) {
     reconcileCursor(at)
   }
 
-  return {
-    open,
+  const api = {
     side,
     cards,
     current,
@@ -137,6 +153,7 @@ export function useMobileCardEditor(controller: CardListController) {
     saving: controller.saving,
     open_at,
     close,
+    onClosed,
     flip,
     prev,
     next,
@@ -144,4 +161,6 @@ export function useMobileCardEditor(controller: CardListController) {
     moveCard,
     deleteCard
   }
+
+  return api
 }

--- a/src/views/deck/mobile-footer/index.vue
+++ b/src/views/deck/mobile-footer/index.vue
@@ -2,15 +2,12 @@
 import { inject } from 'vue'
 import MobileDock from '@/components/mobile-dock/mobile-dock.vue'
 import CrossfadeResize from '@/components/layout-kit/crossfade-resize.vue'
-import MobileEditor from '@/views/deck/mobile-editor/index.vue'
 import MobilePageSettings from './page-settings.vue'
 import FooterActions from './footer-actions.vue'
 import FooterBulkActions from './footer-bulk-actions.vue'
-import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
 import { deckViewShellKey } from '@/views/deck/composables/view-shell'
 import { cardEditorKey } from '@/views/deck/composables'
 
-const { open } = inject(mobileCardEditorKey)!
 const { is_page_settings_open } = inject(deckViewShellKey)!
 const { is_selecting } = inject(cardEditorKey)!.selection
 </script>
@@ -18,8 +15,7 @@ const { is_selecting } = inject(cardEditorKey)!.selection
 <template>
   <mobile-dock>
     <crossfade-resize data-testid="deck-mobile-footer">
-      <mobile-editor v-if="open" key="editor" />
-      <footer-bulk-actions v-else-if="is_selecting" key="bulk-actions" />
+      <footer-bulk-actions v-if="is_selecting" key="bulk-actions" />
       <mobile-page-settings v-else-if="is_page_settings_open" key="page-settings" />
       <footer-actions v-else key="actions" />
     </crossfade-resize>

--- a/src/views/welcome/forgot-password/index.vue
+++ b/src/views/welcome/forgot-password/index.vue
@@ -25,7 +25,7 @@ async function onSubmit() {
 <template>
   <dialog-card
     data-testid="forgot-password-modal-card"
-    class="bg-brown-200 dark:bg-grey-800 gap-0!"
+    class="gap-0!"
     size="sm"
     float_header
     data-theme="brown-50"

--- a/src/views/welcome/reset-password/index.vue
+++ b/src/views/welcome/reset-password/index.vue
@@ -39,7 +39,7 @@ async function onSubmit() {
 <template>
   <dialog-card
     data-testid="reset-password-modal-card"
-    class="bg-brown-200 dark:bg-grey-800 gap-0!"
+    class="gap-0!"
     size="sm"
     float_header
     data-theme="brown-50"

--- a/tests/integration/components/layout-kit/dialog-card/dialog-card.test.js
+++ b/tests/integration/components/layout-kit/dialog-card/dialog-card.test.js
@@ -351,6 +351,26 @@ describe('DialogCard', () => {
     })
   })
 
+  // ── bg_class prop ────────────────────────────────────────────────────────────
+
+  describe('bg_class', () => {
+    test('defaults to bg-brown-200 dark:bg-grey-800 when omitted', () => {
+      const wrapper = mountCard()
+      const classes = wrapper.find('[data-testid="dialog-card"]').classes()
+
+      expect(classes).toContain('bg-brown-200')
+      expect(classes).toContain('dark:bg-grey-800')
+    })
+
+    test('a caller value replaces the default outright', () => {
+      const wrapper = mountCard({ bg_class: 'bg-brown-100 dark:bg-grey-800' })
+      const classes = wrapper.find('[data-testid="dialog-card"]').classes()
+
+      expect(classes).toContain('bg-brown-100')
+      expect(classes).not.toContain('bg-brown-200')
+    })
+  })
+
   // ── dialog_px prop ─────────────────────────────────────────────────────────────
 
   describe('dialog_px', () => {

--- a/tests/integration/views/deck/mobile-editor/editor-header.test.js
+++ b/tests/integration/views/deck/mobile-editor/editor-header.test.js
@@ -1,0 +1,131 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { ref } from 'vue'
+import EditorHeader from '@/views/deck/mobile-editor/editor-header.vue'
+import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEditorContext(overrides = {}) {
+  return {
+    saving: ref(false),
+    has_image: ref(false),
+    image_controls: ref(null),
+    moveCard: vi.fn(),
+    deleteCard: vi.fn(),
+    ...overrides
+  }
+}
+
+function mountHeader(context) {
+  return shallowMount(EditorHeader, {
+    global: { provide: { [mobileCardEditorKey]: context } }
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('EditorHeader', () => {
+  test('renders only the menu, no saving indicator, when not saving', () => {
+    const wrapper = mountHeader(makeEditorContext({ saving: ref(false) }))
+    expect(wrapper.find('[data-testid="mobile-card-editor__saving"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="mobile-card-editor__menu"]').exists()).toBe(true)
+  })
+
+  test('shows the saving indicator when saving is true', () => {
+    const wrapper = mountHeader(makeEditorContext({ saving: ref(true) }))
+    expect(wrapper.find('[data-testid="mobile-card-editor__saving"]').exists()).toBe(true)
+  })
+
+  test('menu options include "add image" when there is no image and image_controls is registered', () => {
+    const context = makeEditorContext({
+      has_image: ref(false),
+      image_controls: ref({ openPicker: vi.fn(), onRemove: vi.fn() })
+    })
+    const wrapper = mountHeader(context)
+    const values = wrapper
+      .findComponent({ name: 'UiDropdownButton' })
+      .props('options')
+      .map((o) => o.value)
+    expect(values).toContain('image-add')
+  })
+
+  test('menu options include "replace" and "remove" image when has_image is true', () => {
+    const context = makeEditorContext({
+      has_image: ref(true),
+      image_controls: ref({ openPicker: vi.fn(), onRemove: vi.fn() })
+    })
+    const wrapper = mountHeader(context)
+    const values = wrapper
+      .findComponent({ name: 'UiDropdownButton' })
+      .props('options')
+      .map((o) => o.value)
+    expect(values).toEqual(expect.arrayContaining(['image-add', 'image-remove']))
+  })
+
+  test('omits image options entirely when image_controls is null (no mounted image layer)', () => {
+    const context = makeEditorContext({ image_controls: ref(null) })
+    const wrapper = mountHeader(context)
+    const values = wrapper
+      .findComponent({ name: 'UiDropdownButton' })
+      .props('options')
+      .map((o) => o.value)
+    expect(values).not.toContain('image-add')
+    expect(values).not.toContain('image-remove')
+  })
+
+  test('always includes move and delete options', () => {
+    const wrapper = mountHeader(makeEditorContext())
+    const values = wrapper
+      .findComponent({ name: 'UiDropdownButton' })
+      .props('options')
+      .map((o) => o.value)
+    expect(values).toEqual(expect.arrayContaining(['move', 'delete']))
+  })
+
+  test('selecting "image-add" calls image_controls.openPicker', async () => {
+    const openPicker = vi.fn()
+    const context = makeEditorContext({
+      has_image: ref(false),
+      image_controls: ref({ openPicker, onRemove: vi.fn() })
+    })
+    const wrapper = mountHeader(context)
+    await wrapper
+      .findComponent({ name: 'UiDropdownButton' })
+      .vm.$emit('select', { value: 'image-add' })
+    expect(openPicker).toHaveBeenCalled()
+  })
+
+  test('selecting "image-remove" calls image_controls.onRemove', async () => {
+    const onRemove = vi.fn()
+    const context = makeEditorContext({
+      has_image: ref(true),
+      image_controls: ref({ openPicker: vi.fn(), onRemove })
+    })
+    const wrapper = mountHeader(context)
+    await wrapper
+      .findComponent({ name: 'UiDropdownButton' })
+      .vm.$emit('select', { value: 'image-remove' })
+    expect(onRemove).toHaveBeenCalled()
+  })
+
+  test('selecting "move" calls moveCard', async () => {
+    const context = makeEditorContext()
+    const wrapper = mountHeader(context)
+    await wrapper.findComponent({ name: 'UiDropdownButton' }).vm.$emit('select', { value: 'move' })
+    expect(context.moveCard).toHaveBeenCalled()
+  })
+
+  test('selecting "delete" calls deleteCard', async () => {
+    const context = makeEditorContext()
+    const wrapper = mountHeader(context)
+    await wrapper
+      .findComponent({ name: 'UiDropdownButton' })
+      .vm.$emit('select', { value: 'delete' })
+    expect(context.deleteCard).toHaveBeenCalled()
+  })
+})

--- a/tests/integration/views/deck/mobile-editor/index.test.js
+++ b/tests/integration/views/deck/mobile-editor/index.test.js
@@ -1,0 +1,212 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import ModalUiKit from '@/components/ui-kit/modal.vue'
+import { useModal, request_close_handlers } from '@/composables/modal'
+import { useMobileCardEditor } from '@/views/deck/mobile-editor/use-mobile-card-editor'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+
+// gsap is imported transitively via modal-mode-config → animations/modal.
+// The mock must call onComplete so transition-group JS hooks finish in browser mode.
+vi.mock('gsap', () => ({
+  gsap: {
+    set: vi.fn(),
+    fromTo: vi.fn((_el, _from, to) => to?.onComplete?.()),
+    to: vi.fn((_el, opts) => opts?.onComplete?.())
+  }
+}))
+
+vi.mock('@/composables/shortcuts', () => ({
+  useShortcuts: vi.fn(() => ({ register: vi.fn(), dispose: vi.fn(), clearScope: vi.fn() }))
+}))
+
+// This suite exercises the real modal system end-to-end — mobile-editor/index.vue
+// (and the editor-header/editor-stage/editor-controls it renders) inject
+// mobileCardEditorKey via plain inject(), but the modal hosting them is mounted
+// by the global modal renderer, which sits OUTSIDE the deck view's own
+// provide/inject tree. A shallow inject() mock would hide a regression where the
+// context is dropped or the key mismatches — only mounting through the real
+// modal-slot proves the wiring holds.
+
+const FaceEditorStub = defineComponent({
+  name: 'FaceEditor',
+  props: ['card', 'side', 'card_attributes', 'placeholder', 'input_testid'],
+  setup(props) {
+    return () => h('div', { 'data-testid': 'face-editor-stub' }, props.card?.client_id)
+  }
+})
+
+const UiDropdownButtonStub = defineComponent({
+  name: 'UiDropdownButton',
+  props: ['options'],
+  setup() {
+    return () => h('div', { 'data-testid': 'mobile-card-editor__menu-stub' })
+  }
+})
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeCard(overrides = {}) {
+  return {
+    id: null,
+    client_id: 'cid-1',
+    front_text: '',
+    back_text: '',
+    front_image_path: null,
+    back_image_path: null,
+    deck_id: 1,
+    ...overrides
+  }
+}
+
+function makeController(cards = []) {
+  const all_cards = ref(cards)
+  const updateCard = vi.fn().mockResolvedValue(undefined)
+  const onMoveCards = vi.fn().mockResolvedValue(undefined)
+  const onDeleteCards = vi.fn().mockResolvedValue(undefined)
+  return {
+    list: { all_cards },
+    card_attributes: { front: {}, back: {} },
+    saving: ref(false),
+    updateCard,
+    actions: { onMoveCards, onDeleteCards }
+  }
+}
+
+// Modal hosts attach real window listeners while open — unmount every mount so
+// they don't leak into later tests.
+const mounted = []
+
+function mountModal() {
+  const wrapper = mount(ModalUiKit, {
+    attachTo: document.body,
+    global: {
+      stubs: { FaceEditor: FaceEditorStub, UiDropdownButton: UiDropdownButtonStub },
+      directives: { sfx: {} }
+    }
+  })
+  mounted.push(wrapper)
+  return wrapper
+}
+
+beforeEach(() => {
+  const { modal_stack, pop } = useModal()
+  while (modal_stack.value.length > 0) pop()
+  request_close_handlers.clear()
+  mockEmitSfx.mockClear()
+})
+
+afterEach(() => {
+  while (mounted.length > 0) mounted.pop().unmount()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('mobile-editor/index (real modal stack) [obligation]', () => {
+  test('open_at opens the editor through the real modal system and the context reaches nested descendants [obligation]', async () => {
+    const controller = makeController([
+      makeCard({ client_id: 'cid-1' }),
+      makeCard({ client_id: 'cid-2' })
+    ])
+    const editor = useMobileCardEditor(controller)
+
+    editor.open_at('cid-1')
+
+    const wrapper = mountModal()
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="mobile-card-editor"]').exists()).toBe(true)
+    // dialog-card title comes from index.vue's own inject of `index`/`cards`
+    expect(wrapper.find('[data-testid="dialog-card-header__title"]').text()).toBe('1 / 2')
+    // editor-header (nested descendant) also resolves the same injected context
+    expect(wrapper.find('[data-testid="mobile-card-editor__header-end"]').exists()).toBe(true)
+    // editor-stage resolves the current card through the injected context
+    expect(wrapper.find('[data-testid="face-editor-stub"]').text()).toBe('cid-1')
+    // editor-controls resolves has_prev/has_next through the injected context
+    expect(
+      wrapper.find('[data-testid="mobile-card-editor__prev"]').attributes('aria-disabled')
+    ).toBe('true')
+    expect(
+      wrapper.find('[data-testid="mobile-card-editor__next"]').attributes('aria-disabled')
+    ).toBeUndefined()
+  })
+
+  test('calling open_at again while open updates the existing modal instead of stacking a second one [obligation]', async () => {
+    const controller = makeController([
+      makeCard({ client_id: 'cid-1' }),
+      makeCard({ client_id: 'cid-2' })
+    ])
+    const editor = useMobileCardEditor(controller)
+
+    editor.open_at('cid-1')
+    const wrapper = mountModal()
+    await nextTick()
+
+    editor.open_at('cid-2')
+    await nextTick()
+
+    expect(wrapper.findAll('[data-testid="mobile-card-editor"]')).toHaveLength(1)
+    expect(wrapper.find('[data-testid="face-editor-stub"]').text()).toBe('cid-2')
+  })
+
+  test('a full close-then-reopen cycle works: dialog-card close dismisses the modal, and a later open_at reopens it [obligation]', async () => {
+    const controller = makeController([makeCard({ client_id: 'cid-1' })])
+    const editor = useMobileCardEditor(controller)
+
+    editor.open_at('cid-1')
+    const wrapper = mountModal()
+    await nextTick()
+
+    await wrapper.find('[data-testid="dialog-card__close"]').trigger('click')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="mobile-card-editor"]').exists()).toBe(false)
+
+    editor.open_at('cid-1')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="mobile-card-editor"]').exists()).toBe(true)
+  })
+
+  test('onClosed fires (resetting internal state) when the modal is dismissed via backdrop, not just via close() [obligation]', async () => {
+    const controller = makeController([makeCard({ client_id: 'cid-1' })])
+    const editor = useMobileCardEditor(controller)
+
+    editor.open_at('cid-1')
+    const wrapper = mountModal()
+    await nextTick()
+
+    await wrapper.find('[data-testid="ui-kit-modal"]').trigger('click')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="mobile-card-editor"]').exists()).toBe(false)
+
+    editor.open_at('cid-1')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="mobile-card-editor"]').exists()).toBe(true)
+  })
+
+  test('reconcileCursor still closes the real modal when deleting the last card empties the deck [obligation]', async () => {
+    const controller = makeController([makeCard({ id: 1, client_id: 'cid-1' })])
+    const editor = useMobileCardEditor(controller)
+
+    editor.open_at('cid-1')
+    const wrapper = mountModal()
+    await nextTick()
+
+    controller.actions.onDeleteCards.mockImplementationOnce(async () => {
+      controller.list.all_cards.value = []
+    })
+
+    await editor.deleteCard()
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="mobile-card-editor"]').exists()).toBe(false)
+  })
+})

--- a/tests/integration/views/deck/mobile-footer/index.test.js
+++ b/tests/integration/views/deck/mobile-footer/index.test.js
@@ -18,11 +18,6 @@ const CrossfadeResizeStub = defineComponent({
       h('div', { ...attrs }, slots.default?.())
 })
 
-const MobileEditorStub = defineComponent({
-  name: 'MobileEditor',
-  setup: () => () => h('div', { 'data-testid': 'mobile-editor-stub' })
-})
-
 const MobilePageSettingsStub = defineComponent({
   name: 'MobilePageSettings',
   setup: () => () => h('div', { 'data-testid': 'mobile-page-settings-stub' })
@@ -39,22 +34,19 @@ const FooterBulkActionsStub = defineComponent({
 })
 
 import MobileFooter from '@/views/deck/mobile-footer/index.vue'
-import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
 import { deckViewShellKey } from '@/views/deck/composables/view-shell'
 import { cardEditorKey } from '@/views/deck/composables'
 
-function mount({ editor_open = false, page_settings_open = false, is_selecting = false } = {}) {
+function mount({ page_settings_open = false, is_selecting = false } = {}) {
   return shallowMount(MobileFooter, {
     global: {
       provide: {
-        [mobileCardEditorKey]: { open: ref(editor_open) },
         [deckViewShellKey]: { is_page_settings_open: ref(page_settings_open) },
         [cardEditorKey]: { selection: { is_selecting: ref(is_selecting) } }
       },
       stubs: {
         MobileDock: MobileDockStub,
         CrossfadeResize: CrossfadeResizeStub,
-        MobileEditor: MobileEditorStub,
         MobilePageSettings: MobilePageSettingsStub,
         FooterActions: FooterActionsStub,
         FooterBulkActions: FooterBulkActionsStub
@@ -67,42 +59,22 @@ describe('mobile-footer/index', () => {
   test('shows footer-actions by default (nothing open)', () => {
     const wrapper = mount()
     expect(wrapper.find('[data-testid="footer-actions-stub"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="mobile-editor-stub"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="mobile-page-settings-stub"]').exists()).toBe(false)
   })
 
-  test('shows mobile-editor when the card editor is open, regardless of page settings', () => {
-    const wrapper = mount({ editor_open: true, page_settings_open: true })
-    expect(wrapper.find('[data-testid="mobile-editor-stub"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="mobile-page-settings-stub"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="footer-actions-stub"]').exists()).toBe(false)
-  })
-
-  test('shows mobile-page-settings when is_page_settings_open is true and editor is closed [obligation]', () => {
-    const wrapper = mount({ editor_open: false, page_settings_open: true })
+  test('shows mobile-page-settings when is_page_settings_open is true [obligation]', () => {
+    const wrapper = mount({ page_settings_open: true })
     expect(wrapper.find('[data-testid="mobile-page-settings-stub"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="footer-actions-stub"]').exists()).toBe(false)
   })
 
-  test('editor takes priority over page settings when both are open [obligation]', () => {
-    const wrapper = mount({ editor_open: true, page_settings_open: true })
-    expect(wrapper.find('[data-testid="mobile-editor-stub"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="mobile-page-settings-stub"]').exists()).toBe(false)
-  })
-
-  test('shows footer-bulk-actions when selecting and editor is closed', () => {
+  test('shows footer-bulk-actions when selecting', () => {
     const wrapper = mount({ is_selecting: true })
     expect(wrapper.find('[data-testid="footer-bulk-actions-stub"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="footer-actions-stub"]').exists()).toBe(false)
   })
 
-  test('editor takes priority over bulk-actions when both are open', () => {
-    const wrapper = mount({ editor_open: true, is_selecting: true })
-    expect(wrapper.find('[data-testid="mobile-editor-stub"]').exists()).toBe(true)
-    expect(wrapper.find('[data-testid="footer-bulk-actions-stub"]').exists()).toBe(false)
-  })
-
-  test('bulk-actions takes priority over page settings when both are open', () => {
+  test('bulk-actions takes priority over page settings when both are open [obligation]', () => {
     const wrapper = mount({ is_selecting: true, page_settings_open: true })
     expect(wrapper.find('[data-testid="footer-bulk-actions-stub"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="mobile-page-settings-stub"]').exists()).toBe(false)

--- a/tests/unit/views/deck/mobile-editor/use-mobile-card-editor.test.js
+++ b/tests/unit/views/deck/mobile-editor/use-mobile-card-editor.test.js
@@ -3,13 +3,25 @@ import { ref, nextTick } from 'vue'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+const { mockEmitSfx, mockOpen, mockClose } = vi.hoisted(() => ({
+  mockEmitSfx: vi.fn(),
+  mockOpen: vi.fn(),
+  mockClose: vi.fn()
+}))
 
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
 
+vi.mock('@/composables/modal', () => ({
+  useModal: () => ({ open: mockOpen })
+}))
+
 // ── Imports ───────────────────────────────────────────────────────────────────
 
-import { useMobileCardEditor } from '@/views/deck/mobile-editor/use-mobile-card-editor'
+import {
+  useMobileCardEditor,
+  mobileCardEditorKey
+} from '@/views/deck/mobile-editor/use-mobile-card-editor'
+import MobileEditor from '@/views/deck/mobile-editor/index.vue'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -52,14 +64,12 @@ function makeEditor(cards = []) {
 
 beforeEach(() => {
   mockEmitSfx.mockClear()
+  mockOpen.mockClear()
+  mockClose.mockClear()
+  mockOpen.mockReturnValue({ response: Promise.resolve(), close: mockClose })
 })
 
 describe('useMobileCardEditor — initial state', () => {
-  test('open is false initially', () => {
-    const { editor } = makeEditor()
-    expect(editor.open.value).toBe(false)
-  })
-
   test('current is undefined when no cursor is set', () => {
     const { editor } = makeEditor([makeCard()])
     expect(editor.current.value).toBeUndefined()
@@ -72,11 +82,15 @@ describe('useMobileCardEditor — initial state', () => {
 })
 
 describe('useMobileCardEditor — open_at [obligation]', () => {
-  test('open_at sets open to true [obligation]', () => {
+  test('open_at opens the editor via useModal().open with MobileEditor, mode popup, and the editor context [obligation]', () => {
     const card = makeCard({ client_id: 'cid-1' })
     const { editor } = makeEditor([card])
     editor.open_at('cid-1')
-    expect(editor.open.value).toBe(true)
+
+    expect(mockOpen).toHaveBeenCalledWith(MobileEditor, {
+      mode: 'popup',
+      context: { key: mobileCardEditorKey, value: editor }
+    })
   })
 
   test('open_at sets cursor to the given client_id [obligation]', () => {
@@ -112,26 +126,67 @@ describe('useMobileCardEditor — open_at [obligation]', () => {
   test('open_at is a no-op when the deck is empty [obligation]', () => {
     const { editor } = makeEditor([])
     editor.open_at()
-    expect(editor.open.value).toBe(false)
+    expect(mockOpen).not.toHaveBeenCalled()
+  })
+
+  test('calling open_at again while already open does not push a second modal [obligation]', () => {
+    const c1 = makeCard({ client_id: 'cid-1' })
+    const c2 = makeCard({ client_id: 'cid-2' })
+    const { editor } = makeEditor([c1, c2])
+
+    editor.open_at('cid-1')
+    editor.open_at('cid-2')
+
+    expect(mockOpen).toHaveBeenCalledTimes(1)
+    expect(editor.current.value?.client_id).toBe('cid-2')
+  })
+
+  test('reopening after onClosed pushes a new modal [obligation]', () => {
+    const c1 = makeCard({ client_id: 'cid-1' })
+    const { editor } = makeEditor([c1])
+
+    editor.open_at('cid-1')
+    editor.close()
+    editor.onClosed()
+    editor.open_at('cid-1')
+
+    expect(mockOpen).toHaveBeenCalledTimes(2)
   })
 })
 
 describe('useMobileCardEditor — close [obligation]', () => {
-  test('close sets open to false [obligation]', () => {
+  test('close invokes the close function returned by modal.open [obligation]', () => {
     const card = makeCard({ client_id: 'cid-1' })
     const { editor } = makeEditor([card])
     editor.open_at('cid-1')
     editor.close()
-    expect(editor.open.value).toBe(false)
+    expect(mockClose).toHaveBeenCalled()
   })
 
-  test('close emits snappy_button_5 [obligation]', () => {
+  test('close is a no-op (does not throw) when the editor was never opened [obligation]', () => {
+    const { editor } = makeEditor([])
+    expect(() => editor.close()).not.toThrow()
+    expect(mockClose).not.toHaveBeenCalled()
+  })
+})
+
+describe('useMobileCardEditor — onClosed [obligation]', () => {
+  test('onClosed emits snappy_button_5 [obligation]', () => {
     const card = makeCard({ client_id: 'cid-1' })
     const { editor } = makeEditor([card])
     editor.open_at('cid-1')
     mockEmitSfx.mockClear()
-    editor.close()
+    editor.onClosed()
     expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+  })
+
+  test('onClosed resets internal state so a later open_at reopens the editor [obligation]', () => {
+    const card = makeCard({ client_id: 'cid-1' })
+    const { editor } = makeEditor([card])
+    editor.open_at('cid-1')
+    editor.onClosed()
+    editor.open_at('cid-1')
+    expect(mockOpen).toHaveBeenCalledTimes(2)
   })
 })
 
@@ -389,7 +444,7 @@ describe('useMobileCardEditor — reconcileCursor after delete [obligation]', ()
     expect(editor.current.value?.client_id).toBe('cid-1')
   })
 
-  test('closes when the deck becomes empty after delete [obligation]', async () => {
+  test('closes (via modal close) when the deck becomes empty after delete [obligation]', async () => {
     const card = makeCard({ id: 1, client_id: 'cid-1' })
     const { editor, controller } = makeEditor([card])
     editor.open_at('cid-1')
@@ -401,7 +456,7 @@ describe('useMobileCardEditor — reconcileCursor after delete [obligation]', ()
     await editor.deleteCard()
     await nextTick()
 
-    expect(editor.open.value).toBe(false)
+    expect(mockClose).toHaveBeenCalled()
   })
 
   test('reconcileCursor is a no-op when the card is still present (user dismissed modal) [obligation]', async () => {
@@ -411,12 +466,13 @@ describe('useMobileCardEditor — reconcileCursor after delete [obligation]', ()
 
     // onDeleteCards resolves without removing the card (dismiss path)
     controller.actions.onDeleteCards.mockResolvedValueOnce(undefined)
+    mockClose.mockClear()
 
     await editor.deleteCard()
     await nextTick()
 
-    // Card is still in the list, cursor stays on it
+    // Card is still in the list, cursor stays on it, and the modal was not closed
     expect(editor.current.value?.client_id).toBe('cid-1')
-    expect(editor.open.value).toBe(true)
+    expect(mockClose).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

The mobile single-card editor previously rendered inline as a mobile-footer pane. It now opens through `useModal()` as a proper `dialog-card` modal, matching every other modal surface in the app instead of being a special case wedged into the dock.

## Changes

- Mobile card editor opens via `useModal()` instead of a boolean ref gating a footer pane
- Editor uses `dialog-card`'s default header (title/close_label props) instead of a hand-rolled header row; `editor-header.vue` trimmed to just the saving indicator + menu
- `dialog-card` gains a `bg_class` prop so callers stop repeating `bg-*`/`dark:bg-*` pairs that collided with a hardcoded default
- Injection key extracted to its own file so the composable (which needs the modal component) and the modal component (which needs the key) don't circularly import each other
- Editor state threaded through `useModal()`'s `context` option so components rendered inside the modal — outside the deck view's own provide/inject tree — can still inject it