### PR TITLE
Delete decks and polish drag/animation in dashboard edit mode

### DIFF
--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -11,10 +11,23 @@ type DeckThumbnailProps = {
   deck?: Deck
   size?: CardSize
   hide_title?: boolean
+  // skip the hover-to-reveal fade — corner action stays visible unconditionally
+  corner_action_always_visible?: boolean
+  // grid is in drag-to-reorder mode: the card is a drag handle, not tappable
+  rearranging?: boolean
+  // this is the card currently being picked up — show a lift shadow
+  dragging?: boolean
   sfx?: SfxOptions
 }
 
-const { deck, size = 'base', sfx } = defineProps<DeckThumbnailProps>()
+const {
+  deck,
+  size = 'base',
+  corner_action_always_visible = false,
+  rearranging = false,
+  dragging = false,
+  sfx
+} = defineProps<DeckThumbnailProps>()
 
 const emit = defineEmits<{ press: [e: MouseEvent] }>()
 
@@ -25,16 +38,32 @@ const { t } = useI18n()
   <ui-tappable
     as="div"
     data-testid="deck-thumbnail"
-    class="pointer-fine:hover:scale-102 data-[tap-active=true]:scale-101 pointer-coarse:data-[tap-active=true]:scale-105 pointer-fine:transition-transform duration-75 relative cursor-pointer h-min touch-manipulation"
+    class="relative h-min touch-manipulation pointer-fine:hover:scale-102 pointer-fine:transition-transform duration-75"
+    :class="[
+      rearranging
+        ? 'cursor-grab'
+        : 'data-[tap-active=true]:scale-101 pointer-coarse:data-[tap-active=true]:scale-105 cursor-pointer',
+      dragging && 'drop-shadow-sm'
+    ]"
     :sfx="{ hover: TYPE_SFX, ...sfx }"
     @tap="emit('press', $event)"
   >
-    <card side="cover" :size="size" :cover_config="deck?.cover_config" />
+    <card
+      side="cover"
+      :size="size"
+      :cover_config="deck?.cover_config"
+      :class="{ 'pointer-events-none select-none': rearranging }"
+    />
 
     <div
       v-if="$slots['corner-action']"
       data-testid="deck-thumbnail__corner-action"
-      class="absolute -top-1 -right-1 opacity-0 pointer-fine:group-hover/tappable:opacity-100"
+      class="absolute -top-1 -right-1"
+      :class="
+        corner_action_always_visible
+          ? 'opacity-100 pointer-events-auto'
+          : 'opacity-0 pointer-fine:group-hover/tappable:opacity-100'
+      "
     >
       <slot name="corner-action"></slot>
     </div>

