### PR TITLE
Capability functions for backend authorization

### DIFF
--- a/.claude/rules/supabase.md
+++ b/.claude/rules/supabase.md
@@ -28,6 +28,15 @@ Gate on `auth.uid()::text = (storage.foldername(name))[1]` when paths start with
 
 `storage.protect_delete` blocks direct `DELETE FROM storage.objects`, so DELETE policies can only be verified in the UI, not via pgTAP.
 
+## Capability functions for authorization
+
+Gate role/plan-based access through named capability functions, not inline `auth_role()`/`auth_plan()` checks. Mirrors `src/composables/can.ts`'s naming rule: name for the grant, not the role — `can_manage_members()`, never `is_admin()`.
+
+- One SQL function per capability, `stable`, returns `boolean`, body combines `auth_role()`/`auth_plan()`.
+- Colocate a new capability function in the migration of the feature that first needs it — don't pre-create capabilities for hypothetical future features.
+- Every capability function needs `grant execute on function public.can_x() to authenticated` — required for edge functions to reach it via `rpc()`.
+- RLS policies: `using (can_x())`. Edge functions: `requireCapability(req, 'can_x')` from `supabase/functions/_shared/require-capability.ts`.
+
 ## Migration workflow
 
 - `supabase migration up --local` immediately after writing — catches errors while the context is fresh. Never `supabase db reset`.

--- a/.claude/skills/update-tests/SKILL.md
+++ b/.claude/skills/update-tests/SKILL.md
@@ -7,7 +7,7 @@ arguments:
     type: string
     description: Optional context to help understand the changes
 argument-hint: '[additional-context]'
-lastUpdated: 2026-06-23T00:00:00Z
+lastUpdated: 2026-07-15T00:00:00Z
 ---
 
 The main thread runs **only** the obligation-mining step below. The subagent has none of this conversation in its context, so the cross-cutting tests that depend on it must be discovered here and passed in explicitly. Everything mechanical (scoped per-file coverage of touched files, diff, type selection, writing, validation, re-measure, report) happens inside the subagent. The subagent measures coverage **only for touched files** and targets ~90% lines each — it does not run the full suite or baseline against master.
@@ -59,30 +59,34 @@ The subagent works from a cold diff and can mis-scope or over-claim. Cross-check
 
 1. **Scope completeness.** Run `git diff master...HEAD --name-only -- src/ supabase/` and `git status --short -- src/` yourself, and compare against the report's coverage table. A file the subagent claims "wasn't in the diff" but that actually appears here is a **missed obligation, not a scope decision** — this is the most common and most damaging failure. Every changed source file must be accounted for (covered, or an explicit justified deferral).
 2. **Obligations.** Every Step-A obligation must appear under "Obligations satisfied" with a ✅. Any ❌ or silent omission is a gap to close.
-3. **No collateral breakage.** The branch's own source changes can have broken existing test files the subagent never ran (it scopes to "touched files" and may not realise an untouched test exercises touched source). A composable that gained a new query dependency, for instance, throws `getActivePinia()` in every pre-existing test until its harness mocks the new hook; a barrel that now re-exports a heavier module makes every partial `vi.mock` of that barrel's transitive deps fail the ESM named-export check.
+3. **No collateral breakage.** The branch's own source changes can have broken existing test files the subagent never ran (it scopes to "touched files" and may not realise an untouched test exercises touched source). A composable that gained a new query dependency, for instance, throws `getActivePinia()` in every pre-existing test until its harness mocks the new hook; a barrel that now re-exports a heavier module makes every partial `vi.mock` of that barrel's transitive deps fail the ESM named-export check. On the backend, a renamed/reshaped `supabase/functions/_shared/*.ts` helper (or a `RETURNS TABLE`/view shape change) silently breaks every untouched edge function or pgTAP file that imports/depends on it — invisible until that gate's full run.
 4. **Coverage floor.** Touched files should be ~90% lines; note any genuine deferrals.
 
-### Mandatory final gate — run the FULL suite once, then scope
+### Mandatory final gate — run each relevant full suite once, then scope
 
-Before you commit, run the **entire** suite exactly once, to identify failures:
+Before you commit, decide which gates apply from the touched-file scope you already gathered for item 1 above, and run **only** those — each **exactly once**:
 
-```
-pnpm test:fast 2>&1 | tee /tmp/update-tests-full-run.log | tail -100
-```
+| Touched scope                                         | Gate          | Command                                                                                                                           |
+| ----------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `src/` or `tests/**`                                  | Vitest (full) | `pnpm test:fast 2>&1 \| tee /tmp/update-tests-full-run.log \| tail -100`                                                          |
+| `supabase/migrations/**` (schema, RLS, RPC, triggers) | pgTAP (full)  | `supabase test db 2>&1 \| tee /tmp/update-tests-pgtap-run.log \| tail -100` (needs `supabase start`)                              |
+| `supabase/functions/**` (incl. `_shared/`)            | Deno (full)   | `cd supabase/functions && deno test --allow-net --allow-env --allow-read 2>&1 \| tee /tmp/update-tests-deno-run.log \| tail -100` |
 
