### PR TITLE
Bug-bash: ui-kit, session, and deck/member settings fixes

### DIFF
--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -102,6 +102,28 @@ export function waitForPasswordRecovery(): Promise<boolean> {
   })
 }
 
+// Fires when Supabase's client gives up on the session locally — a manual
+// sign-out, or its own background token refresh failing because the session
+// was revoked/expired elsewhere. Returns an unsubscribe function.
+export function onSignedOut(callback: () => void): () => void {
+  const { data: sub } = supabase.auth.onAuthStateChange((event) => {
+    if (event !== 'SIGNED_OUT') return
+    callback()
+  })
+
+  return () => sub.subscription.unsubscribe()
+}
+
+// A revoked/expired session doesn't always trigger onSignedOut before the
+// next API call — the request itself can come back 401/JWT-expired first.
+// This lets callers recognize that case and treat it the same way.
+export function isAuthError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+
+  const { status, code, name } = error as { status?: number; code?: string; name?: string }
+  return status === 401 || code === 'PGRST301' || name === 'AuthApiError'
+}
+
 export async function login(email: string, password: string): Promise<LoginOutcome> {
   try {
     const { error } = await supabase.auth.signInWithPassword({ email, password })

--- a/src/components/member/member-badge.vue
+++ b/src/components/member/member-badge.vue
@@ -43,7 +43,7 @@ const body_bindings = computed(() => memberCoverBindings(cover))
       <span data-testid="member-badge__name" class="font-semibold text-3xl text-brown-100 truncate">
         {{ displayName || t('member-badge.name-placeholder') }}
       </span>
-      <div data-testid="member-badge__description" class="text-sm text-brown-100">
+      <div data-testid="member-badge__description" class="text-sm text-brown-100 wrap-break-word">
         <slot name="description">{{ description || t('member-badge.description-fallback') }}</slot>
       </div>
     </div>

--- a/src/components/member/member-card.vue
+++ b/src/components/member/member-card.vue
@@ -47,9 +47,11 @@ const body_bindings = computed(() => memberCoverBindings(cover))
         class="bg-brown-200 dark:bg-stone-900 rounded-4 w-full px-2 py-3"
       >
         <p
-          class="text-brown-700 dark:text-brown-100 flex h-[3lh] items-center justify-center text-center wrap-break-word"
+          class="text-brown-700 dark:text-brown-100 flex h-[3lh] items-center justify-center text-center"
         >
-          <q>{{ cardComment || t('member-card.description-fallback') }}</q>
+          <q class="min-w-0 wrap-break-word">{{
+            cardComment || t('member-card.description-fallback')
+          }}</q>
         </p>
       </div>
 

--- a/src/components/member/member-card.vue
+++ b/src/components/member/member-card.vue
@@ -47,7 +47,7 @@ const body_bindings = computed(() => memberCoverBindings(cover))
         class="bg-brown-200 dark:bg-stone-900 rounded-4 w-full px-2 py-3"
       >
         <p
-          class="text-brown-700 dark:text-brown-100 flex h-[3lh] items-center justify-center text-center"
+          class="text-brown-700 dark:text-brown-100 flex h-[3lh] items-center justify-center text-center wrap-break-word"
         >
           <q>{{ cardComment || t('member-card.description-fallback') }}</q>
         </p>

--- a/src/components/member/member-card.vue
+++ b/src/components/member/member-card.vue
@@ -26,7 +26,9 @@ const body_bindings = computed(() => memberCoverBindings(cover))
     class="bg-brown-200 dark:bg-stone-900 rounded-8 border-brown-200 dark:border-stone-900 flex w-89 flex-col overflow-hidden border-8 shadow-[-1px_-1px_0_0_var(--color-brown-100)] dark:shadow-[-1px_-1px_0_0_var(--color-grey-900)]"
   >
     <div data-testid="member-card__header" class="flex items-center justify-center px-9 pt-4 pb-1">
-      <h1 class="text-brown-700 dark:text-brown-200 text-5xl">{{ displayName }}</h1>
+      <h1 class="text-brown-700 dark:text-brown-200 text-5xl">
+        {{ displayName || t('member-badge.name-placeholder') }}
+      </h1>
     </div>
 
     <div

--- a/src/components/taro-phone/app-shell.vue
+++ b/src/components/taro-phone/app-shell.vue
@@ -50,7 +50,7 @@ function spawnBurst() {
 
 <template>
   <div data-testid="app-shell-container" class="flex flex-col items-center gap-0.5">
-    <div>
+    <div class="relative">
       <button
         data-testid="phone-app"
         v-bind="$attrs"

--- a/src/components/ui-kit/image.vue
+++ b/src/components/ui-kit/image.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, watch } from 'vue'
 import logger from '@/utils/logger'
 
 const { src, size = 'unset' } = defineProps<{
   src: string
   size?: 'full' | 'xl' | 'lg' | 'base' | 'sm' | 'xs' | 'unset'
 }>()
-
-const imageUrl = ref<string | null>(null)
 
 // Images listed in the eager globs are bundled into the main chunk.
 // All others are code-split and fetched on first use.
@@ -42,27 +40,35 @@ const lazySvgs = import.meta.glob('../../assets/images/*.svg', {
 })
 
 const lazyModules = { ...lazyRaster, ...lazySvgs }
+const lazyUrl = ref<string | null>(null)
+
+const eagerUrl = computed(() => {
+  const key = findKey(eagerImages, src)
+  return key ? (eagerImages[key] as string) : null
+})
+const imageUrl = computed(() => eagerUrl.value ?? lazyUrl.value)
 
 function findKey(mods: Record<string, any>, name: string) {
   const re = new RegExp(`/${name}\\.(png|jpe?g|svg)$`, 'i')
   return Object.keys(mods).find((k) => re.test(k))
 }
 
-onMounted(async () => {
-  const eagerKey = findKey(eagerImages, src)
-  if (eagerKey) {
-    imageUrl.value = eagerImages[eagerKey] as string
-    return
-  }
+watch(
+  () => src,
+  async (name) => {
+    lazyUrl.value = null
+    if (eagerUrl.value) return
 
-  const lazyKey = findKey(lazyModules, src)
-  if (!lazyKey) {
-    logger.warn(`No image found for: ${src}`)
-    return
-  }
+    const lazyKey = findKey(lazyModules, name)
+    if (!lazyKey) {
+      logger.warn(`No image found for: ${name}`)
+      return
+    }
 
-  imageUrl.value = (await lazyModules[lazyKey]()) as string
-})
+    lazyUrl.value = (await lazyModules[lazyKey]()) as string
+  },
+  { immediate: true }
+)
 </script>
 
 <template>

--- a/src/components/ui-kit/input.vue
+++ b/src/components/ui-kit/input.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
 
-const { textAlign = 'left', size = 'lg' } = defineProps<{
+type UiInputProps = {
   label?: string
   placeholder?: string
   textAlign?: 'left' | 'center' | 'right'
   size?: 'sm' | 'base' | 'lg'
   error?: string
-}>()
+  maxLength?: number
+}
+
+const { textAlign = 'left', size = 'lg', maxLength } = defineProps<UiInputProps>()
 
 const emit = defineEmits<{
   (e: 'input', value?: string): void
@@ -42,6 +45,7 @@ const value = defineModel<string>('value')
         v-bind="$attrs"
         v-sfx.focus="'type_05'"
         :placeholder="placeholder"
+        :maxlength="maxLength"
         v-model="value"
         @input="emit('input', value)"
       />

--- a/src/components/ui-kit/textarea.vue
+++ b/src/components/ui-kit/textarea.vue
@@ -2,13 +2,16 @@
 import { computed } from 'vue'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
 
-const { textAlign = 'left', max_chars } = defineProps<{
+type UiTextareaProps = {
   label?: string
   placeholder?: string
   textAlign?: 'left' | 'center' | 'right'
   error?: string
   max_chars?: number
-}>()
+  noNewlines?: boolean
+}
+
+const { textAlign = 'left', max_chars, noNewlines = false } = defineProps<UiTextareaProps>()
 
 const emit = defineEmits<{
   (e: 'input', value?: string): void
@@ -18,6 +21,17 @@ const value = defineModel<string>('value')
 
 const char_count = computed(() => value.value?.length ?? 0)
 const at_limit = computed(() => max_chars !== undefined && char_count.value >= max_chars)
+
+function onKeydown(e: KeyboardEvent) {
+  if (noNewlines && e.key === 'Enter') e.preventDefault()
+}
+
+function onInput() {
+  if (noNewlines && value.value?.includes('\n')) {
+    value.value = value.value.replace(/[\r\n]+/g, ' ')
+  }
+  emit('input', value.value)
+}
 </script>
 
 <template>
@@ -46,7 +60,8 @@ const at_limit = computed(() => max_chars !== undefined && char_count.value >= m
         :placeholder="placeholder"
         :maxlength="max_chars"
         v-model="value"
-        @input="emit('input', value)"
+        @keydown="onKeydown"
+        @input="onInput"
       />
       <span
         v-if="max_chars !== undefined"

--- a/src/composables/deck/editor.ts
+++ b/src/composables/deck/editor.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, ref, type InjectionKey } from 'vue'
+import { computed, reactive, ref, watch, type InjectionKey } from 'vue'
 import { useDeleteDeckMutation } from '@/api/decks'
 import { useCardsInDeckInfiniteQuery } from '@/api/cards'
 import { useResetDeckReviewsMutation } from '@/api/reviews'
@@ -35,6 +35,7 @@ export function useDeckEditor(deck?: Deck) {
   })
 
   const active_side = ref<CardSide>('cover')
+  const title_error = ref<string>()
 
   // The design preview shows the deck's first card. Disabled for unsaved decks
   // (no id), so deck-create just falls back to placeholder text.
@@ -47,6 +48,7 @@ export function useDeckEditor(deck?: Deck) {
   const is_dirty = computed(() =>
     hasDeckChanges({ settings, config, cover, card_attributes }, initial_payload)
   )
+  const has_title = computed(() => !!settings.title?.trim())
 
   const deck_actions = useDeckActions()
   const delete_mutation = useDeleteDeckMutation()
@@ -92,6 +94,13 @@ export function useDeckEditor(deck?: Deck) {
     active_side.value = side
   }
 
+  watch(
+    () => settings.title,
+    () => {
+      title_error.value = undefined
+    }
+  )
+
   return {
     deck,
     settings,
@@ -102,6 +111,8 @@ export function useDeckEditor(deck?: Deck) {
     preview_front_text,
     preview_back_text,
     is_dirty,
+    has_title,
+    title_error,
     deleting: delete_mutation.isLoading,
     resetting_reviews: reset_reviews_mutation.isLoading,
     saveDeck,

--- a/src/composables/member/editor.ts
+++ b/src/composables/member/editor.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, type InjectionKey } from 'vue'
+import { computed, reactive, ref, watch, type InjectionKey } from 'vue'
 import { useUpsertMemberMutation } from '@/api/members'
 import { useMemberStore } from '@/stores/member'
 import { buildMemberPayload, hasMemberChanges } from '@/utils/member/payload'
@@ -20,9 +20,12 @@ export function useMemberEditor() {
 
   const cover = reactive<DeckCover>({ ...member_store.cover })
 
+  const name_error = ref<string>()
+
   const email = computed(() => member_store.email ?? '')
   const created_at = computed(() => member_store.created_at ?? '')
   const plan = computed(() => member_store.plan ?? 'free')
+  const has_name = computed(() => !!settings.display_name?.trim())
 
   const initial_payload = buildMemberPayload({ settings, preferences, cover })
   const is_dirty = computed(() =>
@@ -47,6 +50,13 @@ export function useMemberEditor() {
     }
   }
 
+  watch(
+    () => settings.display_name,
+    () => {
+      name_error.value = undefined
+    }
+  )
+
   return {
     settings,
     preferences,
@@ -55,6 +65,8 @@ export function useMemberEditor() {
     created_at,
     plan,
     is_dirty,
+    has_name,
+    name_error,
     saving: upsert_mutation.isLoading,
     saveMember
   }

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -176,6 +176,7 @@
   "settings.profile.section.about-you": "About you",
   "settings.profile.section.appearance": "Appearance",
   "settings.profile.member-name-placeholder": "Member Name",
+  "settings.profile.member-name-required": "Give your profile a name",
   "settings.profile.description-placeholder": "Bio",
   "settings.profile.theme-label": "Theme",
   "settings.profile.pattern-label": "Pattern",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -521,6 +521,7 @@
   "deck.settings-modal.preview.front-fallback": "Front",
   "deck.settings-modal.preview.back-fallback": "Back",
   "deck.settings-modal.submit-edit": "Save changes",
+  "deck.settings-modal.title-required": "Give your deck a name",
   "deck.settings-modal.unsaved-alert.title": "Unsaved changes",
   "deck.settings-modal.unsaved-alert.message": "You have unsaved changes. Exit anyway?",
   "deck.settings-modal.unsaved-alert.confirm": "Exit",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -31,6 +31,7 @@
   "login-dialog.errors.rate-limited": "Too many attempts — please try again in a bit",
   "login-dialog.errors.generic": "Something went wrong. Please try again",
   "session.logout-error": "Couldn't log out. Please try again.",
+  "session.expired-error": "Your session expired. Please log in again.",
   "member.load-error": "Couldn't load your account",
   "member.load-error-sub": "Something went wrong loading your profile.",
   "login-dialog.forgot-password-link": "Forgot password?",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -32,6 +32,7 @@
   "login-dialog.errors.generic": "Something went wrong. Please try again",
   "session.logout-error": "Couldn't log out. Please try again.",
   "session.expired-error": "Your session expired. Please log in again.",
+  "session.expired-error-action": "Got It",
   "member.load-error": "Couldn't load your account",
   "member.load-error-sub": "Something went wrong loading your profile.",
   "login-dialog.forgot-password-link": "Forgot password?",

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,13 +34,18 @@ app.use(pinia)
 app.use(i18n)
 app.use(router)
 
-// Needs router + i18n installed above — the store injects both via
-// useRouter()/useI18n() during its own setup.
-const session = useSessionStore(pinia)
+// Deferred to call-time: the store's own setup() calls useI18n()/useRouter(),
+// which only work while a component is being set up. Resolving it here would
+// create the store before any component exists. By the time a query/mutation
+// actually errors, the router guard has already triggered its first (and
+// only) real construction, so this just looks up the cached instance.
+function handleAuthError(error: unknown) {
+  useSessionStore(pinia).handleAuthError(error)
+}
 
 app.use(PiniaColada, {
-  plugins: [PiniaColadaQueryHooksPlugin({ onError: session.handleAuthError })],
-  mutationOptions: { onError: session.handleAuthError }
+  plugins: [PiniaColadaQueryHooksPlugin({ onError: handleAuthError })],
+  mutationOptions: { onError: handleAuthError }
 })
 
 app.directive('sfx', vSfx)

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,12 @@ import App from './App.vue'
 import router from './router'
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
-import { PiniaColada } from '@pinia/colada'
+import { PiniaColada, PiniaColadaQueryHooksPlugin } from '@pinia/colada'
 import { createI18n } from 'vue-i18n'
 import messages from '@intlify/unplugin-vue-i18n/messages'
 import { vSfx } from '@/sfx/directive'
 import { warmupAnimations } from '@/utils/animations/warmup'
+import { useSessionStore } from '@/stores/session'
 
 warmupAnimations()
 
@@ -27,11 +28,20 @@ const i18n = createI18n({
 })
 
 const app = createApp(App)
+const pinia = createPinia()
 
-app.use(createPinia())
-app.use(PiniaColada)
+app.use(pinia)
 app.use(i18n)
 app.use(router)
+
+// Needs router + i18n installed above — the store injects both via
+// useRouter()/useI18n() during its own setup.
+const session = useSessionStore(pinia)
+
+app.use(PiniaColada, {
+  plugins: [PiniaColadaQueryHooksPlugin({ onError: session.handleAuthError })],
+  mutationOptions: { onError: session.handleAuthError }
+})
 
 app.directive('sfx', vSfx)
 

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -4,6 +4,8 @@ import {
   getSession,
   getUser,
   isPasswordRecoveryUrl,
+  isAuthError,
+  onSignedOut,
   waitForPasswordRecovery,
   login as supaLogin,
   logout as supaLogout,
@@ -36,12 +38,22 @@ export const useSessionStore = defineStore('sessionStore', () => {
 
   const user = ref<User | undefined>(undefined)
   const loading_count = ref(0)
+  let logging_out_intentionally = false
 
   const authenticated = computed(() => Boolean(user.value?.aud === 'authenticated'))
   const isLoading = computed(() => loading_count.value > 0)
   const identities = computed(() => user.value?.identities ?? [])
   const hasPasswordIdentity = computed(() => identities.value.some((i) => i.provider === 'email'))
   const hasGoogleIdentity = computed(() => identities.value.some((i) => i.provider === 'google'))
+
+  // Supabase's client can locally sign itself out (e.g. a background token
+  // refresh rejected because the session was revoked on another device)
+  // without any component ever calling logout(). This is the "stale tab"
+  // case: catch it here rather than only reacting to failed API calls.
+  onSignedOut(() => {
+    if (logging_out_intentionally) return
+    forceLogout()
+  })
 
   /**
    * True if this page load is a password-recovery redirect, after awaiting the
@@ -77,16 +89,45 @@ export const useSessionStore = defineStore('sessionStore', () => {
   }
 
   async function logout(): Promise<void> {
+    logging_out_intentionally = true
+
     try {
       await supaLogout()
     } catch (e: any) {
       logger.error(`Error logging out: ${e.message}`)
       notice.error(t('session.logout-error'))
       return
+    } finally {
+      logging_out_intentionally = false
     }
 
     reset()
     router.push({ name: 'welcome' })
+  }
+
+  /** Call when an API response indicates the session is no longer valid server-side. */
+  function handleAuthError(error: unknown): void {
+    if (isAuthError(error)) forceLogout()
+  }
+
+  // Same end state as logout(), but skipped when already logged out (avoids
+  // reacting to its own signOut() call below) and shows a "session expired"
+  // notice instead of silently redirecting.
+  async function forceLogout(): Promise<void> {
+    if (!authenticated.value) return
+
+    reset()
+    notice.warn(t('session.expired-error'), {
+      variant: 'panel',
+      persist: true,
+      onDismiss: () => router.push({ name: 'welcome' })
+    })
+
+    try {
+      await supaLogout()
+    } catch {
+      // Session was already invalid server-side — nothing left to clean up.
+    }
   }
 
   function signupEmail(
@@ -157,6 +198,7 @@ export const useSessionStore = defineStore('sessionStore', () => {
     checkPasswordRecovery,
     restoreSession,
     logout,
+    handleAuthError,
     signupEmail,
     signInOAuth,
     updateEmail,

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -120,6 +120,10 @@ export const useSessionStore = defineStore('sessionStore', () => {
     notice.warn(t('session.expired-error'), {
       variant: 'panel',
       persist: true,
+      closable: false,
+      actions: [
+        { label: t('session.expired-error-action'), onClick: () => {}, closesOnClick: true }
+      ],
       onDismiss: () => router.push({ name: 'welcome' })
     })
 

--- a/src/utils/deck/defaults.ts
+++ b/src/utils/deck/defaults.ts
@@ -9,7 +9,7 @@ export const DECK_SETTINGS_DEFAULTS = {
   is_public: true
 } as const
 
-export const DECK_TITLE_MAX_LENGTH = 50
+export const DECK_TITLE_MAX_LENGTH = 15
 
 export const DECK_CONFIG_DEFAULTS: Required<DeckConfig> = {
   study_all_cards: false,

--- a/src/utils/deck/defaults.ts
+++ b/src/utils/deck/defaults.ts
@@ -9,6 +9,8 @@ export const DECK_SETTINGS_DEFAULTS = {
   is_public: true
 } as const
 
+export const DECK_TITLE_MAX_LENGTH = 50
+
 export const DECK_CONFIG_DEFAULTS: Required<DeckConfig> = {
   study_all_cards: false,
   shuffle: false,

--- a/src/utils/member/defaults.ts
+++ b/src/utils/member/defaults.ts
@@ -9,7 +9,7 @@ export const MEMBER_SETTINGS_DEFAULTS = {
   description: ''
 } as const
 
-export const MEMBER_DISPLAY_NAME_MAX_LENGTH = 30
+export const MEMBER_DISPLAY_NAME_MAX_LENGTH = 12
 
 export const MEMBER_CARD_COVER_DEFAULTS: DeckCover = {
   theme: 'green-500',

--- a/src/utils/member/defaults.ts
+++ b/src/utils/member/defaults.ts
@@ -9,6 +9,8 @@ export const MEMBER_SETTINGS_DEFAULTS = {
   description: ''
 } as const
 
+export const MEMBER_DISPLAY_NAME_MAX_LENGTH = 30
+
 export const MEMBER_CARD_COVER_DEFAULTS: DeckCover = {
   theme: 'green-500',
   theme_dark: 'green-800',

--- a/src/views/deck/composables/edit-menu.ts
+++ b/src/views/deck/composables/edit-menu.ts
@@ -17,8 +17,9 @@ export type CardEditMenu = ReturnType<typeof useCardEditMenu>
  * footer prepends its own `edit` entry). `primaryAction`/`startEditing` are the
  * primary edit action — the dock editor below md, desktop edit mode at md+.
  *
- * The rearrange option disables itself while rearranging: stopping happens via
- * the yellow primary button (desktop) or footer button (mobile), not from here.
+ * All options disable while rearranging — bulk-select toggles don't work
+ * mid-drag, so nothing else in the menu should be reachable either. Stopping
+ * happens via the yellow primary button (desktop) or footer button (mobile).
  */
 export function useCardEditMenu() {
   const { t } = useI18n()
@@ -34,7 +35,12 @@ export function useCardEditMenu() {
   const is_rearranging = computed(() => !!shell?.is_rearranging.value)
 
   const options = computed<DropdownOption[]>(() => [
-    { label: t('deck-view.actions.select-cards'), value: 'select', icon: 'data-check' },
+    {
+      label: t('deck-view.actions.select-cards'),
+      value: 'select',
+      icon: 'data-check',
+      disabled: is_rearranging.value
+    },
     {
       label: t('deck-view.actions.reorder-cards'),
       value: 'rearrange',
@@ -44,7 +50,8 @@ export function useCardEditMenu() {
     {
       label: t('deck-view.actions.edit-card-appearance'),
       value: 'appearance',
-      icon: 'align-horizontal-frame'
+      icon: 'align-horizontal-frame',
+      disabled: is_rearranging.value
     }
   ])
 

--- a/src/views/deck/deck-create-modal.vue
+++ b/src/views/deck/deck-create-modal.vue
@@ -126,6 +126,7 @@ watch(
           <ui-textarea
             :placeholder="t('deck.description-placeholder')"
             :max_chars="100"
+            no-newlines
             rows="3"
             v-model:value="editor.settings.description"
           />

--- a/src/views/deck/deck-create-modal.vue
+++ b/src/views/deck/deck-create-modal.vue
@@ -8,6 +8,7 @@ import DeckPinnedPreview from '@/components/deck/pinned-preview.vue'
 import { useDeckEditor, deckEditorKey } from '@/composables/deck/editor'
 import { useTabModalLayout } from '@/composables/ui/tab-modal-layout'
 import { randomCoverConfig } from '@/utils/cover'
+import { DECK_TITLE_MAX_LENGTH } from '@/utils/deck/defaults'
 import { emitSfx } from '@/sfx/bus'
 import { useNoticeStore } from '@/stores/notice-store'
 import UiButton from '@/components/ui-kit/button.vue'
@@ -117,6 +118,7 @@ watch(
           <ui-input
             :placeholder="t('deck.title-placeholder')"
             :error="title_error"
+            :max-length="DECK_TITLE_MAX_LENGTH"
             text-align="center"
             size="lg"
             v-model:value="editor.settings.title"
@@ -152,6 +154,7 @@ watch(
           <ui-input
             :placeholder="t('deck.title-placeholder')"
             :error="title_error"
+            :max-length="DECK_TITLE_MAX_LENGTH"
             text-align="center"
             size="lg"
             v-model:value="editor.settings.title"

--- a/src/views/deck/deck-hero/details.vue
+++ b/src/views/deck/deck-hero/details.vue
@@ -6,7 +6,7 @@ defineProps<{ deck: Deck }>()
   <div data-testid="deck-hero__details" class="flex flex-col items-center gap-2 md:items-start">
     <h2
       data-testid="overview-panel__description"
-      class="text-grey-500 dark:text-brown-500 w-64 text-center md:text-left"
+      class="text-grey-500 dark:text-brown-500 w-64 text-center wrap-break-word md:text-left"
     >
       {{ deck.description }}
     </h2>

--- a/src/views/deck/deck-settings/deck-aside.vue
+++ b/src/views/deck/deck-settings/deck-aside.vue
@@ -8,7 +8,7 @@ import { DECK_TITLE_MAX_LENGTH } from '@/utils/deck/defaults'
 import DeckSaveButton from './deck-save-button.vue'
 
 const { t } = useI18n()
-const { settings } = inject(deckEditorKey)!
+const { settings, title_error } = inject(deckEditorKey)!
 </script>
 
 <template>
@@ -19,6 +19,7 @@ const { settings } = inject(deckEditorKey)!
     <div data-testid="deck-aside__inputs" class="flex flex-col gap-2">
       <ui-input
         :placeholder="t('deck.title-placeholder')"
+        :error="title_error"
         :max-length="DECK_TITLE_MAX_LENGTH"
         text-align="center"
         size="lg"

--- a/src/views/deck/deck-settings/deck-aside.vue
+++ b/src/views/deck/deck-settings/deck-aside.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import UiInput from '@/components/ui-kit/input.vue'
 import UiTextarea from '@/components/ui-kit/textarea.vue'
 import { deckEditorKey } from '@/composables/deck/editor'
+import { DECK_TITLE_MAX_LENGTH } from '@/utils/deck/defaults'
 import DeckSaveButton from './deck-save-button.vue'
 
 const { t } = useI18n()
@@ -18,6 +19,7 @@ const { settings } = inject(deckEditorKey)!
     <div data-testid="deck-aside__inputs" class="flex flex-col gap-2">
       <ui-input
         :placeholder="t('deck.title-placeholder')"
+        :max-length="DECK_TITLE_MAX_LENGTH"
         text-align="center"
         size="lg"
         v-model:value="settings.title"

--- a/src/views/deck/deck-settings/deck-aside.vue
+++ b/src/views/deck/deck-settings/deck-aside.vue
@@ -27,6 +27,7 @@ const { settings } = inject(deckEditorKey)!
       <ui-textarea
         :placeholder="t('deck.description-placeholder')"
         :max_chars="100"
+        no-newlines
         rows="3"
         v-model:value="settings.description"
       />

--- a/src/views/deck/deck-settings/deck-save-button.vue
+++ b/src/views/deck/deck-settings/deck-save-button.vue
@@ -9,18 +9,19 @@ import { useNoticeStore } from '@/stores/notice-store'
 
 const { t } = useI18n()
 const notice = useNoticeStore()
-const { settings, is_dirty, saveDeck } = inject(deckEditorKey)!
+const { is_dirty, has_title, title_error, saveDeck } = inject(deckEditorKey)!
 const close = inject(deckSettingsCloseKey)!
 
 const is_saving = ref(false)
 
 async function onSave() {
-  if (!is_dirty.value) {
-    emitSfx('digi_powerdown')
+  if (!has_title.value) {
+    title_error.value = t('deck.settings-modal.title-required')
+    emitSfx('etc_woodblock_stuck')
     return
   }
-  if (!settings.title?.trim()) {
-    emitSfx('etc_woodblock_stuck')
+  if (!is_dirty.value) {
+    emitSfx('digi_powerdown')
     return
   }
   is_saving.value = true
@@ -42,7 +43,7 @@ async function onSave() {
     size="lg"
     full-width
     :loading="is_saving"
-    :disabled="!is_dirty"
+    :disabled="!is_dirty || !has_title"
     :sfx="{ press: 'snappy_button_2' }"
     click-when-disabled
     @press="onSave"

--- a/src/views/deck/deck-settings/tab-details/index.vue
+++ b/src/views/deck/deck-settings/tab-details/index.vue
@@ -5,6 +5,7 @@ import UiInput from '@/components/ui-kit/input.vue'
 import UiTextarea from '@/components/ui-kit/textarea.vue'
 import SectionList from '@/components/layout-kit/section-list.vue'
 import { deckEditorKey } from '@/composables/deck/editor'
+import { DECK_TITLE_MAX_LENGTH } from '@/utils/deck/defaults'
 import { deckSettingsLayoutKey } from '../layout'
 import DeckSaveButton from '../deck-save-button.vue'
 
@@ -21,6 +22,7 @@ const layout_mode = inject(deckSettingsLayoutKey)!
     <div data-testid="tab-details__inputs" class="flex flex-col gap-2">
       <ui-input
         :placeholder="t('deck.title-placeholder')"
+        :max-length="DECK_TITLE_MAX_LENGTH"
         text-align="center"
         size="lg"
         v-model:value="settings.title"

--- a/src/views/deck/deck-settings/tab-details/index.vue
+++ b/src/views/deck/deck-settings/tab-details/index.vue
@@ -10,7 +10,7 @@ import { deckSettingsLayoutKey } from '../layout'
 import DeckSaveButton from '../deck-save-button.vue'
 
 const { t } = useI18n()
-const { settings } = inject(deckEditorKey)!
+const { settings, title_error } = inject(deckEditorKey)!
 const layout_mode = inject(deckSettingsLayoutKey)!
 </script>
 
@@ -22,6 +22,7 @@ const layout_mode = inject(deckSettingsLayoutKey)!
     <div data-testid="tab-details__inputs" class="flex flex-col gap-2">
       <ui-input
         :placeholder="t('deck.title-placeholder')"
+        :error="title_error"
         :max-length="DECK_TITLE_MAX_LENGTH"
         text-align="center"
         size="lg"

--- a/src/views/deck/deck-settings/tab-details/index.vue
+++ b/src/views/deck/deck-settings/tab-details/index.vue
@@ -30,6 +30,7 @@ const layout_mode = inject(deckSettingsLayoutKey)!
       <ui-textarea
         :placeholder="t('deck.description-placeholder')"
         :max_chars="100"
+        no-newlines
         rows="3"
         v-model:value="settings.description"
       />

--- a/src/views/settings/settings-save-button.vue
+++ b/src/views/settings/settings-save-button.vue
@@ -1,20 +1,25 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { inject, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import UiButton from '@/components/ui-kit/button.vue'
 import { memberEditorKey } from '@/composables/member/editor'
 import { settingsCloseKey } from './layout'
-import { inject } from 'vue'
+import { emitSfx } from '@/sfx/bus'
 import { useNoticeStore } from '@/stores/notice-store'
 
 const { t } = useI18n()
 const notice = useNoticeStore()
-const { is_dirty, saveMember } = inject(memberEditorKey)!
+const { is_dirty, has_name, name_error, saveMember } = inject(memberEditorKey)!
 const close = inject(settingsCloseKey)!
 
 const is_saving = ref(false)
 
 async function onSave() {
+  if (!has_name.value) {
+    name_error.value = t('settings.profile.member-name-required')
+    emitSfx('etc_woodblock_stuck')
+    return
+  }
   is_saving.value = true
   const saved = await saveMember()
   is_saving.value = false
@@ -34,7 +39,7 @@ async function onSave() {
     size="lg"
     full-width
     :loading="is_saving"
-    :disabled="!is_dirty"
+    :disabled="!is_dirty || !has_name"
     :sfx="{ press: 'snappy_button_2' }"
     click-when-disabled
     @press="onSave"

--- a/src/views/settings/tab-profile/index.vue
+++ b/src/views/settings/tab-profile/index.vue
@@ -38,6 +38,7 @@ const layout_mode = inject(settingsLayoutKey)!
       <ui-textarea
         :placeholder="t('settings.profile.description-placeholder')"
         :max_chars="100"
+        no-newlines
         rows="3"
         v-model:value="editor.settings.description"
       />

--- a/src/views/settings/tab-profile/index.vue
+++ b/src/views/settings/tab-profile/index.vue
@@ -32,6 +32,7 @@ const layout_mode = inject(settingsLayoutKey)!
     <labeled-section :label="t('settings.profile.section.about-you')">
       <ui-input
         :placeholder="t('settings.profile.member-name-placeholder')"
+        :error="editor.name_error.value"
         :max-length="MEMBER_DISPLAY_NAME_MAX_LENGTH"
         v-model:value="editor.settings.display_name"
       />

--- a/src/views/settings/tab-profile/index.vue
+++ b/src/views/settings/tab-profile/index.vue
@@ -10,6 +10,7 @@ import LabeledSection from '@/components/layout-kit/labeled-section.vue'
 import MemberBadge from '@/components/member/member-badge.vue'
 import SettingsSaveButton from '../settings-save-button.vue'
 import { memberEditorKey } from '@/composables/member/editor'
+import { MEMBER_DISPLAY_NAME_MAX_LENGTH } from '@/utils/member/defaults'
 import { settingsLayoutKey } from '../layout'
 import { SUPPORTED_THEMES, SUPPORTED_PATTERNS } from '@/utils/cover'
 
@@ -31,6 +32,7 @@ const layout_mode = inject(settingsLayoutKey)!
     <labeled-section :label="t('settings.profile.section.about-you')">
       <ui-input
         :placeholder="t('settings.profile.member-name-placeholder')"
+        :max-length="MEMBER_DISPLAY_NAME_MAX_LENGTH"
         v-model:value="editor.settings.display_name"
       />
       <ui-textarea

--- a/src/views/welcome/signup/form.vue
+++ b/src/views/welcome/signup/form.vue
@@ -5,6 +5,7 @@ import UiButton from '@/components/ui-kit/button.vue'
 import { useI18n } from 'vue-i18n'
 import type { OAuthProvider } from '@/api/session'
 import type { SignupFieldErrors } from '@/composables/auth/use-signup-actions'
+import { MEMBER_DISPLAY_NAME_MAX_LENGTH } from '@/utils/member/defaults'
 
 const { errors = {} } = defineProps<{ errors?: SignupFieldErrors }>()
 
@@ -43,6 +44,7 @@ const { t } = useI18n()
       <ui-input
         size="lg"
         :placeholder="t('signup-dialog.form.username-placeholder')"
+        :max-length="MEMBER_DISPLAY_NAME_MAX_LENGTH"
         v-model="username"
         :error="errors.username"
       />

--- a/tests/integration/components/member/member-card.test.js
+++ b/tests/integration/components/member/member-card.test.js
@@ -54,9 +54,19 @@ describe('MemberCard', () => {
     expect(wrapper.find('[data-testid="member-card__header"]').text()).toContain('Nina')
   })
 
-  test('header is empty when displayName omitted', () => {
+  test('shows the name-placeholder fallback when displayName is omitted [obligation]', () => {
     const wrapper = mountCard()
-    expect(wrapper.find('[data-testid="member-card__header"]').text()).toBe('')
+    expect(wrapper.find('h1').text()).toBe('Member Name')
+  })
+
+  test('shows the name-placeholder fallback when displayName is an empty string [obligation]', () => {
+    const wrapper = mountCard({ displayName: '' })
+    expect(wrapper.find('h1').text()).toBe('Member Name')
+  })
+
+  test('renders displayName as-is when provided, not the fallback [obligation]', () => {
+    const wrapper = mountCard({ displayName: 'Nina' })
+    expect(wrapper.find('h1').text()).toBe('Nina')
   })
 
   test('renders cardComment when provided', () => {

--- a/tests/integration/components/modals/deck-settings/deck-aside.test.js
+++ b/tests/integration/components/modals/deck-settings/deck-aside.test.js
@@ -9,13 +9,21 @@ vi.mock('@/sfx/bus', () => ({ emitSfx: vi.fn() }))
 
 const InputStub = defineComponent({
   name: 'UiInput',
-  props: { placeholder: String, error: String, value: String, textAlign: String, size: String },
+  props: {
+    placeholder: String,
+    error: String,
+    value: String,
+    textAlign: String,
+    size: String,
+    maxLength: Number
+  },
   emits: ['update:value'],
   setup(props, { emit }) {
     return () =>
       h('input', {
         'data-testid': 'ui-kit-input',
         'data-error': props.error ?? '',
+        maxlength: props.maxLength,
         value: props.value ?? '',
         onInput: (e) => emit('update:value', e.target.value)
       })
@@ -100,5 +108,22 @@ describe('DeckAside — layout', () => {
     const { settings } = makeAside({ title: 'A' })
     settings.description = 'new desc'
     expect(settings.description).toBe('new desc')
+  })
+
+  test('typing in the description textarea updates settings.description via v-model', async () => {
+    const { wrapper, settings } = makeAside({ title: 'A' })
+    await wrapper.find('[data-testid="ui-kit-textarea"]').setValue('typed description')
+    expect(settings.description).toBe('typed description')
+  })
+
+  test('typing in the title input updates settings.title via v-model', async () => {
+    const { wrapper, settings } = makeAside({ title: 'A' })
+    await wrapper.find('[data-testid="ui-kit-input"]').setValue('New Title')
+    expect(settings.title).toBe('New Title')
+  })
+
+  test('title input carries DECK_TITLE_MAX_LENGTH as maxlength', () => {
+    const { wrapper } = makeAside({ title: 'A' })
+    expect(wrapper.find('[data-testid="ui-kit-input"]').attributes('maxlength')).toBe('15')
   })
 })

--- a/tests/integration/components/modals/deck-settings/deck-aside.test.js
+++ b/tests/integration/components/modals/deck-settings/deck-aside.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { defineComponent, h, reactive, ref, computed } from 'vue'
 import DeckAside from '@/views/deck/deck-settings/deck-aside.vue'
 import { deckEditorKey } from '@/composables/deck/editor'
 import { deckSettingsCloseKey } from '@/views/deck/deck-settings/layout'
@@ -63,7 +63,7 @@ const ButtonStub = defineComponent({
   }
 })
 
-function makeAside({ title = '', is_dirty = false } = {}) {
+function makeAside({ title = '', is_dirty = false, title_error = undefined } = {}) {
   const settings = reactive({ title, description: '' })
   const editor = {
     settings,
@@ -71,6 +71,8 @@ function makeAside({ title = '', is_dirty = false } = {}) {
     cover: reactive({}),
     card_attributes: reactive({ front: {}, back: {} }),
     is_dirty: ref(is_dirty),
+    has_title: computed(() => !!settings.title?.trim()),
+    title_error: ref(title_error),
     active_side: ref('cover'),
     saveDeck: vi.fn(async () => null),
     deleteDeck: vi.fn(async () => false),
@@ -125,5 +127,12 @@ describe('DeckAside — layout', () => {
   test('title input carries DECK_TITLE_MAX_LENGTH as maxlength', () => {
     const { wrapper } = makeAside({ title: 'A' })
     expect(wrapper.find('[data-testid="ui-kit-input"]').attributes('maxlength')).toBe('15')
+  })
+
+  test('title input error reflects editor.title_error (destructured, no .value) [obligation]', () => {
+    const { wrapper } = makeAside({ title: '', title_error: 'Give this deck a title' })
+    expect(wrapper.find('[data-testid="ui-kit-input"]').attributes('data-error')).toBe(
+      'Give this deck a title'
+    )
   })
 })

--- a/tests/integration/components/modals/deck-settings/deck-aside.test.js
+++ b/tests/integration/components/modals/deck-settings/deck-aside.test.js
@@ -63,7 +63,7 @@ const ButtonStub = defineComponent({
   }
 })
 
-function makeAside({ title = '', is_dirty = false, title_error = undefined } = {}) {
+function makeAside({ title = '', is_dirty = false, title_error } = {}) {
   const settings = reactive({ title, description: '' })
   const editor = {
     settings,

--- a/tests/integration/components/modals/deck-settings/deck-save-button.test.js
+++ b/tests/integration/components/modals/deck-settings/deck-save-button.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
-import { defineComponent, h, nextTick, reactive, ref } from 'vue'
+import { defineComponent, h, nextTick, reactive, ref, computed } from 'vue'
 import DeckSaveButton from '@/views/deck/deck-settings/deck-save-button.vue'
 import { deckEditorKey } from '@/composables/deck/editor'
 import { deckSettingsCloseKey } from '@/views/deck/deck-settings/layout'
@@ -46,6 +46,8 @@ function makeSaveButton({ title = 'My Deck', is_dirty = true } = {}) {
   const editor = {
     settings,
     is_dirty: ref(is_dirty),
+    has_title: computed(() => !!settings.title?.trim()),
+    title_error: ref(undefined),
     saveDeck
   }
 
@@ -118,6 +120,54 @@ describe('DeckSaveButton — empty title', () => {
     await wrapper.find('[data-testid="deck-settings__save-button"]').trigger('click')
 
     expect(saveDeck).not.toHaveBeenCalled()
+  })
+
+  test('sets title_error to the required-title copy when title is empty [obligation]', async () => {
+    const { wrapper, editor } = makeSaveButton({ title: '', is_dirty: true })
+
+    await wrapper.find('[data-testid="deck-settings__save-button"]').trigger('click')
+
+    expect(editor.title_error.value).toBe('Give your deck a name')
+  })
+
+  test('does NOT show an error notice when title is empty (blank-title path) [obligation]', async () => {
+    const { wrapper } = makeSaveButton({ title: '', is_dirty: true })
+
+    await wrapper.find('[data-testid="deck-settings__save-button"]').trigger('click')
+    await flushPromises()
+
+    expect(mockNotice.error).not.toHaveBeenCalled()
+  })
+
+  test('does not close when title is empty', async () => {
+    const { wrapper, close } = makeSaveButton({ title: '', is_dirty: true })
+
+    await wrapper.find('[data-testid="deck-settings__save-button"]').trigger('click')
+
+    expect(close).not.toHaveBeenCalled()
+  })
+})
+
+describe('DeckSaveButton — disabled state [obligation]', () => {
+  test('disabled when not dirty', () => {
+    const { wrapper } = makeSaveButton({ is_dirty: false })
+    expect(
+      wrapper.find('[data-testid="deck-settings__save-button"]').attributes('data-disabled')
+    ).toBe('true')
+  })
+
+  test('disabled when title is blank, even if dirty', () => {
+    const { wrapper } = makeSaveButton({ title: '', is_dirty: true })
+    expect(
+      wrapper.find('[data-testid="deck-settings__save-button"]').attributes('data-disabled')
+    ).toBe('true')
+  })
+
+  test('not disabled when dirty and title is non-empty', () => {
+    const { wrapper } = makeSaveButton({ title: 'My Deck', is_dirty: true })
+    expect(
+      wrapper.find('[data-testid="deck-settings__save-button"]').attributes('data-disabled')
+    ).toBe('false')
   })
 })
 
@@ -201,14 +251,13 @@ describe('DeckSaveButton — loading state', () => {
   })
 })
 
-describe('DeckSaveButton — not dirty plays woodblock only when title is empty first check', () => {
-  test('not-dirty check fires before empty-title check', async () => {
-    // When not dirty AND title is empty: digi_powerdown fires (not woodblock)
+describe('DeckSaveButton — empty-title check fires before not-dirty check [obligation]', () => {
+  test('when not dirty AND title is empty: etc_woodblock_stuck fires (title check runs first)', async () => {
     const { wrapper } = makeSaveButton({ title: '', is_dirty: false })
 
     await wrapper.find('[data-testid="deck-settings__save-button"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('etc_woodblock_stuck')
+    expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('digi_powerdown')
   })
 })

--- a/tests/integration/components/modals/deck-settings/tab-details.test.js
+++ b/tests/integration/components/modals/deck-settings/tab-details.test.js
@@ -12,7 +12,11 @@ import { deckSettingsCloseKey } from '@/views/deck/deck-settings/layout'
 
 const InputStub = defineComponent({
   name: 'UiInput',
-  props: { value: { type: String, default: '' }, placeholder: { type: String, default: '' } },
+  props: {
+    value: { type: String, default: '' },
+    placeholder: { type: String, default: '' },
+    maxLength: { type: Number, default: undefined }
+  },
   emits: ['update:value'],
   inheritAttrs: false,
   setup(props, { emit }) {
@@ -22,6 +26,7 @@ const InputStub = defineComponent({
         ...attrs,
         'data-testid': 'ui-input',
         'data-placeholder': props.placeholder,
+        maxlength: props.maxLength,
         value: props.value,
         onInput: (e) => emit('update:value', e.target.value)
       })
@@ -141,6 +146,11 @@ describe('TabDetails [obligation]', () => {
     const { wrapper } = makeTab('sheet', editor)
     await wrapper.find('[data-testid="ui-textarea"]').setValue('New desc')
     expect(editor.settings.description).toBe('New desc')
+  })
+
+  test('title input carries DECK_TITLE_MAX_LENGTH as maxlength', () => {
+    const { wrapper } = makeTab()
+    expect(wrapper.find('[data-testid="ui-input"]').attributes('maxlength')).toBe('15')
   })
 
   test('does not render a back button (chrome-driven back replaced the inline button) [obligation]', () => {

--- a/tests/integration/components/modals/deck-settings/tab-details.test.js
+++ b/tests/integration/components/modals/deck-settings/tab-details.test.js
@@ -6,9 +6,14 @@ vi.mock('@/sfx/bus', () => ({ emitSfx: vi.fn() }))
 vi.mock('@/composables/ui/media-query', () => ({ useMatchMedia: () => ({ value: false }) }))
 
 import TabDetails from '@/views/deck/deck-settings/tab-details/index.vue'
+import DeckSaveButton from '@/views/deck/deck-settings/deck-save-button.vue'
 import { deckEditorKey } from '@/composables/deck/editor'
 import { deckSettingsLayoutKey } from '@/views/deck/deck-settings/layout'
 import { deckSettingsCloseKey } from '@/views/deck/deck-settings/layout'
+
+vi.mock('@/stores/notice-store', () => ({
+  useNoticeStore: () => ({ error: vi.fn(), success: vi.fn(), warn: vi.fn() })
+}))
 
 const InputStub = defineComponent({
   name: 'UiInput',
@@ -68,7 +73,7 @@ const ButtonStub = defineComponent({
           type: 'button',
           ...attrs,
           'data-loading': String(!!props.loading),
-          disabled: props.loading || props.disabled,
+          'data-disabled': String(!!props.disabled),
           onClick: (e) => emit('press', e)
         },
         slots.default?.()
@@ -92,9 +97,12 @@ const SaveButtonStub = defineComponent({
 })
 
 function makeEditor(overrides = {}) {
+  const settings = reactive({ title: 'My Deck', description: 'A test deck', ...overrides })
   return {
-    settings: reactive({ title: 'My Deck', description: 'A test deck', ...overrides }),
+    settings,
     is_dirty: ref(false),
+    has_title: computed(() => !!settings.title?.trim()),
+    title_error: ref(undefined),
     saveDeck: vi.fn().mockResolvedValue(true)
   }
 }
@@ -167,5 +175,47 @@ describe('TabDetails [obligation]', () => {
   test('save button not rendered in tablet mode', () => {
     const { wrapper } = makeTab('tablet')
     expect(wrapper.find('[data-testid="deck-save-button-stub"]').exists()).toBe(false)
+  })
+
+  test('title input carries the error set on the shared editor instance [obligation]', () => {
+    const editor = makeEditor({ title: '' })
+    const { wrapper } = makeTab('sheet', editor)
+    editor.title_error.value = 'Give this deck a title'
+    return wrapper.vm.$nextTick().then(() => {
+      expect(wrapper.find('[data-testid="ui-input"]').attributes('error')).toBe(
+        'Give this deck a title'
+      )
+    })
+  })
+})
+
+describe('TabDetails + DeckSaveButton — shared editor instance [obligation]', () => {
+  test('title_error set by deck-save-button onSave is visible in tab-details rendered error', async () => {
+    const editor = makeEditor({ title: '' })
+    const close = vi.fn()
+    const wrapper = mount(TabDetails, {
+      global: {
+        provide: {
+          [deckEditorKey]: editor,
+          [deckSettingsLayoutKey]: computed(() => 'sheet'),
+          [deckSettingsCloseKey]: close
+        },
+        stubs: {
+          UiInput: InputStub,
+          UiTextarea: TextareaStub,
+          UiButton: ButtonStub,
+          DeckSaveButton,
+          SectionList: PassthroughStub
+        },
+        mocks: { $t: (k) => k }
+      }
+    })
+
+    await wrapper.find('button').trigger('click')
+
+    expect(wrapper.find('[data-testid="ui-input"]').attributes('error')).toBe(
+      'Give your deck a name'
+    )
+    expect(close).not.toHaveBeenCalled()
   })
 })

--- a/tests/integration/components/settings/settings-save-button.test.js
+++ b/tests/integration/components/settings/settings-save-button.test.js
@@ -40,12 +40,14 @@ vi.mock('@/stores/notice-store', () => ({ useNoticeStore: () => mockNotice }))
 
 // ── Factory ───────────────────────────────────────────────────────────────────
 
-function makeWrapper({ is_dirty = true, save_result = true } = {}) {
+function makeWrapper({ is_dirty = true, save_result = true, has_name = true } = {}) {
   const saveMember = vi.fn().mockResolvedValue(save_result)
   const close = vi.fn()
 
   const editor = {
     is_dirty: ref(is_dirty),
+    has_name: ref(has_name),
+    name_error: ref(undefined),
     saveMember
   }
 
@@ -59,7 +61,7 @@ function makeWrapper({ is_dirty = true, save_result = true } = {}) {
     }
   })
 
-  return { wrapper, saveMember, close }
+  return { wrapper, saveMember, close, editor }
 }
 
 beforeEach(() => {
@@ -88,6 +90,36 @@ describe('settings-save-button — disabled state [obligation]', () => {
     expect(
       wrapper.find('[data-testid="settings__save-button"]').attributes('data-click-when-disabled')
     ).toBe('true')
+  })
+
+  test('button is disabled when has_name is false, even if dirty', () => {
+    const { wrapper } = makeWrapper({ is_dirty: true, has_name: false })
+    expect(wrapper.find('[data-testid="settings__save-button"]').attributes('data-disabled')).toBe(
+      'true'
+    )
+  })
+})
+
+// ── Blank-name save guard ──────────────────────────────────────────────────────
+
+describe('settings-save-button — blank-name save guard [obligation]', () => {
+  test('sets name_error to the required-name copy when has_name is false', async () => {
+    const { wrapper, editor } = makeWrapper({ is_dirty: true, has_name: false })
+    await wrapper.find('[data-testid="settings__save-button"]').trigger('click')
+    expect(editor.name_error.value).toBe('Give your profile a name')
+  })
+
+  test('does not call saveMember when has_name is false', async () => {
+    const { wrapper, saveMember } = makeWrapper({ is_dirty: true, has_name: false })
+    await wrapper.find('[data-testid="settings__save-button"]').trigger('click')
+    expect(saveMember).not.toHaveBeenCalled()
+  })
+
+  test('does NOT show notice.error when has_name is false (regression: blank name used to fall through to saveMember)', async () => {
+    const { wrapper } = makeWrapper({ is_dirty: true, has_name: false })
+    await wrapper.find('[data-testid="settings__save-button"]').trigger('click')
+    await flushPromises()
+    expect(mockNotice.error).not.toHaveBeenCalled()
   })
 })
 
@@ -135,7 +167,12 @@ describe('settings-save-button — save behaviour [obligation]', () => {
     const wrapper = mount(SettingsSaveButton, {
       global: {
         provide: {
-          [memberEditorKey]: { is_dirty: ref(true), saveMember },
+          [memberEditorKey]: {
+            is_dirty: ref(true),
+            has_name: ref(true),
+            name_error: ref(undefined),
+            saveMember
+          },
           [settingsCloseKey]: close
         },
         stubs: { UiButton: UiButtonStub }

--- a/tests/integration/components/settings/tab-profile.test.js
+++ b/tests/integration/components/settings/tab-profile.test.js
@@ -19,7 +19,10 @@ import { computed } from 'vue'
 
 const InputStub = defineComponent({
   name: 'UiInput',
-  props: { value: { type: String, default: '' } },
+  props: {
+    value: { type: String, default: '' },
+    maxLength: { type: Number, default: undefined }
+  },
   emits: ['update:value'],
   inheritAttrs: false,
   setup(props, { emit }) {
@@ -27,6 +30,7 @@ const InputStub = defineComponent({
     return () =>
       h('input', {
         ...attrs,
+        maxlength: props.maxLength,
         value: props.value,
         onInput: (e) => emit('update:value', e.target.value)
       })
@@ -126,6 +130,12 @@ describe('TabProfile', () => {
     const input = wrapper.findAll('input')[0]
     await input.setValue('Nina')
     expect(editor.settings.display_name).toBe('Nina')
+  })
+
+  test('name input carries MEMBER_DISPLAY_NAME_MAX_LENGTH as maxlength', () => {
+    const { wrapper } = makeTab()
+    const input = wrapper.findAll('input')[0]
+    expect(input.attributes('maxlength')).toBe('12')
   })
 
   test('typing into the bio textarea updates editor.settings.description', async () => {

--- a/tests/integration/components/settings/tab-profile.test.js
+++ b/tests/integration/components/settings/tab-profile.test.js
@@ -83,6 +83,8 @@ function makeEditor() {
     created_at: ref('2024-04-15T00:00:00Z'),
     plan: ref('free'),
     is_dirty: ref(false),
+    has_name: ref(true),
+    name_error: ref(undefined),
     saving: ref(false),
     saveMember: () => Promise.resolve(false)
   }
@@ -136,6 +138,14 @@ describe('TabProfile', () => {
     const { wrapper } = makeTab()
     const input = wrapper.findAll('input')[0]
     expect(input.attributes('maxlength')).toBe('12')
+  })
+
+  test('name input error reflects editor.name_error.value [obligation]', async () => {
+    const editor = makeEditor()
+    editor.name_error.value = 'Give this member a name'
+    const { wrapper } = makeTab(editor)
+    const input = wrapper.findAll('input')[0]
+    expect(input.attributes('error')).toBe('Give this member a name')
   })
 
   test('typing into the bio textarea updates editor.settings.description', async () => {

--- a/tests/integration/components/ui-kit/image.test.js
+++ b/tests/integration/components/ui-kit/image.test.js
@@ -51,4 +51,41 @@ describe('UiImage', () => {
     const img = wrapper.find('img')
     expect(img.classes()).toContain('ui-kit-image--unset')
   })
+
+  // ── eager src resolves synchronously [obligation] ─────────────────────────
+
+  test('an eager-whitelisted src renders its <img> synchronously, with no separate tick needed after mount [obligation]', () => {
+    const wrapper = mountImage({ src: 'shortcuts' })
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBeTruthy()
+  })
+
+  // ── reactive src prop changes [obligation] ────────────────────────────────
+
+  test('changing src to another eager image re-resolves the rendered <img> [obligation]', async () => {
+    const wrapper = mountImage({ src: 'shortcuts' })
+    await flushPromises()
+    const firstSrc = wrapper.find('img').attributes('src')
+
+    await wrapper.setProps({ src: 'darkmode-dark' })
+    await flushPromises()
+
+    const secondSrc = wrapper.find('img').attributes('src')
+    expect(secondSrc).toBeTruthy()
+    expect(secondSrc).not.toBe(firstSrc)
+    expect(wrapper.find('img').attributes('alt')).toBe('darkmode-dark')
+  })
+
+  test('changing src from an eager image to a lazy image re-resolves the rendered <img> (regression) [obligation]', async () => {
+    const wrapper = mountImage({ src: 'shortcuts' })
+    await flushPromises()
+    expect(wrapper.find('img').exists()).toBe(true)
+
+    await wrapper.setProps({ src: 'binder-clip' })
+    await vi.waitFor(() => expect(wrapper.find('img').exists()).toBe(true))
+
+    const img = wrapper.find('img')
+    expect(img.attributes('alt')).toBe('binder-clip')
+  })
 })

--- a/tests/integration/components/ui-kit/input.test.js
+++ b/tests/integration/components/ui-kit/input.test.js
@@ -87,6 +87,18 @@ describe('UiInput', () => {
     expect(wrapper.find('input').attributes('type')).toBe('email')
   })
 
+  // ── maxLength ──────────────────────────────────────────────────────────────
+
+  test('sets maxlength attribute on the <input> when maxLength prop is provided [obligation]', () => {
+    const wrapper = mountInput({ maxLength: 12 })
+    expect(wrapper.find('input').attributes('maxlength')).toBe('12')
+  })
+
+  test('does not set maxlength attribute when maxLength prop is omitted [obligation]', () => {
+    const wrapper = mountInput()
+    expect(wrapper.find('input').attributes('maxlength')).toBeUndefined()
+  })
+
   // ── sfx on focus ──────────────────────────────────────────────────────────
 
   test('plays type_05 sfx when the <input> receives focus [obligation]', async () => {

--- a/tests/integration/components/ui-kit/textarea.test.js
+++ b/tests/integration/components/ui-kit/textarea.test.js
@@ -146,6 +146,66 @@ describe('UiTextarea — label', () => {
   })
 })
 
+describe('UiTextarea — noNewlines [obligation]', () => {
+  test('pressing Enter does NOT insert a newline into the model value when noNewlines is true [obligation]', async () => {
+    const wrapper = mountTextarea({ value: 'hello', noNewlines: true })
+    const ta = wrapper.find('textarea')
+    await ta.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:value')).toBeFalsy()
+  })
+
+  test('pressing Enter does not preventDefault when noNewlines is false [obligation]', async () => {
+    const wrapper = mountTextarea({ value: 'hello', noNewlines: false })
+    const ta = wrapper.find('textarea').element
+    const event = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+    ta.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  test('pressing Enter does not preventDefault when noNewlines is omitted [obligation]', async () => {
+    const wrapper = mountTextarea({ value: 'hello' })
+    const ta = wrapper.find('textarea').element
+    const event = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+    ta.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  test('pressing Enter calls preventDefault when noNewlines is true [obligation]', async () => {
+    const wrapper = mountTextarea({ value: 'hello', noNewlines: true })
+    const ta = wrapper.find('textarea').element
+    const event = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+    ta.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('sanitizes a pasted value containing newlines to spaces when noNewlines is true [obligation]', async () => {
+    const wrapper = mountTextarea({ noNewlines: true })
+    const ta = wrapper.find('textarea')
+    await ta.setValue('line one\nline two\r\nline three')
+    const emitted = wrapper.emitted('update:value')
+    const last = emitted[emitted.length - 1][0]
+    expect(last).not.toContain('\n')
+    expect(last).not.toContain('\r')
+  })
+
+  test('does not sanitize newlines when noNewlines is false', async () => {
+    const wrapper = mountTextarea({ noNewlines: false })
+    const ta = wrapper.find('textarea')
+    await ta.setValue('line one\nline two')
+    const emitted = wrapper.emitted('update:value')
+    const last = emitted[emitted.length - 1][0]
+    expect(last).toBe('line one\nline two')
+  })
+})
+
+describe('UiTextarea — max_chars behavior unaffected by noNewlines [obligation]', () => {
+  test('char count still reflects value length when noNewlines is true [obligation]', () => {
+    const wrapper = mountTextarea({ max_chars: 100, value: 'hello', noNewlines: true })
+    const counter = wrapper.find('[data-testid="ui-kit-textarea-char-count"]')
+    expect(counter.text()).toBe('5/100')
+  })
+})
+
 describe('UiTextarea — sfx', () => {
   beforeEach(() => {
     mockEmitSfx.mockReset()

--- a/tests/integration/views/deck/deck-create-modal.test.js
+++ b/tests/integration/views/deck/deck-create-modal.test.js
@@ -1,0 +1,242 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, reactive } from 'vue'
+
+vi.mock('@/composables/ui/media-query', async () => {
+  const m = await import('../../../helpers/responsive-mock')
+  return m.responsiveMockModule
+})
+
+const { mockEmitSfx, mockNoticeError, mockPush, mockSaveDeck } = vi.hoisted(() => ({
+  mockEmitSfx: vi.fn(),
+  mockNoticeError: vi.fn(),
+  mockPush: vi.fn(),
+  mockSaveDeck: vi.fn()
+}))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+vi.mock('@/stores/notice-store', () => ({
+  useNoticeStore: () => ({ error: mockNoticeError, success: vi.fn(), warn: vi.fn() })
+}))
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: mockPush }) }))
+vi.mock('@/utils/cover', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, randomCoverConfig: () => ({}) }
+})
+
+let editorSettings
+
+vi.mock('@/composables/deck/editor', () => ({
+  deckEditorKey: Symbol('deck-editor'),
+  useDeckEditor: () => ({
+    settings: editorSettings,
+    cover: reactive({}),
+    card_attributes: reactive({ front: {}, back: {} }),
+    saveDeck: mockSaveDeck
+  })
+}))
+
+import { setBelowMd, resetResponsive } from '../../../helpers/responsive-mock'
+import DeckCreateModal from '@/views/deck/deck-create-modal.vue'
+
+const MobileSheetStub = defineComponent({
+  name: 'MobileSheet',
+  inheritAttrs: false,
+  emits: ['close'],
+  setup(_p, { slots, emit }) {
+    return () =>
+      h('div', { 'data-testid': 'mobile-sheet-stub' }, [
+        h('button', {
+          'data-testid': 'mobile-sheet-stub__close',
+          onClick: () => emit('close')
+        }),
+        slots['header-content']?.(),
+        slots.overlay?.(),
+        slots.default?.()
+      ])
+  }
+})
+
+const InputStub = defineComponent({
+  name: 'UiInput',
+  props: {
+    placeholder: String,
+    error: String,
+    value: String,
+    maxLength: Number,
+    size: String,
+    textAlign: String
+  },
+  emits: ['update:value'],
+  setup(props, { emit }) {
+    return () =>
+      h('input', {
+        'data-testid': 'ui-kit-input',
+        maxlength: props.maxLength,
+        value: props.value ?? '',
+        onInput: (e) => emit('update:value', e.target.value)
+      })
+  }
+})
+
+const ButtonStub = defineComponent({
+  name: 'UiButton',
+  props: { disabled: Boolean },
+  emits: ['press'],
+  setup(props, { slots, emit }) {
+    return () =>
+      h(
+        'button',
+        {
+          'data-testid': 'ui-kit-button',
+          'data-disabled': String(!!props.disabled),
+          onClick: () => emit('press')
+        },
+        slots.default?.()
+      )
+  }
+})
+
+function makeModal({ title = '' } = {}) {
+  editorSettings = reactive({ title, description: '' })
+  const close = vi.fn()
+  const wrapper = mount(DeckCreateModal, {
+    props: { close },
+    global: {
+      stubs: {
+        MobileSheet: MobileSheetStub,
+        CoverDesigner: true,
+        DeckDesignPreview: true,
+        DeckPinnedPreview: true,
+        UiInput: InputStub,
+        UiTextarea: true,
+        UiButton: ButtonStub
+      }
+    }
+  })
+  return { wrapper, close, settings: editorSettings }
+}
+
+describe('DeckCreateModal', () => {
+  beforeEach(() => {
+    resetResponsive()
+    mockEmitSfx.mockReset()
+    mockNoticeError.mockReset()
+    mockPush.mockReset()
+    mockSaveDeck.mockReset()
+  })
+
+  // ── layout ─────────────────────────────────────────────────────────────────
+
+  test('renders the aside inputs in tablet layout', () => {
+    setBelowMd(false)
+    const { wrapper } = makeModal()
+    expect(wrapper.find('[data-testid="deck-create__aside-inputs"]').exists()).toBe(true)
+  })
+
+  test('renders the mobile inputs in sheet layout', () => {
+    setBelowMd(true)
+    const { wrapper } = makeModal()
+    expect(wrapper.find('[data-testid="deck-create__mobile-inputs"]').exists()).toBe(true)
+  })
+
+  // ── title max length ───────────────────────────────────────────────────────
+
+  test('title input carries DECK_TITLE_MAX_LENGTH as maxlength', () => {
+    setBelowMd(false)
+    const { wrapper } = makeModal()
+    expect(wrapper.find('[data-testid="ui-kit-input"]').attributes('maxlength')).toBe('15')
+  })
+
+  // ── save validation ────────────────────────────────────────────────────────
+
+  test('pressing submit with no title sets a validation error and does not save [obligation]', async () => {
+    setBelowMd(false)
+    const { wrapper } = makeModal({ title: '' })
+
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
+
+    expect(mockSaveDeck).not.toHaveBeenCalled()
+    expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+  })
+
+  test('pressing submit with a title saves the deck and closes with true [obligation]', async () => {
+    setBelowMd(false)
+    mockSaveDeck.mockResolvedValueOnce({ id: 42 })
+    const { wrapper, close } = makeModal({ title: 'My Deck' })
+
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
+    await vi.waitFor(() => expect(mockSaveDeck).toHaveBeenCalled())
+
+    expect(close).toHaveBeenCalledWith(true)
+    expect(mockPush).toHaveBeenCalledWith({ name: 'deck', params: { id: 42 } })
+  })
+
+  test('shows an error notice and does not close when saveDeck fails [obligation]', async () => {
+    setBelowMd(false)
+    mockSaveDeck.mockResolvedValueOnce(null)
+    const { wrapper, close } = makeModal({ title: 'My Deck' })
+
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
+    await vi.waitFor(() => expect(mockSaveDeck).toHaveBeenCalled())
+
+    expect(mockNoticeError).toHaveBeenCalledWith("Couldn't save this deck. Please try again.")
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  // ── title error reset watcher ──────────────────────────────────────────────
+
+  test('editing the title after a validation error clears title_error [obligation]', async () => {
+    setBelowMd(false)
+    const { wrapper, settings } = makeModal({ title: '' })
+
+    await wrapper.find('[data-testid="deck-create__aside-submit"]').trigger('click')
+    expect(wrapper.find('[data-testid="ui-kit-input"]').attributes('data-error')).toBeUndefined()
+
+    settings.title = 'New title'
+    await wrapper.vm.$nextTick()
+
+    expect(mockNoticeError).not.toHaveBeenCalled()
+  })
+
+  // ── model bindings ─────────────────────────────────────────────────────────
+
+  test('typing into the title input updates editor.settings.title in tablet layout', async () => {
+    setBelowMd(false)
+    const { wrapper, settings } = makeModal({ title: '' })
+
+    await wrapper.find('[data-testid="ui-kit-input"]').setValue('Tablet title')
+
+    expect(settings.title).toBe('Tablet title')
+  })
+
+  test('typing into the title input updates editor.settings.title in sheet layout', async () => {
+    setBelowMd(true)
+    const { wrapper, settings } = makeModal({ title: '' })
+
+    await wrapper.find('[data-testid="ui-kit-input"]').setValue('Sheet title')
+
+    expect(settings.title).toBe('Sheet title')
+  })
+
+  // ── cancel ─────────────────────────────────────────────────────────────────
+
+  test('pressing cancel in sheet mode closes with false', async () => {
+    setBelowMd(true)
+    const { wrapper, close } = makeModal()
+
+    const cancelBtn = wrapper.findAll('[data-testid="ui-kit-button"]')[0]
+    await cancelBtn.trigger('click')
+
+    expect(close).toHaveBeenCalledWith(false)
+  })
+
+  test('closing the mobile sheet closes the modal with false', async () => {
+    setBelowMd(false)
+    const { wrapper, close } = makeModal()
+
+    await wrapper.find('[data-testid="mobile-sheet-stub__close"]').trigger('click')
+
+    expect(close).toHaveBeenCalledWith(false)
+  })
+})

--- a/tests/integration/views/welcome/signup/form.test.js
+++ b/tests/integration/views/welcome/signup/form.test.js
@@ -23,7 +23,16 @@ vi.mock('vue-i18n', () => ({
 const UiInputStub = defineComponent({
   name: 'UiInput',
   inheritAttrs: false,
-  props: ['placeholder', 'error', 'size', 'type', 'name', 'autocomplete', 'modelValue'],
+  props: [
+    'placeholder',
+    'error',
+    'size',
+    'type',
+    'name',
+    'autocomplete',
+    'modelValue',
+    'maxLength'
+  ],
   emits: ['update:modelValue'],
   setup(props, { attrs, emit }) {
     return () =>
@@ -31,6 +40,7 @@ const UiInputStub = defineComponent({
         ...attrs,
         type: props.type ?? 'text',
         placeholder: props.placeholder,
+        maxlength: props.maxLength,
         value: props.modelValue ?? '',
         onInput: (e) => emit('update:modelValue', e.target.value)
       })
@@ -138,6 +148,12 @@ describe('SignupForm (signup/form.vue)', () => {
     expect(form.findAll('input').length).toBe(4)
   })
 
+  test('username input carries MEMBER_DISPLAY_NAME_MAX_LENGTH as maxlength', () => {
+    const wrapper = mountForm()
+    const inputs = wrapper.find('[data-testid="email-auth"]').findAll('input')
+    expect(inputs[0].attributes('maxlength')).toBe('12')
+  })
+
   test('passes errors.username to the username input via error prop', () => {
     const wrapper = mountForm({ errors: { username: 'Required' } })
     const inputs = wrapper.findAllComponents({ name: 'UiInput' })
@@ -160,5 +176,35 @@ describe('SignupForm (signup/form.vue)', () => {
     const wrapper = mountForm({ errors: { confirm_password: 'Mismatch' } })
     const inputs = wrapper.findAllComponents({ name: 'UiInput' })
     expect(inputs[3].props('error')).toBe('Mismatch')
+  })
+
+  // ── model bindings ─────────────────────────────────────────────────────────
+
+  test('typing into the username input emits update:username', async () => {
+    const wrapper = mountForm()
+    const inputs = wrapper.find('[data-testid="email-auth"]').findAll('input')
+    await inputs[0].setValue('Nina')
+    expect(wrapper.emitted('update:username')).toEqual([['Nina']])
+  })
+
+  test('typing into the email input emits update:email', async () => {
+    const wrapper = mountForm()
+    const inputs = wrapper.find('[data-testid="email-auth"]').findAll('input')
+    await inputs[1].setValue('nina@example.com')
+    expect(wrapper.emitted('update:email')).toEqual([['nina@example.com']])
+  })
+
+  test('typing into the password input emits update:password', async () => {
+    const wrapper = mountForm()
+    const inputs = wrapper.find('[data-testid="email-auth"]').findAll('input')
+    await inputs[2].setValue('hunter22')
+    expect(wrapper.emitted('update:password')).toEqual([['hunter22']])
+  })
+
+  test('typing into the confirm-password input emits update:confirmPassword', async () => {
+    const wrapper = mountForm()
+    const inputs = wrapper.find('[data-testid="email-auth"]').findAll('input')
+    await inputs[3].setValue('hunter22')
+    expect(wrapper.emitted('update:confirmPassword')).toEqual([['hunter22']])
   })
 })

--- a/tests/integration/views/welcome/signup/form.test.js
+++ b/tests/integration/views/welcome/signup/form.test.js
@@ -1,12 +1,8 @@
-import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { describe, test, expect, vi } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────────
-
-const { mockSubmitOAuth } = vi.hoisted(() => ({
-  mockSubmitOAuth: vi.fn()
-}))
 
 vi.mock('@/sfx/bus', () => ({
   emitSfx: vi.fn(),

--- a/tests/unit/api/session.test.js
+++ b/tests/unit/api/session.test.js
@@ -49,7 +49,9 @@ import {
   updatePassword,
   isPasswordRecoveryUrl,
   waitForPasswordRecovery,
-  requestPasswordReset
+  requestPasswordReset,
+  isAuthError,
+  onSignedOut
 } from '@/api/session'
 
 beforeEach(() => {
@@ -679,6 +681,87 @@ describe('waitForPasswordRecovery [obligation]', () => {
     promise.then(() => (settled = true))
     await Promise.resolve()
     expect(settled).toBe(false)
+  })
+})
+
+describe('isAuthError [obligation]', () => {
+  test('returns true for a 401 status error [obligation]', () => {
+    expect(isAuthError({ status: 401 })).toBe(true)
+  })
+
+  test('returns true for a PGRST301 code error [obligation]', () => {
+    expect(isAuthError({ code: 'PGRST301' })).toBe(true)
+  })
+
+  test('returns true for an AuthApiError name [obligation]', () => {
+    expect(isAuthError({ name: 'AuthApiError' })).toBe(true)
+  })
+
+  test('returns false for an unrelated error shape [obligation]', () => {
+    expect(isAuthError({ status: 500, code: 'server_error', message: 'boom' })).toBe(false)
+  })
+
+  test('returns false for null [obligation]', () => {
+    expect(isAuthError(null)).toBe(false)
+  })
+
+  test('returns false for undefined [obligation]', () => {
+    expect(isAuthError(undefined)).toBe(false)
+  })
+
+  test('returns false for a plain non-auth error [obligation]', () => {
+    expect(isAuthError(new Error('generic failure'))).toBe(false)
+  })
+})
+
+describe('onSignedOut [obligation]', () => {
+  function captureAuthCallback() {
+    let cb
+    const unsubscribe = vi.fn()
+    mocks.onAuthStateChange.mockImplementationOnce((fn) => {
+      cb = fn
+      return { data: { subscription: { unsubscribe } } }
+    })
+    return { get: () => cb, unsubscribe }
+  }
+
+  test('invokes the callback when SIGNED_OUT fires [obligation]', () => {
+    const cb = captureAuthCallback()
+    const callback = vi.fn()
+    onSignedOut(callback)
+
+    cb.get()('SIGNED_OUT')
+
+    expect(callback).toHaveBeenCalledOnce()
+  })
+
+  test('does not invoke the callback for SIGNED_IN [obligation]', () => {
+    const cb = captureAuthCallback()
+    const callback = vi.fn()
+    onSignedOut(callback)
+
+    cb.get()('SIGNED_IN')
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  test('does not invoke the callback for TOKEN_REFRESHED [obligation]', () => {
+    const cb = captureAuthCallback()
+    const callback = vi.fn()
+    onSignedOut(callback)
+
+    cb.get()('TOKEN_REFRESHED')
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  test('returned unsubscribe function unsubscribes from the auth listener [obligation]', () => {
+    const cb = captureAuthCallback()
+    const unsubscribeFn = onSignedOut(vi.fn())
+
+    unsubscribeFn()
+
+    expect(cb.unsubscribe).toHaveBeenCalledOnce()
   })
 })
 

--- a/tests/unit/components/settings/account-access/use-google-actions.test.js
+++ b/tests/unit/components/settings/account-access/use-google-actions.test.js
@@ -17,7 +17,9 @@ vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k) => k }) }))
 vi.mock('@/api/session', () => ({
   linkGoogleIdentity: mockLinkGoogleIdentity,
   unlinkGoogleIdentity: mockUnlinkGoogleIdentity,
-  getUser: mockGetUser
+  getUser: mockGetUser,
+  onSignedOut: vi.fn(() => vi.fn()),
+  isAuthError: vi.fn()
 }))
 
 import { useSessionStore } from '@/stores/session'

--- a/tests/unit/stores/session.test.js
+++ b/tests/unit/stores/session.test.js
@@ -39,6 +39,11 @@ const { mockNotice } = vi.hoisted(() => ({
   mockNotice: { error: vi.fn(), success: vi.fn(), warn: vi.fn() }
 }))
 
+const { mockOnSignedOut, mockIsAuthError } = vi.hoisted(() => ({
+  mockOnSignedOut: vi.fn(() => vi.fn()),
+  mockIsAuthError: vi.fn()
+}))
+
 vi.mock('@/stores/notice-store', () => ({ useNoticeStore: () => mockNotice }))
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }))
 
@@ -55,7 +60,9 @@ vi.mock('@/api/session', () => ({
   linkGoogleIdentity: mockLinkGoogleIdentity,
   unlinkGoogleIdentity: mockUnlinkGoogleIdentity,
   isPasswordRecoveryUrl: mockIsPasswordRecoveryUrl,
-  waitForPasswordRecovery: mockWaitForPasswordRecovery
+  waitForPasswordRecovery: mockWaitForPasswordRecovery,
+  onSignedOut: mockOnSignedOut,
+  isAuthError: mockIsAuthError
 }))
 
 vi.mock('vue-router', () => ({
@@ -83,6 +90,10 @@ beforeEach(() => {
   mockWaitForPasswordRecovery.mockReset()
   mockPush.mockReset()
   mockNotice.error.mockReset()
+  mockNotice.warn.mockReset()
+  mockOnSignedOut.mockReset()
+  mockOnSignedOut.mockImplementation(() => vi.fn())
+  mockIsAuthError.mockReset()
 })
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -390,6 +401,110 @@ describe('useSessionStore', () => {
       expect(mockGetUser).toHaveBeenCalledOnce()
       expect(mockGetSession).not.toHaveBeenCalled()
       expect(store.hasGoogleIdentity).toBe(false)
+    })
+  })
+
+  // ── handleAuthError / forceLogout [obligation] ────────────────────────────
+
+  describe('handleAuthError [obligation]', () => {
+    test('forces a logout when isAuthError returns true [obligation]', async () => {
+      const user = { id: 'u1', aud: 'authenticated' }
+      mockGetSession.mockResolvedValueOnce({ user })
+      mockIsAuthError.mockReturnValueOnce(true)
+      mockLogout.mockResolvedValueOnce(undefined)
+      const store = useSessionStore()
+      await store.restoreSession()
+
+      store.handleAuthError({ status: 401 })
+      await Promise.resolve()
+
+      expect(store.user).toBeUndefined()
+      expect(mockNotice.warn).toHaveBeenCalledOnce()
+    })
+
+    test('does NOT force a logout when isAuthError returns false [obligation]', async () => {
+      const user = { id: 'u1', aud: 'authenticated' }
+      mockGetSession.mockResolvedValueOnce({ user })
+      mockIsAuthError.mockReturnValueOnce(false)
+      const store = useSessionStore()
+      await store.restoreSession()
+
+      store.handleAuthError({ status: 500 })
+      await Promise.resolve()
+
+      expect(store.user).toEqual(user)
+      expect(mockNotice.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('forceLogout guard [obligation]', () => {
+    test('is a no-op when already logged out, preventing its own supaLogout from re-triggering it [obligation]', async () => {
+      // Store is never authenticated in this test (no restoreSession call).
+      mockIsAuthError.mockReturnValueOnce(true)
+      const store = useSessionStore()
+
+      store.handleAuthError({ status: 401 })
+      await Promise.resolve()
+
+      expect(mockLogout).not.toHaveBeenCalled()
+      expect(mockNotice.warn).not.toHaveBeenCalled()
+    })
+
+    test('shows a panel notice whose onDismiss navigates to welcome, not immediately [obligation]', async () => {
+      const user = { id: 'u1', aud: 'authenticated' }
+      mockGetSession.mockResolvedValueOnce({ user })
+      mockIsAuthError.mockReturnValueOnce(true)
+      mockLogout.mockResolvedValueOnce(undefined)
+      const store = useSessionStore()
+      await store.restoreSession()
+
+      store.handleAuthError({ status: 401 })
+      await Promise.resolve()
+
+      expect(mockNotice.warn).toHaveBeenCalledWith(
+        'session.expired-error',
+        expect.objectContaining({ variant: 'panel' })
+      )
+      expect(mockPush).not.toHaveBeenCalledWith({ name: 'welcome' })
+
+      const [, options] = mockNotice.warn.mock.calls[0]
+      options.onDismiss()
+
+      expect(mockPush).toHaveBeenCalledWith({ name: 'welcome' })
+    })
+  })
+
+  describe('onSignedOut wiring [obligation]', () => {
+    test('forces a logout when the stale-tab listener fires and we are not already logging out [obligation]', async () => {
+      const user = { id: 'u1', aud: 'authenticated' }
+      mockGetSession.mockResolvedValueOnce({ user })
+      mockLogout.mockResolvedValueOnce(undefined)
+      let staleTabCallback
+      mockOnSignedOut.mockImplementationOnce((cb) => {
+        staleTabCallback = cb
+        return vi.fn()
+      })
+      const store = useSessionStore()
+      await store.restoreSession()
+
+      staleTabCallback()
+      await Promise.resolve()
+
+      expect(store.user).toBeUndefined()
+      expect(mockNotice.warn).toHaveBeenCalledOnce()
+    })
+
+    test('manual logout() does not trigger the forced/expired panel notice path [obligation]', async () => {
+      const user = { id: 'u1', aud: 'authenticated' }
+      mockGetSession.mockResolvedValueOnce({ user })
+      mockLogout.mockResolvedValueOnce(undefined)
+      const store = useSessionStore()
+      await store.restoreSession()
+
+      await store.logout()
+
+      expect(mockNotice.warn).not.toHaveBeenCalled()
+      expect(mockPush).toHaveBeenCalledWith({ name: 'welcome' })
     })
   })
 

--- a/tests/unit/views/deck/composables/use-card-edit-menu.test.js
+++ b/tests/unit/views/deck/composables/use-card-edit-menu.test.js
@@ -108,20 +108,24 @@ describe('useCardEditMenu — options', () => {
     result // lint-happy
   })
 
-  test('rearrange option has disabled:true exactly when is_rearranging [obligation]', () => {
+  test('all three options have disabled:true when is_rearranging [obligation]', () => {
     const shell = makeShell({ is_rearranging: true })
     const r = setup({ shell })
     app = r.app
-    const rearrange_opt = r.result.options.value.find((o) => o.value === 'rearrange')
-    expect(rearrange_opt.disabled).toBe(true)
+    for (const value of ['select', 'rearrange', 'appearance']) {
+      const opt = r.result.options.value.find((o) => o.value === value)
+      expect(opt.disabled).toBe(true)
+    }
   })
 
-  test('rearrange option is NOT disabled when not rearranging [obligation]', () => {
+  test('none of the three options are disabled when not rearranging [obligation]', () => {
     const shell = makeShell({ is_rearranging: false })
     const r = setup({ shell })
     app = r.app
-    const rearrange_opt = r.result.options.value.find((o) => o.value === 'rearrange')
-    expect(rearrange_opt.disabled).toBeFalsy()
+    for (const value of ['select', 'rearrange', 'appearance']) {
+      const opt = r.result.options.value.find((o) => o.value === value)
+      expect(opt.disabled).toBeFalsy()
+    }
   })
 
   test('is_rearranging computed reflects shell.is_rearranging', () => {

--- a/tests/unit/views/deck/composables/use-card-edit-menu.test.js
+++ b/tests/unit/views/deck/composables/use-card-edit-menu.test.js
@@ -105,7 +105,6 @@ describe('useCardEditMenu — options', () => {
     expect(result.options.value[0].value).toBe('select')
     expect(result.options.value[1].value).toBe('rearrange')
     expect(result.options.value[2].value).toBe('appearance')
-    result // lint-happy
   })
 
   test('all three options have disabled:true when is_rearranging [obligation]', () => {


### PR DESCRIPTION
## Summary

Bug-bash pass across ui-kit, session handling, and deck/member settings:

- Add `max-length` to `ui-input` and apply sane caps to deck-title and member display-name inputs.
- Fix `ui-image` popping in / failing to update on prop-driven `src` changes (dark-mode toggle icon, phone app icons).
- Auto-logout when a stale tab's session is revoked elsewhere, with a dismissible panel notice.
- Add opt-in `no-newlines` to `ui-textarea`, applied to deck/member descriptions.
- Fix unbroken description text overflowing its container instead of wrapping.
- Fix the burst effect on phone app icons rendering at the phone's center instead of the tapped icon.
- Disable all edit-menu options (not just rearrange) while reordering cards, since bulk-select silently did nothing mid-drag.
- Add a name placeholder to `member-card` and disable the settings/deck-settings save buttons when the name/title is blank, surfacing inline validation instead of saving silently or doing nothing.
