### PR TITLE
fix(ci): read google client id from vars, not secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -246,7 +246,7 @@ jobs:
         run: supabase config push --yes
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
+          AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ vars.AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
           AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET: ${{ secrets.AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET }}
 
   frontend:


### PR DESCRIPTION
## Summary
- AUTH_EXTERNAL_GOOGLE_CLIENT_ID is stored as a repo/env variable, not a secret — `secrets.AUTH_EXTERNAL_GOOGLE_CLIENT_ID` resolved empty, breaking `supabase config push` with a missing client_id schema error
- Read it via `vars.AUTH_EXTERNAL_GOOGLE_CLIENT_ID` instead

Follow-up to #402 — this commit was pushed after that PR had already merged, so it never landed.