-(Unit + Integration, no coverage — the fast full-suite runner. Never add `--coverage` here; this gate only needs pass/fail, not instrumentation.)
+Skip a gate whose scope wasn't touched entirely — a pure `supabase/` change never runs `pnpm test:fast`; a pure `src/` change never runs `supabase test db` or `deno test`. A change spanning both (e.g. a migration plus the FE query hook that consumes it) runs every applicable gate, each once.
 
-Capture the full output to a file via `tee` in the same invocation. The tail may only show a coverage table, not the pass/fail summary — re-grep the saved log (`grep -E "Test Files|Tests |FAIL|failed" /tmp/update-tests-full-run.log`) instead of re-running the command. **Never re-invoke `pnpm test:fast` just to see a different slice of output you didn't capture the first time** — that silently violates the once-per-invocation rule below.
+(Unit + Integration, no coverage, for the Vitest row — the fast full-suite runner. Never add `--coverage` to any of these; each gate only needs pass/fail, not instrumentation.)
 
-This is non-negotiable. The subagent only ever runs touched-file scope, so collateral breakage in **untouched** test files is invisible to it — and that is the single most common reason these PRs fail CI (it happens on nearly every move/barrel/mock-shape change). The mirror-file check in item 3 is necessary but **not sufficient**: a file-move or barrel-widening refactor breaks tests that don't mirror any touched source at all (e.g. a sibling feature whose `vi.mock('@/some/barrel')` is now missing a newly-transitive export). Only a full run catches those.
+Capture each gate's full output to its own log file via `tee` in the same invocation. Tails may only show a coverage table or the last few tests, not the pass/fail summary — re-grep the saved log (e.g. `grep -E "Test Files|Tests |FAIL|failed" /tmp/update-tests-full-run.log`) instead of re-running the command. **Never re-invoke a gate just to see a different slice of output you didn't capture the first time** — that silently violates the once-per-invocation rule below.
 
-**`pnpm test:fast` runs at most once per skill invocation.** Use it only to identify which files are failing. Every subsequent run — while fixing failures, after a re-dispatch, before final commit — must be scoped to the specific failing test file(s) (`vp test --no-coverage <path> ...`), never the full suite again. If you suspect the fixes had wider fallout, re-scope to the broader set of files plausibly affected (e.g. everything importing the changed barrel), not to a second full-suite run.
+This is non-negotiable for whichever gates apply. The subagent only ever runs touched-file scope, so collateral breakage in **untouched** test files is invisible to it — and that is the single most common reason these PRs fail CI (it happens on nearly every move/barrel/mock-shape change, frontend or backend). The mirror-file check in item 3 is necessary but **not sufficient**: a file-move or barrel-widening refactor breaks tests that don't mirror any touched source at all (e.g. a sibling feature whose `vi.mock('@/some/barrel')` is now missing a newly-transitive export, or a sibling edge function importing a renamed `_shared/*.ts` export). Only a full run per gate catches those.
 
-If the full suite is red:
+**Each applicable gate runs at most once per skill invocation** — except pgTAP: `supabase test db` has no per-file scoping in the CLI (it runs the whole `supabase/tests/*.sql` suite as one transaction-wrapped batch), so if it's the failing gate, re-running it in full is the only option and is acceptable (it's DB-only, no browser, and fast). For Vitest and Deno, use the once-per-invocation full run only to identify which files are failing, then scope every subsequent run to those files (`vp test --no-coverage <path> ...` / `deno test --allow-net --allow-env --allow-read <file>`), never the full suite again. If you suspect the fixes had wider fallout, re-scope to the broader set of files plausibly affected (e.g. everything importing the changed barrel or shared helper), not to a second full-suite run.
 
-- Fix the failures yourself when they're mechanical (repoint a moved import, add the missing export to a `vi.mock` factory, mock the barrel the source now imports instead of the old deep path). These are review fixes, not new authoring — keep them in the test commit.
+If a gate is red:
+
+- Fix the failures yourself when they're mechanical (repoint a moved import, add the missing export to a `vi.mock` factory or Deno fake-supabase, mock the barrel the source now imports instead of the old deep path). These are review fixes, not new authoring — keep them in the test commit.
 - Re-dispatch the subagent only if the failures reveal a genuine missing-coverage gap, not just a broken harness.
-- Verify fixes with the scoped run above, not another `pnpm test:fast`. Do **not** commit until every file identified as failing is confirmed green via its scoped run.
+- Verify fixes with the scoped run above (or, for pgTAP, a fresh full `supabase test db`), not a second full Vitest/Deno run. Do **not** commit until every file identified as failing is confirmed green.
 
 ### Decide
 

