### PR TITLE
chore(ci): route deploy secrets through Doppler

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,14 +134,13 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
+      - name: Setup Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
       - name: Build
-        run: pnpm run build
+        run: doppler run -- pnpm run build
         env:
-          VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
-          VITE_SUPABASE_API_KEY: ${{ secrets.VITE_SUPABASE_API_KEY }}
-          VITE_STRIPE_PUBLIC_KEY: ${{ vars.VITE_STRIPE_PUBLIC_KEY }}
-          VITE_MEMBERSHIP_PRICE_ID: ${{ vars.VITE_MEMBERSHIP_PRICE_ID }}
-          VITE_AUTH_REDIRECT_URL: ${{ vars.VITE_AUTH_REDIRECT_URL }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -171,12 +170,15 @@ jobs:
         with:
           version: latest
 
+      - name: Setup Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
       - name: Run migrations
         run: |
-          supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }} --password "${{ secrets.SUPABASE_DB_PASSWORD }}"
-          supabase migration up --linked
+          doppler run -- supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }} --password "$(doppler secrets get SUPABASE_DB_PASSWORD --plain)"
+          doppler run -- supabase migration up --linked
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
   functions:
     name: Deploy edge functions
@@ -200,24 +202,27 @@ jobs:
         with:
           version: latest
 
+      - name: Setup Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
       - name: Link project
-        run: supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }} --password "${{ secrets.SUPABASE_DB_PASSWORD }}"
+        run: doppler run -- supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }} --password "$(doppler secrets get SUPABASE_DB_PASSWORD --plain)"
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
       - name: Set edge function secrets
         run: |
-          supabase secrets set \
-            STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }} \
-            STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }} \
+          doppler run -- supabase secrets set \
+            STRIPE_SECRET_KEY="$(doppler secrets get STRIPE_SECRET_KEY --plain)" \
+            STRIPE_WEBHOOK_SECRET="$(doppler secrets get STRIPE_WEBHOOK_SECRET --plain)" \
             --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
       - name: Deploy functions
-        run: supabase functions deploy --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
+        run: doppler run -- supabase functions deploy --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
   config:
     name: Push Supabase config
@@ -237,17 +242,18 @@ jobs:
         with:
           version: latest
 
+      - name: Setup Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
       - name: Link project
-        run: supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }} --password "${{ secrets.SUPABASE_DB_PASSWORD }}"
+        run: doppler run -- supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }} --password "$(doppler secrets get SUPABASE_DB_PASSWORD --plain)"
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
       - name: Push config
-        run: supabase config push --yes
+        run: doppler run -- supabase config push --yes
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ vars.AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
-          AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET: ${{ secrets.AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
   frontend:
     name: Deploy frontend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -276,11 +276,13 @@ jobs:
           name: dist
           path: dist
 
+      - name: Setup Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
       - name: Deploy to Netlify
-        run: npx --yes netlify-cli deploy --dir=dist --prod --no-build
+        run: doppler run -- npx --yes netlify-cli deploy --dir=dist --prod --no-build
         env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ vars.NETLIFY_SITE_ID }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
   tag-release:
     name: Tag + release (semantic-release)

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "./scripts/bootstrap-env.sh && mprocs",
-    "dev:vite": "vp dev",
-    "dev:host": "vp dev --host",
+    "dev": "./scripts/bootstrap-env.sh && doppler run -- mprocs",
+    "dev:vite": "doppler run -- vp dev",
+    "dev:host": "doppler run -- vp dev --host",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vp preview",
     "test": "vp test run --coverage",

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Ensures local dev env vars exist before the stack boots.
-# Idempotent — safe to run on every `pnpm dev:full`.
-# Currently: caches the Stripe CLI webhook signing secret so the
-# stripe-webhook Edge Function can verify incoming events.
+# Idempotent — safe to run on every `pnpm dev`.
+# Edge functions run in an isolated container and don't inherit `doppler run`'s
+# env (unlike vite/supabase start, which are direct child processes), so their
+# secrets are cached into this file instead — the channel `supabase functions
+# serve` actually reads.
 set -euo pipefail
 
 ENV_FILE="supabase/functions/.env.local"
@@ -16,3 +18,11 @@ if ! grep -q '^STRIPE_WEBHOOK_SECRET=' "$ENV_FILE"; then
   echo "STRIPE_WEBHOOK_SECRET=$secret" >> "$ENV_FILE"
   echo "Cached STRIPE_WEBHOOK_SECRET → $ENV_FILE"
 fi
+
+for key in STRIPE_SECRET_KEY OPENAI_API_KEY ANTHROPIC_API_KEY; do
+  if ! grep -q "^${key}=" "$ENV_FILE"; then
+    value=$(doppler secrets get "$key" --plain)
+    echo "${key}=${value}" >> "$ENV_FILE"
+    echo "Cached ${key} → $ENV_FILE"
+  fi
+done


### PR DESCRIPTION
## Summary

- `build`, `migrate`, `functions`, and `config` jobs in `deploy.yml` now run through `doppler run --`, reading a single `DOPPLER_TOKEN` per GitHub Environment instead of enumerating each `VITE_*`/`SUPABASE_*` var by hand.
- Fixes the failure mode where a missing var in the workflow YAML silently broke the frontend build.

Requires `DOPPLER_TOKEN` to be added as an environment secret for both `staging` and `production` before this can deploy — see conversation for setup steps.