### PR TITLE
fix(deck-hero): stop bulk-actions overflow from being clipped

### DIFF
--- a/src/views/deck/deck-hero/index.vue
+++ b/src/views/deck/deck-hero/index.vue
@@ -37,17 +37,22 @@ const is_desktop = useMatchMedia('w>=xl')
     >
       <deck-details :deck="deck" />
 
-      <div v-if="!hideActions" data-testid="deck-hero__actions-wrap" class="relative w-full">
+      <div
+        v-if="!hideActions"
+        data-testid="deck-hero__actions-wrap"
+        class="grid w-full items-start pb-0.5"
+      >
         <Transition :css="false" @enter="defaultEnter" @leave="defaultLeave">
           <actions
             v-if="!is_desktop || !is_selecting"
+            class="col-start-1 row-start-1"
             :deck="deck"
             :is-selecting="!!is_selecting"
           />
         </Transition>
 
         <Transition :css="false" @enter="bulkEnter" @leave="bulkLeave">
-          <bulk-actions v-if="is_desktop && is_selecting" class="absolute inset-0" />
+          <bulk-actions v-if="is_desktop && is_selecting" class="col-start-1 row-start-1" />
         </Transition>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- `deck-hero__actions-wrap` swapped `actions`/`bulk-actions` via `relative`/`absolute inset-0`, so the wrapper collapsed to 0 height while selecting — `bulk-actions` (much taller) overflowed past the page's actual scrollable height and got cut off on decks with too few cards to make the card grid column taller than the hero.
- Switched the wrapper to CSS grid stacking (both children share `col-start-1 row-start-1`) so it always sizes to whichever child is present.
- Anchored `items-start` so `actions` isn't force-stretched to `bulk-actions`' row height during the crossfade (was causing the edit-cards button to visually snap to the wrong position and clip its hover outline).
- Added a hair of bottom padding so hover outlines clear the `overflow-clip` boundary on `<main>` in `authenticated.vue`.