--- a/supabase/functions/_shared/require-capability.test.ts
+++ b/supabase/functions/_shared/require-capability.test.ts
@@ -1,0 +1,103 @@
+import { assertEquals } from '@std/assert'
+import { requireCapability } from './require-capability.ts'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+function fakeUserClient(opts: {
+  user?: { id: string; email?: string } | null
+  authError?: unknown
+  allowed?: boolean
+  rpcError?: unknown
+}): SupabaseClient {
+  return {
+    auth: {
+      getUser: () =>
+        Promise.resolve({
+          data: { user: opts.user ?? null },
+          error: opts.authError ?? null
+        })
+    },
+    rpc: () =>
+      Promise.resolve({
+        data: opts.allowed ?? false,
+        error: opts.rpcError ?? null
+      })
+  } as unknown as SupabaseClient
+}
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost', { headers })
+}
+
+Deno.test('returns 401 when no Authorization header is present', async () => {
+  const result = await requireCapability(req(), 'can_manage_members')
+
+  if (!('error' in result)) throw new Error('expected an error result')
+  assertEquals(result.error.status, 401)
+})
+
+Deno.test('returns 401 when auth.getUser() errors (invalid token)', async () => {
+  const userClient = fakeUserClient({ authError: { message: 'invalid JWT' } })
+
+  const result = await requireCapability(
+    req({ Authorization: 'Bearer bad' }),
+    'can_manage_members',
+    {
+      userClient
+    }
+  )
+
+  if (!('error' in result)) throw new Error('expected an error result')
+  assertEquals(result.error.status, 401)
+})
+
+Deno.test('returns 401 when auth.getUser() resolves no user', async () => {
+  const userClient = fakeUserClient({ user: null })
+
+  const result = await requireCapability(req({ Authorization: 'Bearer x' }), 'can_manage_members', {
+    userClient
+  })
+
+  if (!('error' in result)) throw new Error('expected an error result')
+  assertEquals(result.error.status, 401)
+})
+
+Deno.test('returns 403 when the capability RPC returns false', async () => {
+  const userClient = fakeUserClient({ user: { id: 'u1' }, allowed: false })
+
+  const result = await requireCapability(req({ Authorization: 'Bearer x' }), 'can_manage_members', {
+    userClient
+  })
+
+  if (!('error' in result)) throw new Error('expected an error result')
+  assertEquals(result.error.status, 403)
+})
+
+Deno.test('returns 403 when the capability RPC errors', async () => {
+  const userClient = fakeUserClient({
+    user: { id: 'u1' },
+    allowed: true,
+    rpcError: { message: 'function not found' }
+  })
+
+  const result = await requireCapability(req({ Authorization: 'Bearer x' }), 'can_manage_members', {
+    userClient
+  })
+
+  if (!('error' in result)) throw new Error('expected an error result')
+  assertEquals(result.error.status, 403)
+})
+
+Deno.test('returns { user, admin, userClient } when the capability RPC allows', async () => {
+  const userClient = fakeUserClient({ user: { id: 'u1', email: 'u1@test.com' }, allowed: true })
+  const adminClient = {} as SupabaseClient
+
+  const result = await requireCapability(req({ Authorization: 'Bearer x' }), 'can_manage_members', {
+    userClient,
+    adminClient
+  })
+
+  if ('error' in result) throw new Error('expected a success result')
+  assertEquals(result.user, { id: 'u1', email: 'u1@test.com' })
+  assertEquals(result.userClient, userClient)
+  assertEquals(result.admin, adminClient)
+})

--- a/supabase/functions/_shared/require-capability.ts
+++ b/supabase/functions/_shared/require-capability.ts
@@ -1,11 +1,12 @@
-// Shared auth gate for admin-only edge functions.
+// Shared auth gate for capability-gated edge functions.
 //
-// Authenticates the caller from the request's Authorization header, then asserts
-// their members.role is 'admin'. The frontend useCan() gate is UX only — this is
-// the real security boundary, so every admin-only function calls this first.
+// Authenticates the caller from the request's Authorization header, then checks
+// a named capability function (e.g. `can_read_lesson_audio`) via RPC as the
+// caller. The frontend useCan() gate is UX only — this is the real security
+// boundary, so every gated function calls this first.
 //
 // Returns either { user, admin, userClient } on success, or { error: Response }
-// to return verbatim (401 missing/invalid auth, 403 authenticated-but-not-admin).
+// to return verbatim (401 missing/invalid auth, 403 capability denied).
 //
 // `admin` is service-role (bypasses RLS) for trusted writes; `userClient` carries
 // the caller's JWT, so inserts run under RLS and the set_member_id trigger stamps
@@ -18,18 +19,22 @@ export const cors = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type'
 }
 
