### PR TITLE
fix(auth): stuck refresh redirect + oauth popup close

### DIFF
--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -42,8 +42,22 @@ const RESET_PASSWORD_REDIRECT_URL = buildRedirectUrl(
   import.meta.env.VITE_RESET_PASSWORD_REDIRECT_URL
 )
 
+const GET_SESSION_TIMEOUT_MS = 2000
+
+// getSession() triggers a background refresh_token request when the cached
+// session is expired. supabase-js wraps any network failure on that request
+// (e.g. connection refused) as retryable and retries with backoff for up to
+// 30s before surfacing an error — there's no way to special-case it sooner
+// from out here. Race it against a short timeout so a dead connection still
+// bails out fast instead of stalling anything awaiting it (e.g. the root
+// route's auth guard) for the full retry window.
 export async function getSession(): Promise<Session | null> {
-  const { data, error } = await supabase.auth.getSession()
+  const { data, error } = await Promise.race([
+    supabase.auth.getSession(),
+    new Promise<never>((_, reject) => {
+      window.setTimeout(() => reject(new Error('getSession timed out')), GET_SESSION_TIMEOUT_MS)
+    })
+  ])
 
   if (error) {
     throw new Error(error.message)

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -200,6 +200,29 @@ type StartOAuth = (options: {
   skipBrowserRedirect?: boolean
 }) => Promise<{ data: { url: string | null } | null; error: unknown }>
 
+// Google's consent screen sends Cross-Origin-Opener-Policy, which forces a
+// permanent browsing-context-group switch on the popup — window.opener is
+// severed for good, and window.name (tied to that same context) doesn't
+// survive the swap either, even once the popup navigates back to our own
+// origin. localStorage isn't scoped to the browsing-context group the way
+// those are, so a flag written right before window.open() is still readable
+// once the popup lands back on our site.
+const OAUTH_POPUP_FLAG = 'oauth-popup-pending'
+
+// Cleared unconditionally up front so a flag left behind by an abandoned
+// popup (closed before completing auth) can't misfire on a later full-page
+// redirect flow.
+function clearOAuthPopupFlag(): void {
+  window.localStorage.removeItem(OAUTH_POPUP_FLAG)
+}
+
+/** Callback view checks this to decide whether to close itself or navigate to the dashboard. */
+export function consumeOAuthPopupFlag(): boolean {
+  const pending = window.localStorage.getItem(OAUTH_POPUP_FLAG) === '1'
+  clearOAuthPopupFlag()
+  return pending
+}
+
 // Sign-in resolves on the store's own 'SIGNED_IN' auth event; linking a new
 // identity to an already-signed-in user doesn't fire that event, so it resolves
 // once the popup/redirect tab closes instead.
@@ -207,6 +230,8 @@ async function runOAuthFlow(
   start: StartOAuth,
   waitFor: 'signed-in' | 'popup-closed'
 ): Promise<void> {
+  clearOAuthPopupFlag()
+
   if (prefersFullRedirect()) {
     const { error } = await start({ redirectTo: AUTH_REDIRECT_URL })
     if (error) throw error
@@ -231,6 +256,8 @@ async function runOAuthFlow(
     window.location.href = data.url
     return
   }
+
+  window.localStorage.setItem(OAUTH_POPUP_FLAG, '1')
 
   const TIMEOUT_MS = 5 * 60 * 1000
 

--- a/src/views/auth/callback.vue
+++ b/src/views/auth/callback.vue
@@ -2,13 +2,14 @@
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { supabase } from '@/supabase-client'
+import { consumeOAuthPopupFlag } from '@/api/session'
 
 const router = useRouter()
 
 onMounted(async () => {
   await supabase.auth.getSession()
 
-  if (window.name === 'oauthFlow') {
+  if (consumeOAuthPopupFlag()) {
     window.close()
     return
   }

--- a/tests/integration/views/auth/callback.test.js
+++ b/tests/integration/views/auth/callback.test.js
@@ -3,7 +3,8 @@ import { flushPromises, mount } from '@vue/test-utils'
 
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
-  push: vi.fn()
+  push: vi.fn(),
+  consumeOAuthPopupFlag: vi.fn()
 }))
 
 vi.mock('@/supabase-client', () => ({
@@ -14,82 +15,44 @@ vi.mock('vue-router', () => ({
   useRouter: () => ({ push: mocks.push })
 }))
 
+vi.mock('@/api/session', () => ({
+  consumeOAuthPopupFlag: mocks.consumeOAuthPopupFlag
+}))
+
 import Callback from '@/views/auth/callback.vue'
-
-function setWindowName(value) {
-  Object.defineProperty(window, 'name', {
-    configurable: true,
-    value
-  })
-}
-
-function setOpener(value) {
-  Object.defineProperty(window, 'opener', {
-    configurable: true,
-    get: () => value
-  })
-}
 
 describe('auth/callback', () => {
   let closeSpy
-  let originalNameDescriptor
-  let originalOpenerDescriptor
 
   beforeEach(() => {
     mocks.getSession.mockReset()
     mocks.getSession.mockResolvedValue({ data: { session: null }, error: null })
     mocks.push.mockReset()
-    originalNameDescriptor = Object.getOwnPropertyDescriptor(window, 'name')
-    originalOpenerDescriptor = Object.getOwnPropertyDescriptor(window, 'opener')
+    mocks.consumeOAuthPopupFlag.mockReset()
     closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {})
   })
 
   afterEach(() => {
     closeSpy.mockRestore()
-    if (originalNameDescriptor) {
-      Object.defineProperty(window, 'name', originalNameDescriptor)
-    } else {
-      setWindowName('')
-    }
-    if (originalOpenerDescriptor) {
-      Object.defineProperty(window, 'opener', originalOpenerDescriptor)
-    } else {
-      try {
-        // eslint-disable-next-line no-self-assign
-        delete window.opener
-      } catch {
-        setOpener(null)
-      }
-    }
   })
 
   test('awaits getSession on mount', async () => {
-    setWindowName('')
+    mocks.consumeOAuthPopupFlag.mockReturnValue(false)
     mount(Callback)
     await flushPromises()
     expect(mocks.getSession).toHaveBeenCalledTimes(1)
   })
 
-  test('pushes to the dashboard route when window.name is not oauthFlow', async () => {
-    setWindowName('')
-    mount(Callback)
-    await flushPromises()
-    expect(mocks.push).toHaveBeenCalledWith({ name: 'dashboard' })
-    expect(closeSpy).not.toHaveBeenCalled()
-  })
-
-  test('closes the window and does not navigate when window.name is oauthFlow, even with opener severed by COOP [obligation]', async () => {
-    setWindowName('oauthFlow')
-    setOpener(null)
+  test('closes the window and does not navigate when consumeOAuthPopupFlag returns true [obligation]', async () => {
+    mocks.consumeOAuthPopupFlag.mockReturnValue(true)
     mount(Callback)
     await flushPromises()
     expect(closeSpy).toHaveBeenCalledTimes(1)
     expect(mocks.push).not.toHaveBeenCalled()
   })
 
-  test('navigates to the dashboard for a plain full-page redirect (window.name unset, no popup) [obligation]', async () => {
-    setWindowName('')
-    setOpener(null)
+  test('navigates to the dashboard when consumeOAuthPopupFlag returns false [obligation]', async () => {
+    mocks.consumeOAuthPopupFlag.mockReturnValue(false)
     mount(Callback)
     await flushPromises()
     expect(mocks.push).toHaveBeenCalledWith({ name: 'dashboard' })

--- a/tests/unit/api/session.test.js
+++ b/tests/unit/api/session.test.js
@@ -51,7 +51,8 @@ import {
   waitForPasswordRecovery,
   requestPasswordReset,
   isAuthError,
-  onSignedOut
+  onSignedOut,
+  consumeOAuthPopupFlag
 } from '@/api/session'
 
 beforeEach(() => {
@@ -75,6 +76,30 @@ describe('getSession', () => {
   test('throws when supabase returns an error', async () => {
     mocks.getSession.mockResolvedValueOnce({ data: null, error: { message: 'nope' } })
     await expect(getSession()).rejects.toThrow('nope')
+  })
+
+  test('resolves with the session when supabase.auth.getSession() settles before the timeout [obligation]', async () => {
+    vi.useFakeTimers()
+    const session = { user: { id: 'u1' } }
+    mocks.getSession.mockResolvedValueOnce({ data: { session }, error: null })
+
+    const promise = getSession()
+    await vi.advanceTimersByTimeAsync(0)
+
+    await expect(promise).resolves.toEqual(session)
+    vi.useRealTimers()
+  })
+
+  test('rejects once the 2s timeout elapses when supabase.auth.getSession() never resolves [obligation]', async () => {
+    vi.useFakeTimers()
+    mocks.getSession.mockImplementationOnce(() => new Promise(() => {}))
+
+    const promise = getSession()
+    promise.catch(() => {})
+    await vi.advanceTimersByTimeAsync(2000)
+
+    await expect(promise).rejects.toThrow('getSession timed out')
+    vi.useRealTimers()
   })
 })
 
@@ -236,6 +261,16 @@ describe('signInOAuth', () => {
       mocks.signInWithOAuth.mockResolvedValueOnce({ data: null, error: new Error('boom') })
       await expect(signInOAuth('google')).rejects.toThrow('boom')
     })
+
+    test('clears a stale oauth-popup-pending flag left by an abandoned popup [obligation]', async () => {
+      global.__matchMedia.matches = true
+      window.localStorage.setItem('oauth-popup-pending', '1')
+      mocks.signInWithOAuth.mockResolvedValueOnce({ data: null, error: null })
+
+      await signInOAuth('google')
+
+      expect(consumeOAuthPopupFlag()).toBe(false)
+    })
   })
 
   describe('popup path', () => {
@@ -248,6 +283,36 @@ describe('signInOAuth', () => {
       })
       return { get: () => cb, unsubscribe }
     }
+
+    test('sets the oauth-popup-pending flag when a genuine popup opens [obligation]', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({
+        data: { url: 'https://auth.x/login' },
+        error: null
+      })
+      const popup = { closed: false }
+      openSpy.mockReturnValue(popup)
+      captureAuthCallback()
+
+      signInOAuth('google')
+      await Promise.resolve()
+
+      expect(consumeOAuthPopupFlag()).toBe(true)
+      expect(consumeOAuthPopupFlag()).toBe(false)
+    })
+
+    test('does not set the oauth-popup-pending flag when window.open is blocked [obligation]', async () => {
+      mocks.signInWithOAuth.mockResolvedValueOnce({
+        data: { url: 'https://auth.x' },
+        error: null
+      })
+      openSpy.mockReturnValue(null)
+      const locationStub = { href: '' }
+      vi.stubGlobal('location', locationStub)
+
+      await signInOAuth('google')
+
+      expect(consumeOAuthPopupFlag()).toBe(false)
+    })
 
     test('passes skipBrowserRedirect=true and opens the popup', async () => {
       mocks.signInWithOAuth.mockResolvedValueOnce({
@@ -762,6 +827,32 @@ describe('onSignedOut [obligation]', () => {
     unsubscribeFn()
 
     expect(cb.unsubscribe).toHaveBeenCalledOnce()
+  })
+})
+
+describe('consumeOAuthPopupFlag [obligation]', () => {
+  afterEach(() => {
+    window.localStorage.removeItem('oauth-popup-pending')
+  })
+
+  test('returns true when the flag is exactly "1" [obligation]', () => {
+    window.localStorage.setItem('oauth-popup-pending', '1')
+    expect(consumeOAuthPopupFlag()).toBe(true)
+  })
+
+  test('returns false when the flag is absent [obligation]', () => {
+    expect(consumeOAuthPopupFlag()).toBe(false)
+  })
+
+  test('returns false for any non-"1" value [obligation]', () => {
+    window.localStorage.setItem('oauth-popup-pending', 'true')
+    expect(consumeOAuthPopupFlag()).toBe(false)
+  })
+
+  test('clears the flag as a side effect, so a second call returns false [obligation]', () => {
+    window.localStorage.setItem('oauth-popup-pending', '1')
+    expect(consumeOAuthPopupFlag()).toBe(true)
+    expect(consumeOAuthPopupFlag()).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary
- `getSession()` now races the internal `supabase.auth.getSession()` call against a 2s timeout, so a stuck refresh_token request (e.g. connection refused) fails fast instead of hanging the root route's auth guard on a blank screen.
- Replaces the OAuth popup-close detection (`window.name`, from #404) with a localStorage flag — `window.name` turned out to be severed by Google's COOP-triggered browsing-context-group swap the same way `window.opener` was, so the popup stayed open in prod after login.