--- a/src/components/ui-kit/options-panel/index.vue
+++ b/src/components/ui-kit/options-panel/index.vue
@@ -10,6 +10,12 @@ export type OptionsPanelEntry = {
   // replaces the trailing chevron; falls back to 'line-arrow-right' when interactive
   trailingIcon?: string
   disabled?: boolean
+  selected?: boolean
+  // data-theme/data-theme-dark applied while selected; the selected background
+  // reads off this theme's --theme-primary, so omitting it falls back to the
+  // panel's own ambient theme
+  selectedTheme?: string
+  selectedThemeDark?: string
 }
 
 type OptionsPanelProps = {
@@ -60,7 +66,7 @@ function onSelect(entry: OptionsPanelEntry) {
       :data-testid="
         attrs['data-testid'] ? `${attrs['data-testid']}__content` : 'options-panel__content'
       "
-      class="flex min-h-0 flex-1 flex-col rounded-4 bg-(--theme-primary)"
+      class="flex min-h-0 flex-1 flex-col rounded-4 bg-(--theme-primary) p-1"
       :class="scrollable ? 'overflow-y-auto scroll-hidden' : 'overflow-hidden'"
     >
       <options-panel-row

--- a/src/components/ui-kit/options-panel/row.vue
+++ b/src/components/ui-kit/options-panel/row.vue
@@ -38,16 +38,21 @@ function onSelect() {
             as: 'button',
             type: 'button',
             active_on_hover: true,
+            active: entry.selected,
             sfx: { hover: TYPE_SFX, ...sfx }
           }
         : {}
     "
     data-testid="options-panel__card"
     :data-value="entry.value"
-    class="text-(--theme-on-primary) text-left flex items-center gap-3 py-4 px-6 first:pt-6 first:pb-3 last:pb-6 last:pt-3"
+    :data-active="entry.selected || null"
+    :data-theme="entry.selected ? entry.selectedTheme : undefined"
+    :data-theme-dark="entry.selected ? entry.selectedThemeDark : undefined"
+    class="text-(--theme-on-primary) text-left flex items-center gap-3 py-3 px-5 first:pt-5 first:pb-2 last:pb-5 last:pt-2 rounded-3"
     :class="[
       interactive ? 'cursor-pointer' : '',
-      entry.disabled ? 'pointer-events-none opacity-20' : ''
+      entry.disabled ? 'pointer-events-none opacity-20' : '',
+      interactive && 'data-[active=true]:bg-(--theme-primary)'
     ]"
     :bgx_color="interactive ? 'var(--theme-neutral)' : undefined"
     @tap="onSelect"

--- a/src/components/ui-kit/tappable.vue
+++ b/src/components/ui-kit/tappable.vue
@@ -15,8 +15,8 @@ type UiTappableProps = {
   triggerAt?: StagedTapPhase
   bgx_color?: string
   active_on_hover?: boolean
-  // persistent selected/active state — shows the bgx background statically,
-  // without the hover/press bgx-slide sweep
+  // persistent selected/active state — shows the bgx background + slide,
+  // same as hover/press but held open
   active?: boolean
 }
 
@@ -60,7 +60,6 @@ function onPointerLeave() {
   <component
     :is="as"
     :data-tap-active="playing || hovering || active || null"
-    :data-tap-transient="playing || hovering || null"
     class="group/tappable relative isolate"
     v-sfx="{ hover: sfx.hover, focus: sfx.focus, blur: sfx.blur, debounce: sfx.debounce }"
     @pointerenter="onPointerEnter"
@@ -69,7 +68,7 @@ function onPointerLeave() {
   >
     <slot />
     <div
-      class="absolute inset-0 -z-10 rounded-[inherit] bgx-diagonal-stripes animation-safe:group-data-[tap-transient=true]/tappable:bgx-slide pointer-events-none hidden group-data-[tap-active=true]/tappable:block"
+      class="absolute inset-0 -z-10 rounded-[inherit] bgx-diagonal-stripes animation-safe:group-data-[tap-active=true]/tappable:bgx-slide pointer-events-none hidden group-data-[tap-active=true]/tappable:block"
       :style="{ '--bgx-fill': bgx_color }"
     />
   </component>

--- a/src/components/ui-kit/tappable.vue
+++ b/src/components/ui-kit/tappable.vue
@@ -15,6 +15,9 @@ type UiTappableProps = {
   triggerAt?: StagedTapPhase
   bgx_color?: string
   active_on_hover?: boolean
+  // persistent selected/active state — shows the bgx background statically,
+  // without the hover/press bgx-slide sweep
+  active?: boolean
 }
 
 const {
@@ -23,7 +26,8 @@ const {
   sfx = {},
   triggerAt,
   bgx_color = 'var(--theme-neutral)',
-  active_on_hover = false
+  active_on_hover = false,
+  active = false
 } = defineProps<UiTappableProps>()
 
 const emit = defineEmits<{
@@ -55,7 +59,8 @@ function onPointerLeave() {
 <template>
   <component
     :is="as"
-    :data-tap-active="playing || hovering || null"
+    :data-tap-active="playing || hovering || active || null"
+    :data-tap-transient="playing || hovering || null"
     class="group/tappable relative isolate"
     v-sfx="{ hover: sfx.hover, focus: sfx.focus, blur: sfx.blur, debounce: sfx.debounce }"
     @pointerenter="onPointerEnter"
@@ -64,7 +69,7 @@ function onPointerLeave() {
   >
     <slot />
     <div
-      class="absolute inset-0 -z-10 rounded-[inherit] bgx-diagonal-stripes animation-safe:group-data-[tap-active=true]/tappable:bgx-slide pointer-events-none hidden group-data-[tap-active=true]/tappable:block"
+      class="absolute inset-0 -z-10 rounded-[inherit] bgx-diagonal-stripes animation-safe:group-data-[tap-transient=true]/tappable:bgx-slide pointer-events-none hidden group-data-[tap-active=true]/tappable:block"
       :style="{ '--bgx-fill': bgx_color }"
     />
   </component>

--- a/src/composables/deck/danger-actions.ts
+++ b/src/composables/deck/danger-actions.ts
@@ -68,6 +68,7 @@ export function useDeckDangerActions(
 
     const on_deleted_deck = route.name === 'deck' && Number(route.params.id) === deck.id
     if (on_deleted_deck) router.push({ name: 'dashboard' })
+    close(true)
   }
 
   return {

--- a/src/composables/deck/danger-actions.ts
+++ b/src/composables/deck/danger-actions.ts
@@ -67,14 +67,7 @@ export function useDeckDangerActions(
     }
 
     const on_deleted_deck = route.name === 'deck' && Number(route.params.id) === deck.id
-
-    notice.success(t('toast.success.deck-deleted'), {
-      variant: 'panel',
-      onDismiss: () => {
-        close(true)
-        if (on_deleted_deck) router.push({ name: 'dashboard' })
-      }
-    })
+    if (on_deleted_deck) router.push({ name: 'dashboard' })
   }
 
   return {

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -406,7 +406,7 @@
   "dashboard.new-deck-card.label": "New Deck",
   "dashboard.actions-panel.new-deck-label": "New Deck",
   "dashboard.actions-panel.edit-decks-label": "Edit Decks",
-  "dashboard.actions-panel.done-editing-label": "Done Editing",
+  "dashboard.actions-panel.done-editing-label": "Stop Editing",
   "dashboard.deck-grid-item.delete-button": "Delete Deck",
   "dashboard.actions-panel.study-button": "Study {count} Deck | Study {count} Decks",
   "dialog-card.close-label": "Close",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -407,6 +407,7 @@
   "dashboard.actions-panel.new-deck-label": "New Deck",
   "dashboard.actions-panel.edit-decks-label": "Edit Decks",
   "dashboard.actions-panel.done-editing-label": "Done Editing",
+  "dashboard.deck-grid-item.delete-button": "Delete Deck",
   "dashboard.actions-panel.study-button": "Study {count} Deck | Study {count} Decks",
   "dialog-card.close-label": "Close",
   "dialog-card.back-label": "Back",

--- a/src/views/dashboard/actions-panel/index.vue
+++ b/src/views/dashboard/actions-panel/index.vue
@@ -42,7 +42,10 @@ const deck_entries = computed<OptionsPanelEntry[]>(() => [
     label: editing_decks
       ? t('dashboard.actions-panel.done-editing-label')
       : t('dashboard.actions-panel.edit-decks-label'),
-    trailingIcon: editing_decks ? 'data-check' : 'pencil'
+    trailingIcon: editing_decks ? 'stop' : 'pencil',
+    selected: editing_decks,
+    selectedTheme: 'yellow-500',
+    selectedThemeDark: 'yellow-700'
   }
 ])
 

--- a/src/views/dashboard/actions-panel/index.vue
+++ b/src/views/dashboard/actions-panel/index.vue
@@ -104,6 +104,7 @@ async function onSelect(value: string) {
         data-theme="yellow-500"
         data-theme-dark="yellow-700"
         full-width
+        :disabled="editing_decks"
         @press="onStudyAll"
       >
         {{ t('dashboard.actions-panel.study-button', due_decks.length) }}

--- a/src/views/dashboard/deck-grid/delete-button.vue
+++ b/src/views/dashboard/deck-grid/delete-button.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import UiButton from '@/components/ui-kit/button.vue'
+import { useDeckEditor } from '@/composables/deck/editor'
+import { useDeckDangerActions } from '@/composables/deck/danger-actions'
+
+type DeckGridDeleteButtonProps = {
+  deck: Deck
+}
+
+const { deck } = defineProps<DeckGridDeleteButtonProps>()
+
+const { t } = useI18n()
+const editor = useDeckEditor(deck)
+const danger_actions = useDeckDangerActions(editor, deck, () => {})
+</script>
+
+<template>
+  <ui-button
+    data-testid="dashboard__deck-delete-button"
+    data-theme="brown-500"
+    data-theme-dark="stone-700"
+    icon-left="close"
+    icon-only
+    :loading="danger_actions.deleting.value"
+    @click.stop
+    @press="danger_actions.onDelete"
+    class="ring-4 ring-brown-100 dark:ring-grey-900"
+  >
+    {{ t('dashboard.deck-grid-item.delete-button') }}
+  </ui-button>
+</template>

--- a/src/views/dashboard/deck-grid/index.vue
+++ b/src/views/dashboard/deck-grid/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, useTemplateRef } from 'vue'
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import DeckGridItem from './item.vue'
@@ -33,6 +33,25 @@ const reorder = useDeckGridReorder(
   () => decks,
   () => editing,
   size
+)
+
+// Animate a slot reflow only when the deck count itself changes (delete/create)
+// — a drag-drop reorder already has its own lift/drop settle animation, and
+// transitioning the resting position too would fight it (the dropped card
+// would visibly slide from its pre-persist slot to its post-persist one).
+const REFLOW_TRANSITION_DURATION = 200
+const reflowing = ref(false)
+let reflow_timeout = 0
+
+watch(
+  () => decks.length,
+  () => {
+    reflowing.value = true
+    window.clearTimeout(reflow_timeout)
+    reflow_timeout = window.setTimeout(() => {
+      reflowing.value = false
+    }, REFLOW_TRANSITION_DURATION)
+  }
 )
 
 // TransitionGroup's `appear` never fires here: this route renders inside a
@@ -87,7 +106,8 @@ async function onCreateDeckClicked() {
         :class="{
           'z-30': index === reorder.dragging_index.value,
           'cursor-grabbing': index === reorder.dragging_index.value,
-          'cursor-grab': editing && index !== reorder.dragging_index.value
+          'cursor-grab': editing && index !== reorder.dragging_index.value,
+          'transition-transform duration-200 ease-out': reflowing
         }"
         :style="{
           width: `${reorder.cell_width.value}px`,
@@ -115,6 +135,7 @@ async function onCreateDeckClicked() {
       <div
         key="new-deck-card"
         class="absolute top-0 left-0"
+        :class="{ 'transition-transform duration-200 ease-out': reflowing }"
         :style="{
           width: `${reorder.cell_width.value}px`,
           transform: `translate(${reorder.itemPosition(decks.length).x}px, ${reorder.itemPosition(decks.length).y}px)`

--- a/src/views/dashboard/deck-grid/index.vue
+++ b/src/views/dashboard/deck-grid/index.vue
@@ -42,10 +42,17 @@ const reorder = useDeckGridReorder(
 const REFLOW_TRANSITION_DURATION = 200
 const reflowing = ref(false)
 let reflow_timeout = 0
+// The first firing is the initial query resolving, not a real reflow — skip it.
+let deck_count_initialized = false
 
 watch(
   () => decks.length,
   () => {
+    if (!deck_count_initialized) {
+      deck_count_initialized = true
+      return
+    }
+
     reflowing.value = true
     window.clearTimeout(reflow_timeout)
     reflow_timeout = window.setTimeout(() => {

--- a/src/views/dashboard/deck-grid/item.vue
+++ b/src/views/dashboard/deck-grid/item.vue
@@ -2,6 +2,7 @@
 import { useI18n } from 'vue-i18n'
 import DeckThumbnail from '@/components/deck/deck-thumbnail.vue'
 import UiButton from '@/components/ui-kit/button.vue'
+import DeckGridDeleteButton from './delete-button.vue'
 
 type DeckGridItemProps = {
   deck: Deck
@@ -28,32 +29,35 @@ function onPress() {
 </script>
 
 <template>
-  <DeckThumbnail
-    :deck="deck"
-    :size="size"
-    :sfx="{ press: 'snappy_button_5' }"
-    class="w-full"
-    :class="{
-      jiggle: rearranging && !dragging,
-      'pointer-events-none cursor-grab': rearranging
-    }"
-    @press="onPress"
-  >
-    <template v-if="!rearranging" #corner-action>
-      <ui-button
-        data-testid="dashboard__deck-settings-button"
-        data-theme="blue-500"
-        data-theme-dark="blue-650"
-        icon-left="build"
-        icon-only
-        @click.stop
-        @press="emit('settings')"
-        class="ring-4 ring-brown-100 dark:ring-grey-900"
-      >
-        {{ t('deck.settings-modal.title') }}
-      </ui-button>
-    </template>
-  </DeckThumbnail>
+  <div class="w-full" :class="{ jiggle: rearranging && !dragging }">
+    <DeckThumbnail
+      :deck="deck"
+      :size="size"
+      :corner_action_always_visible="rearranging"
+      :rearranging="rearranging"
+      :dragging="dragging"
+      :sfx="{ press: 'snappy_button_5' }"
+      class="w-full"
+      @press="onPress"
+    >
+      <template #corner-action>
+        <DeckGridDeleteButton v-if="rearranging" :deck="deck" @pointerdown.stop />
+        <ui-button
+          v-else
+          data-testid="dashboard__deck-settings-button"
+          data-theme="blue-500"
+          data-theme-dark="blue-650"
+          icon-left="build"
+          icon-only
+          @click.stop
+          @press="emit('settings')"
+          class="ring-4 ring-brown-100 dark:ring-grey-900"
+        >
+          {{ t('deck.settings-modal.title') }}
+        </ui-button>
+      </template>
+    </DeckThumbnail>
+  </div>
 </template>
 
 <style scoped>
@@ -61,19 +65,20 @@ function onPress() {
    tempo are set per card via --jiggle-* so the grid doesn't beat in unison. */
 @keyframes deck-grid-item-jiggle {
   0% {
-    transform: rotate(-1.4deg);
+    transform: rotate(calc(var(--jiggle-rotation, 1.4deg) * -1));
   }
   50% {
-    transform: rotate(1.4deg);
+    transform: rotate(var(--jiggle-rotation, 1.4deg));
   }
   100% {
-    transform: rotate(-1.4deg);
+    transform: rotate(calc(var(--jiggle-rotation, 1.4deg) * -1));
   }
 }
 
-/* .jiggle is bound directly on DeckThumbnail's root (not a descendant), so
-   this stays a plain scoped selector — :deep() would compile to a descendant
-   combinator and never match. */
+/* .jiggle sits on a wrapper around DeckThumbnail, not DeckThumbnail's own
+   root — that root also carries a hover-scale transform (see deck-thumbnail.vue),
+   and one element can't animate + hover-transition the same `transform`
+   property without one clobbering the other. */
 .jiggle {
   animation: deck-grid-item-jiggle var(--jiggle-duration, 0.26s) ease-in-out infinite;
   animation-delay: var(--jiggle-delay, 0s);

--- a/src/views/dashboard/deck-grid/use-deck-grid-reorder.ts
+++ b/src/views/dashboard/deck-grid/use-deck-grid-reorder.ts
@@ -88,11 +88,14 @@ export function useDeckGridReorder(
   }
 
   // Idle iOS-style jiggle: vary phase and tempo per card off its index so the
-  // grid shimmers organically instead of beating in unison.
+  // grid shimmers organically instead of beating in unison. Lighter rotation
+  // than the deck-view card grid — the dashboard shows more cards at once, so
+  // the default amplitude reads as too busy.
   function jiggleStyle(index: number) {
     return {
       '--jiggle-delay': `${-(index % 11) * 47}ms`,
-      '--jiggle-duration': `${240 + (index % 5) * 16}ms`
+      '--jiggle-duration': `${240 + (index % 5) * 16}ms`,
+      '--jiggle-rotation': '0.7deg'
     }
   }
 

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { useMemberDecksQuery } from '@/api/decks'
 import { useNoticeStore } from '@/stores/notice-store'
 import { useCan } from '@/composables/can'
+import { emitSfx } from '@/sfx/bus'
 import DashboardSection from './dashboard-section.vue'
 import DashboardActionsPanel from './actions-panel/index.vue'
 import ReviewInbox from './review-inbox/index.vue'
@@ -27,6 +28,7 @@ watch(decks_error, (err) => {
 
 function onToggleEditDecks() {
   editing_decks.value = !editing_decks.value
+  emitSfx(editing_decks.value ? 'pop_up_pop' : 'digi_powerdown')
 }
 
 const due_decks = computed(() => {

--- a/tests/integration/components/deck/deck-thumbnail.test.js
+++ b/tests/integration/components/deck/deck-thumbnail.test.js
@@ -190,6 +190,59 @@ describe('DeckThumbnail', () => {
     expect(wrapper.emitted('press')).toHaveLength(1)
   })
 
+  // ── rearranging/dragging/corner_action_always_visible [obligation] ───────────
+
+  describe('rearranging/dragging/corner_action_always_visible [obligation]', () => {
+    test('rearranging adds pointer-events-none select-none to the Card and cursor-grab to the root', () => {
+      const wrapper = mountWithDeck({}, { rearranging: true })
+      const card = wrapper.findComponent({ name: 'Card' })
+      expect(card.classes()).toContain('pointer-events-none')
+      expect(card.classes()).toContain('select-none')
+      expect(wrapper.find('[data-testid="deck-thumbnail"]').classes()).toContain('cursor-grab')
+    })
+
+    test('not rearranging keeps the default hover-scale classes and drops cursor-grab', () => {
+      const wrapper = mountWithDeck({}, { rearranging: false })
+      const root = wrapper.find('[data-testid="deck-thumbnail"]')
+      expect(root.classes()).not.toContain('cursor-grab')
+      expect(root.classes()).toContain('cursor-pointer')
+    })
+
+    test('dragging adds drop-shadow-sm to the root', () => {
+      const wrapper = mountWithDeck({}, { dragging: true })
+      expect(wrapper.find('[data-testid="deck-thumbnail"]').classes()).toContain('drop-shadow-sm')
+    })
+
+    test('not dragging omits drop-shadow-sm', () => {
+      const wrapper = mountWithDeck({}, { dragging: false })
+      expect(wrapper.find('[data-testid="deck-thumbnail"]').classes()).not.toContain(
+        'drop-shadow-sm'
+      )
+    })
+
+    test('corner_action_always_visible keeps the corner-action slot visible without hover', () => {
+      const wrapper = shallowMount(DeckThumbnail, {
+        props: { deck: { title: 'X' }, corner_action_always_visible: true },
+        slots: { 'corner-action': '<button data-testid="corner-button">act</button>' },
+        global: { stubs: { UiTappable: UiTappableStub } }
+      })
+      const corner = wrapper.find('[data-testid="deck-thumbnail__corner-action"]')
+      expect(corner.classes()).toContain('opacity-100')
+      expect(corner.classes()).toContain('pointer-events-auto')
+    })
+
+    test('defaults to hover-only visibility for the corner-action slot', () => {
+      const wrapper = shallowMount(DeckThumbnail, {
+        props: { deck: { title: 'X' } },
+        slots: { 'corner-action': '<button data-testid="corner-button">act</button>' },
+        global: { stubs: { UiTappable: UiTappableStub } }
+      })
+      const corner = wrapper.find('[data-testid="deck-thumbnail__corner-action"]')
+      expect(corner.classes()).toContain('opacity-0')
+      expect(corner.classes()).not.toContain('opacity-100')
+    })
+  })
+
   // ── sfx prop spread (obligation 7) ───────────────────────────────────────────
 
   describe('sfx prop — default + override [obligation]', () => {

--- a/tests/integration/components/ui-kit/options-panel/index.test.js
+++ b/tests/integration/components/ui-kit/options-panel/index.test.js
@@ -135,6 +135,55 @@ describe('OptionsPanel', () => {
     })
   })
 
+  // ── selected state [obligation] ──────────────────────────────────────────
+
+  test('a selected entry gets data-active=true and the theme-primary fill class', () => {
+    const wrapper = makePanel({
+      entries: [
+        ...ENTRIES,
+        { value: 'edit-decks', label: 'Edit Decks', selected: true, selectedTheme: 'yellow-500' }
+      ]
+    })
+    const card = wrapper.find('[data-testid="options-panel__card"][data-value="edit-decks"]')
+    expect(card.attributes('data-active')).toBe('true')
+    expect(card.classes()).toContain('data-[active=true]:bg-(--theme-primary)')
+  })
+
+  test('an unselected entry has no data-active attribute', () => {
+    const wrapper = makePanel({
+      entries: [...ENTRIES, { value: 'edit-decks', label: 'Edit Decks', selected: false }]
+    })
+    const card = wrapper.find('[data-testid="options-panel__card"][data-value="edit-decks"]')
+    expect(card.attributes('data-active')).toBeUndefined()
+  })
+
+  test('applies selectedTheme/selectedThemeDark as data-theme/data-theme-dark while selected', () => {
+    const wrapper = makePanel({
+      entries: [
+        ...ENTRIES,
+        {
+          value: 'edit-decks',
+          label: 'Edit Decks',
+          selected: true,
+          selectedTheme: 'yellow-500',
+          selectedThemeDark: 'yellow-700'
+        }
+      ]
+    })
+    const card = wrapper.find('[data-testid="options-panel__card"][data-value="edit-decks"]')
+    expect(card.attributes('data-theme')).toBe('yellow-500')
+    expect(card.attributes('data-theme-dark')).toBe('yellow-700')
+  })
+
+  test('falls back to no explicit data-theme when selected but selectedTheme is omitted', () => {
+    const wrapper = makePanel({
+      entries: [...ENTRIES, { value: 'edit-decks', label: 'Edit Decks', selected: true }]
+    })
+    const card = wrapper.find('[data-testid="options-panel__card"][data-value="edit-decks"]')
+    expect(card.attributes('data-theme')).toBeUndefined()
+    expect(card.attributes('data-theme-dark')).toBeUndefined()
+  })
+
   // ── content testid derivation ────────────────────────────────────────────
 
   test('content div falls back to options-panel__content when caller passes no data-testid', () => {

--- a/tests/integration/components/ui-kit/tappable.test.js
+++ b/tests/integration/components/ui-kit/tappable.test.js
@@ -139,6 +139,18 @@ describe('UiTappable — data-tap-active state', () => {
   })
 })
 
+describe('UiTappable — active prop [obligation]', () => {
+  test('data-tap-active is "true" when active is true, with no hover or press', () => {
+    const wrapper = mountTappable({ active: true })
+    expect(wrapper.attributes('data-tap-active')).toBe('true')
+  })
+
+  test('data-tap-active is absent when active is false and nothing else is active', () => {
+    const wrapper = mountTappable({ active: false })
+    expect(wrapper.attributes('data-tap-active')).toBeUndefined()
+  })
+})
+
 describe('UiTappable — active_on_hover [obligation]', () => {
   test('hover does not set data-tap-active when active_on_hover is unset (default off)', async () => {
     fineRef.value = true

--- a/tests/integration/views/dashboard/actions-panel/index.test.js
+++ b/tests/integration/views/dashboard/actions-panel/index.test.js
@@ -73,6 +73,11 @@ import DashboardActionsPanel from '@/views/dashboard/actions-panel/index.vue'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+function wrapper_entry(wrapper) {
+  const entries = wrapper.findComponent(UiOptionsPanelStub).props('entries')
+  return entries.find((e) => e.value === 'edit-decks')
+}
+
 function mount(due_decks = [], editing_decks = false) {
   return shallowMount(DashboardActionsPanel, {
     props: { due_decks, editing_decks },
@@ -108,6 +113,20 @@ describe('DashboardActionsPanel — study button', () => {
     const wrapper = mount(due_decks)
     await wrapper.find('[data-testid="dashboard-actions-panel__study-button"]').trigger('click')
     expect(mockStartStudy).toHaveBeenCalledWith(due_decks)
+  })
+
+  test('is disabled while editing_decks is true [obligation]', () => {
+    const wrapper = mount([], true)
+    expect(
+      wrapper.find('[data-testid="dashboard-actions-panel__study-button"]').attributes('disabled')
+    ).not.toBeUndefined()
+  })
+
+  test('is enabled when editing_decks is false [obligation]', () => {
+    const wrapper = mount([], false)
+    expect(
+      wrapper.find('[data-testid="dashboard-actions-panel__study-button"]').attributes('disabled')
+    ).toBeUndefined()
   })
 })
 
@@ -146,12 +165,24 @@ describe('DashboardActionsPanel — edit-decks entry reflects editing_decks stat
     expect(edit_entry.trailingIcon).toBe('pencil')
   })
 
-  test('shows the done-editing label and check icon when editing [obligation]', () => {
+  test('shows the done-editing label and stop icon when editing [obligation]', () => {
     const wrapper = mount([], true)
     const entries = wrapper.findComponent(UiOptionsPanelStub).props('entries')
     const edit_entry = entries.find((e) => e.value === 'edit-decks')
-    expect(edit_entry.label).toBe('Done Editing')
-    expect(edit_entry.trailingIcon).toBe('data-check')
+    expect(edit_entry.label).toBe('Stop Editing')
+    expect(edit_entry.trailingIcon).toBe('stop')
+  })
+
+  test('carries selected/selectedTheme/selectedThemeDark reflecting editing_decks [obligation]', () => {
+    const not_editing = wrapper_entry(mount([], false))
+    expect(not_editing.selected).toBe(false)
+    expect(not_editing.selectedTheme).toBe('yellow-500')
+    expect(not_editing.selectedThemeDark).toBe('yellow-700')
+
+    const editing = wrapper_entry(mount([], true))
+    expect(editing.selected).toBe(true)
+    expect(editing.selectedTheme).toBe('yellow-500')
+    expect(editing.selectedThemeDark).toBe('yellow-700')
   })
 })
 

--- a/tests/integration/views/dashboard/deck-grid/delete-button.test.js
+++ b/tests/integration/views/dashboard/deck-grid/delete-button.test.js
@@ -1,0 +1,129 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockAlertWarn, mockNoticeError, mockRouterPush, mockDeleteDeck } = vi.hoisted(() => ({
+  mockAlertWarn: vi.fn(),
+  mockNoticeError: vi.fn(),
+  mockRouterPush: vi.fn(),
+  mockDeleteDeck: vi.fn()
+}))
+
+// Created at module level (not inside vi.hoisted) so Vue's ref() is available.
+const mockDeletingRef = ref(false)
+
+vi.mock('@/composables/alert', () => ({
+  useAlert: () => ({ warn: mockAlertWarn })
+}))
+
+vi.mock('@/stores/notice-store', () => ({
+  useNoticeStore: () => ({ error: mockNoticeError, success: vi.fn() })
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+  useRoute: () => ({ name: 'dashboard', params: {} })
+}))
+
+vi.mock('@/composables/deck/editor', () => ({
+  useDeckEditor: () => ({
+    deleting: mockDeletingRef,
+    resetting_reviews: ref(false),
+    deleteDeck: mockDeleteDeck
+  })
+}))
+
+vi.mock('@/composables/ui/media-query', () => ({
+  // fine pointer — staged-tap fires the press action immediately, no
+  // animation timing to advance in the test
+  useMatchMedia: () => ref(false)
+}))
+
+vi.mock('gsap', () => ({
+  gsap: { to: vi.fn((_el, opts) => opts?.onComplete?.()) }
+}))
+
+vi.mock('@/sfx/bus', () => ({
+  emitSfx: vi.fn(),
+  emitHoverSfx: vi.fn()
+}))
+
+// ── Component import (after mocks) ────────────────────────────────────────────
+
+import DeckGridDeleteButton from '@/views/dashboard/deck-grid/delete-button.vue'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const DECK = { id: 7, title: 'Deck 7' }
+
+function mountButton() {
+  return mount(DeckGridDeleteButton, {
+    props: { deck: DECK },
+    global: { directives: { sfx: {} } }
+  })
+}
+
+function confirmResponse(value) {
+  mockAlertWarn.mockReturnValueOnce({ response: Promise.resolve(value) })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockAlertWarn.mockReset()
+  mockNoticeError.mockReset()
+  mockRouterPush.mockReset()
+  mockDeleteDeck.mockReset()
+  mockDeleteDeck.mockResolvedValue(true)
+  mockDeletingRef.value = false
+})
+
+describe('DeckGridDeleteButton — press calls danger_actions.onDelete', () => {
+  test('confirming the alert deletes the deck', async () => {
+    confirmResponse(true)
+    const wrapper = mountButton()
+
+    await wrapper.find('[data-testid="dashboard__deck-delete-button"]').trigger('click')
+    await flushPromises()
+
+    expect(mockDeleteDeck).toHaveBeenCalledTimes(1)
+  })
+
+  test('cancelling the alert does not delete the deck', async () => {
+    confirmResponse(false)
+    const wrapper = mountButton()
+
+    await wrapper.find('[data-testid="dashboard__deck-delete-button"]').trigger('click')
+    await flushPromises()
+
+    expect(mockDeleteDeck).not.toHaveBeenCalled()
+  })
+
+  test('a failed delete shows an error notice', async () => {
+    confirmResponse(true)
+    mockDeleteDeck.mockResolvedValue(false)
+    const wrapper = mountButton()
+
+    await wrapper.find('[data-testid="dashboard__deck-delete-button"]').trigger('click')
+    await flushPromises()
+
+    expect(mockNoticeError).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('DeckGridDeleteButton — loading state', () => {
+  test('reflects danger_actions.deleting as the loading prop', () => {
+    mockDeletingRef.value = true
+    const wrapper = mountButton()
+    // UiButton renders the loading-dots icon only while loading is true.
+    expect(wrapper.find('[data-testid="ui-kit-icon"][alt="loading-dots"]').exists()).toBe(true)
+  })
+
+  test('does not render the loading-dots icon when not deleting', () => {
+    mockDeletingRef.value = false
+    const wrapper = mountButton()
+    expect(wrapper.find('[data-testid="ui-kit-icon"][alt="loading-dots"]').exists()).toBe(false)
+  })
+})

--- a/tests/integration/views/dashboard/deck-grid/index.test.js
+++ b/tests/integration/views/dashboard/deck-grid/index.test.js
@@ -33,7 +33,13 @@ const reorderState = {
 }
 
 vi.mock('vue-router', () => ({
-  useRouter: () => ({ push: routerPushMock })
+  useRouter: () => ({ push: routerPushMock }),
+  // DeckGridDeleteButton (rendered inside DeckGridItem, which is stubbed by
+  // name below) still gets statically imported through item.vue -> its own
+  // module graph reaches composables/deck/danger-actions.ts, which calls
+  // useRoute() at setup — needs a resolvable named export even though the
+  // stub means it's never actually invoked here.
+  useRoute: () => ({ name: 'dashboard', params: {} })
 }))
 
 vi.mock('@/composables/deck/actions', () => ({
@@ -253,6 +259,46 @@ describe('DeckGrid — editing mode forwards rearranging/dragging to each item [
     const items = wrapper.findAllComponents(DeckGridItemStub)
     expect(items[0].props('dragging')).toBe(false)
     expect(items[1].props('dragging')).toBe(true)
+  })
+})
+
+describe('DeckGrid — reflow transition [obligation]', () => {
+  test('does not apply the transition class on the initial decks.length change from mount', async () => {
+    const wrapper = mount([])
+    await wrapper.setProps({ decks: [makeDeck(1)] })
+    expect(wrapper.find('[data-testid="deck-grid__item"]').classes()).not.toContain(
+      'transition-transform'
+    )
+  })
+
+  test('applies the transition class on a genuine subsequent decks.length change (create/delete)', async () => {
+    const wrapper = mount([makeDeck(1)])
+    // First length change after mount is the skipped "initial load" firing.
+    await wrapper.setProps({ decks: [makeDeck(1), makeDeck(2)] })
+    // Second length change is a real reflow (e.g. a delete).
+    await wrapper.setProps({ decks: [makeDeck(2)] })
+    expect(wrapper.find('[data-testid="deck-grid__item"]').classes()).toContain(
+      'transition-transform'
+    )
+  })
+
+  test('does not apply the transition class for a same-length reorder (drag-drop resort)', async () => {
+    const wrapper = mount([makeDeck(1), makeDeck(2)])
+    // Same length, different order — the reflow watcher is keyed off
+    // decks.length only, so this change must not fire it at all.
+    await wrapper.setProps({ decks: [makeDeck(2), makeDeck(1)] })
+    const items = wrapper.findAll('[data-testid="deck-grid__item"]')
+    expect(items.every((i) => !i.classes().includes('transition-transform'))).toBe(true)
+  })
+
+  test('does not key reflow off reorder.dragging_index becoming null', async () => {
+    const wrapper = mount([makeDeck(1), makeDeck(2)])
+    reorderState.dragging_index.value = 1
+    await wrapper.vm.$nextTick()
+    reorderState.dragging_index.value = null
+    await wrapper.vm.$nextTick()
+    const items = wrapper.findAll('[data-testid="deck-grid__item"]')
+    expect(items.every((i) => !i.classes().includes('transition-transform'))).toBe(true)
   })
 })
 

--- a/tests/integration/views/dashboard/deck-grid/item.test.js
+++ b/tests/integration/views/dashboard/deck-grid/item.test.js
@@ -4,7 +4,7 @@ import { defineComponent, h } from 'vue'
 
 const DeckThumbnailStub = defineComponent({
   name: 'DeckThumbnail',
-  props: ['deck', 'size', 'sfx'],
+  props: ['deck', 'size', 'sfx', 'rearranging', 'dragging', 'corner_action_always_visible'],
   emits: ['press'],
   setup(props, { emit, slots }) {
     return () =>
@@ -16,6 +16,15 @@ const DeckThumbnailStub = defineComponent({
         },
         [slots['corner-action']?.()]
       )
+  }
+})
+
+const DeckGridDeleteButtonStub = defineComponent({
+  name: 'DeckGridDeleteButton',
+  props: ['deck'],
+  setup(props) {
+    return () =>
+      h('div', { 'data-testid': 'deck-grid-delete-button', 'data-deck-id': props.deck.id })
   }
 })
 
@@ -45,7 +54,13 @@ import DeckGridItem from '@/views/dashboard/deck-grid/item.vue'
 function mount(props) {
   return shallowMount(DeckGridItem, {
     props,
-    global: { stubs: { DeckThumbnail: DeckThumbnailStub, UiButton: UiButtonStub } }
+    global: {
+      stubs: {
+        DeckThumbnail: DeckThumbnailStub,
+        UiButton: UiButtonStub,
+        DeckGridDeleteButton: DeckGridDeleteButtonStub
+      }
+    }
   })
 }
 
@@ -78,5 +93,51 @@ describe('DeckGridItem — rearranging mode suppresses press [obligation]', () =
   test('the corner-action (settings button) is not rendered while rearranging', () => {
     const wrapper = mount({ deck: DECK, size: 'base', rearranging: true })
     expect(wrapper.find('[data-testid="dashboard__deck-settings-button"]').exists()).toBe(false)
+  })
+})
+
+describe('DeckGridItem — jiggle sits on the wrapper, not DeckThumbnail root [obligation]', () => {
+  test('applies .jiggle to the outer wrapper element while rearranging and not dragging', () => {
+    const wrapper = mount({ deck: DECK, size: 'base', rearranging: true, dragging: false })
+    expect(wrapper.classes()).toContain('jiggle')
+    expect(wrapper.find('[data-testid="deck-thumbnail"]').classes()).not.toContain('jiggle')
+  })
+
+  test('omits .jiggle while dragging (opts out of the idle jiggle)', () => {
+    const wrapper = mount({ deck: DECK, size: 'base', rearranging: true, dragging: true })
+    expect(wrapper.classes()).not.toContain('jiggle')
+  })
+
+  test('omits .jiggle when not rearranging', () => {
+    const wrapper = mount({ deck: DECK, size: 'base' })
+    expect(wrapper.classes()).not.toContain('jiggle')
+  })
+})
+
+describe('DeckGridItem — corner-action swaps to the delete button while rearranging [obligation]', () => {
+  test('renders DeckGridDeleteButton with the deck while rearranging', () => {
+    const wrapper = mount({ deck: DECK, size: 'base', rearranging: true })
+    const delete_button = wrapper.findComponent(DeckGridDeleteButtonStub)
+    expect(delete_button.exists()).toBe(true)
+    expect(delete_button.props('deck')).toEqual(DECK)
+  })
+
+  test('does not render DeckGridDeleteButton when not rearranging', () => {
+    const wrapper = mount({ deck: DECK, size: 'base', rearranging: false })
+    expect(wrapper.findComponent(DeckGridDeleteButtonStub).exists()).toBe(false)
+  })
+})
+
+describe('DeckGridItem — forwards rearranging/dragging to DeckThumbnail [obligation]', () => {
+  test('forwards rearranging as corner_action_always_visible and rearranging', () => {
+    const wrapper = mount({ deck: DECK, size: 'base', rearranging: true })
+    const thumbnail = wrapper.findComponent(DeckThumbnailStub)
+    expect(thumbnail.props('rearranging')).toBe(true)
+    expect(thumbnail.props('corner_action_always_visible')).toBe(true)
+  })
+
+  test('forwards dragging to DeckThumbnail', () => {
+    const wrapper = mount({ deck: DECK, size: 'base', rearranging: true, dragging: true })
+    expect(wrapper.findComponent(DeckThumbnailStub).props('dragging')).toBe(true)
   })
 })

--- a/tests/integration/views/dashboard/index.test.js
+++ b/tests/integration/views/dashboard/index.test.js
@@ -4,8 +4,9 @@ import { defineComponent, h, ref } from 'vue'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
-const { noticeErrorMock } = vi.hoisted(() => ({
-  noticeErrorMock: vi.fn()
+const { noticeErrorMock, mockEmitSfx } = vi.hoisted(() => ({
+  noticeErrorMock: vi.fn(),
+  mockEmitSfx: vi.fn()
 }))
 
 // Reactive state shared between mock factories and tests. Created at module
@@ -18,8 +19,16 @@ vi.mock('@/api/decks', () => ({
   useMemberDecksQuery: () => ({ data: decksDataRef, error: decksErrorRef }),
   // Not exercised here (DeckGrid is stubbed by name below) — only needs to
   // exist so the real deck-grid module graph (statically imported for the
-  // stub-by-name resolution) can resolve this named import.
-  useMoveDeckMutation: () => ({ mutateAsync: () => Promise.resolve() })
+  // stub-by-name resolution) can resolve this named import. That graph now
+  // reaches deck-grid/delete-button.vue -> composables/deck/editor.ts, which
+  // imports useDeleteDeckMutation.
+  useMoveDeckMutation: () => ({ mutateAsync: () => Promise.resolve() }),
+  useDeleteDeckMutation: () => ({ mutateAsync: () => Promise.resolve() })
+}))
+
+vi.mock('@/sfx/bus', () => ({
+  emitSfx: mockEmitSfx,
+  emitHoverSfx: vi.fn()
 }))
 
 vi.mock('@/composables/can', () => ({
@@ -36,7 +45,8 @@ vi.mock('@/stores/notice-store', () => ({
 // directly in deck-grid/index.test.js and actions-panel/index.test.js.
 
 vi.mock('vue-router', () => ({
-  useRouter: () => ({ push: vi.fn() })
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ name: 'dashboard', params: {} })
 }))
 
 vi.mock('@/composables/deck/actions', () => ({
@@ -194,6 +204,16 @@ describe('DashboardIndex — edit-decks toggle', () => {
 
     await wrapper.find('[data-testid="dashboard-actions-panel"]').trigger('click')
     expect(wrapper.findComponent(DeckGridStub).props('editing')).toBe(false)
+  })
+
+  test('emits pop_up_pop sfx when editing_decks flips true, and digi_powerdown when it flips false [obligation]', async () => {
+    const wrapper = mountDashboard()
+    await wrapper.find('[data-testid="dashboard-actions-panel"]').trigger('click')
+    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_pop')
+
+    mockEmitSfx.mockClear()
+    await wrapper.find('[data-testid="dashboard-actions-panel"]').trigger('click')
+    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
   })
 })
 

--- a/tests/unit/composables/use-deck-danger-actions.test.js
+++ b/tests/unit/composables/use-deck-danger-actions.test.js
@@ -108,22 +108,19 @@ describe('useDeckDangerActions', () => {
       expect(close).not.toHaveBeenCalled()
     })
 
-    test('fires the success notice but does not close or navigate yet', async () => {
+    test('deletes and closes immediately without a success notice [obligation]', async () => {
       const editor = makeEditor({ deleteOk: true })
       const { onDelete } = useDeckDangerActions(editor, deck, close)
       confirmResponse(true)
 
       await onDelete()
 
-      expect(mockNotice.success).toHaveBeenCalledWith(
-        'toast.success.deck-deleted',
-        expect.objectContaining({ variant: 'panel' })
-      )
-      expect(close).not.toHaveBeenCalled()
-      expect(mockRouter.push).not.toHaveBeenCalled()
+      expect(editor.deleteDeck).toHaveBeenCalledTimes(1)
+      expect(close).toHaveBeenCalledWith(true)
+      expect(mockNotice.success).not.toHaveBeenCalled()
     })
 
-    test('onDismiss closes with true and navigates to dashboard when viewing the deleted deck', async () => {
+    test('navigates to dashboard when viewing the deleted deck [obligation]', async () => {
       const editor = makeEditor({ deleteOk: true })
       mockRoute.name = 'deck'
       mockRoute.params = { id: '42' }
@@ -131,28 +128,24 @@ describe('useDeckDangerActions', () => {
       confirmResponse(true)
 
       await onDelete()
-      const [, options] = mockNotice.success.mock.calls[0]
-      options.onDismiss()
 
       expect(close).toHaveBeenCalledWith(true)
       expect(mockRouter.push).toHaveBeenCalledWith({ name: 'dashboard' })
     })
 
-    test('onDismiss closes with true but does not navigate when viewing an unrelated route', async () => {
+    test('does not navigate when viewing an unrelated route [obligation]', async () => {
       const editor = makeEditor({ deleteOk: true })
       mockRoute.name = 'dashboard'
       const { onDelete } = useDeckDangerActions(editor, deck, close)
       confirmResponse(true)
 
       await onDelete()
-      const [, options] = mockNotice.success.mock.calls[0]
-      options.onDismiss()
 
       expect(close).toHaveBeenCalledWith(true)
       expect(mockRouter.push).not.toHaveBeenCalled()
     })
 
-    test('onDismiss does not navigate when viewing a different deck', async () => {
+    test('does not navigate when viewing a different deck [obligation]', async () => {
       const editor = makeEditor({ deleteOk: true })
       mockRoute.name = 'deck'
       mockRoute.params = { id: '99' }
@@ -160,9 +153,8 @@ describe('useDeckDangerActions', () => {
       confirmResponse(true)
 
       await onDelete()
-      const [, options] = mockNotice.success.mock.calls[0]
-      options.onDismiss()
 
+      expect(close).toHaveBeenCalledWith(true)
       expect(mockRouter.push).not.toHaveBeenCalled()
     })
 

--- a/tests/unit/views/dashboard/deck-grid/use-deck-grid-reorder.test.js
+++ b/tests/unit/views/dashboard/deck-grid/use-deck-grid-reorder.test.js
@@ -232,6 +232,21 @@ describe('useDeckGridReorder — jiggleStyle', () => {
     expect(a['--jiggle-delay']).not.toBe(b['--jiggle-delay'])
     expect(a['--jiggle-duration']).not.toBe(b['--jiggle-duration'])
   })
+
+  test('sets a lighter --jiggle-rotation than the deck-view card grid default [obligation]', () => {
+    const container_el = ref(document.createElement('div'))
+    let reorder
+    ;({ app, result: reorder } = withSetup(() =>
+      useDeckGridReorder(
+        container_el,
+        () => [deck(1)],
+        () => true,
+        () => 'base'
+      )
+    ))
+
+    expect(reorder.jiggleStyle(0)['--jiggle-rotation']).toBe('0.7deg')
+  })
 })
 
 // ── onItemPointerdown ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a per-deck delete button to the dashboard's edit mode (reusing the deck danger-actions confirm/delete flow), fixes several animation issues in the deck grid (jiggle/hover-scale transform conflicts, a reflow transition that fought drag-drop settling and fired incorrectly on initial page load), and adds a reusable "selected" state to `options-panel` (with bindable theme + bgx styling) used to highlight the edit-decks toggle while active.