-type RequireAdminResult =
+type RequireCapabilityResult =
   | { user: { id: string; email?: string }; admin: SupabaseClient; userClient: SupabaseClient }
   | { error: Response }
 
-export async function requireAdmin(req: Request): Promise<RequireAdminResult> {
+export async function requireCapability(
+  req: Request,
+  capability: string
+): Promise<RequireCapabilityResult> {
   const authHeader = req.headers.get('Authorization')
   if (!authHeader) {
     return { error: new Response('Unauthorized', { status: 401, headers: cors }) }
   }
 
   // User-scoped client: carries the caller's JWT, so auth.getUser() resolves to
-  // the real signed-in member and any reads run under their RLS.
+  // the real signed-in member, and rpc() calls run as them — auth.uid() inside
+  // the capability function resolves from this JWT, not a service-role lookup.
   const userClient = createClient(
     Deno.env.get('SUPABASE_URL')!,
     Deno.env.get('SUPABASE_ANON_KEY')!,
@@ -44,17 +49,16 @@ export async function requireAdmin(req: Request): Promise<RequireAdminResult> {
     return { error: new Response('Unauthorized', { status: 401, headers: cors }) }
   }
 
-  // Service-role client bypasses RLS for the privileged role lookup.
+  const { data: allowed, error: capabilityError } = await userClient.rpc(capability)
+  if (capabilityError || !allowed) {
+    return { error: new Response('Forbidden', { status: 403, headers: cors }) }
+  }
+
+  // Service-role client for privileged writes once the capability check passes.
   const admin = createClient(
     Deno.env.get('SUPABASE_URL')!,
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
   )
-
-  const { data: member } = await admin.from('members').select('role').eq('id', user.id).single()
-
-  if (member?.role !== 'admin') {
-    return { error: new Response('Forbidden', { status: 403, headers: cors }) }
-  }
 
   return { user, admin, userClient }
 }

--- a/supabase/functions/_shared/require-capability.ts
+++ b/supabase/functions/_shared/require-capability.ts
@@ -23,9 +23,17 @@ type RequireCapabilityResult =
   | { user: { id: string; email?: string }; admin: SupabaseClient; userClient: SupabaseClient }
   | { error: Response }
 
+// Injectable clients for tests — real callers never pass these, so
+// createClient() (and the real network) is untouched in production.
+export type RequireCapabilityDeps = {
+  userClient?: SupabaseClient
+  adminClient?: SupabaseClient
+}
+
 export async function requireCapability(
   req: Request,
-  capability: string
+  capability: string,
+  deps: RequireCapabilityDeps = {}
 ): Promise<RequireCapabilityResult> {
   const authHeader = req.headers.get('Authorization')
   if (!authHeader) {
@@ -35,11 +43,11 @@ export async function requireCapability(
   // User-scoped client: carries the caller's JWT, so auth.getUser() resolves to
   // the real signed-in member, and rpc() calls run as them — auth.uid() inside
   // the capability function resolves from this JWT, not a service-role lookup.
-  const userClient = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_ANON_KEY')!,
-    { global: { headers: { Authorization: authHeader } } }
-  )
+  const userClient =
+    deps.userClient ??
+    createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_ANON_KEY')!, {
+      global: { headers: { Authorization: authHeader } }
+    })
 
   const {
     data: { user },
@@ -55,10 +63,9 @@ export async function requireCapability(
   }
 
   // Service-role client for privileged writes once the capability check passes.
-  const admin = createClient(
-    Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-  )
+  const admin =
+    deps.adminClient ??
+    createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
 
   return { user, admin, userClient }
 }

--- a/supabase/functions/transcribe-lesson/index.test.ts
+++ b/supabase/functions/transcribe-lesson/index.test.ts
@@ -1,0 +1,49 @@
+import { assertEquals } from '@std/assert'
+import { handler } from './index.ts'
+
+// The gate call site is the only thing this branch changed (requireAdmin ->
+// requireCapability). Full handler coverage (worker orchestration, chain
+// trigger phases) is out of proportion to that change.
+
+Deno.test('start action: returns the gate response when the capability check is denied', async () => {
+  const forbidden = new Response('Forbidden', { status: 403 })
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({ action: 'start' })
+  })
+
+  const res = await handler(req, { requireCapability: () => Promise.resolve({ error: forbidden }) })
+
+  assertEquals(res.status, 403)
+})
+
+Deno.test('retry action: returns the gate response when the capability check is denied', async () => {
+  const unauthorized = new Response('Unauthorized', { status: 401 })
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({ action: 'retry', lesson_id: 1 })
+  })
+
+  const res = await handler(req, {
+    requireCapability: () => Promise.resolve({ error: unauthorized })
+  })
+
+  assertEquals(res.status, 401)
+})
+
+Deno.test('process action bypasses the capability gate entirely (internal service-role call)', async () => {
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({ action: 'process', lesson_id: 1 })
+  })
+
+  const res = await handler(req, {
+    requireCapability: () => {
+      throw new Error('requireCapability must not be called for the process action')
+    }
+  })
+
+  // No service-role Authorization header supplied, so it's rejected on that
+  // check instead — proves the gate itself was never reached.
+  assertEquals(res.status, 403)
+})

