### PR TITLE
Default cover for decks created outside the FE

### DIFF
--- a/supabase/migrations/20260715000007_deck-cover-config-default.sql
+++ b/supabase/migrations/20260715000007_deck-cover-config-default.sql
@@ -1,0 +1,23 @@
+-- =============================================================================
+-- decks.cover_config was a plain nullable jsonb column with no default —
+-- the FE always sets a random cover on create (buildNewDeckPayload →
+-- randomCoverConfig()), but a deck inserted directly via SQL (seed data,
+-- manual fixes) got no cover, so card-cover.vue fell back to a flat purple
+-- background. Give it a real DB-level default and backfill existing rows.
+-- =============================================================================
+
+begin;
+
+alter table public.decks
+  alter column cover_config set default '{
+    "theme": "blue-500",
+    "theme_dark": "blue-650",
+    "pattern": "diagonal-stripes",
+    "icon": "symbol-spades"
+  }'::jsonb;
+
+update public.decks
+set cover_config = default
+where cover_config is null;
+
+commit;

--- a/supabase/tests/00025_decks_cover_config_default.sql
+++ b/supabase/tests/00025_decks_cover_config_default.sql
@@ -1,0 +1,91 @@
+-- =============================================================================
+-- decks.cover_config default: a deck inserted without cover_config should get
+-- the blue-500/diagonal-stripes/symbol-spades fallback, not null. A deck that
+-- explicitly supplies its own cover_config keeps it.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(3);
+
+-- ── Setup ─────────────────────────────────────────────────────────────────────
+
+SELECT tests.create_user('33333333-3333-3333-3333-333333333333'::uuid, 'carol_cover');
+
+SELECT tests.set_claims('33333333-3333-3333-3333-333333333333'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 1: omitting cover_config lands with the DB-level default, not null.
+INSERT INTO public.decks (id, title) VALUES (300, 'Carol Default Cover Deck');
+
+SELECT is(
+  (SELECT cover_config FROM public.decks WHERE id = 300),
+  '{
+    "theme": "blue-500",
+    "theme_dark": "blue-650",
+    "pattern": "diagonal-stripes",
+    "icon": "symbol-spades"
+  }'::jsonb,
+  'deck inserted without cover_config gets the default cover, not null'
+);
+
+-- Test 2: explicitly supplying cover_config is not overwritten by the default.
+INSERT INTO public.decks (id, title, cover_config) VALUES (
+  301,
+  'Carol Custom Cover Deck',
+  '{
+    "theme": "green-500",
+    "theme_dark": "green-650",
+    "pattern": "polka-dots",
+    "icon": "symbol-clubs"
+  }'::jsonb
+);
+
+SELECT is(
+  (SELECT cover_config FROM public.decks WHERE id = 301),
+  '{
+    "theme": "green-500",
+    "theme_dark": "green-650",
+    "pattern": "polka-dots",
+    "icon": "symbol-clubs"
+  }'::jsonb,
+  'deck inserted with an explicit cover_config keeps it, not overwritten by the default'
+);
+
+-- Test 3: the column default itself is the expected jsonb (proxy for backfill
+-- correctness, since existing rows in this DB were already backfilled by the
+-- migration and re-nulling a row to retest backfill semantics isn't practical).
+SET LOCAL role = 'postgres';
+
+-- column_default is the literal SQL text (e.g. `'{"icon": "symbol-spades", ...}'::jsonb`),
+-- not a jsonb value itself, so evaluate it to compare as real jsonb.
+DO $$
+DECLARE
+  default_sql text;
+  evaluated jsonb;
+BEGIN
+  SELECT column_default INTO default_sql
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'decks'
+    AND column_name = 'cover_config';
+
+  EXECUTE format('SELECT %s', default_sql) INTO evaluated;
+
+  PERFORM set_config('tests.decks_cover_config_default', evaluated::text, true);
+END;
+$$;
+
+SELECT is(
+  current_setting('tests.decks_cover_config_default')::jsonb,
+  '{
+    "theme": "blue-500",
+    "theme_dark": "blue-650",
+    "pattern": "diagonal-stripes",
+    "icon": "symbol-spades"
+  }'::jsonb,
+  'decks.cover_config column default is set to the fallback cover'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

Decks inserted directly via SQL (seed data, manual fixes) had a null `cover_config` and rendered as a flat purple card, since `card-cover.vue`'s fallback theme is purple. This gives `decks.cover_config` a real DB-level default so any raw insert gets a proper cover, and backfills existing null rows.

## Changes

- `supabase/migrations/20260715000007_deck-cover-config-default.sql` — sets a column default (`blue-500`/`blue-650`, `diagonal-stripes` pattern, `symbol-spades` icon) and backfills existing null rows.
- `supabase/tests/00025_decks_cover_config_default.sql` — pgTAP coverage: omitted `cover_config` gets the default, an explicit `cover_config` is preserved, and the column default itself is correct.

## Test plan

- [x] `supabase test db` — full suite green (28 files, 234 tests)
- [x] `vp lint` / `pnpm type-check` clean