### PR TITLE
chore(supabase): seed local DB with dummy member/decks/cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ vp check         # format + lint + type-check
 
 Local Supabase runs on port 54321 (API) and 54322 (Postgres). Start it with `supabase start` and apply migrations with `supabase migration up`. See [Supabase setup](docs/src/supabase/index.md) for details.
 
+`supabase db reset` seeds a demo member — log in with `cheesy@example.com` / `password` (2 decks, 500 + 200 dummy cards).
+
 ---
 
 ## Deploy

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -32,6 +32,12 @@ values (
 )
 on conflict (id) do nothing;
 
+-- Promote Cheesy to admin. The feedback board's roadmap-item seed migration
+-- (20260715000004) skips itself on a fresh DB because no admin exists yet at
+-- migration time — this also gives the feedback board something to moderate
+-- locally.
+update public.members set role = 'admin' where id = '00000000-0000-0000-0000-000000000001';
+
 -- -----------------------------------------------------------------------------
 -- 2. Impersonate Cheesy so member_id / rank triggers and RLS policies behave
 --    exactly as they would for a real authenticated request (same pattern as
@@ -94,6 +100,48 @@ where not exists (
   select 1 from public.cards c
   join public.decks d on d.id = c.deck_id
   where d.title = 'Deck Two' and d.member_id = '00000000-0000-0000-0000-000000000001'
+);
+
+-- -----------------------------------------------------------------------------
+-- 5. Feedback board roadmap items — same seed list as migration
+--    20260715000004, which skips itself when no admin exists yet.
+-- -----------------------------------------------------------------------------
+insert into public.feedback_items (title, body, type, status, visibility)
+select title, body, type, 'accepted', 'public'
+from (values
+  (
+    'Import & Export Decks',
+    'Import/export support for common flashcard formats so switching tools doesn''t mean losing your decks.',
+    'idea'::feedback_type
+  ),
+  (
+    'Card Audio Upload',
+    'Add sound to your cards — perfect for language decks, music theory, or anything that needs to be heard, not just read.',
+    'idea'::feedback_type
+  ),
+  (
+    'Share Decks with the Community',
+    'A community hub where members browse, save, and study each other''s public decks.',
+    'idea'::feedback_type
+  ),
+  (
+    'Challenges',
+    'Complete daily/weekly challenges to earn bonus rewards on top of normal study.',
+    'idea'::feedback_type
+  ),
+  (
+    'Collect Rewards for Everything You Do',
+    'Rewards for both big milestones and small daily actions, so there''s always something to work toward.',
+    'idea'::feedback_type
+  ),
+  (
+    'Paperclips & a Shop to Spend Them In',
+    'Paperclips are the in-app currency — earn them, then spend on shop items.',
+    'idea'::feedback_type
+  )
+) as seed(title, body, type)
+where not exists (
+  select 1 from public.feedback_items f where f.title = seed.title
 );
 
 set local role = 'postgres';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,102 @@
+-- =============================================================================
+-- Local dev seed data — runs automatically after `supabase migrations up`
+-- resets the local DB (see [db.seed] in supabase/config.toml).
+--
+-- Creates one member ("Cheesy") with two decks of dummy cards, so a fresh
+-- local DB always has something to look at without manual setup.
+-- =============================================================================
+
+begin;
+
+-- -----------------------------------------------------------------------------
+-- 1. Auth user. The create_member_on_new_user() trigger (see migration
+--    20250124191125) creates the matching public.members row automatically.
+-- -----------------------------------------------------------------------------
+insert into auth.users (
+  id, instance_id, aud, role, email, encrypted_password,
+  email_confirmed_at, raw_user_meta_data, created_at, updated_at,
+  confirmation_token, recovery_token, email_change_token_new, email_change
+)
+values (
+  '00000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000000',
+  'authenticated',
+  'authenticated',
+  'cheesy@example.com',
+  crypt('password', gen_salt('bf')),
+  now(),
+  jsonb_build_object('display_name', 'Cheesy'),
+  now(),
+  now(),
+  '', '', '', ''
+)
+on conflict (id) do nothing;
+
+-- -----------------------------------------------------------------------------
+-- 2. Impersonate Cheesy so member_id / rank triggers and RLS policies behave
+--    exactly as they would for a real authenticated request (same pattern as
+--    tests.set_claims() in supabase/tests/00000_helpers.sql).
+-- -----------------------------------------------------------------------------
+select set_config(
+  'request.jwt.claims',
+  json_build_object('sub', '00000000-0000-0000-0000-000000000001', 'role', 'authenticated')::text,
+  true
+);
+
+set local role = 'authenticated';
+
+-- -----------------------------------------------------------------------------
+-- 3. Decks
+-- -----------------------------------------------------------------------------
+insert into public.decks (title, description)
+select 'Everyday Japanese', 'Common words and phrases for daily conversation'
+where not exists (
+  select 1 from public.decks
+  where title = 'Everyday Japanese' and member_id = '00000000-0000-0000-0000-000000000001'
+);
+
+insert into public.decks (title, description)
+select 'JLPT N5 Vocabulary', 'Core vocab for the JLPT N5 exam'
+where not exists (
+  select 1 from public.decks
+  where title = 'JLPT N5 Vocabulary' and member_id = '00000000-0000-0000-0000-000000000001'
+);
+
+-- -----------------------------------------------------------------------------
+-- 4. Cards — via bulk_insert_cards_in_deck, same RPC the FE card importer
+--    uses (never raw cards.insert; rank must be server-computed).
+-- -----------------------------------------------------------------------------
+select public.bulk_insert_cards_in_deck(
+  (select id from public.decks
+   where title = 'Everyday Japanese' and member_id = '00000000-0000-0000-0000-000000000001'),
+  (select jsonb_agg(jsonb_build_object(
+     'front_text', 'Card ' || i || ' front',
+     'back_text', 'Card ' || i || ' back'
+   ))
+   from generate_series(1, 500) i)
+)
+where not exists (
+  select 1 from public.cards c
+  join public.decks d on d.id = c.deck_id
+  where d.title = 'Everyday Japanese' and d.member_id = '00000000-0000-0000-0000-000000000001'
+);
+
+select public.bulk_insert_cards_in_deck(
+  (select id from public.decks
+   where title = 'JLPT N5 Vocabulary' and member_id = '00000000-0000-0000-0000-000000000001'),
+  (select jsonb_agg(jsonb_build_object(
+     'front_text', 'Card ' || i || ' front',
+     'back_text', 'Card ' || i || ' back'
+   ))
+   from generate_series(1, 200) i)
+)
+where not exists (
+  select 1 from public.cards c
+  join public.decks d on d.id = c.deck_id
+  where d.title = 'JLPT N5 Vocabulary' and d.member_id = '00000000-0000-0000-0000-000000000001'
+);
+
+set local role = 'postgres';
+select set_config('request.jwt.claims', '', true);
+
+commit;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -49,17 +49,17 @@ set local role = 'authenticated';
 -- 3. Decks
 -- -----------------------------------------------------------------------------
 insert into public.decks (title, description)
-select 'Everyday Japanese', 'Common words and phrases for daily conversation'
+select 'Deck One', 'Dummy seed deck'
 where not exists (
   select 1 from public.decks
-  where title = 'Everyday Japanese' and member_id = '00000000-0000-0000-0000-000000000001'
+  where title = 'Deck One' and member_id = '00000000-0000-0000-0000-000000000001'
 );
 
 insert into public.decks (title, description)
-select 'JLPT N5 Vocabulary', 'Core vocab for the JLPT N5 exam'
+select 'Deck Two', 'Dummy seed deck'
 where not exists (
   select 1 from public.decks
-  where title = 'JLPT N5 Vocabulary' and member_id = '00000000-0000-0000-0000-000000000001'
+  where title = 'Deck Two' and member_id = '00000000-0000-0000-0000-000000000001'
 );
 
 -- -----------------------------------------------------------------------------
@@ -68,7 +68,7 @@ where not exists (
 -- -----------------------------------------------------------------------------
 select public.bulk_insert_cards_in_deck(
   (select id from public.decks
-   where title = 'Everyday Japanese' and member_id = '00000000-0000-0000-0000-000000000001'),
+   where title = 'Deck One' and member_id = '00000000-0000-0000-0000-000000000001'),
   (select jsonb_agg(jsonb_build_object(
      'front_text', 'Card ' || i || ' front',
      'back_text', 'Card ' || i || ' back'
@@ -78,12 +78,12 @@ select public.bulk_insert_cards_in_deck(
 where not exists (
   select 1 from public.cards c
   join public.decks d on d.id = c.deck_id
-  where d.title = 'Everyday Japanese' and d.member_id = '00000000-0000-0000-0000-000000000001'
+  where d.title = 'Deck One' and d.member_id = '00000000-0000-0000-0000-000000000001'
 );
 
 select public.bulk_insert_cards_in_deck(
   (select id from public.decks
-   where title = 'JLPT N5 Vocabulary' and member_id = '00000000-0000-0000-0000-000000000001'),
+   where title = 'Deck Two' and member_id = '00000000-0000-0000-0000-000000000001'),
   (select jsonb_agg(jsonb_build_object(
      'front_text', 'Card ' || i || ' front',
      'back_text', 'Card ' || i || ' back'
@@ -93,7 +93,7 @@ select public.bulk_insert_cards_in_deck(
 where not exists (
   select 1 from public.cards c
   join public.decks d on d.id = c.deck_id
-  where d.title = 'JLPT N5 Vocabulary' and d.member_id = '00000000-0000-0000-0000-000000000001'
+  where d.title = 'Deck Two' and d.member_id = '00000000-0000-0000-0000-000000000001'
 );
 
 set local role = 'postgres';


### PR DESCRIPTION
## Summary
- `supabase/seed.sql` seeds a demo member "Cheesy" (`cheesy@example.com` / `password`) with two decks ("Deck One": 500 cards, "Deck Two": 200 cards) via `bulk_insert_cards_in_deck`, so `supabase db reset` always lands in a usable state.
- README: note the seeded login credentials in the local dev section.