--- a/supabase/functions/transcribe-lesson/index.ts
+++ b/supabase/functions/transcribe-lesson/index.ts
@@ -14,7 +14,7 @@
 //
 // The OpenAI/Anthropic keys never reach the client.
 
-import { cors, requireAdmin } from '../_shared/require-admin.ts'
+import { cors, requireCapability } from '../_shared/require-capability.ts'
 import { isTargetScript } from '../_shared/transcription/script.ts'
 import { processLessonPhase, serviceClient } from './worker.ts'
 import { type SupabaseClient } from '@supabase/supabase-js'
@@ -48,7 +48,7 @@ Deno.serve(async (req) => {
   // admin gate that 'start'/'retry' go through.
   if (body?.action === 'process') return handleProcess(req, body)
 
-  const auth = await requireAdmin(req)
+  const auth = await requireCapability(req, 'can_read_lesson_audio')
   if ('error' in auth) return auth.error
 
   if (body?.action === 'start') return handleStart(body, auth.userClient)

--- a/supabase/functions/transcribe-lesson/index.ts
+++ b/supabase/functions/transcribe-lesson/index.ts
@@ -14,7 +14,10 @@
 //
 // The OpenAI/Anthropic keys never reach the client.
 
-import { cors, requireCapability } from '../_shared/require-capability.ts'
+import {
+  cors,
+  requireCapability as defaultRequireCapability
+} from '../_shared/require-capability.ts'
 import { isTargetScript } from '../_shared/transcription/script.ts'
 import { processLessonPhase, serviceClient } from './worker.ts'
 import { type SupabaseClient } from '@supabase/supabase-js'
@@ -33,7 +36,13 @@ function accepted(lesson: unknown): Response {
   })
 }
 
-Deno.serve(async (req) => {
+// Injectable gate for tests — real callers never pass this, so the shared
+// requireCapability() (and its real network calls) is untouched in production.
+export type Deps = { requireCapability?: typeof defaultRequireCapability }
+
+export async function handler(req: Request, deps: Deps = {}): Promise<Response> {
+  const requireCapability = deps.requireCapability ?? defaultRequireCapability
+
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: cors })
   }
@@ -54,7 +63,11 @@ Deno.serve(async (req) => {
   if (body?.action === 'start') return handleStart(body, auth.userClient)
   if (body?.action === 'retry') return handleRetry(body, auth.admin, auth.userClient)
   return jsonError('bad_request', 400)
-})
+}
+
+if (import.meta.main) {
+  Deno.serve((req) => handler(req))
+}
 
 async function handleStart(
   body: Record<string, unknown>,

--- a/supabase/functions/translate-term/index.test.ts
+++ b/supabase/functions/translate-term/index.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from '@std/assert'
+import { handler } from './index.ts'
+
+// The gate call site is the only thing this branch changed (requireAdmin ->
+// requireCapability). Full handler coverage (Anthropic call, schema parsing)
+// is out of proportion to that change.
+
+Deno.test('returns the gate response when the capability check is denied', async () => {
+  const forbidden = new Response('Forbidden', { status: 403 })
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({ term: 'x', sentence: 'y', target_lang: 'en' })
+  })
+
+  const res = await handler(req, { requireCapability: () => Promise.resolve({ error: forbidden }) })
+
+  assertEquals(res.status, 403)
+})

--- a/supabase/functions/translate-term/index.ts
+++ b/supabase/functions/translate-term/index.ts
@@ -7,9 +7,9 @@
 // Response: { translation, reading, pos, description }  // all strings
 //
 // The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
-// Admin-only: requireAdmin() runs before any work.
+// Admin-only: requireCapability() runs before any work.
 
-import { cors, requireAdmin } from '../_shared/require-admin.ts'
+import { cors, requireCapability } from '../_shared/require-capability.ts'
 
 // Machine-readable failure codes the FE switches on (read from the error body).
 // `output_truncated` is split out so the UI can say "selection too long" rather
