### PR TITLE
fix(member): resolve default avatar svg as url instead of component

### DIFF
--- a/src/components/member/avatar-image.vue
+++ b/src/components/member/avatar-image.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { loadAvatarUrl } from './avatars'
-import avatarDefaultUrl from '@/assets/avatars/frog.svg'
+import avatarDefaultUrl from '@/assets/avatars/frog.svg?url'
 
 type MemberAvatarImageProps = {
   avatar?: string


### PR DESCRIPTION
## Summary
- Default avatar broke with `<img src="[object Object]">` because `vite-svg-loader` resolves bare `.svg` imports to a Vue component, not a URL string. Fixed by importing with `?url`.