### PR TITLE
Dashboard skeleton loader with shared layout shells

### DIFF
--- a/src/views/dashboard/actions-panel/index.vue
+++ b/src/views/dashboard/actions-panel/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import DashboardActionsPanelShell from './shell.vue'
 import DashboardActionsPanelPolaroid from './polaroid.vue'
 import UiOptionsPanel, { type OptionsPanelEntry } from '@/components/ui-kit/options-panel/index.vue'
 import UiButton from '@/components/ui-kit/button.vue'
@@ -63,24 +64,26 @@ async function onSelect(value: string) {
 </script>
 
 <template>
-  <div
+  <dashboard-actions-panel-shell
     data-testid="dashboard-actions-panel"
     v-bind="root_bindings"
-    class="bg-(--theme-primary) rounded-8 relative flex flex-col w-full max-w-100"
+    class="bg-(--theme-primary)"
+    body_class="bg-brown-300 dark:bg-stone-900"
   >
-    <dashboard-actions-panel-polaroid />
+    <template #polaroid>
+      <dashboard-actions-panel-polaroid />
+    </template>
 
-    <span
-      data-testid="dashboard-actions-panel__header"
-      class="text-(--theme-on-primary) text-4xl font-semibold truncate p-6 pl-34"
-    >
-      {{ member_store.display_name || t('member-badge.name-placeholder') }}
-    </span>
+    <template #header>
+      <span
+        data-testid="dashboard-actions-panel__header"
+        class="text-(--theme-on-primary) text-4xl font-semibold truncate"
+      >
+        {{ member_store.display_name || t('member-badge.name-placeholder') }}
+      </span>
+    </template>
 
-    <div
-      data-testid="dashboard-actions-panel__body"
-      class="cloud-top-[40px] bg-brown-300 dark:bg-stone-900 rounded-b-8 flex flex-col gap-6 px-4 pt-14 pb-6"
-    >
+    <template #body>
       <ui-options-panel
         data-theme-dark="stone-700"
         :entries="deck_entries"
@@ -107,6 +110,6 @@ async function onSelect(value: string) {
             : t('dashboard.actions-panel.study-button', due_decks.length)
         }}
       </ui-button>
-    </div>
-  </div>
+    </template>
+  </dashboard-actions-panel-shell>
 </template>

--- a/src/views/dashboard/actions-panel/shell.vue
+++ b/src/views/dashboard/actions-panel/shell.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+type DashboardActionsPanelShellProps = {
+  body_class?: string
+}
+
+const { body_class = '' } = defineProps<DashboardActionsPanelShellProps>()
+
+defineSlots<{
+  polaroid(): unknown
+  header(): unknown
+  body(): unknown
+}>()
+</script>
+
+<template>
+  <div class="rounded-8 relative flex flex-col w-full max-w-100">
+    <slot name="polaroid" />
+
+    <div data-testid="dashboard-actions-panel-shell__header" class="p-6 pl-34">
+      <slot name="header" />
+    </div>
+
+    <div
+      data-testid="dashboard-actions-panel-shell__body"
+      class="cloud-top-[40px] rounded-b-8 flex flex-col gap-6 px-4 pt-14 pb-6"
+      :class="body_class"
+    >
+      <slot name="body" />
+    </div>
+  </div>
+</template>

--- a/src/views/dashboard/actions-panel/skeleton.vue
+++ b/src/views/dashboard/actions-panel/skeleton.vue
@@ -1,19 +1,29 @@
-<template>
-  <div
-    data-testid="dashboard-actions-panel-skeleton"
-    class="bg-brown-200 dark:bg-grey-800 rounded-8 relative flex flex-col w-full max-w-100 animate-pulse"
-  >
-    <div
-      data-testid="dashboard-actions-panel-skeleton__header"
-      class="h-11 w-40 bg-brown-300 dark:bg-grey-700 rounded-sm m-6 mb-0"
-    ></div>
+<script setup lang="ts">
+import DashboardActionsPanelShell from './shell.vue'
+</script>
 
-    <div
-      data-testid="dashboard-actions-panel-skeleton__body"
-      class="flex flex-col gap-6 px-4 pt-8 pb-6"
-    >
-      <div class="h-14 w-full bg-brown-300 dark:bg-grey-700 rounded-lg max-mxl:hidden"></div>
-      <div class="h-14 w-full bg-brown-300 dark:bg-grey-700 rounded-lg max-mxl:hidden!"></div>
-    </div>
-  </div>
+<template>
+  <dashboard-actions-panel-shell
+    data-testid="dashboard-actions-panel-skeleton"
+    class="bg-brown-200 dark:bg-grey-800 animate-pulse bgx-diagonal-stripes bgx-size-30"
+    body_class="bg-brown-300 dark:bg-grey-700"
+  >
+    <template #polaroid>
+      <div
+        data-testid="dashboard-actions-panel-skeleton__polaroid"
+        class="absolute top-1 -left-1 z-10 -rotate-12 select-none bg-brown-50 dark:bg-stone-700 rounded-2 shadow-xs w-30 p-2 pb-6"
+      >
+        <div class="bg-brown-200 dark:bg-stone-900 rounded-1 aspect-square"></div>
+      </div>
+    </template>
+
+    <template #header>
+      <div class="h-11 w-40 bg-brown-300 dark:bg-grey-600 rounded-3"></div>
+    </template>
+
+    <template #body>
+      <div class="h-14 w-full bg-brown-200 dark:bg-grey-800 rounded-lg max-mxl:hidden"></div>
+      <div class="h-14 w-full bg-brown-200 dark:bg-grey-800 rounded-lg max-mxl:hidden!"></div>
+    </template>
+  </dashboard-actions-panel-shell>
 </template>

--- a/src/views/dashboard/actions-panel/skeleton.vue
+++ b/src/views/dashboard/actions-panel/skeleton.vue
@@ -5,13 +5,13 @@ import DashboardActionsPanelShell from './shell.vue'
 <template>
   <dashboard-actions-panel-shell
     data-testid="dashboard-actions-panel-skeleton"
-    class="bg-brown-200 dark:bg-grey-800 animate-pulse bgx-diagonal-stripes bgx-size-30"
-    body_class="bg-brown-300 dark:bg-grey-700"
+    class="bg-brown-200 dark:bg-stone-900 animate-pulse bgx-diagonal-stripes bgx-size-15 bgx-opacity-40"
+    body_class="bg-brown-300 dark:bg-stone-900"
   >
     <template #polaroid>
       <div
         data-testid="dashboard-actions-panel-skeleton__polaroid"