@@ -73,7 +73,7 @@ Deno.serve(async (req) => {
     return new Response('Method Not Allowed', { status: 405, headers: cors })
   }
 
-  const auth = await requireAdmin(req)
+  const auth = await requireCapability(req, 'can_read_lesson_audio')
   if ('error' in auth) return auth.error
 
   const { term, sentence, target_lang }: Partial<TranslateRequest> = await req

--- a/supabase/functions/translate-term/index.ts
+++ b/supabase/functions/translate-term/index.ts
@@ -9,7 +9,10 @@
 // The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
 // Admin-only: requireCapability() runs before any work.
 
-import { cors, requireCapability } from '../_shared/require-capability.ts'
+import {
+  cors,
+  requireCapability as defaultRequireCapability
+} from '../_shared/require-capability.ts'
 
 // Machine-readable failure codes the FE switches on (read from the error body).
 // `output_truncated` is split out so the UI can say "selection too long" rather
@@ -65,7 +68,13 @@ const SYSTEM_PROMPT =
   'description: 1-3 short sentences. If the selection is only part of a larger word in this sentence, begin by naming that larger word (the word itself — do not gloss it). Then call out the specific meaning the selection carries in this sentence, and mention its other common meanings or uses when it has them. Whenever you name a character, word, or compound in the description — whether the selection itself or a related term — always append its phonetic reading in parentheses immediately after it, e.g. 日落(rìluò) or 落(luò). Never leave a character or compound unreadable. ' +
   'difficulty: integer 1-10 rating how advanced this term is for a learner of the target language. 1 = most basic vocabulary taught in the very first lessons; 10 = rare, literary, or highly specialised vocabulary. Base this on how commonly the term appears in everyday language and how early it would typically be introduced in a structured course.'
 
-Deno.serve(async (req) => {
+// Injectable gate for tests — real callers never pass this, so the shared
+// requireCapability() (and its real network calls) is untouched in production.
+export type Deps = { requireCapability?: typeof defaultRequireCapability }
+
+export async function handler(req: Request, deps: Deps = {}): Promise<Response> {
+  const requireCapability = deps.requireCapability ?? defaultRequireCapability
+
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: cors })
   }
@@ -128,4 +137,8 @@ Deno.serve(async (req) => {
   return new Response(JSON.stringify(parsed), {
     headers: { ...cors, 'Content-Type': 'application/json' }
   })
-})
+}
+
+if (import.meta.main) {
+  Deno.serve((req) => handler(req))
+}

--- a/supabase/functions/translate-transcript/index.test.ts
+++ b/supabase/functions/translate-transcript/index.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from '@std/assert'
+import { handler } from './index.ts'
+
+// The gate call site is the only thing this branch changed (requireAdmin ->
+// requireCapability). Full handler coverage (translateSentences call) is out
+// of proportion to that change.
+
+Deno.test('returns the gate response when the capability check is denied', async () => {
+  const forbidden = new Response('Forbidden', { status: 403 })
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({ sentences: ['hi'], target_lang: 'en' })
+  })
+
+  const res = await handler(req, { requireCapability: () => Promise.resolve({ error: forbidden }) })
+
+  assertEquals(res.status, 403)
+})

--- a/supabase/functions/translate-transcript/index.ts
+++ b/supabase/functions/translate-transcript/index.ts
@@ -6,9 +6,9 @@
 // Response: { translations: string[] }  // same length/order as `sentences`
 //
 // The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
-// Admin-only: requireAdmin() runs before any work.
+// Admin-only: requireCapability() runs before any work.
 
-import { cors, requireAdmin } from '../_shared/require-admin.ts'
+import { cors, requireCapability } from '../_shared/require-capability.ts'
 import { translateSentences } from '../_shared/transcription/translate.ts'
 
 type TranslateRequest = { sentences: string[]; target_lang: string }
@@ -29,7 +29,7 @@ Deno.serve(async (req) => {
     return new Response('Method Not Allowed', { status: 405, headers: cors })
   }
 
-  const auth = await requireAdmin(req)
+  const auth = await requireCapability(req, 'can_read_lesson_audio')
   if ('error' in auth) return auth.error
 
   const { sentences, target_lang }: Partial<TranslateRequest> = await req.json().catch(() => ({}))

--- a/supabase/functions/translate-transcript/index.ts
+++ b/supabase/functions/translate-transcript/index.ts
@@ -8,7 +8,10 @@
 // The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
 // Admin-only: requireCapability() runs before any work.
 
-import { cors, requireCapability } from '../_shared/require-capability.ts'
+import {
+  cors,
+  requireCapability as defaultRequireCapability
+} from '../_shared/require-capability.ts'
 import { translateSentences } from '../_shared/transcription/translate.ts'
 
 type TranslateRequest = { sentences: string[]; target_lang: string }
@@ -21,7 +24,13 @@ function jsonError(code: string, status: number): Response {
   })
 }
 
-Deno.serve(async (req) => {
+// Injectable gate for tests — real callers never pass this, so the shared
+// requireCapability() (and its real network calls) is untouched in production.
+export type Deps = { requireCapability?: typeof defaultRequireCapability }
+
+export async function handler(req: Request, deps: Deps = {}): Promise<Response> {
+  const requireCapability = deps.requireCapability ?? defaultRequireCapability
+
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: cors })
   }
