### PR TITLE
Dashboard edit-mode guards, sfx sync, and sort-options wiring

### DIFF
--- a/src/components/deck/new-deck-card.vue
+++ b/src/components/deck/new-deck-card.vue
@@ -10,9 +10,10 @@ type CardSize = InstanceType<typeof Card>['$props']['size']
 type NewDeckCardProps = {
   size?: CardSize
   loading?: boolean
+  disabled?: boolean
 }
 
-const { size = 'base', loading = false } = defineProps<NewDeckCardProps>()
+const { size = 'base', loading = false, disabled = false } = defineProps<NewDeckCardProps>()
 
 const emit = defineEmits<{ press: [e: MouseEvent] }>()
 
@@ -25,9 +26,9 @@ const { t } = useI18n()
     data-testid="new-deck-card"
     :aria-label="t('dashboard.create-deck-button')"
     class="pointer-fine:hover:scale-102 data-[tap-active=true]:scale-101 pointer-coarse:data-[tap-active=true]:scale-105 pointer-fine:transition-transform duration-75 relative cursor-pointer h-min touch-manipulation"
-    :class="loading && 'opacity-50 pointer-events-none'"
+    :class="(loading || disabled) && 'opacity-50 pointer-events-none'"
     :sfx="{ hover: TYPE_SFX, press: 'pop_up_pop' }"
-    @tap="emit('press', $event)"
+    @tap="!disabled && emit('press', $event)"
   >
     <card :size="size" side="front">
       <template #front>

--- a/src/composables/deck/actions.ts
+++ b/src/composables/deck/actions.ts
@@ -4,6 +4,7 @@ import { useAlert } from '@/composables/alert'
 import { useModal } from '@/composables/modal'
 import { useCan } from '@/composables/can'
 import { useDeckSettingsModal } from '@/composables/deck/settings-modal'
+import { useNoticeStore } from '@/stores/notice-store'
 import { waitForDeckPopIn } from '@/utils/animations/deck-grid'
 import Checkout from '@/components/billing/checkout-modal/index.vue'
 