-        class="absolute top-1 -left-1 z-10 -rotate-12 select-none bg-brown-50 dark:bg-stone-700 rounded-2 shadow-xs w-30 p-2 pb-6"
+        class="absolute top-1 -left-1 z-10 -rotate-12 select-none bg-brown-50 dark:bg-stone-700 rounded-2 w-30 p-2 pb-6"
       >
         <div class="bg-brown-200 dark:bg-stone-900 rounded-1 aspect-square"></div>
       </div>
@@ -22,8 +22,8 @@ import DashboardActionsPanelShell from './shell.vue'
     </template>
 
     <template #body>
-      <div class="h-14 w-full bg-brown-200 dark:bg-grey-800 rounded-lg max-mxl:hidden"></div>
-      <div class="h-14 w-full bg-brown-200 dark:bg-grey-800 rounded-lg max-mxl:hidden!"></div>
+      <div class="h-30 w-full bg-brown-200 dark:bg-stone-700 rounded-4 max-mxl:hidden"></div>
+      <div class="h-14 w-full bg-brown-200 dark:bg-grey-800 rounded-4 max-mxl:hidden!"></div>
     </template>
   </dashboard-actions-panel-shell>
 </template>

--- a/src/views/dashboard/actions-panel/skeleton.vue
+++ b/src/views/dashboard/actions-panel/skeleton.vue
@@ -1,0 +1,19 @@
+<template>
+  <div
+    data-testid="dashboard-actions-panel-skeleton"
+    class="bg-brown-200 dark:bg-grey-800 rounded-8 relative flex flex-col w-full max-w-100 animate-pulse"
+  >
+    <div
+      data-testid="dashboard-actions-panel-skeleton__header"
+      class="h-11 w-40 bg-brown-300 dark:bg-grey-700 rounded-sm m-6 mb-0"
+    ></div>
+
+    <div
+      data-testid="dashboard-actions-panel-skeleton__body"
+      class="flex flex-col gap-6 px-4 pt-8 pb-6"
+    >
+      <div class="h-14 w-full bg-brown-300 dark:bg-grey-700 rounded-lg max-mxl:hidden"></div>
+      <div class="h-14 w-full bg-brown-300 dark:bg-grey-700 rounded-lg max-mxl:hidden!"></div>
+    </div>
+  </div>
+</template>

--- a/src/views/dashboard/dashboard-section.vue
+++ b/src/views/dashboard/dashboard-section.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 type DashboardSectionProps = {
   label: string
+  loading?: boolean
 }
 