@@ -43,4 +52,8 @@ Deno.serve(async (req) => {
   return new Response(JSON.stringify({ translations }), {
     headers: { ...cors, 'Content-Type': 'application/json' }
   })
-})
+}
+
+if (import.meta.main) {
+  Deno.serve((req) => handler(req))
+}

--- a/supabase/functions/transliterate-transcript/index.test.ts
+++ b/supabase/functions/transliterate-transcript/index.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from '@std/assert'
+import { handler } from './index.ts'
+
+// The gate call site is the only thing this branch changed (requireAdmin ->
+// requireCapability). Full handler coverage (readSentences call) is out of
+// proportion to that change.
+
+Deno.test('returns the gate response when the capability check is denied', async () => {
+  const forbidden = new Response('Forbidden', { status: 403 })
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({ sentences: [{ text: 'hi', words: ['hi'] }], lang: 'en' })
+  })
+
+  const res = await handler(req, { requireCapability: () => Promise.resolve({ error: forbidden }) })
+
+  assertEquals(res.status, 403)
+})

--- a/supabase/functions/transliterate-transcript/index.ts
+++ b/supabase/functions/transliterate-transcript/index.ts
@@ -9,7 +9,10 @@
 // The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
 // Admin-only: requireCapability() runs before any work.
 
-import { cors, requireCapability } from '../_shared/require-capability.ts'
+import {
+  cors,
+  requireCapability as defaultRequireCapability
+} from '../_shared/require-capability.ts'
 import { readSentences, type ReadingSentence } from '../_shared/transcription/transliterate.ts'
 
 type TransliterateRequest = { sentences: ReadingSentence[]; lang: string }
@@ -22,7 +25,13 @@ function jsonError(code: string, status: number): Response {
   })
 }
 
-Deno.serve(async (req) => {
+// Injectable gate for tests — real callers never pass this, so the shared
+// requireCapability() (and its real network calls) is untouched in production.
+export type Deps = { requireCapability?: typeof defaultRequireCapability }
+
+export async function handler(req: Request, deps: Deps = {}): Promise<Response> {
+  const requireCapability = deps.requireCapability ?? defaultRequireCapability
+
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: cors })
   }
@@ -45,4 +54,8 @@ Deno.serve(async (req) => {
   return new Response(JSON.stringify({ readings }), {
     headers: { ...cors, 'Content-Type': 'application/json' }
   })
-})
+}
+
+if (import.meta.main) {
+  Deno.serve((req) => handler(req))
+}

--- a/supabase/functions/transliterate-transcript/index.ts
+++ b/supabase/functions/transliterate-transcript/index.ts
@@ -7,9 +7,9 @@
 // Response: { readings: string[] }  // flat, aligned to the sentences' words
 //
 // The Anthropic key never reaches the client — it lives in ANTHROPIC_API_KEY.
-// Admin-only: requireAdmin() runs before any work.
+// Admin-only: requireCapability() runs before any work.
 
-import { cors, requireAdmin } from '../_shared/require-admin.ts'
+import { cors, requireCapability } from '../_shared/require-capability.ts'
 import { readSentences, type ReadingSentence } from '../_shared/transcription/transliterate.ts'
 
 type TransliterateRequest = { sentences: ReadingSentence[]; lang: string }