@@ -20,6 +21,7 @@ export function useDeckActions() {
   const modal = useModal()
   const can = useCan()
   const deck_settings_modal = useDeckSettingsModal()
+  const notice = useNoticeStore()
   const deck_count_query = useMemberDeckCountQuery()
   const upsert_mutation = useUpsertDeckMutation()
 
@@ -52,6 +54,7 @@ export function useDeckActions() {
     try {
       created = await upsert_mutation.mutateAsync(deck)
     } catch {
+      notice.error(t('toast.error.deck-create-failed'))
       return null
     }
 

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -337,6 +337,7 @@
   "alert.reset-reviews.message": "This wipes your study progress and review history for every card in this deck. This can't be undone.",
   "alert.reset-reviews.confirm": "Reset",
   "toast.error.add-card-failed": "Failed to add a new card",
+  "toast.error.deck-create-failed": "Couldn't create this deck. Please try again.",
   "toast.error.deck-delete-failed": "Couldn't delete this deck. Please try again.",
   "toast.error.deck-save-failed": "Couldn't save this deck. Please try again.",
   "toast.error.reset-reviews-failed": "Couldn't reset reviews for this deck. Please try again.",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -402,7 +402,6 @@
   "dashboard.deck-grid-sort.custom-label": "Custom",
   "dashboard.deck-grid-sort.date-created-label": "Date Created",
   "dashboard.deck-grid-sort.last-updated-label": "Last Updated",
-  "dashboard.deck-grid-sort.last-studied-label": "Last Studied",
   "dashboard.create-deck-button": "Make a New Deck",
   "dashboard.new-deck-card.label": "New Deck",
   "dashboard.actions-panel.new-deck-label": "New Deck",

--- a/src/views/dashboard/actions-panel/index.vue
+++ b/src/views/dashboard/actions-panel/index.vue
@@ -35,7 +35,7 @@ const deck_entries = computed<OptionsPanelEntry[]>(() => [
     value: 'new-deck',
     label: t('dashboard.actions-panel.new-deck-label'),
     trailingIcon: 'card-add',
-    disabled: creating_deck.value
+    disabled: creating_deck.value || editing_decks
   },
   {
     value: 'edit-decks',
@@ -59,7 +59,7 @@ async function onSelect(value: string) {
     return
   }
 
-  if (value !== 'new-deck' || creating_deck.value) return
+  if (value !== 'new-deck' || creating_deck.value || editing_decks) return
 
   creating_deck.value = true
   emitSfx('pop_up_pop')

--- a/src/views/dashboard/deck-grid/index.vue
+++ b/src/views/dashboard/deck-grid/index.vue
@@ -82,7 +82,7 @@ function onDeckSettingsClicked(deck: Deck) {
 }
 
 async function onCreateDeckClicked() {
-  if (creating_deck.value) return
+  if (creating_deck.value || editing) return
   creating_deck.value = true
 
   await deck_actions.createDeck(buildNewDeckPayload(t('deck.default-title')))
@@ -148,7 +148,12 @@ async function onCreateDeckClicked() {
           transform: `translate(${reorder.itemPosition(decks.length).x}px, ${reorder.itemPosition(decks.length).y}px)`
         }"
       >
-        <NewDeckCard :size="size" :loading="creating_deck" @press="onCreateDeckClicked" />
+        <NewDeckCard
+          :size="size"
+          :loading="creating_deck"
+          :disabled="editing"
+          @press="onCreateDeckClicked"
+        />
       </div>
     </transition-group>
   </div>

--- a/src/views/dashboard/deck-grid/sort-options.vue
+++ b/src/views/dashboard/deck-grid/sort-options.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 
-type SortOption = 'custom' | 'date-created' | 'last-updated' | 'last-studied'
+export type SortOption = 'custom' | 'date-created' | 'last-updated'
 
 type DeckGridSortOptionsProps = {
   selected?: SortOption
@@ -9,13 +9,14 @@ type DeckGridSortOptionsProps = {
 
 const { selected = 'custom' } = defineProps<DeckGridSortOptionsProps>()
 
+const emit = defineEmits<{ select: [option: SortOption] }>()
+
 const { t } = useI18n()
 
 const OPTIONS: { key: SortOption; label_key: string }[] = [
   { key: 'custom', label_key: 'dashboard.deck-grid-sort.custom-label' },
   { key: 'date-created', label_key: 'dashboard.deck-grid-sort.date-created-label' },
-  { key: 'last-updated', label_key: 'dashboard.deck-grid-sort.last-updated-label' },
-  { key: 'last-studied', label_key: 'dashboard.deck-grid-sort.last-studied-label' }
+  { key: 'last-updated', label_key: 'dashboard.deck-grid-sort.last-updated-label' }
 ]
 </script>
 
@@ -30,6 +31,7 @@ const OPTIONS: { key: SortOption; label_key: string }[] = [
       :data-testid="`deck-grid-sort-options__${option.key}`"
       :data-active="option.key === selected"
       class="cursor-pointer shrink-0 data-[active=true]:text-brown-700 data-[active=true]:underline data-[active=true]:underline-offset-8 dark:data-[active=true]:text-brown-100"
+      @click="emit('select', option.key)"
     >
       {{ t(option.label_key) }}
     </span>

--- a/src/views/dashboard/deck-grid/sort-options.vue
+++ b/src/views/dashboard/deck-grid/sort-options.vue
@@ -20,13 +20,16 @@ const OPTIONS: { key: SortOption; label_key: string }[] = [
 </script>
 
 <template>
-  <div data-testid="deck-grid-sort-options" class="flex gap-8 text-brown-500">
+  <div
+    data-testid="deck-grid-sort-options"
+    class="flex gap-8 text-brown-500 overflow-x-auto scroll-hidden"
+  >
     <span
       v-for="option in OPTIONS"
       :key="option.key"
       :data-testid="`deck-grid-sort-options__${option.key}`"
       :data-active="option.key === selected"
-      class="cursor-pointer data-[active=true]:text-brown-700 data-[active=true]:underline data-[active=true]:underline-offset-8 dark:data-[active=true]:text-brown-100"
+      class="cursor-pointer shrink-0 data-[active=true]:text-brown-700 data-[active=true]:underline data-[active=true]:underline-offset-8 dark:data-[active=true]:text-brown-100"
     >
       {{ t(option.label_key) }}
     </span>

--- a/src/views/dashboard/deck-grid/sort-options.vue
+++ b/src/views/dashboard/deck-grid/sort-options.vue
@@ -23,7 +23,7 @@ const OPTIONS: { key: SortOption; label_key: string }[] = [
 <template>
   <div
     data-testid="deck-grid-sort-options"
-    class="flex gap-8 text-brown-500 overflow-x-auto scroll-hidden"
+    class="flex gap-8 text-brown-500 overflow-x-auto scroll-hidden pb-2"
   >
     <span
       v-for="option in OPTIONS"

--- a/src/views/dashboard/deck-grid/sort-options.vue
+++ b/src/views/dashboard/deck-grid/sort-options.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { emitSfx } from '@/sfx/bus'
 
 export type SortOption = 'custom' | 'date-created' | 'last-updated'
 
@@ -18,6 +19,11 @@ const OPTIONS: { key: SortOption; label_key: string }[] = [
   { key: 'date-created', label_key: 'dashboard.deck-grid-sort.date-created-label' },
   { key: 'last-updated', label_key: 'dashboard.deck-grid-sort.last-updated-label' }
 ]
+
+function onOptionClicked(option: SortOption) {
+  emitSfx(option === selected ? 'digi_powerdown' : 'snappy_button_5')
+  emit('select', option)
+}
 </script>
 
 <template>
@@ -31,7 +37,7 @@ const OPTIONS: { key: SortOption; label_key: string }[] = [
       :data-testid="`deck-grid-sort-options__${option.key}`"
       :data-active="option.key === selected"
       class="cursor-pointer shrink-0 data-[active=true]:text-brown-700 data-[active=true]:underline data-[active=true]:underline-offset-8 dark:data-[active=true]:text-brown-100"
-      @click="emit('select', option.key)"
+      @click="onOptionClicked(option.key)"
     >
       {{ t(option.label_key) }}
     </span>

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -4,21 +4,29 @@ import { useI18n } from 'vue-i18n'
 import { useMemberDecksQuery } from '@/api/decks'
 import { useNoticeStore } from '@/stores/notice-store'
 import { useCan } from '@/composables/can'
+import { useLocalRef } from '@/composables/storage/local-ref'
 import { emitSfx } from '@/sfx/bus'
 import DashboardSection from './dashboard-section.vue'
 import DashboardActionsPanel from './actions-panel/index.vue'
 import ReviewInbox from './review-inbox/index.vue'
 import DeckGrid from './deck-grid/index.vue'
-import DeckGridSortOptions from './deck-grid/sort-options.vue'
+import DeckGridSortOptions, { type SortOption } from './deck-grid/sort-options.vue'
 import AudioReaderSection from './audio-reader-section.vue'
+
+const DECK_SORT_COMPARATORS: Record<SortOption, (a: Deck, b: Deck) => number> = {
+  custom: (a, b) => (a.rank ?? 0) - (b.rank ?? 0),
+  'date-created': (a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''),
+  'last-updated': (a, b) => (b.updated_at ?? '').localeCompare(a.updated_at ?? '')
+}
 
 const { t } = useI18n()
 const notice = useNoticeStore()
 const can = useCan()
 
 const { data: decks_data, error: decks_error } = useMemberDecksQuery()
+const sort_by = useLocalRef<SortOption>('dashboard-deck-sort', 'custom')
 const decks = computed(() => {
-  return [...(decks_data.value ?? [])].sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))
+  return [...(decks_data.value ?? [])].sort(DECK_SORT_COMPARATORS[sort_by.value])
 })
 const editing_decks = ref(false)
 
@@ -56,7 +64,7 @@ const due_decks = computed(() => {
 
       <dashboard-section :label="t('dashboard.deck-filter.all-label')">
         <template #subheader>
-          <deck-grid-sort-options />
+          <deck-grid-sort-options :selected="sort_by" @select="sort_by = $event" />
         </template>
 
         <deck-grid :decks="decks" :editing="editing_decks" />

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -28,7 +28,7 @@ watch(decks_error, (err) => {
 
 function onToggleEditDecks() {
   editing_decks.value = !editing_decks.value
-  emitSfx(editing_decks.value ? 'pop_up_pop' : 'digi_powerdown')
+  emitSfx(editing_decks.value ? 'pop_up_pop' : 'pop_up_close')
 }
 
 const due_decks = computed(() => {

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -40,7 +40,9 @@ function onToggleEditDecks() {
 }
 
 const due_decks = computed(() => {
-  return decks.value.filter((deck) => (deck.due_count ?? 0) > 0)
+  return decks.value
+    .filter((deck) => (deck.due_count ?? 0) > 0)
+    .sort((a, b) => (b.due_count ?? 0) - (a.due_count ?? 0))
 })
 </script>
 

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -51,7 +51,7 @@ const due_decks = computed(() => {
 
     <div data-testid="dashboard__right-column" class="flex flex-col gap-y-13 min-w-0">
       <dashboard-section v-if="due_decks.length > 0" :label="t('dashboard.deck-filter.due-label')">
-        <review-inbox :due_decks="due_decks" />
+        <review-inbox :due_decks="due_decks" :editing="editing_decks" />
       </dashboard-section>
 
       <dashboard-section :label="t('dashboard.deck-filter.all-label')">

--- a/src/views/dashboard/review-inbox/index.vue
+++ b/src/views/dashboard/review-inbox/index.vue
@@ -4,12 +4,14 @@ import ReviewInboxNavButton from './nav-button.vue'
 import { useStudyModal } from '@/views/study-session/composables/study-modal'
 import { useReviewInboxScroll } from './use-scroll'
 import { useReviewInboxTickSfx } from './use-tick-sfx'
+import { emitSfx } from '@/sfx/bus'
 
 type ReviewInboxProps = {
   due_decks: Deck[]
+  editing?: boolean
 }
 
-const { due_decks } = defineProps<ReviewInboxProps>()
+const { due_decks, editing = false } = defineProps<ReviewInboxProps>()
 
 const study_session = useStudyModal()
 const { items_el, has_overflow, can_scroll_prev, can_scroll_next, prev, next } =
@@ -18,6 +20,11 @@ const { items_el, has_overflow, can_scroll_prev, can_scroll_next, prev, next } =
 useReviewInboxTickSfx(items_el)
 
 function onItemClicked(deck: Deck) {
+  if (editing) {
+    emitSfx('digi_powerdown')
+    return
+  }
+
   study_session.start([deck])
 }
 </script>
@@ -40,6 +47,7 @@ function onItemClicked(deck: Deck) {
         v-for="deck in due_decks"
         :key="deck.id"
         :deck="deck"
+        :disabled="editing"
         class="snap-start shrink-0"
         @click="onItemClicked(deck)"
       />

--- a/src/views/dashboard/review-inbox/item.vue
+++ b/src/views/dashboard/review-inbox/item.vue
@@ -2,13 +2,19 @@
 import Card from '@/components/card/index.vue'
 import { TYPE_SFX } from '@/sfx/config'
 
-defineProps<{ deck: Deck }>()
+type ReviewInboxItemProps = {
+  deck: Deck
+  disabled?: boolean
+}
+
+const { disabled = false } = defineProps<ReviewInboxItemProps>()
 </script>
 
 <template>
   <div
     data-testid="review-inbox-item"
     class="flex flex-col items-center gap-2.5 pointer-fine:hover:scale-102 pointer-fine:hover:z-10 pointer-fine:transition-transform duration-75 relative cursor-pointer touch-manipulation"
+    :class="disabled && 'opacity-50'"
     v-sfx="{ hover: TYPE_SFX }"
   >
     <card side="cover" size="xs" :cover_config="deck.cover_config" />

--- a/src/views/dashboard/review-inbox/use-tick-sfx.ts
+++ b/src/views/dashboard/review-inbox/use-tick-sfx.ts
@@ -35,7 +35,7 @@ export function useReviewInboxTickSfx(items_el: Ref<HTMLElement | null>) {
       const scroll_left = Math.min(Math.max(el.scrollLeft, 0), max_scroll_left)
 
       const index = Math.round(scroll_left / cardPitch(el))
-      if (index !== last_index && !is_fine.value) emitSfx('tap_05', { volume: 0.025 })
+      if (index !== last_index && !is_fine.value) emitSfx('tap_05', { volume: 0.1 })
       last_index = index
     })
   }

--- a/src/views/deck/composables/view-shell.ts
+++ b/src/views/deck/composables/view-shell.ts
@@ -109,7 +109,7 @@ export function useDeckViewShell() {
   /** Flip drag-to-reorder on the base grid; turning it on returns to the view. */
   function toggleRearrange() {
     is_rearranging.value = !is_rearranging.value
-    emitSfx(is_rearranging.value ? 'generic_button_15' : 'pop_up_close')
+    emitSfx(is_rearranging.value ? 'pop_up_pop' : 'pop_up_close')
     if (is_rearranging.value) {
       mode.value = 'view'
       sort_by.value = 'default'

--- a/tests/integration/components/deck/new-deck-card.test.js
+++ b/tests/integration/components/deck/new-deck-card.test.js
@@ -89,6 +89,20 @@ describe('NewDeckCard', () => {
     expect(wrapper.emitted('press')).toHaveLength(1)
   })
 
+  describe('disabled prop [obligation]', () => {
+    test('does not emit press when tapped while disabled', async () => {
+      const wrapper = mount({ disabled: true })
+      await wrapper.find('[data-testid="new-deck-card"]').trigger('click')
+      expect(wrapper.emitted('press')).toBeFalsy()
+    })
+
+    test('still emits press when tapped and not disabled', async () => {
+      const wrapper = mount({ disabled: false })
+      await wrapper.find('[data-testid="new-deck-card"]').trigger('click')
+      expect(wrapper.emitted('press')).toHaveLength(1)
+    })
+  })
+
   describe('loading prop [obligation]', () => {
     test('does not apply the disabled visual classes by default', () => {
       const wrapper = mount()

--- a/tests/integration/views/dashboard/actions-panel/index.test.js
+++ b/tests/integration/views/dashboard/actions-panel/index.test.js
@@ -146,6 +146,14 @@ describe('DashboardActionsPanel — onSelect only wires new-deck', () => {
     expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_pop')
   })
 
+  test('selecting new-deck while editing_decks is true does not create a deck, even bypassing the disabled UI state [obligation]', async () => {
+    const wrapper = mount([], true)
+    await wrapper.find('[data-testid="entry-new-deck"]').trigger('click')
+    await Promise.resolve()
+    expect(mockCreateDeck).not.toHaveBeenCalled()
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+  })
+
   test('selecting edit-decks emits toggle-edit-decks and does not create a deck [obligation]', async () => {
     const wrapper = mount()
     await wrapper.find('[data-testid="entry-edit-decks"]').trigger('click')

--- a/tests/integration/views/dashboard/deck-grid/index.test.js
+++ b/tests/integration/views/dashboard/deck-grid/index.test.js
@@ -103,13 +103,14 @@ const DeckGridItemStub = defineComponent({
 
 const NewDeckCardStub = defineComponent({
   name: 'NewDeckCard',
-  props: ['size', 'loading'],
+  props: ['size', 'loading', 'disabled'],
   emits: ['press'],
   setup(props, { emit }) {
     return () =>
       h('div', {
         'data-testid': 'new-deck-card',
         'data-loading': String(!!props.loading),
+        'data-disabled': String(!!props.disabled),
         onClick: () => emit('press')
       })
   }
@@ -223,6 +224,22 @@ describe('DeckGrid — create deck', () => {
     resolve_create({ id: 1 })
     await Promise.resolve()
     await Promise.resolve()
+  })
+
+  test('does not call createDeck when editing is true, even bypassing the disabled UI state [obligation]', async () => {
+    const wrapper = mount([], true)
+    await wrapper.find('[data-testid="new-deck-card"]').trigger('click')
+    expect(createDeckMock).not.toHaveBeenCalled()
+  })
+
+  test('passes disabled=true to new-deck-card when editing [obligation]', () => {
+    const wrapper = mount([], true)
+    expect(wrapper.find('[data-testid="new-deck-card"]').attributes('data-disabled')).toBe('true')
+  })
+
+  test('passes disabled=false to new-deck-card when not editing [obligation]', () => {
+    const wrapper = mount([], false)
+    expect(wrapper.find('[data-testid="new-deck-card"]').attributes('data-disabled')).toBe('false')
   })
 })
 

--- a/tests/integration/views/dashboard/deck-grid/sort-options.test.js
+++ b/tests/integration/views/dashboard/deck-grid/sort-options.test.js
@@ -1,12 +1,15 @@
-import { describe, test, expect } from 'vite-plus/test'
+import { describe, test, expect, vi } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+
 import DeckGridSortOptions from '@/views/dashboard/deck-grid/sort-options.vue'
 
 const OPTION_TESTIDS = [
   'deck-grid-sort-options__custom',
   'deck-grid-sort-options__date-created',
-  'deck-grid-sort-options__last-updated',
-  'deck-grid-sort-options__last-studied'
+  'deck-grid-sort-options__last-updated'
 ]
 
 function mount(props) {
@@ -14,12 +17,12 @@ function mount(props) {
 }
 
 describe('DeckGridSortOptions — options rendered', () => {
-  test('renders exactly 4 options', () => {
+  test('renders exactly 3 options', () => {
     const wrapper = mount()
     expect(
       OPTION_TESTIDS.every((testid) => wrapper.find(`[data-testid="${testid}"]`).exists())
     ).toBe(true)
-    expect(wrapper.findAll('[data-testid^="deck-grid-sort-options__"]')).toHaveLength(4)
+    expect(wrapper.findAll('[data-testid^="deck-grid-sort-options__"]')).toHaveLength(3)
   })
 })
 
@@ -42,16 +45,36 @@ describe('DeckGridSortOptions — selected default', () => {
 
 describe('DeckGridSortOptions — selected prop drives data-active', () => {
   test('marks only the matching option as data-active=true', () => {
-    const wrapper = mount({ selected: 'last-studied' })
+    const wrapper = mount({ selected: 'last-updated' })
 
     expect(
-      wrapper.find('[data-testid="deck-grid-sort-options__last-studied"]').attributes('data-active')
+      wrapper.find('[data-testid="deck-grid-sort-options__last-updated"]').attributes('data-active')
     ).toBe('true')
 
-    OPTION_TESTIDS.filter((testid) => testid !== 'deck-grid-sort-options__last-studied').forEach(
+    OPTION_TESTIDS.filter((testid) => testid !== 'deck-grid-sort-options__last-updated').forEach(
       (testid) => {
         expect(wrapper.find(`[data-testid="${testid}"]`).attributes('data-active')).toBe('false')
       }
     )
+  })
+})
+
+describe('DeckGridSortOptions — click behavior', () => {
+  test('clicking a non-selected option emits select with that key and plays snappy_button_5 [obligation]', async () => {
+    const wrapper = mount({ selected: 'custom' })
+
+    await wrapper.find('[data-testid="deck-grid-sort-options__date-created"]').trigger('click')
+
+    expect(wrapper.emitted('select')).toEqual([['date-created']])
+    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+  })
+
+  test('clicking the currently selected option still emits select but plays digi_powerdown [obligation]', async () => {
+    const wrapper = mount({ selected: 'custom' })
+
+    await wrapper.find('[data-testid="deck-grid-sort-options__custom"]').trigger('click')
+
+    expect(wrapper.emitted('select')).toEqual([['custom']])
+    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
   })
 })

--- a/tests/integration/views/dashboard/index.test.js
+++ b/tests/integration/views/dashboard/index.test.js
@@ -62,7 +62,7 @@ vi.mock('@/composables/ui/media-query', () => ({
 }))
 
 vi.mock('@/composables/storage/local-ref', () => ({
-  useLocalRef: () => ref(false)
+  useLocalRef: (_key, default_value) => ref(default_value)
 }))
 
 vi.mock('@/stores/member', () => ({
@@ -126,8 +126,11 @@ const DeckGridStub = defineComponent({
 
 const DeckGridSortOptionsStub = defineComponent({
   name: 'DeckGridSortOptions',
-  setup() {
-    return () => h('div', { 'data-testid': 'deck-grid-sort-options' })
+  props: ['selected'],
+  emits: ['select'],
+  setup(props) {
+    return () =>
+      h('div', { 'data-testid': 'deck-grid-sort-options', 'data-selected': props.selected })
   }
 })
 
@@ -144,8 +147,8 @@ import DashboardIndex from '@/views/dashboard/index.vue'
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-function makeDeck(id, { due_count = 0, rank = id } = {}) {
-  return { id, title: `Deck ${id}`, due_count, rank }
+function makeDeck(id, { due_count = 0, rank = id, created_at, updated_at } = {}) {
+  return { id, title: `Deck ${id}`, due_count, rank, created_at, updated_at }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -189,6 +192,42 @@ describe('DashboardIndex — deck ordering', () => {
         .map((d) => d.id)
     ).toEqual([1, 2, 3])
   })
+
+  test('sorts decks by created_at descending when sort-options emits date-created [obligation]', async () => {
+    decksDataRef.value = [
+      makeDeck(1, { created_at: '2026-01-01' }),
+      makeDeck(2, { created_at: '2026-03-01' }),
+      makeDeck(3, { created_at: '2026-02-01' })
+    ]
+    const wrapper = mountDashboard()
+    wrapper.findComponent(DeckGridSortOptionsStub).vm.$emit('select', 'date-created')
+    await wrapper.vm.$nextTick()
+
+    expect(
+      wrapper
+        .findComponent(DeckGridStub)
+        .props('decks')
+        .map((d) => d.id)
+    ).toEqual([2, 3, 1])
+  })
+
+  test('sorts decks by updated_at descending when sort-options emits last-updated [obligation]', async () => {
+    decksDataRef.value = [
+      makeDeck(1, { updated_at: '2026-01-01' }),
+      makeDeck(2, { updated_at: '2026-03-01' }),
+      makeDeck(3, { updated_at: '2026-02-01' })
+    ]
+    const wrapper = mountDashboard()
+    wrapper.findComponent(DeckGridSortOptionsStub).vm.$emit('select', 'last-updated')
+    await wrapper.vm.$nextTick()
+
+    expect(
+      wrapper
+        .findComponent(DeckGridStub)
+        .props('decks')
+        .map((d) => d.id)
+    ).toEqual([2, 3, 1])
+  })
 })
 
 describe('DashboardIndex — edit-decks toggle', () => {
@@ -206,14 +245,14 @@ describe('DashboardIndex — edit-decks toggle', () => {
     expect(wrapper.findComponent(DeckGridStub).props('editing')).toBe(false)
   })
 
-  test('emits pop_up_pop sfx when editing_decks flips true, and digi_powerdown when it flips false [obligation]', async () => {
+  test('emits pop_up_pop sfx when editing_decks flips true, and pop_up_close when it flips false [obligation]', async () => {
     const wrapper = mountDashboard()
     await wrapper.find('[data-testid="dashboard-actions-panel"]').trigger('click')
     expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_pop')
 
     mockEmitSfx.mockClear()
     await wrapper.find('[data-testid="dashboard-actions-panel"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
   })
 })
 
@@ -227,6 +266,20 @@ describe('DashboardIndex — due decks derivation', () => {
     const wrapper = mountDashboard()
     expect(wrapper.findComponent(DashboardActionsPanelStub).props('due_decks')).toHaveLength(2)
     expect(wrapper.findComponent(ReviewInboxStub).props('due_decks')).toHaveLength(2)
+  })
+
+  test('sorts due decks by due_count descending [obligation]', () => {
+    decksDataRef.value = [
+      makeDeck(1, { due_count: 2 }),
+      makeDeck(2, { due_count: 9 }),
+      makeDeck(3, { due_count: 5 })
+    ]
+    const wrapper = mountDashboard()
+    const ids = wrapper
+      .findComponent(ReviewInboxStub)
+      .props('due_decks')
+      .map((d) => d.id)
+    expect(ids).toEqual([2, 3, 1])
   })
 })
 

--- a/tests/integration/views/dashboard/review-inbox/index.test.js
+++ b/tests/integration/views/dashboard/review-inbox/index.test.js
@@ -5,11 +5,14 @@ import { defineComponent, h, ref } from 'vue'
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 // Only functions go in vi.hoisted — Vue ref() is not available there.
 
-const { studyStartMock, prevMock, nextMock } = vi.hoisted(() => ({
+const { studyStartMock, prevMock, nextMock, mockEmitSfx } = vi.hoisted(() => ({
   studyStartMock: vi.fn(),
   prevMock: vi.fn(),
-  nextMock: vi.fn()
+  nextMock: vi.fn(),
+  mockEmitSfx: vi.fn()
 }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: vi.fn() }))
 
 // Reactive state shared between the mock factory and tests. Created at module
 // level (not inside vi.hoisted) so Vue's ref() is available.
@@ -36,13 +39,14 @@ vi.mock('@/views/dashboard/review-inbox/use-scroll', () => ({
 
 const ReviewInboxItemStub = defineComponent({
   name: 'ReviewInboxItem',
-  props: ['deck'],
+  props: ['deck', 'disabled'],
   emits: ['click'],
   setup(props, { emit }) {
     return () =>
       h('div', {
         'data-testid': 'review-inbox-item',
         'data-deck-id': props.deck.id,
+        'data-disabled': String(!!props.disabled),
         onClick: () => emit('click')
       })
   }
@@ -78,9 +82,9 @@ function makeDecks(n) {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function mountInbox(due_decks) {
+function mountInbox(due_decks, editing = false) {
   return shallowMount(ReviewInbox, {
-    props: { due_decks },
+    props: { due_decks, editing },
     global: {
       stubs: {
         ReviewInboxItem: ReviewInboxItemStub,
@@ -163,5 +167,36 @@ describe('ReviewInbox — clicking an item starts a study session for just that 
     const wrapper = mountInbox(decks)
     await wrapper.findAll('[data-testid="review-inbox-item"]')[1].trigger('click')
     expect(studyStartMock).toHaveBeenCalledWith([decks[1]])
+  })
+
+  test('does not play digi_powerdown when not editing [obligation]', async () => {
+    const decks = makeDecks(3)
+    const wrapper = mountInbox(decks)
+    await wrapper.findAll('[data-testid="review-inbox-item"]')[1].trigger('click')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('digi_powerdown')
+  })
+})
+
+describe('ReviewInbox — clicking an item while editing [obligation]', () => {
+  test('plays digi_powerdown and does not start a study session', async () => {
+    const decks = makeDecks(3)
+    const wrapper = mountInbox(decks, true)
+    await wrapper.findAll('[data-testid="review-inbox-item"]')[1].trigger('click')
+    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(studyStartMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('ReviewInbox — forwards editing as the disabled prop to each item [obligation]', () => {
+  test('forwards disabled=true to items when editing', () => {
+    const wrapper = mountInbox(makeDecks(2), true)
+    const items = wrapper.findAllComponents(ReviewInboxItemStub)
+    expect(items.every((i) => i.props('disabled') === true)).toBe(true)
+  })
+
+  test('forwards disabled=false to items when not editing', () => {
+    const wrapper = mountInbox(makeDecks(2), false)
+    const items = wrapper.findAllComponents(ReviewInboxItemStub)
+    expect(items.every((i) => i.props('disabled') === false)).toBe(true)
   })
 })

--- a/tests/integration/views/dashboard/review-inbox/item.test.js
+++ b/tests/integration/views/dashboard/review-inbox/item.test.js
@@ -14,9 +14,9 @@ import ReviewInboxItem from '@/views/dashboard/review-inbox/item.vue'
 import { vSfx } from '@/sfx/directive'
 import { TYPE_SFX } from '@/sfx/config'
 
-function mount(deck) {
+function mount(deck, props = {}) {
   return shallowMount(ReviewInboxItem, {
-    props: { deck },
+    props: { deck, ...props },
     global: { directives: { sfx: vSfx } }
   })
 }
@@ -46,5 +46,17 @@ describe('ReviewInboxItem', () => {
       .find('[data-testid="review-inbox-item"]')
       .element.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
     expect(mockEmitHoverSfx).toHaveBeenCalledWith(TYPE_SFX, expect.anything())
+  })
+
+  describe('disabled prop [obligation]', () => {
+    test('defaults to not disabled', () => {
+      const wrapper = mount({ id: 1, due_count: 3 })
+      expect(wrapper.props('disabled')).toBe(false)
+    })
+
+    test('reflects a disabled=true prop', () => {
+      const wrapper = mount({ id: 1, due_count: 3 }, { disabled: true })
+      expect(wrapper.props('disabled')).toBe(true)
+    })
   })
 })

--- a/tests/unit/composables/card-editor/deck-view-shell.test.js
+++ b/tests/unit/composables/card-editor/deck-view-shell.test.js
@@ -197,10 +197,10 @@ describe('useDeckViewShell', () => {
     expect(shell.mode.value).toBe('view') // still view (no mode side-effect)
   })
 
-  test('toggleRearrange emits generic_button_15 when turning ON', () => {
+  test('toggleRearrange emits pop_up_pop when turning ON [obligation]', () => {
     const shell = useDeckViewShell()
     shell.toggleRearrange()
-    expect(emitSfxMock).toHaveBeenCalledWith('generic_button_15')
+    expect(emitSfxMock).toHaveBeenCalledWith('pop_up_pop')
   })
 
   test('toggleRearrange emits pop_up_close when turning OFF', () => {

--- a/tests/unit/composables/deck/use-deck-actions.test.js
+++ b/tests/unit/composables/deck/use-deck-actions.test.js
@@ -8,6 +8,7 @@ const {
   mockModalOpen,
   mockDeckSettingsOpen,
   mockWaitForDeckPopIn,
+  mockNoticeError,
   call_order
 } = vi.hoisted(() => ({
   refreshMock: vi.fn().mockResolvedValue(undefined),
@@ -17,6 +18,7 @@ const {
   mockModalOpen: vi.fn(),
   mockDeckSettingsOpen: vi.fn(),
   mockWaitForDeckPopIn: vi.fn().mockResolvedValue(undefined),
+  mockNoticeError: vi.fn(),
   call_order: []
 }))
 
@@ -35,6 +37,10 @@ vi.mock('@/composables/alert', () => ({
 
 vi.mock('@/composables/modal', () => ({
   useModal: () => ({ open: mockModalOpen })
+}))
+
+vi.mock('@/stores/notice-store', () => ({
+  useNoticeStore: () => ({ error: mockNoticeError })
 }))
 
 vi.mock('@/composables/deck/settings-modal', () => ({
@@ -78,6 +84,7 @@ describe('useDeckActions', () => {
     mockDeckSettingsOpen.mockClear()
     mockWaitForDeckPopIn.mockClear()
     mockWaitForDeckPopIn.mockResolvedValue(undefined)
+    mockNoticeError.mockReset()
     call_order.length = 0
     canCreateDeck.value = true
   })
@@ -161,6 +168,17 @@ describe('useDeckActions', () => {
       const { createDeck } = useDeckActions()
 
       await expect(createDeck({ title: 'New Deck' })).resolves.toBeNull()
+    })
+
+    test('shows an error toast when the mutation rejects [obligation]', async () => {
+      canCreateDeck.value = true
+      upsertMock.mockRejectedValueOnce(new Error('boom'))
+      const { createDeck } = useDeckActions()
+
+      const result = await createDeck({ title: 'New Deck' })
+
+      expect(mockNoticeError).toHaveBeenCalledWith('toast.error.deck-create-failed')
+      expect(result).toBeNull()
     })
 
     describe('openSettingsAfterCreate', () => {

--- a/tests/unit/views/dashboard/review-inbox/use-tick-sfx.test.js
+++ b/tests/unit/views/dashboard/review-inbox/use-tick-sfx.test.js
@@ -81,7 +81,7 @@ describe('useReviewInboxTickSfx — tick firing', () => {
     await scrollTo(el, 100)
 
     expect(mockEmitSfx).toHaveBeenCalledTimes(1)
-    expect(mockEmitSfx).toHaveBeenCalledWith('tap_05', { volume: 0.025 })
+    expect(mockEmitSfx).toHaveBeenCalledWith('tap_05', { volume: 0.1 })
   })
 
   test('does not fire when the scroll delta stays within the same quantized index [obligation]', async () => {


### PR DESCRIPTION
## Summary

A batch of small dashboard/deck-view UX fixes: edit-mode now disables the new-deck and review-inbox entry points, rearrange-mode sound cues are synced between the dashboard and deck view, failed deck creation surfaces a toast, and the deck-grid sort options are wired up (with click sfx and persisted selection) instead of being purely decorative.

## Changes

- Disable "new deck" (actions panel entry + deck-grid card) while dashboard edit mode is active
- Disable review-inbox items while editing; clicking one plays `digi_powerdown` instead of starting a study session
- Sync rearrange-mode sfx between dashboard and deck view: `pop_up_pop` on enter, `pop_up_close` on exit for both
- Toast an error (`toast.error.deck-create-failed`) when deck creation fails
- Deck-grid sort options: scroll on overflow instead of wrapping/clipping (and fix the underline getting clipped)
- Wire up sort options (custom / date-created / last-updated) to actually resort the deck grid, with the choice persisted via `useLocalRef`; dropped the non-functional "last-studied" option
- Add click sfx to sort options: `snappy_button_5` on switching, `digi_powerdown` on re-clicking the active option
- Order review-inbox by due count, greatest to least
- Raise the review-inbox scroll-tick sfx volume (0.025 → 0.1)

## Test plan

- [x] Full test suite green (426 files / 5801 tests)
- [x] `vp lint` and `pnpm type-check` clean
