### PR TITLE
chore(ci): wire google oauth secrets into config push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -220,6 +220,8 @@ jobs:
         run: supabase config push --yes
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
+          AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET: ${{ secrets.AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET }}
 
   frontend:
     name: Deploy frontend


### PR DESCRIPTION
## Summary
- The `config` job's `Push config` step never passed `AUTH_EXTERNAL_GOOGLE_CLIENT_ID`/`SECRET` through to its shell env, so `supabase config push` resolved `env(...)` to empty and wiped prod's Google OAuth provider config on every deploy that touched `supabase/config.toml`. This caused the `invalid_client` / "OAuth client was not found" error on Google sign-in in prod.