### PR TITLE
Dialog-card grid layout: header/viewport as siblings, fix mobile overflow

### DIFF
--- a/src/components/billing/checkout-modal/index.vue
+++ b/src/components/billing/checkout-modal/index.vue
@@ -22,7 +22,7 @@ const { status, is_ready, onSubmit } = useCheckout(close)
   <dialog-card
     data-testid="checkout"
     class="pb-6"
-    bg_class="bg-brown-100 dark:bg-grey-800"
+    bg_class="bg-brown-200 dark:bg-grey-800"
     size="md"
     data-theme="brown-300"
     data-theme-dark="stone-700"

--- a/src/components/card/move-cards-modal.vue
+++ b/src/components/card/move-cards-modal.vue
@@ -90,7 +90,10 @@ function onClick(deck_id?: number) {
     class="grid-rows-[auto_1fr_auto]! pb-(--dialog-px)"
     @close="close(false)"
   >
-    <div data-testid="move-cards__deck-list-wrap" class="relative flex min-h-0 flex-1 flex-col">
+    <div
+      data-testid="move-cards__deck-list-wrap"
+      class="relative flex min-h-0 flex-1 flex-col px-(--dialog-px)"
+    >
       <grouped-list data-testid="move-cards__deck-list" scrollable class="my-4 min-h-0 flex-1">
         <ui-tappable
           v-for="(deck, index) in decks"
@@ -137,7 +140,7 @@ function onClick(deck_id?: number) {
       />
     </div>
 
-    <div data-testid="move-cards__actions" class="flex w-full justify-end gap-3">
+    <div data-testid="move-cards__actions" class="flex w-full justify-end gap-3 px-(--dialog-px)">
       <ui-button
         data-testid="move-cards__move"
         data-theme="blue-500"

--- a/src/components/card/move-cards-modal.vue
+++ b/src/components/card/move-cards-modal.vue
@@ -83,69 +83,73 @@ function onClick(deck_id?: number) {
 </script>
 
 <template>
-  <dialog-card data-testid="move-cards" size="md" :title="title" @close="close(false)">
-    <div data-testid="move-cards__body" class="flex h-full min-h-0 flex-col">
-      <div data-testid="move-cards__deck-list-wrap" class="relative flex min-h-0 flex-1 flex-col">
-        <grouped-list data-testid="move-cards__deck-list" scrollable class="my-4 min-h-0 flex-1">
-          <ui-tappable
-            v-for="(deck, index) in decks"
-            :key="index"
-            data-testid="move-cards__deck-item"
-            :class="[
-              deck.id === current_deck_id || isDeckFull(deck)
-                ? ' bg-brown-300 dark:bg-stone-700 pointer-events-none text-(--theme-on-primary)/20'
-                : 'cursor-pointer'
-            ]"
-            class="text-(--theme-on-primary) text-left flex items-center gap-3 p-4"
-            active_on_hover
-            :sfx="{ press: 'snappy_button_2', hover: TYPE_SFX }"
-            @tap="onClick(deck.id)"
-            @mouseenter="hovered_deck_id = deck.id"
-            @mouseleave="hovered_deck_id = undefined"
-          >
-            <card size="2xs" :cover_config="deck.cover_config" side="cover" />
-            <span class="flex-1">{{ deck.title }}</span>
-            <span
-              v-if="deck.id !== current_deck_id && isDeckFull(deck)"
-              data-testid="move-cards__deck-full-label"
-              class="text-sm"
-            >
-              {{ t('move-cards-modal.deck-full-label') }}
-            </span>
-            <ui-radio
-              v-else
-              :class="{ 'opacity-20': deck.id === current_deck_id }"
-              data-theme="blue-500"
-              data-theme-dark="blue-650"
-              :sfx="{ press: 'snappy_button_2' }"
-              :checked="deck.id === selected_deck_id || deck.id === current_deck_id"
-              :active="deck.id === hovered_deck_id"
-              @click.stop="selected_deck_id = deck.id"
-            />
-          </ui-tappable>
-        </grouped-list>
-
-        <scroll-bar
-          target="[data-testid='move-cards__deck-list__content']"
-          min-width="sm"
-          class="absolute right-0 top-4 bottom-4"
-        />
-      </div>
-
-      <div data-testid="move-cards__actions" class="pb-6 flex w-full justify-end gap-3">
-        <ui-button
-          data-testid="move-cards__move"
-          data-theme="blue-500"
-          icon-left="move-item"
-          size="xl"
-          full-width
-          :loading="moving"
-          @press="onMove"
-          :disabled="!selected_deck_id || moving"
+  <dialog-card
+    data-testid="move-cards"
+    size="md"
+    :title="title"
+    class="grid-rows-[auto_1fr_auto]! pb-(--dialog-px)"
+    @close="close(false)"
+  >
+    <div data-testid="move-cards__deck-list-wrap" class="relative flex min-h-0 flex-1 flex-col">
+      <grouped-list data-testid="move-cards__deck-list" scrollable class="my-4 min-h-0 flex-1">
+        <ui-tappable
+          v-for="(deck, index) in decks"
+          :key="index"
+          data-testid="move-cards__deck-item"
+          :class="[
+            deck.id === current_deck_id || isDeckFull(deck)
+              ? ' bg-brown-300 dark:bg-stone-700 pointer-events-none text-(--theme-on-primary)/20'
+              : 'cursor-pointer'
+          ]"
+          class="text-(--theme-on-primary) text-left flex items-center gap-3 p-4"
+          active_on_hover
+          :sfx="{ press: 'snappy_button_2', hover: TYPE_SFX }"
+          @tap="onClick(deck.id)"
+          @mouseenter="hovered_deck_id = deck.id"
+          @mouseleave="hovered_deck_id = undefined"
         >
-          {{ t('move-cards-modal.confirm') }}
-        </ui-button>
-      </div>
+          <card size="2xs" :cover_config="deck.cover_config" side="cover" />
+          <span class="flex-1">{{ deck.title }}</span>
+          <span
+            v-if="deck.id !== current_deck_id && isDeckFull(deck)"
+            data-testid="move-cards__deck-full-label"
+            class="text-sm"
+          >
+            {{ t('move-cards-modal.deck-full-label') }}
+          </span>
+          <ui-radio
+            v-else
+            :class="{ 'opacity-20': deck.id === current_deck_id }"
+            data-theme="blue-500"
+            data-theme-dark="blue-650"
+            :sfx="{ press: 'snappy_button_2' }"
+            :checked="deck.id === selected_deck_id || deck.id === current_deck_id"
+            :active="deck.id === hovered_deck_id"
+            @click.stop="selected_deck_id = deck.id"
+          />
+        </ui-tappable>
+      </grouped-list>
+
+      <scroll-bar
+        target="[data-testid='move-cards__deck-list__content']"
+        min-width="sm"
+        class="absolute -right-6 top-4 bottom-4"
+      />
+    </div>
+
+    <div data-testid="move-cards__actions" class="flex w-full justify-end gap-3">
+      <ui-button
+        data-testid="move-cards__move"
+        data-theme="blue-500"
+        icon-left="move-item"
+        size="xl"
+        full-width
+        :loading="moving"
+        @press="onMove"
+        :disabled="!selected_deck_id || moving"
+      >
+        {{ t('move-cards-modal.confirm') }}
+      </ui-button>
     </div>
   </dialog-card>
 </template>

--- a/src/components/layout-kit/dialog-card/index.vue
+++ b/src/components/layout-kit/dialog-card/index.vue
@@ -10,13 +10,13 @@ export type DialogCardSize = 'sm' | 'md' | 'lg'
 const SIZE_CLASSES: Record<DialogCardSize, string> = {
   sm: 'w-140 h-110',
   md: 'w-150 h-160',
-  lg: 'w-full max-w-160 h-170'
+  lg: 'w-160 h-170'
 }
 
 const SIZE_FULL_BLEED_AT: Record<DialogCardSize, string> = {
   sm: 'w<sm | h<sm',
   md: 'w<sm | h<sm',
-  lg: 'w<sm'
+  lg: 'w<sm | h<md'
 }
 
 const SIZE_CONTENT_MAX_WIDTH: Record<DialogCardSize, string> = {

--- a/src/components/layout-kit/dialog-card/index.vue
+++ b/src/components/layout-kit/dialog-card/index.vue
@@ -25,6 +25,12 @@ const SIZE_CONTENT_MAX_WIDTH: Record<DialogCardSize, string> = {
   lg: '35rem'
 }
 
+const SIZE_CONTENT_BREAKOUT_MAX_WIDTH: Record<DialogCardSize, string> = {
+  sm: '35rem',
+  md: '37.5rem',
+  lg: '40rem'
+}
+
 export type DialogCardProps = {
   title?: string
   show_header?: boolean
@@ -77,13 +83,11 @@ const slots = defineSlots<{
 const { t } = useI18n()
 const viewport = provideDialogCardViewport(full_bleed_at ?? SIZE_FULL_BLEED_AT[size])
 
-const card_style = computed(() => (dialog_px ? { '--dialog-px': dialog_px } : undefined))
-
-const body_style = computed(() => ({
+const card_style = computed(() => ({
+  ...(dialog_px && { '--dialog-px': dialog_px }),
   '--content-grid-max-width': content_max_width ?? SIZE_CONTENT_MAX_WIDTH[size],
-  ...(content_breakout_max_width && {
-    '--content-grid-breakout-max-width': content_breakout_max_width
-  })
+  '--content-grid-breakout-max-width':
+    content_breakout_max_width ?? SIZE_CONTENT_BREAKOUT_MAX_WIDTH[size]
 }))
 
 defineExpose({ viewport })
@@ -92,57 +96,48 @@ defineExpose({ viewport })
 <template>
   <div
     data-testid="dialog-card"
-    class="relative flex flex-col gap-4 overflow-hidden [--dialog-px:1.5rem] sm:[--dialog-px:2rem]"
+    class="content-grid content-grid-px-(--dialog-px) relative gap-4 overflow-hidden [--dialog-px:1.5rem] sm:[--dialog-px:2rem]"
     :class="[
       SIZE_CLASSES[size],
       bg_class,
+      float_header ? 'grid-rows-[minmax(0,1fr)]' : 'grid-rows-[auto_minmax(0,1fr)]',
       viewport === 'mobile'
         ? 'h-full! w-full! rounded-none!'
         : 'rounded-8 shadow-lg border-t border-l border-brown-100 dark:border-grey-900'
     ]"
     :style="card_style"
   >
-    <div
-      data-testid="dialog-card__header-wrap"
-      :class="float_header ? 'absolute inset-x-0 top-0 z-10' : ''"
-    >
-      <slot name="header">
-        <dialog-card-header
-          v-if="show_header && (title || show_close_button || slots['header-start'])"
-          :title="title"
-          class="full-width"
-        >
-          <template #start>
-            <slot name="header-start">
-              <ui-button
-                v-if="show_close_button"
-                data-testid="dialog-card__close"
-                data-theme="brown-100"
-                data-theme-dark="stone-700"
-                icon-left="close"
-                icon-only
-                rounded-full
-                :disabled="close_disabled"
-                @press="emit('close')"
-              >
-                {{ close_label ?? t('dialog-card.close-label') }}
-              </ui-button>
-            </slot>
-          </template>
+    <slot name="header">
+      <dialog-card-header
+        v-if="show_header && (title || show_close_button || slots['header-start'])"
+        :title="title"
+        class="full-width"
+        :class="float_header ? 'absolute inset-x-0 top-0 z-10' : ''"
+      >
+        <template #start>
+          <slot name="header-start">
+            <ui-button
+              v-if="show_close_button"
+              data-testid="dialog-card__close"
+              data-theme="brown-100"
+              data-theme-dark="stone-700"
+              icon-left="close"
+              icon-only
+              rounded-full
+              :disabled="close_disabled"
+              @press="emit('close')"
+            >
+              {{ close_label ?? t('dialog-card.close-label') }}
+            </ui-button>
+          </slot>
+        </template>
 
-          <template v-if="slots['header-end']" #end>
-            <slot name="header-end"></slot>
-          </template>
-        </dialog-card-header>
-      </slot>
-    </div>
+        <template v-if="slots['header-end']" #end>
+          <slot name="header-end"></slot>
+        </template>
+      </dialog-card-header>
+    </slot>
 
-    <div
-      data-testid="dialog-card__body"
-      class="content-grid content-grid-px-(--dialog-px) min-h-0 flex-1"
-      :style="body_style"
-    >
-      <slot :viewport="viewport"></slot>
-    </div>
+    <slot :viewport="viewport"></slot>
   </div>
 </template>

--- a/src/components/layout-kit/dialog-card/index.vue
+++ b/src/components/layout-kit/dialog-card/index.vue
@@ -96,7 +96,7 @@ defineExpose({ viewport })
 <template>
   <div
     data-testid="dialog-card"
-    class="content-grid content-grid-px-(--dialog-px) relative gap-4 overflow-hidden [--dialog-px:1.5rem] sm:[--dialog-px:2rem]"
+    class="content-grid content-grid-px-(--dialog-px) relative gap-y-4 overflow-hidden [--dialog-px:1.5rem] sm:[--dialog-px:2rem]"
     :class="[
       SIZE_CLASSES[size],
       bg_class,

--- a/src/styles/content-grid.css
+++ b/src/styles/content-grid.css
@@ -22,6 +22,8 @@
 
   & > * {
     grid-column: content;
+    min-width: 0;
+    min-height: 0;
   }
 }
 

--- a/src/views/deck/mobile-editor/index.vue
+++ b/src/views/deck/mobile-editor/index.vue
@@ -28,15 +28,14 @@ onUnmounted(() => onClosed())
     :title="title"
     :close_label="t('deck-view.mobile-editor.done-button')"
     size="lg"
+    class="grid-rows-[auto_1fr_auto]! pb-(--dialog-px)"
     @close="close"
   >
     <template #header-end>
       <editor-header />
     </template>
 
-    <div class="flex w-full h-full flex-col justify-between gap-4 pt-4 pb-6">
-      <editor-stage />
-      <editor-controls />
-    </div>
+    <editor-stage class="self-center" />
+    <editor-controls />
   </dialog-card>
 </template>

--- a/src/views/deck/mobile-editor/index.vue
+++ b/src/views/deck/mobile-editor/index.vue
@@ -29,7 +29,7 @@ onUnmounted(() => onClosed())
     :close_label="t('deck-view.mobile-editor.done-button')"
     size="lg"
     class="grid-rows-[auto_1fr_auto]! pb-(--dialog-px) bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-brown-500"
-    bg_class="bg-brown-100 dark:bg-grey-900"
+    bg_class="bg-brown-300 dark:bg-grey-900"
     @close="close"
   >
     <template #header-end>

--- a/src/views/deck/mobile-editor/index.vue
+++ b/src/views/deck/mobile-editor/index.vue
@@ -28,7 +28,8 @@ onUnmounted(() => onClosed())
     :title="title"
     :close_label="t('deck-view.mobile-editor.done-button')"
     size="lg"
-    class="grid-rows-[auto_1fr_auto]! pb-(--dialog-px)"
+    class="grid-rows-[auto_1fr_auto]! pb-(--dialog-px) bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-brown-500"
+    bg_class="bg-brown-100 dark:bg-grey-900"
     @close="close"
   >
     <template #header-end>

--- a/src/views/deck/mobile-editor/use-mobile-card-editor.ts
+++ b/src/views/deck/mobile-editor/use-mobile-card-editor.ts
@@ -62,6 +62,7 @@ export function useMobileCardEditor(controller: CardListController) {
 
     close_modal = modal.open(MobileEditor, {
       mode: 'popup',
+      backdrop: true,
       context: { key: mobileCardEditorKey, value: api }
     }).close
   }

--- a/src/views/settings/tab-subscription/change-cc-modal.vue
+++ b/src/views/settings/tab-subscription/change-cc-modal.vue
@@ -33,7 +33,7 @@ const submit_label = computed(() =>
   <dialog-card
     data-testid="change-card-modal"
     class="pb-6"
-    bg_class="bg-brown-100 dark:bg-grey-800"
+    bg_class="bg-brown-200 dark:bg-grey-800"
     size="lg"
     data-theme="brown-300"
     data-theme-dark="stone-700"

--- a/src/views/study-session/session-studying/index.vue
+++ b/src/views/study-session/session-studying/index.vue
@@ -47,7 +47,7 @@ function onRated(grade: Grade) {
   <div data-testid="session-flashcard" class="relative h-full w-full">
     <div
       data-testid="study-session__main"
-      class="h-full flex flex-col items-center gap-8 py-(--dialog-px)"
+      class="h-full flex flex-col items-center gap-8 p-(--dialog-px)"
       :class="{ 'opacity-0 pointer-events-none': mode !== 'studying' }"
     >
       <div

--- a/tests/integration/components/layout-kit/dialog-card/dialog-card.test.js
+++ b/tests/integration/components/layout-kit/dialog-card/dialog-card.test.js
@@ -113,7 +113,7 @@ describe('DialogCard', () => {
 
       expect(classes).toContain('w-150')
       expect(classes).toContain('h-160')
-      expect(wrapper.find('[data-testid="dialog-card__body"]').attributes('style')).toContain(
+      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).toContain(
         '--content-grid-max-width: 32.5rem'
       )
     })
@@ -125,21 +125,20 @@ describe('DialogCard', () => {
       expect(classes).toContain('w-140')
       expect(classes).toContain('h-110')
       expect(capturedQueries).toContain('w<sm | h<sm')
-      expect(wrapper.find('[data-testid="dialog-card__body"]').attributes('style')).toContain(
+      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).toContain(
         '--content-grid-max-width: 25rem'
       )
     })
 
-    test('size="lg" applies w-full max-w-160 h-170, full_bleed_at "w<sm", and a 35rem content max width', () => {
+    test('size="lg" applies w-160 h-170, full_bleed_at "w<sm | h<md", and a 35rem content max width', () => {
       const wrapper = mountCard({ size: 'lg' })
       const classes = wrapper.find('[data-testid="dialog-card"]').classes()
 
-      expect(classes).toContain('w-full')
-      expect(classes).toContain('max-w-160')
+      expect(classes).toContain('w-160')
       expect(classes).toContain('h-170')
-      expect(capturedQueries).toContain('w<sm')
+      expect(capturedQueries).toContain('w<sm | h<md')
       expect(capturedQueries).not.toContain('w<sm | h<sm')
-      expect(wrapper.find('[data-testid="dialog-card__body"]').attributes('style')).toContain(
+      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).toContain(
         '--content-grid-max-width: 35rem'
       )
     })
@@ -152,8 +151,40 @@ describe('DialogCard', () => {
 
     test('an explicit content_max_width wins over the size default', () => {
       const wrapper = mountCard({ size: 'sm', content_max_width: '50rem' })
-      expect(wrapper.find('[data-testid="dialog-card__body"]').attributes('style')).toContain(
+      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).toContain(
         '--content-grid-max-width: 50rem'
+      )
+    })
+  })
+
+  // ── content_breakout_max_width per size [obligation] ────────────────────────
+
+  describe('content_breakout_max_width [obligation]', () => {
+    test('size="sm" defaults --content-grid-breakout-max-width to 35rem', () => {
+      const wrapper = mountCard({ size: 'sm' })
+      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).toContain(
+        '--content-grid-breakout-max-width: 35rem'
+      )
+    })
+
+    test('size="md" (default) sets --content-grid-breakout-max-width to 37.5rem', () => {
+      const wrapper = mountCard()
+      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).toContain(
+        '--content-grid-breakout-max-width: 37.5rem'
+      )
+    })
+
+    test('size="lg" sets --content-grid-breakout-max-width to 40rem', () => {
+      const wrapper = mountCard({ size: 'lg' })
+      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).toContain(
+        '--content-grid-breakout-max-width: 40rem'
+      )
+    })
+
+    test('an explicit content_breakout_max_width wins over the size default', () => {
+      const wrapper = mountCard({ size: 'sm', content_breakout_max_width: '60rem' })
+      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).toContain(
+        '--content-grid-breakout-max-width: 60rem'
       )
     })
   })
@@ -335,7 +366,7 @@ describe('DialogCard', () => {
   describe('float_header [obligation]', () => {
     test('takes the header out of flow (absolute inset-x-0 top-0 z-10) when true [obligation]', () => {
       const wrapper = mountCard({ title: 'x', float_header: true })
-      const classes = wrapper.find('[data-testid="dialog-card__header-wrap"]').classes()
+      const classes = wrapper.find('[data-testid="dialog-card-header"]').classes()
 
       expect(classes).toContain('absolute')
       expect(classes).toContain('inset-x-0')
@@ -343,9 +374,9 @@ describe('DialogCard', () => {
       expect(classes).toContain('z-10')
     })
 
-    test('leaves the header in normal flex flow by default (no absolute classes) [obligation]', () => {
+    test('leaves the header in normal flow by default (no absolute classes) [obligation]', () => {
       const wrapper = mountCard({ title: 'x' })
-      const classes = wrapper.find('[data-testid="dialog-card__header-wrap"]').classes()
+      const classes = wrapper.find('[data-testid="dialog-card-header"]').classes()
 
       expect(classes).not.toContain('absolute')
     })
@@ -383,7 +414,9 @@ describe('DialogCard', () => {
 
     test('leaves --dialog-px unset (falls back to the Tailwind arbitrary value) when omitted', () => {
       const wrapper = mountCard()
-      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).toBeUndefined()
+      expect(wrapper.find('[data-testid="dialog-card"]').attributes('style')).not.toContain(
+        '--dialog-px'
+      )
     })
   })
 })

--- a/tests/integration/components/modals/study-session/index.test.js
+++ b/tests/integration/components/modals/study-session/index.test.js
@@ -360,11 +360,11 @@ describe('StudySession (index.vue)', () => {
     expect(title.length).toBeGreaterThan(0)
   })
 
-  // ── dialog-card size="lg" sources full_bleed_at="w<sm" ─────────────────────
+  // ── dialog-card size="lg" sources full_bleed_at="w<sm | h<md" ──────────────
 
-  test('size="lg" resolves full_bleed_at to "w<sm"', () => {
+  test('size="lg" resolves full_bleed_at to "w<sm | h<md"', () => {
     makeWrapper()
-    expect(capturedQueries).toContain('w<sm')
+    expect(capturedQueries).toContain('w<sm | h<md')
     expect(capturedQueries).not.toContain('w<sm | h<sm')
   })
 

--- a/tests/integration/views/welcome/reset-password/index.test.js
+++ b/tests/integration/views/welcome/reset-password/index.test.js
@@ -223,12 +223,12 @@ describe('ResetPasswordModal (reset-password/index.vue)', () => {
       const wrapper = makeWrapper()
       await flushTransition()
 
-      expect(wrapper.find('[data-testid="dialog-card__header-wrap"] header').exists()).toBe(false)
+      expect(wrapper.find('header[data-testid="dialog-card-header"]').exists()).toBe(false)
     })
 
     test('shows the dialog-card header while not yet successful', () => {
       const wrapper = makeWrapper()
-      expect(wrapper.find('[data-testid="dialog-card__header-wrap"] header').exists()).toBe(true)
+      expect(wrapper.find('header[data-testid="dialog-card-header"]').exists()).toBe(true)
     })
 
     test('renders the party-popper icon on the success page [obligation]', async () => {

--- a/tests/unit/views/deck/mobile-editor/use-mobile-card-editor.test.js
+++ b/tests/unit/views/deck/mobile-editor/use-mobile-card-editor.test.js
@@ -89,6 +89,7 @@ describe('useMobileCardEditor — open_at [obligation]', () => {
 
     expect(mockOpen).toHaveBeenCalledWith(MobileEditor, {
       mode: 'popup',
+      backdrop: true,
       context: { key: mobileCardEditorKey, value: editor }
     })
   })


### PR DESCRIPTION
## Summary

Restructures dialog-card's root from a flex column into a CSS grid so the header and the default (viewport) slot render as direct grid siblings, letting consumers lay content out alongside the header instead of being boxed into a fixed header+body stack. Fixes a real overflow bug this surfaced, and updates the mobile-editor and move-cards-modal consumers to use the new layout.

## Changes

- `dialog-card`: root is now `content-grid` itself (`grid-rows-[auto_minmax(0,1fr)]`, collapsing to a single row when `float_header`); drops the `dialog-card__header-wrap`/`dialog-card__body` wrapper divs
- Adds per-size `content_breakout_max_width` defaults (`SIZE_CONTENT_BREAKOUT_MAX_WIDTH`)
- Fixes a layout bug where `column-gap` was inserted between every track a `full-width`/`breakout` item spans, inflating it past the card's own width on narrow viewports (e.g. the header rendering 435px inside a 371px card) — switched to `gap-y-4`
- `content-grid` children get `min-width`/`min-height: 0` by default, since CSS Grid applies automatic-minimum-size on both axes (flex-col only applied it on the main axis)
- `mobile-editor` and `move-cards-modal`: drop manual flex wrappers, lay content out directly as grid siblings via a `grid-rows-[auto_1fr_auto]!` override for a space-between header/stage/controls layout
- `dialog-card` `lg` size switches to a fixed `w-160` (was full-bleed to `max-w-160`) with a matching `h<md` full-bleed breakpoint
- Repoints tests broken by the removed wrapper testids, adds coverage for the new breakout-width defaults