-defineProps<DashboardSectionProps>()
+const { loading = false } = defineProps<DashboardSectionProps>()
 
 defineSlots<{
   default(): any
@@ -17,7 +18,10 @@ defineSlots<{
     <div data-testid="dashboard-section__heading" class="flex flex-col gap-1.5">
       <h2
         data-testid="dashboard-section__label"
-        class="text-3xl text-brown-700 dark:text-brown-300"
+        class="text-3xl"
+        :class="
+          loading ? 'text-brown-300 dark:text-stone-700' : 'text-brown-700 dark:text-brown-300'
+        "
       >
         {{ label }}
       </h2>

--- a/src/views/dashboard/dashboard-shell.vue
+++ b/src/views/dashboard/dashboard-shell.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineSlots<{
+  left(): unknown
+  right(): unknown
+}>()
+</script>
+
+<template>
+  <div
+    data-testid="dashboard-shell"
+    class="grid grid-cols-[1fr] mxl:grid-cols-[345px_1fr] gap-x-15.5 gap-y-8 mxl:gap-y-0 px-(--page-px) pt-(--page-pt) pb-12 w-full max-w-229 mx-auto mxl:max-w-none mxl:mx-0"
+  >
+    <div
+      data-testid="dashboard-shell__left-column"
+      class="flex flex-col gap-6 self-start mxl:sticky mxl:top-(--nav-height)"
+    >
+      <slot name="left" />
+    </div>
+
+    <div data-testid="dashboard-shell__right-column" class="flex flex-col gap-y-13 min-w-0">
+      <slot name="right" />
+    </div>
+  </div>
+</template>

--- a/src/views/dashboard/deck-grid/skeleton.vue
+++ b/src/views/dashboard/deck-grid/skeleton.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Card from '@/components/card/index.vue'
+import { useMatchMedia } from '@/composables/ui/media-query'
+
+type DeckGridSkeletonProps = {
+  count?: number
+}
+
+const { count = 12 } = defineProps<DeckGridSkeletonProps>()
+
+const DEFAULT_COVER: DeckCover = {
+  theme: 'brown-300',
+  theme_dark: 'stone-900',
+  pattern: 'diagonal-stripes'
+}
+
+const is_md = useMatchMedia('w>=md')
+const size = computed(() => (is_md.value ? 'base' : 'sm'))
+</script>
+
+<template>
+  <div data-testid="deck-grid-skeleton" class="flex gap-x-3 gap-y-8 flex-wrap">
+    <card
+      v-for="n in count"
+      :key="n"
+      side="cover"
+      :size="size"
+      shimmer
+      :cover_config="DEFAULT_COVER"
+    />
+  </div>
+</template>

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -7,6 +7,8 @@ import { useCan } from '@/composables/can'
 import { useLocalRef } from '@/composables/storage/local-ref'
 import { emitSfx } from '@/sfx/bus'
 import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
+import DashboardShell from './dashboard-shell.vue'
+import DashboardSkeleton from './skeleton.vue'
 import DashboardSection from './dashboard-section.vue'
 import DashboardActionsPanel from './actions-panel/index.vue'
 import DashboardMobileFooter from './mobile-footer/index.vue'
@@ -46,39 +48,42 @@ const due_decks = computed(() => {
     .filter((deck) => (deck.due_count ?? 0) > 0)
     .sort((a, b) => (b.due_count ?? 0) - (a.due_count ?? 0))
 })
+
+const show_skeleton = computed(() => !decks_data.value)
 </script>
 
 <template>
-  <div
-    data-testid="dashboard"
-    class="grid grid-cols-[1fr] mxl:grid-cols-[345px_1fr] gap-x-15.5 gap-y-8 mxl:gap-y-0 px-(--page-px) pt-(--page-pt) pb-12 w-full max-w-229 mx-auto mxl:max-w-none mxl:mx-0"
-  >
-    <div
-      data-testid="dashboard__left-column"
-      class="flex flex-col gap-6 self-start mxl:sticky mxl:top-(--nav-height)"
-    >
-      <dashboard-actions-panel
-        :due_decks="due_decks"
-        :editing_decks="editing_decks"
-        @toggle-edit-decks="onToggleEditDecks"
-      />
-    </div>
+  <dashboard-skeleton v-if="show_skeleton" />
 
-    <div data-testid="dashboard__right-column" class="flex flex-col gap-y-13 min-w-0">
-      <dashboard-section v-if="due_decks.length > 0" :label="t('dashboard.deck-filter.due-label')">
-        <review-inbox :due_decks="due_decks" :editing="editing_decks" />
-      </dashboard-section>
+  <div v-else data-testid="dashboard" class="w-full">
+    <dashboard-shell>
+      <template #left>
+        <dashboard-actions-panel
+          :due_decks="due_decks"
+          :editing_decks="editing_decks"
+          @toggle-edit-decks="onToggleEditDecks"
+        />
+      </template>
 
-      <dashboard-section :label="t('dashboard.deck-filter.all-label')">
-        <template #subheader>
-          <deck-grid-sort-options :selected="sort_by" @select="sort_by = $event" />
-        </template>
+      <template #right>
+        <dashboard-section
+          v-if="due_decks.length > 0"
+          :label="t('dashboard.deck-filter.due-label')"
+        >
+          <review-inbox :due_decks="due_decks" :editing="editing_decks" />
+        </dashboard-section>
 
-        <deck-grid :decks="decks" :editing="editing_decks" />
-      </dashboard-section>
+        <dashboard-section :label="t('dashboard.deck-filter.all-label')">
+          <template #subheader>
+            <deck-grid-sort-options :selected="sort_by" @select="sort_by = $event" />
+          </template>
 
-      <audio-reader-section v-if="can.useAudioReader.value" />
-    </div>
+          <deck-grid :decks="decks" :editing="editing_decks" />
+        </dashboard-section>
+
+        <audio-reader-section v-if="can.useAudioReader.value" />
+      </template>
+    </dashboard-shell>
 
     <scroll-bar class="fixed right-4 top-(--nav-height) bottom-10 z-30" target="html" />
 

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -53,7 +53,7 @@ const show_skeleton = computed(() => !decks_data.value)
 </script>
 
 <template>
-  <dashboard-skeleton v-if="show_skeleton" />
+  <dashboard-skeleton v-if="true" />
 
   <div v-else data-testid="dashboard" class="w-full">
     <dashboard-shell>

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -53,7 +53,7 @@ const show_skeleton = computed(() => !decks_data.value)
 </script>
 
 <template>
-  <dashboard-skeleton v-if="true" />
+  <dashboard-skeleton v-if="show_skeleton" />
 
   <div v-else data-testid="dashboard" class="w-full">
     <dashboard-shell>

--- a/src/views/dashboard/review-inbox/skeleton.vue
+++ b/src/views/dashboard/review-inbox/skeleton.vue
@@ -29,7 +29,7 @@ const DEFAULT_COVER: DeckCover = {
 
       <div
         data-testid="review-inbox-skeleton__label"
-        class="h-5 w-16 bg-brown-200 dark:bg-grey-800 rounded-sm animate-pulse"
+        class="h-5 w-16 bg-brown-200 dark:bg-grey-800 rounded-2 animate-pulse"
       ></div>
     </div>
   </div>

--- a/src/views/dashboard/review-inbox/skeleton.vue
+++ b/src/views/dashboard/review-inbox/skeleton.vue
@@ -19,14 +19,18 @@ const DEFAULT_COVER: DeckCover = {
     data-testid="review-inbox-skeleton"
     class="relative w-full flex gap-3 overflow-hidden pt-1.5 -mt-1.5"
   >
-    <card
+    <div
       v-for="n in count"
       :key="n"
-      side="cover"
-      size="xs"
-      shimmer
-      :cover_config="DEFAULT_COVER"
-      class="shrink-0"
-    />
+      data-testid="review-inbox-skeleton__item"
+      class="flex flex-col items-center gap-2.5 shrink-0"
+    >
+      <card side="cover" size="xs" shimmer :cover_config="DEFAULT_COVER" />
+
+      <div
+        data-testid="review-inbox-skeleton__label"
+        class="h-5 w-16 bg-brown-200 dark:bg-grey-800 rounded-sm animate-pulse"
+      ></div>
+    </div>
   </div>
 </template>

--- a/src/views/dashboard/review-inbox/skeleton.vue
+++ b/src/views/dashboard/review-inbox/skeleton.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import Card from '@/components/card/index.vue'
+
+type ReviewInboxSkeletonProps = {
+  count?: number
+}
+
+const { count = 6 } = defineProps<ReviewInboxSkeletonProps>()
+
+const DEFAULT_COVER: DeckCover = {
+  theme: 'brown-300',
+  theme_dark: 'stone-900',
+  pattern: 'diagonal-stripes'
+}
+</script>
+
+<template>
+  <div
+    data-testid="review-inbox-skeleton"
+    class="relative w-full flex gap-3 overflow-hidden pt-1.5 -mt-1.5"
+  >
+    <card
+      v-for="n in count"
+      :key="n"
+      side="cover"
+      size="xs"
+      shimmer
+      :cover_config="DEFAULT_COVER"
+      class="shrink-0"
+    />
+  </div>
+</template>

--- a/src/views/dashboard/skeleton.vue
+++ b/src/views/dashboard/skeleton.vue
@@ -21,11 +21,11 @@ onUnmounted(() => (document.documentElement.style.overflow = ''))
       </template>
 
       <template #right>
-        <dashboard-section :label="t('dashboard.deck-filter.due-label')">
+        <dashboard-section loading :label="t('dashboard.deck-filter.due-label')">
           <review-inbox-skeleton />
         </dashboard-section>
 
-        <dashboard-section :label="t('dashboard.deck-filter.all-label')">
+        <dashboard-section loading :label="t('dashboard.deck-filter.all-label')">
           <deck-grid-skeleton />
         </dashboard-section>
       </template>

--- a/src/views/dashboard/skeleton.vue
+++ b/src/views/dashboard/skeleton.vue
@@ -1,30 +1,34 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import DashboardShell from './dashboard-shell.vue'
+import DashboardSection from './dashboard-section.vue'
+import DashboardActionsPanelSkeleton from './actions-panel/skeleton.vue'
+import ReviewInboxSkeleton from './review-inbox/skeleton.vue'
+import DeckGridSkeleton from './deck-grid/skeleton.vue'
+
+const { t } = useI18n()
+
+onMounted(() => (document.documentElement.style.overflow = 'hidden'))
+onUnmounted(() => (document.documentElement.style.overflow = ''))
+</script>
 
 <template>
-  <div
-    data-testid="dashboard-skeleton"
-    class="grid grid-cols-[1fr] md:grid-cols-[345px_1fr] md:grid-rows-[auto_1fr] gap-x-15.5 gap-y-6 md:gap-y-11.5 h-full px-(--page-px) pt-(--page-pt) pb-12 animate-pulse"
-  >
-    <div
-      data-testid="dashboard-skeleton__create-button"
-      class="h-12 w-full bg-brown-300 dark:bg-grey-700 rounded-lg max-md:row-start-4"
-    ></div>
+  <div data-testid="dashboard-skeleton" class="w-full">
+    <dashboard-shell>
+      <template #left>
+        <dashboard-actions-panel-skeleton />
+      </template>
 
-    <div
-      data-testid="dashboard-skeleton__title"
-      class="h-10 w-40 bg-brown-300 dark:bg-grey-700 rounded-sm max-md:row-start-2"
-    ></div>
+      <template #right>
+        <dashboard-section :label="t('dashboard.deck-filter.due-label')">
+          <review-inbox-skeleton />
+        </dashboard-section>
 
-    <div
-      data-testid="dashboard-skeleton__inbox"
-      class="h-64 w-full bg-brown-200 dark:bg-grey-800 rounded-xl"
-    ></div>
-
-    <div
-      data-testid="dashboard-skeleton__decks"
-      class="flex gap-x-6.5 gap-y-8 flex-wrap md:col-start-2"
-    >
-      <div v-for="n in 6" :key="n" class="h-64 w-44 bg-brown-200 dark:bg-grey-800 rounded-xl"></div>
-    </div>
+        <dashboard-section :label="t('dashboard.deck-filter.all-label')">
+          <deck-grid-skeleton />
+        </dashboard-section>
+      </template>
+    </dashboard-shell>
   </div>
 </template>

--- a/src/views/dashboard/skeleton.vue
+++ b/src/views/dashboard/skeleton.vue
@@ -26,6 +26,16 @@ onUnmounted(() => (document.documentElement.style.overflow = ''))
         </dashboard-section>
 
         <dashboard-section loading :label="t('dashboard.deck-filter.all-label')">
+          <template #subheader>
+            <div data-testid="deck-grid-sort-options-skeleton" class="flex gap-8">
+              <div
+                v-for="n in 3"
+                :key="n"
+                class="h-6 w-20 bg-brown-200 dark:bg-grey-800 rounded-2 animate-pulse"
+              ></div>
+            </div>
+          </template>
+
           <deck-grid-skeleton />
         </dashboard-section>
       </template>

--- a/src/views/deck/deck-shell.vue
+++ b/src/views/deck/deck-shell.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+defineSlots<{
+  hero(): unknown
+  main(): unknown
+}>()
+</script>
+
+<template>
+  <div
+    data-testid="deck-shell"
+    class="flex flex-col xl:flex-row items-center xl:items-start gap-6 md:gap-15"
+  >
+    <slot name="hero" />
+    <slot name="main" />
+  </div>
+</template>

--- a/src/views/deck/deck-view.vue
+++ b/src/views/deck/deck-view.vue
@@ -3,6 +3,7 @@ import { computed, provide, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useNoticeStore } from '@/stores/notice-store'
 import DeckHero from '@/views/deck/deck-hero/index.vue'
+import DeckShell from './deck-shell.vue'
 import DeckSkeleton from './skeleton.vue'
 import ModeToolbar from './mode-toolbar/index.vue'
 import ModeToolbarSkeleton from './mode-toolbar/skeleton.vue'
@@ -70,47 +71,51 @@ const show_skeleton = computed(() => !deck.value)
   <deck-skeleton v-if="show_skeleton" />
 
   <section v-else data-testid="deck-view" class="flex flex-col px-(--page-px) pt-(--page-pt) gap-3">
-    <div class="flex flex-col xl:flex-row items-center xl:items-start gap-6 md:gap-15">
-      <deck-hero
-        class="relative z-30 xl:sticky xl:top-(--nav-height)"
-        :deck="deck!"
-        :image-url="image_url"
-        :hide-actions="view_state === 'empty'"
-      />
+    <deck-shell>
+      <template #hero>
+        <deck-hero
+          class="relative z-30 xl:sticky xl:top-(--nav-height)"
+          :deck="deck!"
+          :image-url="image_url"
+          :hide-actions="view_state === 'empty'"
+        />
+      </template>
 
-      <div
-        data-testid="deck-view__main"
-        :data-mode="shell.mode.value"
-        class="relative w-full"
-        :class="
-          view_state === 'empty'
-            ? 'xl:flex xl:flex-col xl:h-[calc(100dvh-var(--nav-height))]'
-            : 'pb-[calc(1rem+var(--mobile-dock-height,0px))]'
-        "
-      >
+      <template #main>
         <div
-          ref="toolbar"
-          data-testid="deck-view__toolbar"
-          class="sticky top-(--nav-height) z-20 max-md:hidden"
+          data-testid="deck-view__main"
+          :data-mode="shell.mode.value"
+          class="relative w-full"
+          :class="
+            view_state === 'empty'
+              ? 'xl:flex xl:flex-col xl:h-[calc(100dvh-var(--nav-height))]'
+              : 'pb-[calc(1rem+var(--mobile-dock-height,0px))]'
+          "
         >
           <div
-            data-testid="deck-view__toolbar-backing"
-            aria-hidden="true"
-            class="absolute inset-x-0 bottom-0 top-[calc(var(--nav-height)*-1)] -z-10 bg-brown-100 dark:bg-grey-900"
-          ></div>
-          <mode-toolbar-skeleton v-if="view_state === 'empty'" />
-          <mode-toolbar v-else />
-        </div>
+            ref="toolbar"
+            data-testid="deck-view__toolbar"
+            class="sticky top-(--nav-height) z-20 max-md:hidden"
+          >
+            <div
+              data-testid="deck-view__toolbar-backing"
+              aria-hidden="true"
+              class="absolute inset-x-0 bottom-0 top-[calc(var(--nav-height)*-1)] -z-10 bg-brown-100 dark:bg-grey-900"
+            ></div>
+            <mode-toolbar-skeleton v-if="view_state === 'empty'" />
+            <mode-toolbar v-else />
+          </div>
 
-        <card-grid-empty
-          v-if="view_state === 'empty'"
-          data-testid="deck-view__empty"
-          class="md:mt-6"
-        />
-        <card-grid-skeleton v-else-if="view_state === 'loading'" class="md:mt-6" />
-        <mode-stack v-else class="md:mt-6" :sticky_header="toolbar" />
-      </div>
-    </div>
+          <card-grid-empty
+            v-if="view_state === 'empty'"
+            data-testid="deck-view__empty"
+            class="md:mt-6"
+          />
+          <card-grid-skeleton v-else-if="view_state === 'loading'" class="md:mt-6" />
+          <mode-stack v-else class="md:mt-6" :sticky_header="toolbar" />
+        </div>
+      </template>
+    </deck-shell>
 
     <scroll-bar
       v-if="view_state === 'ready'"

--- a/src/views/deck/skeleton.vue
+++ b/src/views/deck/skeleton.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import DeckShell from './deck-shell.vue'
 import DeckHeroSkeleton from './deck-hero/skeleton.vue'
 import ModeToolbarSkeleton from './mode-toolbar/skeleton.vue'
 import CardGridSkeleton from './card-grid/skeleton.vue'
@@ -9,15 +10,18 @@ onUnmounted(() => (document.documentElement.style.overflow = ''))
 </script>
 
 <template>
-  <section
-    data-testid="deck-skeleton"
-    class="flex h-full flex-col xl:flex-row items-center xl:items-start gap-6 md:gap-15 px-(--page-px) pt-(--page-pt) pb-24"
-  >
-    <deck-hero-skeleton class="relative z-30 xl:sticky xl:top-(--nav-height)" />
+  <section data-testid="deck-skeleton" class="h-full px-(--page-px) pt-(--page-pt) pb-24">
+    <deck-shell>
+      <template #hero>
+        <deck-hero-skeleton class="relative z-30 xl:sticky xl:top-(--nav-height)" />
+      </template>
 
-    <div class="relative w-full pb-4">
-      <mode-toolbar-skeleton class="max-md:hidden" />
-      <card-grid-skeleton class="md:mt-6" />
-    </div>
+      <template #main>
+        <div class="relative w-full pb-4">
+          <mode-toolbar-skeleton class="max-md:hidden" />
+          <card-grid-skeleton class="md:mt-6" />
+        </div>
+      </template>
+    </deck-shell>
   </section>
 </template>

--- a/tests/integration/components/member/avatar-image.test.js
+++ b/tests/integration/components/member/avatar-image.test.js
@@ -9,7 +9,7 @@ vi.mock('@/components/member/avatars', () => ({
   loadAvatarUrl: mockLoadAvatarUrl
 }))
 
-vi.mock('@/assets/avatars/frog.svg', () => ({
+vi.mock('@/assets/avatars/frog.svg?url', () => ({
   default: '/mock/frog.svg'
 }))
 

--- a/tests/integration/views/dashboard/actions-panel/index.test.js
+++ b/tests/integration/views/dashboard/actions-panel/index.test.js
@@ -67,6 +67,15 @@ const UiButtonStub = defineComponent({
   }
 })
 
+const DashboardActionsPanelShellStub = defineComponent({
+  name: 'DashboardActionsPanelShell',
+  inheritAttrs: false,
+  setup(_props, { slots }) {
+    const attrs = useAttrs()
+    return () => h('div', { ...attrs }, [slots.polaroid?.(), slots.header?.(), slots.body?.()])
+  }
+})
+
 // ── Component import (after mocks) ────────────────────────────────────────────
 
 import DashboardActionsPanel from '@/views/dashboard/actions-panel/index.vue'
@@ -83,6 +92,7 @@ function mount(due_decks = [], editing_decks = false) {
     props: { due_decks, editing_decks },
     global: {
       stubs: {
+        DashboardActionsPanelShell: DashboardActionsPanelShellStub,
         DashboardActionsPanelPolaroid: PolaroidStub,
         UiOptionsPanel: UiOptionsPanelStub,
         UiButton: UiButtonStub

--- a/tests/integration/views/dashboard/actions-panel/shell.test.js
+++ b/tests/integration/views/dashboard/actions-panel/shell.test.js
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import DashboardActionsPanelShell from '@/views/dashboard/actions-panel/shell.vue'
+
+function mountShell(props, slots) {
+  return mount(DashboardActionsPanelShell, { props, slots })
+}
+
+describe('DashboardActionsPanelShell (views/dashboard/actions-panel/shell.vue)', () => {
+  test('renders the polaroid slot content', () => {
+    const wrapper = mountShell(
+      {},
+      { polaroid: () => h('div', { 'data-testid': 'polaroid-content' }) }
+    )
+    expect(wrapper.find('[data-testid="polaroid-content"]').exists()).toBe(true)
+  })
+
+  test('renders the header slot content inside the header wrapper', () => {
+    const wrapper = mountShell({}, { header: () => h('div', { 'data-testid': 'header-content' }) })
+    const header = wrapper.find('[data-testid="dashboard-actions-panel-shell__header"]')
+    expect(header.find('[data-testid="header-content"]').exists()).toBe(true)
+  })
+
+  test('renders the body slot content inside the body wrapper', () => {
+    const wrapper = mountShell({}, { body: () => h('div', { 'data-testid': 'body-content' }) })
+    const body = wrapper.find('[data-testid="dashboard-actions-panel-shell__body"]')
+    expect(body.find('[data-testid="body-content"]').exists()).toBe(true)
+  })
+
+  test('applies the static shape classes on the body wrapper', () => {
+    const wrapper = mountShell()
+    const body = wrapper.find('[data-testid="dashboard-actions-panel-shell__body"]')
+    expect(body.classes()).toEqual(
+      expect.arrayContaining(['cloud-top-[40px]', 'rounded-b-8', 'flex', 'flex-col'])
+    )
+  })
+
+  test('merges body_class onto the body wrapper alongside the static shape classes', () => {
+    const wrapper = mountShell({ body_class: 'bg-brown-300 dark:bg-stone-900' })
+    const body = wrapper.find('[data-testid="dashboard-actions-panel-shell__body"]')
+    expect(body.classes()).toEqual(
+      expect.arrayContaining(['cloud-top-[40px]', 'rounded-b-8', 'bg-brown-300'])
+    )
+  })
+
+  test('omitting body_class does not error and still applies the static shape classes', () => {
+    const wrapper = mountShell({})
+    const body = wrapper.find('[data-testid="dashboard-actions-panel-shell__body"]')
+    expect(body.classes()).toContain('cloud-top-[40px]')
+  })
+})

--- a/tests/integration/views/dashboard/actions-panel/skeleton.test.js
+++ b/tests/integration/views/dashboard/actions-panel/skeleton.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import DashboardActionsPanelSkeleton from '@/views/dashboard/actions-panel/skeleton.vue'
+
+describe('DashboardActionsPanelSkeleton (views/dashboard/actions-panel/skeleton.vue)', () => {
+  test('renders the root skeleton with data-testid="dashboard-actions-panel-skeleton"', () => {
+    const wrapper = mount(DashboardActionsPanelSkeleton)
+    expect(wrapper.find('[data-testid="dashboard-actions-panel-skeleton"]').exists()).toBe(true)
+  })
+
+  test('renders the polaroid placeholder', () => {
+    const wrapper = mount(DashboardActionsPanelSkeleton)
+    expect(
+      wrapper.find('[data-testid="dashboard-actions-panel-skeleton__polaroid"]').exists()
+    ).toBe(true)
+  })
+
+  test('renders inside the shared shell header and body wrappers', () => {
+    const wrapper = mount(DashboardActionsPanelSkeleton)
+    expect(wrapper.find('[data-testid="dashboard-actions-panel-shell__header"]').exists()).toBe(
+      true
+    )
+    expect(wrapper.find('[data-testid="dashboard-actions-panel-shell__body"]').exists()).toBe(true)
+  })
+})

--- a/tests/integration/views/dashboard/dashboard-section.test.js
+++ b/tests/integration/views/dashboard/dashboard-section.test.js
@@ -28,6 +28,35 @@ describe('DashboardSection — default slot', () => {
   })
 })
 
+describe('DashboardSection — loading prop [obligation]', () => {
+  test('uses the flat loading color classes when loading is true', () => {
+    const wrapper = mountSection({ label: 'All Decks', loading: true })
+    const label = wrapper.find('[data-testid="dashboard-section__label"]')
+    expect(label.classes()).toEqual(
+      expect.arrayContaining(['text-brown-300', 'dark:text-stone-700'])
+    )
+    expect(label.classes()).not.toEqual(
+      expect.arrayContaining(['text-brown-700', 'dark:text-brown-300'])
+    )
+  })
+
+  test('uses the default heading color classes when loading is false', () => {
+    const wrapper = mountSection({ label: 'All Decks', loading: false })
+    const label = wrapper.find('[data-testid="dashboard-section__label"]')
+    expect(label.classes()).toEqual(
+      expect.arrayContaining(['text-brown-700', 'dark:text-brown-300'])
+    )
+  })
+
+  test('omitting the loading prop preserves the original non-loading appearance', () => {
+    const wrapper = mountSection({ label: 'All Decks' })
+    const label = wrapper.find('[data-testid="dashboard-section__label"]')
+    expect(label.classes()).toEqual(
+      expect.arrayContaining(['text-brown-700', 'dark:text-brown-300'])
+    )
+  })
+})
+
 describe('DashboardSection — subheader slot', () => {
   test('does not render the subheader wrapper when the subheader slot is not provided', () => {
     const wrapper = mountSection({ label: 'All Decks' })

--- a/tests/integration/views/dashboard/dashboard-shell.test.js
+++ b/tests/integration/views/dashboard/dashboard-shell.test.js
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import DashboardShell from '@/views/dashboard/dashboard-shell.vue'
+
+function mountShell(slots) {
+  return mount(DashboardShell, { slots })
+}
+
+describe('DashboardShell (views/dashboard/dashboard-shell.vue)', () => {
+  test('renders the left slot content inside the left column', () => {
+    const wrapper = mountShell({ left: () => h('div', { 'data-testid': 'left-content' }) })
+    const left_column = wrapper.find('[data-testid="dashboard-shell__left-column"]')
+    expect(left_column.find('[data-testid="left-content"]').exists()).toBe(true)
+  })
+
+  test('renders the right slot content inside the right column', () => {
+    const wrapper = mountShell({ right: () => h('div', { 'data-testid': 'right-content' }) })
+    const right_column = wrapper.find('[data-testid="dashboard-shell__right-column"]')
+    expect(right_column.find('[data-testid="right-content"]').exists()).toBe(true)
+  })
+
+  test('left slot content does not leak into the right column', () => {
+    const wrapper = mountShell({ left: () => h('div', { 'data-testid': 'left-content' }) })
+    const right_column = wrapper.find('[data-testid="dashboard-shell__right-column"]')
+    expect(right_column.find('[data-testid="left-content"]').exists()).toBe(false)
+  })
+})

--- a/tests/integration/views/dashboard/deck-grid/skeleton.test.js
+++ b/tests/integration/views/dashboard/deck-grid/skeleton.test.js
@@ -1,0 +1,89 @@
+import { describe, test, expect, vi } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h, ref } from 'vue'
+
+const { useMatchMediaMock } = vi.hoisted(() => ({
+  useMatchMediaMock: vi.fn()
+}))
+
+vi.mock('@/composables/ui/media-query', () => ({
+  useMatchMedia: useMatchMediaMock
+}))
+
+import DeckGridSkeleton from '@/views/dashboard/deck-grid/skeleton.vue'
+
+const CardStub = defineComponent({
+  name: 'Card',
+  props: {
+    size: String,
+    side: String,
+    shimmer: Boolean,
+    cover_config: Object
+  },
+  setup(props) {
+    return () =>
+      h('div', {
+        'data-testid': 'card-stub',
+        'data-size': props.size,
+        'data-side': props.side,
+        'data-shimmer': String(props.shimmer),
+        'data-cover-theme': props.cover_config?.theme,
+        'data-cover-theme-dark': props.cover_config?.theme_dark,
+        'data-cover-pattern': props.cover_config?.pattern
+      })
+  }
+})
+
+function mountSkeleton(props = {}, is_md = true) {
+  useMatchMediaMock.mockReturnValue(ref(is_md))
+  return shallowMount(DeckGridSkeleton, {
+    props,
+    global: { stubs: { Card: CardStub } }
+  })
+}
+
+describe('DeckGridSkeleton (views/dashboard/deck-grid/skeleton.vue)', () => {
+  test('renders the root with data-testid="deck-grid-skeleton"', () => {
+    const wrapper = mountSkeleton()
+    expect(wrapper.find('[data-testid="deck-grid-skeleton"]').exists()).toBe(true)
+  })
+
+  test('renders 12 card stubs by default (count=12)', () => {
+    const wrapper = mountSkeleton()
+    expect(wrapper.findAll('[data-testid="card-stub"]')).toHaveLength(12)
+  })
+
+  test('renders exactly count card stubs when count prop is provided', () => {
+    const wrapper = mountSkeleton({ count: 5 })
+    expect(wrapper.findAll('[data-testid="card-stub"]')).toHaveLength(5)
+  })
+
+  test('all cards use side="cover" and shimmer=true', () => {
+    const wrapper = mountSkeleton()
+    for (const card of wrapper.findAllComponents(CardStub)) {
+      expect(card.props('side')).toBe('cover')
+      expect(card.props('shimmer')).toBe(true)
+    }
+  })
+
+  test('all cards use the DEFAULT_COVER theme/theme_dark/pattern', () => {
+    const wrapper = mountSkeleton()
+    for (const card of wrapper.findAllComponents(CardStub)) {
+      expect(card.props('cover_config')).toEqual({
+        theme: 'brown-300',
+        theme_dark: 'stone-900',
+        pattern: 'diagonal-stripes'
+      })
+    }
+  })
+
+  test('renders cards at size="base" when useMatchMedia is true (md+)', () => {
+    const wrapper = mountSkeleton({}, true)
+    expect(wrapper.findComponent(CardStub).props('size')).toBe('base')
+  })
+
+  test('renders cards at size="sm" when useMatchMedia is false (below md)', () => {
+    const wrapper = mountSkeleton({}, false)
+    expect(wrapper.findComponent(CardStub).props('size')).toBe('sm')
+  })
+})

--- a/tests/integration/views/dashboard/index.test.js
+++ b/tests/integration/views/dashboard/index.test.js
@@ -75,6 +75,18 @@ vi.mock('@/views/study-session/composables/study-modal', () => ({
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
+const DashboardSkeletonStub = defineComponent({
+  name: 'DashboardSkeleton',
+  setup: () => () => h('div', { 'data-testid': 'dashboard-skeleton-stub' })
+})
+
+const DashboardShellStub = defineComponent({
+  name: 'DashboardShell',
+  setup(_props, { slots }) {
+    return () => h('div', { 'data-testid': 'dashboard-shell' }, [slots.left?.(), slots.right?.()])
+  }
+})
+
 const DashboardActionsPanelStub = defineComponent({
   name: 'DashboardActionsPanel',
   props: ['due_decks', 'editing_decks'],
@@ -171,6 +183,8 @@ function mountDashboard() {
   return shallowMount(DashboardIndex, {
     global: {
       stubs: {
+        DashboardSkeleton: DashboardSkeletonStub,
+        DashboardShell: DashboardShellStub,
         DashboardActionsPanel: DashboardActionsPanelStub,
         DashboardSection: DashboardSectionStub,
         ReviewInbox: ReviewInboxStub,
@@ -341,6 +355,39 @@ describe('DashboardIndex — decks error watch', () => {
     decksErrorRef.value = { message: 'Network error' }
     await Promise.resolve()
     expect(noticeErrorMock).toHaveBeenCalledWith('Network error')
+  })
+})
+
+describe('DashboardIndex — skeleton gating [obligation]', () => {
+  test('renders dashboard-skeleton while useMemberDecksQuery data is undefined', () => {
+    decksDataRef.value = undefined
+    const wrapper = mountDashboard()
+    expect(wrapper.find('[data-testid="dashboard-skeleton-stub"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="dashboard"]').exists()).toBe(false)
+  })
+
+  test('switches to real content once data resolves', async () => {
+    decksDataRef.value = undefined
+    const wrapper = mountDashboard()
+    expect(wrapper.find('[data-testid="dashboard-skeleton-stub"]').exists()).toBe(true)
+
+    decksDataRef.value = [makeDeck(1)]
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="dashboard-skeleton-stub"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="dashboard"]').exists()).toBe(true)
+  })
+
+  test('stays on dashboard-skeleton when the decks query errors before ever resolving data', async () => {
+    decksDataRef.value = undefined
+    const wrapper = mountDashboard()
+
+    decksErrorRef.value = { message: 'Network error' }
+    await Promise.resolve()
+
+    expect(noticeErrorMock).toHaveBeenCalledWith('Network error')
+    expect(wrapper.find('[data-testid="dashboard-skeleton-stub"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="dashboard"]').exists()).toBe(false)
   })
 })
 

--- a/tests/integration/views/dashboard/review-inbox/skeleton.test.js
+++ b/tests/integration/views/dashboard/review-inbox/skeleton.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import ReviewInboxSkeleton from '@/views/dashboard/review-inbox/skeleton.vue'
+
+const CardStub = defineComponent({
+  name: 'Card',
+  props: {
+    size: String,
+    side: String,
+    shimmer: Boolean,
+    cover_config: Object
+  },
+  setup(props) {
+    return () =>
+      h('div', {
+        'data-testid': 'card-stub',
+        'data-size': props.size,
+        'data-side': props.side,
+        'data-shimmer': String(props.shimmer)
+      })
+  }
+})
+
+function mountSkeleton(props = {}) {
+  return shallowMount(ReviewInboxSkeleton, {
+    props,
+    global: { stubs: { Card: CardStub } }
+  })
+}
+
+describe('ReviewInboxSkeleton (views/dashboard/review-inbox/skeleton.vue) [obligation]', () => {
+  test('renders the root with data-testid="review-inbox-skeleton"', () => {
+    const wrapper = mountSkeleton()
+    expect(wrapper.find('[data-testid="review-inbox-skeleton"]').exists()).toBe(true)
+  })
+
+  test('renders 6 item pairs by default (count=6)', () => {
+    const wrapper = mountSkeleton()
+    expect(wrapper.findAll('[data-testid="review-inbox-skeleton__item"]')).toHaveLength(6)
+    expect(wrapper.findAll('[data-testid="card-stub"]')).toHaveLength(6)
+    expect(wrapper.findAll('[data-testid="review-inbox-skeleton__label"]')).toHaveLength(6)
+  })
+
+  test('renders exactly count item pairs when count prop is provided', () => {
+    const wrapper = mountSkeleton({ count: 3 })
+    expect(wrapper.findAll('[data-testid="review-inbox-skeleton__item"]')).toHaveLength(3)
+    expect(wrapper.findAll('[data-testid="card-stub"]')).toHaveLength(3)
+    expect(wrapper.findAll('[data-testid="review-inbox-skeleton__label"]')).toHaveLength(3)
+  })
+
+  test('renders 1 item pair when count=1', () => {
+    const wrapper = mountSkeleton({ count: 1 })
+    expect(wrapper.findAll('[data-testid="review-inbox-skeleton__item"]')).toHaveLength(1)
+  })
+
+  test('all cards use side="cover" size="xs" and shimmer=true', () => {
+    const wrapper = mountSkeleton()
+    for (const card of wrapper.findAllComponents(CardStub)) {
+      expect(card.props('side')).toBe('cover')
+      expect(card.props('size')).toBe('xs')
+      expect(card.props('shimmer')).toBe(true)
+    }
+  })
+})

--- a/tests/integration/views/dashboard/skeleton.test.js
+++ b/tests/integration/views/dashboard/skeleton.test.js
@@ -1,0 +1,88 @@
+import { describe, test, expect, afterEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import DashboardSkeleton from '@/views/dashboard/skeleton.vue'
+
+const DashboardActionsPanelSkeletonStub = defineComponent({
+  name: 'DashboardActionsPanelSkeleton',
+  setup: () => () => h('div', { 'data-testid': 'actions-panel-skeleton-stub' })
+})
+
+const ReviewInboxSkeletonStub = defineComponent({
+  name: 'ReviewInboxSkeleton',
+  setup: () => () => h('div', { 'data-testid': 'review-inbox-skeleton-stub' })
+})
+
+const DeckGridSkeletonStub = defineComponent({
+  name: 'DeckGridSkeleton',
+  setup: () => () => h('div', { 'data-testid': 'deck-grid-skeleton-stub' })
+})
+
+function mountSkeleton() {
+  return mount(DashboardSkeleton, {
+    global: {
+      stubs: {
+        DashboardActionsPanelSkeleton: DashboardActionsPanelSkeletonStub,
+        ReviewInboxSkeleton: ReviewInboxSkeletonStub,
+        DeckGridSkeleton: DeckGridSkeletonStub
+      }
+    }
+  })
+}
+
+describe('DashboardSkeleton (views/dashboard/skeleton.vue)', () => {
+  afterEach(() => {
+    document.documentElement.style.overflow = ''
+  })
+
+  test('sets document.documentElement.style.overflow to "hidden" on mount [obligation]', () => {
+    mountSkeleton()
+    expect(document.documentElement.style.overflow).toBe('hidden')
+  })
+
+  test('clears document.documentElement.style.overflow to "" on unmount [obligation]', () => {
+    const wrapper = mountSkeleton()
+    expect(document.documentElement.style.overflow).toBe('hidden')
+
+    wrapper.unmount()
+    expect(document.documentElement.style.overflow).toBe('')
+  })
+
+  test('renders the root with data-testid="dashboard-skeleton"', () => {
+    const wrapper = mountSkeleton()
+    expect(wrapper.find('[data-testid="dashboard-skeleton"]').exists()).toBe(true)
+  })
+
+  test('includes DashboardActionsPanelSkeleton in the left column', () => {
+    const wrapper = mountSkeleton()
+    expect(wrapper.find('[data-testid="actions-panel-skeleton-stub"]').exists()).toBe(true)
+  })
+
+  test('includes ReviewInboxSkeleton and DeckGridSkeleton in the right column', () => {
+    const wrapper = mountSkeleton()
+    expect(wrapper.find('[data-testid="review-inbox-skeleton-stub"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="deck-grid-skeleton-stub"]').exists()).toBe(true)
+  })
+
+  test('renders both dashboard-section headers in loading state', () => {
+    const wrapper = mountSkeleton()
+    const labels = wrapper.findAll('[data-testid="dashboard-section__label"]')
+    for (const label of labels) {
+      expect(label.classes()).toEqual(
+        expect.arrayContaining(['text-brown-300', 'dark:text-stone-700'])
+      )
+    }
+  })
+
+  test('restores overflow after each mount/unmount cycle', () => {
+    const a = mountSkeleton()
+    expect(document.documentElement.style.overflow).toBe('hidden')
+    a.unmount()
+    expect(document.documentElement.style.overflow).toBe('')
+
+    const b = mountSkeleton()
+    expect(document.documentElement.style.overflow).toBe('hidden')
+    b.unmount()
+    expect(document.documentElement.style.overflow).toBe('')
+  })
+})

--- a/tests/integration/views/deck/deck-shell.test.js
+++ b/tests/integration/views/deck/deck-shell.test.js
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import DeckShell from '@/views/deck/deck-shell.vue'
+
+function mountShell(slots) {
+  return mount(DeckShell, { slots })
+}
+
+describe('DeckShell (views/deck/deck-shell.vue)', () => {
+  test('renders the hero slot content', () => {
+    const wrapper = mountShell({ hero: () => h('div', { 'data-testid': 'hero-content' }) })
+    expect(wrapper.find('[data-testid="hero-content"]').exists()).toBe(true)
+  })
+
+  test('renders the main slot content', () => {
+    const wrapper = mountShell({ main: () => h('div', { 'data-testid': 'main-content' }) })
+    expect(wrapper.find('[data-testid="main-content"]').exists()).toBe(true)
+  })
+
+  test('renders hero before main within the shell root', () => {
+    const wrapper = mountShell({
+      hero: () => h('div', { 'data-testid': 'hero-content' }),
+      main: () => h('div', { 'data-testid': 'main-content' })
+    })
+    const root = wrapper.find('[data-testid="deck-shell"]')
+    const children = root.element.children
+    expect(children[0].getAttribute('data-testid')).toBe('hero-content')
+    expect(children[1].getAttribute('data-testid')).toBe('main-content')
+  })
+})

--- a/tests/integration/views/deck/index.test.js
+++ b/tests/integration/views/deck/index.test.js
@@ -54,6 +54,14 @@ vi.mock('@/views/deck/composables/card-sort', () => ({
 
 import DeckView from '@/views/deck/deck-view.vue'
 
+const DeckShellStub = defineComponent({
+  name: 'DeckShell',
+  setup:
+    (_props, { slots }) =>
+    () =>
+      h('div', { 'data-testid': 'deck-shell-stub' }, [slots.hero?.(), slots.main?.()])
+})
+
 const DeckHeroStub = defineComponent({
   name: 'DeckHero',
   setup: () => () => h('div', { 'data-testid': 'deck-hero-stub' })
@@ -149,6 +157,7 @@ function mount({
     props: { id: '1' },
     global: {
       stubs: {
+        DeckShell: DeckShellStub,
         DeckHero: withHideActionsCheck ? DeckHeroStubWithProps : DeckHeroStub,
         DeckSkeleton: DeckSkeletonStub,
         ModeToolbar: ModeToolbarStub,
@@ -417,6 +426,7 @@ describe('DeckView (views/deck/deck-view.vue)', () => {
       props: { id: '1' },
       global: {
         stubs: {
+          DeckShell: DeckShellStub,
           DeckHero: DeckHeroStub,
           DeckSkeleton: DeckSkeletonStub,
           ModeToolbar: ModeToolbarStub,


### PR DESCRIPTION
## Summary

Adds a full skeleton loader for the dashboard, matching the deck view's pattern: colocated sub-skeletons composed into a page skeleton, gated on the decks query's loading state instead of only covering the Suspense route fallback.

## Changes

- Extract `deck-shell.vue` and `dashboard-shell.vue` to share layout geometry (hero/main row, left/right grid) between each view and its skeleton, preventing style drift between the two.
- Extract `actions-panel/shell.vue` to share the panel's rounded/cloud-top container shape the same way.
- Add colocated skeletons for `actions-panel`, `review-inbox`, and `deck-grid`, reusing real `Card`/`DashboardSection` components in a loading state instead of hand-rolled placeholder divs.
- Wire `dashboard/index.vue` to switch between the skeleton and real content based on `useMemberDecksQuery`'s data, mirroring `deck-view.vue`'s existing pattern.
- `dashboard-section.vue` gains a `loading` prop that mutes its header color; only the skeleton passes it.
- Fix a hardcoded `v-if="true"` (leftover from visual testing) that had shipped mid-branch, permanently hiding real dashboard content.