@@ -30,7 +30,7 @@ Deno.serve(async (req) => {
     return new Response('Method Not Allowed', { status: 405, headers: cors })
   }
 
-  const auth = await requireAdmin(req)
+  const auth = await requireCapability(req, 'can_read_lesson_audio')
   if ('error' in auth) return auth.error
 
   const { sentences, lang }: Partial<TransliterateRequest> = await req.json().catch(() => ({}))

--- a/supabase/migrations/20260715000000_capability-functions.sql
+++ b/supabase/migrations/20260715000000_capability-functions.sql
@@ -1,0 +1,47 @@
+-- Capability functions: one SQL function per grant, not per role.
+--
+-- Mirrors the frontend's useCan() pattern (src/composables/can.ts) — name
+-- capabilities by what they grant ("can_manage_members"), not by the role
+-- that happens to have it today ("is_admin"). Each function combines
+-- auth_role()/auth_plan() however the capability needs; callers never check
+-- role/plan directly. When a policy changes, only the function body changes —
+-- every call site (RLS policy, edge function) picks it up automatically.
+--
+-- Retrofits the two existing role-checks: the members admin-update policy,
+-- and the audio-reader edge functions' admin gate.
+
+create or replace function public.can_manage_members()
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+  select auth_role() = 'admin'
+$$;
+
+create or replace function public.can_read_lesson_audio()
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+  select auth_role() = 'admin'
+$$;
+
+-- Supabase grants EXECUTE on new public functions to anon + authenticated by
+-- default (via ALTER DEFAULT PRIVILEGES) — REVOKE FROM public alone leaves
+-- those in place, so name each role explicitly. Only authenticated members
+-- should be able to check a capability at all.
+revoke all on function public.can_manage_members() from public, anon, authenticated;
+revoke all on function public.can_read_lesson_audio() from public, anon, authenticated;
+grant execute on function public.can_manage_members() to authenticated;
+grant execute on function public.can_read_lesson_audio() to authenticated;
+
+drop policy if exists "admins can update any member" on public.members;
+
+create policy "admins can update any member"
+on public.members
+for update
+to authenticated
+using (can_manage_members())
+with check (can_manage_members());

--- a/supabase/tests/00023_capability_functions.sql
+++ b/supabase/tests/00023_capability_functions.sql
@@ -1,0 +1,85 @@
+-- =============================================================================
+-- Capability functions introduced in 20260715000000_capability-functions.sql
+--
+--   - can_manage_members() / can_read_lesson_audio() are locked to
+--     `authenticated` only — Postgres grants EXECUTE to anon + PUBLIC on new
+--     functions by default, so the migration must explicitly revoke both
+--     before granting to authenticated. Regression guard for that bug.
+--   - can_manage_members() backs the members admin-update RLS policy; behavior
+--     must be identical to the old inline `auth_role() = 'admin'` check.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(6);
+
+-- ── EXECUTE privilege lockdown ────────────────────────────────────────────────
+
+-- Test 1-2: anon cannot execute either capability function.
+SELECT is(
+  has_function_privilege('anon', 'public.can_manage_members()', 'EXECUTE'),
+  false,
+  'anon cannot execute can_manage_members()'
+);
+
+SELECT is(
+  has_function_privilege('anon', 'public.can_read_lesson_audio()', 'EXECUTE'),
+  false,
+  'anon cannot execute can_read_lesson_audio()'
+);
+
+-- Test 3-4: authenticated can execute both.
+SELECT is(
+  has_function_privilege('authenticated', 'public.can_manage_members()', 'EXECUTE'),
+  true,
+  'authenticated can execute can_manage_members()'
+);
+
+SELECT is(
+  has_function_privilege('authenticated', 'public.can_read_lesson_audio()', 'EXECUTE'),
+  true,
+  'authenticated can execute can_read_lesson_audio()'
+);
+
+-- ── can_manage_members() drives the members admin-update policy ───────────────
+
+SELECT tests.create_user('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid, 'erin');
+SELECT tests.create_user('ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid, 'frank_admin');
+
+UPDATE public.members SET role = 'admin'
+  WHERE id = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+
+-- Test 5: non-admin cannot update another member's row.
+SELECT tests.set_claims('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid);
+SET LOCAL role = 'authenticated';
+
+UPDATE public.members
+SET description = 'hacked'
+WHERE id = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims(NULL);
+SELECT isnt(
+  (SELECT description FROM public.members WHERE id = 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+  'hacked',
+  'non-admin cannot update another member''s row via can_manage_members()'
+);
+
+-- Test 6: admin can update another member's row.
+SELECT tests.set_claims('ffffffff-ffff-ffff-ffff-ffffffffffff'::uuid);
+SET LOCAL role = 'authenticated';
+
+SELECT lives_ok(
+  $$
+    UPDATE public.members
+    SET description = 'moderated by admin'
+    WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+  $$,
+  'admin can update another member''s row via can_manage_members()'
+);
+
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims(NULL);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

Replaces ad-hoc `auth_role() = 'admin'` checks with named capability functions (mirroring the frontend's `useCan()`), and generalizes the edge-function admin gate to use them — the foundation for the upcoming feedback-board admin surface and any future role/plan-gated feature.

## Changes

- `can_manage_members()` / `can_read_lesson_audio()` SQL capability functions, locked to `authenticated` only (Postgres grants EXECUTE to `anon`/`PUBLIC` by default on new functions — explicitly revoked)
- Retrofits the `members` admin-update RLS policy onto `can_manage_members()`
- Generalizes `requireAdmin()` → `requireCapability(req, capability)`, checked via RPC as the caller instead of a service-role role lookup; updates the 4 audio-reader edge functions to use it
- Adds DI seams (`handler(req, deps)`) to make the capability-gated edge functions testable, mirroring the existing `cleanup-media`/`manage-subscription` pattern
- Documents the capability-function convention in `.claude/rules/supabase.md`
- pgTAP + Deno test coverage for the new functions and gate
- Makes the `update-tests` skill's final CI gate scope-aware (pgTAP/Deno for backend-only branches instead of a no-op Vitest run)

## Test plan

- [ ] pgTAP suite passes (`supabase test db`)
- [ ] Deno suite passes (`deno test` in `supabase/functions/`)
- [ ] Admin can still update another member's role/plan; non-admin cannot
- [ ] Audio-reader edge functions still reject non-admin callers with 403