### PR TITLE
Rotating tip card on the dashboard

### DIFF
--- a/.claude/skills/fork-dev/SKILL.md
+++ b/.claude/skills/fork-dev/SKILL.md
@@ -61,20 +61,28 @@ Symlink `node_modules` so Vite runs without a fresh install:
 ln -s "$(pwd)/node_modules" "../TaroFlash-<slug>/node_modules"
 ```
 
-Copy all gitignored env files that exist — missing env vars cause silent runtime crashes:
+Copy all gitignored env files that exist — missing env vars cause silent runtime crashes. Use `setopt nullglob` (not a bare glob) so a non-matching pattern doesn't abort the whole loop under zsh:
 
 ```sh
+setopt nullglob
 for f in .env .env.local .env.*.local; do
   [ -f "$f" ] && cp "$f" "../TaroFlash-<slug>/$f"
 done
+unsetopt nullglob
+```
+
+**Secrets manager**: this project pulls `VITE_SUPABASE_*` and other secrets from Doppler at runtime (`doppler run -- vp dev`), not from `.env` — `.env` only holds non-secret vars like `VITE_LOG_LEVEL`. Doppler's project/config scope is set per-directory and does **not** carry over to the worktree, so it must be scoped there explicitly or the dev server will fail with errors like `supabaseUrl is required`:
+
+```sh
+cd ../TaroFlash-<slug> && doppler setup --project taroflash --config dev --no-interactive
 ```
 
 ### Step 4 — Start the dev server
 
-Run in the background (`run_in_background: true`):
+Run in the background (`run_in_background: true`), through Doppler so secrets are injected:
 
 ```sh
-cd ../TaroFlash-<slug> && VITE_APP_TITLE="[<slug>] TaroFlash" node_modules/.bin/vp dev --port <port> --host 2>&1 | tee /tmp/fork-dev-<slug>.log
+cd ../TaroFlash-<slug> && VITE_APP_TITLE="[<slug>] TaroFlash" doppler run -- node_modules/.bin/vp dev --port <port> --host 2>&1 | tee /tmp/fork-dev-<slug>.log
 ```
 
 Poll for the URL instead of sleeping a fixed amount:
@@ -102,6 +110,7 @@ To clean: git worktree remove ../TaroFlash-<slug>
 - The worktree shares the main repo's git object store — branches are isolated from each other and from the main checkout.
 - Don't run `vp install` in the worktree — `node_modules` is symlinked from the main repo.
 - If `vp dev` fails to start, read `/tmp/fork-dev-<slug>.log` and surface the error.
+- If the log shows `supabaseUrl is required` (or other missing-secret errors), Doppler wasn't scoped to the worktree — run `doppler setup --project taroflash --config dev --no-interactive` in it and restart the server.
 - `git worktree remove ../TaroFlash-<slug>` will refuse if there are uncommitted changes; use `--force` only after the agent's work is merged or discarded.
 
 ---

--- a/src/components/ui-kit/tape.vue
+++ b/src/components/ui-kit/tape.vue
@@ -1,20 +1,16 @@
 <script setup lang="ts">
-defineSlots<{
-  default?(): unknown
+defineProps<{
+  label?: string
 }>()
 </script>
 
 <template>
   <div
     data-testid="ui-kit-tape"
-    class="relative inline-flex items-center justify-center whitespace-nowrap px-8 py-2 opacity-90 bg-(--theme-accent) bgx-leaf bgx-color-[var(--theme-on-accent)] bgx-opacity-15 bgx-size-20 tape-edges"
+    class="inline-flex items-center justify-center whitespace-nowrap px-8 py-2 bg-(--theme-primary)/70 tape-edges"
   >
-    <span
-      v-if="$slots.default"
-      data-testid="ui-kit-tape__label"
-      class="relative text-(--theme-on-accent)"
-    >
-      <slot></slot>
+    <span v-if="label" data-testid="ui-kit-tape__label" class="text-brown-100 text-xl">
+      {{ label }}
     </span>
   </div>
 </template>

--- a/src/components/ui-kit/tape.vue
+++ b/src/components/ui-kit/tape.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+defineSlots<{
+  default?(): unknown
+}>()
+</script>
+
+<template>
+  <div
+    data-testid="ui-kit-tape"
+    class="relative inline-flex items-center justify-center whitespace-nowrap px-8 py-2 opacity-90 bg-(--theme-accent) bgx-leaf bgx-color-[var(--theme-on-accent)] bgx-opacity-15 bgx-size-20 tape-edges"
+  >
+    <span
+      v-if="$slots.default"
+      data-testid="ui-kit-tape__label"
+      class="relative text-(--theme-on-accent)"
+    >
+      <slot></slot>
+    </span>
+  </div>
+</template>

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -416,6 +416,7 @@
   "dashboard.mobile-footer.edit-decks-label": "Edit Decks",
   "dashboard.mobile-footer.done-editing-label": "Stop Editing",
   "dashboard.mobile-footer.study-button": "Study {count} Deck | Study {count} Decks",
+  "dashboard.tip-card.tape-label": "Tip",
   "dialog-card.close-label": "Close",
   "dialog-card.back-label": "Back",
   "review-inbox.cards-due-heading": "{count} card due | {count} cards due",
@@ -771,5 +772,7 @@
   "terms-of-service.section-6.title": "Termination",
   "terms-of-service.section-6.content": "Accounts may be suspended or deleted if these terms are violated.",
   "terms-of-service.section-7.title": "Changes to These Terms",
-  "terms-of-service.section-7.content": "These terms may be updated periodically. Continued use of the service constitutes acceptance of the updated terms."
+  "terms-of-service.section-7.content": "These terms may be updated periodically. Continued use of the service constitutes acceptance of the updated terms.",
+  "tips.shortcuts-overview.title": "Shortcuts",
+  "tips.shortcuts-overview.body": "Most actions have a keyboard shortcut! Take a look at the shortcuts app in the Phone Menu to see which shortcuts are available at any time."
 }

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -777,7 +777,7 @@
   "tips.sound.body": "If you're not hearing sounds on your phone try taking it off silent or wearing headphones!",
   "tips.cards.title": "Cards",
   "tips.cards.body": "The front and back faces of your cards are fully customizable in the deck settings.",
-  "tips.companion-window.title": "Small Window",
+  "tips.companion-window.title": "Pocket Size",
   "tips.companion-window.body": "TaroFlash works great at small sizes — keep it as a companion window beside your other tabs.",
   "tips.horizontal-scroll.title": "Scrolling",
   "tips.horizontal-scroll.body": "Need to scroll sideways? Hold shift while you scroll.",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -773,6 +773,16 @@
   "terms-of-service.section-6.content": "Accounts may be suspended or deleted if these terms are violated.",
   "terms-of-service.section-7.title": "Changes to These Terms",
   "terms-of-service.section-7.content": "These terms may be updated periodically. Continued use of the service constitutes acceptance of the updated terms.",
-  "tips.shortcuts-overview.title": "Shortcuts",
-  "tips.shortcuts-overview.body": "Most actions have a keyboard shortcut! Take a look at the shortcuts app in the Phone Menu to see which shortcuts are available at any time."
+  "tips.sound.title": "Sound",
+  "tips.sound.body": "If you're not hearing sounds on your phone try taking it off silent or wearing headphones!",
+  "tips.cards.title": "Cards",
+  "tips.cards.body": "The front and back faces of your cards are fully customizable in the deck settings.",
+  "tips.companion-window.title": "Small Window",
+  "tips.companion-window.body": "TaroFlash works great at small sizes — keep it as a companion window beside your other tabs.",
+  "tips.horizontal-scroll.title": "Scrolling",
+  "tips.horizontal-scroll.body": "Need to scroll sideways? Hold shift while you scroll.",
+  "tips.swipe-rating.title": "Study Session",
+  "tips.swipe-rating.body": "Swiping right to pass a card? Drag up or down before releasing to choose how well it went.",
+  "tips.feedback.title": "Feedback",
+  "tips.feedback.body": "Have a feature idea, or found something broken? Send it through the feedback app in the phone menu."
 }

--- a/src/styles/border-utils.css
+++ b/src/styles/border-utils.css
@@ -72,6 +72,28 @@
   mask: var(--cloud-mask);
 }
 
+@utility tape-edges {
+  /* 3-tooth sawtooth cut into the left and right edges; top/bottom stay flat. */
+  --tape-cut: 7%;
+
+  clip-path: polygon(
+    0% 0%,
+    var(--tape-cut) 16.667%,
+    0% 33.333%,
+    var(--tape-cut) 50%,
+    0% 66.667%,
+    var(--tape-cut) 83.333%,
+    0% 100%,
+    100% 100%,
+    calc(100% - var(--tape-cut)) 83.333%,
+    100% 66.667%,
+    calc(100% - var(--tape-cut)) 50%,
+    100% 33.333%,
+    calc(100% - var(--tape-cut)) 16.667%,
+    100% 0%
+  );
+}
+
 @utility cloud-top-* {
   /* main control — depth of the flat cut, not the bump radius */
   --cloud-size: --value([length]);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -244,7 +244,7 @@
     font-family: var(--font-primary);
     font-size: var(--text-base);
     line-height: var(--text-base--line-height);
-    background-color: var(--color-brown-200);
+    background-color: var(--color-brown-100);
   }
 
   body {

--- a/src/utils/tips/catalog.ts
+++ b/src/utils/tips/catalog.ts
@@ -1,4 +1,4 @@
-export type TipCategory = 'shortcuts'
+export type TipCategory = 'sound' | 'cards' | 'browser' | 'shortcuts' | 'study-session' | 'feedback'
 
 export type Tip = {
   id: string
@@ -13,9 +13,39 @@ export type Tip = {
  */
 export const TIPS: Tip[] = [
   {
-    id: 'shortcuts-overview',
+    id: 'sound',
+    category: 'sound',
+    title_key: 'tips.sound.title',
+    body_key: 'tips.sound.body'
+  },
+  {
+    id: 'cards',
+    category: 'cards',
+    title_key: 'tips.cards.title',
+    body_key: 'tips.cards.body'
+  },
+  {
+    id: 'companion-window',
+    category: 'browser',
+    title_key: 'tips.companion-window.title',
+    body_key: 'tips.companion-window.body'
+  },
+  {
+    id: 'horizontal-scroll',
     category: 'shortcuts',
-    title_key: 'tips.shortcuts-overview.title',
-    body_key: 'tips.shortcuts-overview.body'
+    title_key: 'tips.horizontal-scroll.title',
+    body_key: 'tips.horizontal-scroll.body'
+  },
+  {
+    id: 'swipe-rating',
+    category: 'study-session',
+    title_key: 'tips.swipe-rating.title',
+    body_key: 'tips.swipe-rating.body'
+  },
+  {
+    id: 'feedback',
+    category: 'feedback',
+    title_key: 'tips.feedback.title',
+    body_key: 'tips.feedback.body'
   }
 ]

--- a/src/utils/tips/catalog.ts
+++ b/src/utils/tips/catalog.ts
@@ -1,0 +1,21 @@
+export type TipCategory = 'shortcuts'
+
+export type Tip = {
+  id: string
+  category: TipCategory
+  title_key: string
+  body_key: string
+}
+
+/**
+ * Single source of truth for tip content. The dashboard rotates through these;
+ * a future standalone tips app will browse/filter the same list by `category`.
+ */
+export const TIPS: Tip[] = [
+  {
+    id: 'shortcuts-overview',
+    category: 'shortcuts',
+    title_key: 'tips.shortcuts-overview.title',
+    body_key: 'tips.shortcuts-overview.body'
+  }
+]

--- a/src/views/dashboard/actions-panel/index.vue
+++ b/src/views/dashboard/actions-panel/index.vue
@@ -97,8 +97,8 @@ async function onSelect(value: string) {
         data-testid="dashboard-actions-panel__study-button"
         size="xl"
         icon-left="book-flip-page"
-        data-theme="yellow-500"
-        data-theme-dark="yellow-700"
+        data-theme="blue-500"
+        data-theme-dark="blue-650"
         full-width
         :disabled="editing_decks || due_decks.length === 0"
         @press="onStudyAll"

--- a/src/views/dashboard/actions-panel/index.vue
+++ b/src/views/dashboard/actions-panel/index.vue
@@ -100,7 +100,6 @@ async function onSelect(value: string) {
         data-theme="yellow-500"
         data-theme-dark="yellow-700"
         full-width
-        class="max-mxl:hidden!"
         :disabled="editing_decks || due_decks.length === 0"
         @press="onStudyAll"
       >

--- a/src/views/dashboard/actions-panel/shell.vue
+++ b/src/views/dashboard/actions-panel/shell.vue
@@ -13,7 +13,7 @@ defineSlots<{
 </script>
 
 <template>
-  <div class="rounded-8 relative flex flex-col w-full max-w-100">
+  <div class="rounded-8 relative flex flex-col w-full max-w-86.25 shrink-0">
     <slot name="polaroid" />
 
     <div data-testid="dashboard-actions-panel-shell__header" class="p-6 pl-34">
@@ -22,7 +22,7 @@ defineSlots<{
 
     <div
       data-testid="dashboard-actions-panel-shell__body"
-      class="cloud-top-[40px] rounded-b-8 flex flex-col gap-6 px-4 pt-14 pb-6"
+      class="cloud-top-[40px] rounded-b-8 flex flex-col gap-6 px-4 pt-14 pb-6 h-full max-mxl:justify-end"
       :class="body_class"
     >
       <slot name="body" />

--- a/src/views/dashboard/dashboard-shell.vue
+++ b/src/views/dashboard/dashboard-shell.vue
@@ -12,7 +12,7 @@ defineSlots<{
   >
     <div
       data-testid="dashboard-shell__left-column"
-      class="flex flex-col gap-6 self-start mxl:sticky mxl:top-(--nav-height)"
+      class="flex justify-center xs:justify-start mxl:flex-col gap-6 self-start mxl:sticky mxl:top-(--nav-height)"
     >
       <slot name="left" />
     </div>

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -65,9 +65,7 @@ const show_skeleton = computed(() => !decks_data.value)
           @toggle-edit-decks="onToggleEditDecks"
         />
 
-        <div class="mt-6">
-          <dashboard-tip-card />
-        </div>
+        <dashboard-tip-card />
       </template>
 
       <template #right>

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -7,6 +7,7 @@ import { useCan } from '@/composables/can'
 import { useLocalRef } from '@/composables/storage/local-ref'
 import { emitSfx } from '@/sfx/bus'
 import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
+import UiTape from '@/components/ui-kit/tape.vue'
 import DashboardShell from './dashboard-shell.vue'
 import DashboardSkeleton from './skeleton.vue'
 import DashboardSection from './dashboard-section.vue'
@@ -63,6 +64,10 @@ const show_skeleton = computed(() => !decks_data.value)
           :editing_decks="editing_decks"
           @toggle-edit-decks="onToggleEditDecks"
         />
+
+        <div class="mt-6 flex justify-center">
+          <ui-tape>Tip</ui-tape>
+        </div>
       </template>
 
       <template #right>

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -7,7 +7,6 @@ import { useCan } from '@/composables/can'
 import { useLocalRef } from '@/composables/storage/local-ref'
 import { emitSfx } from '@/sfx/bus'
 import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
-import UiTape from '@/components/ui-kit/tape.vue'
 import DashboardShell from './dashboard-shell.vue'
 import DashboardSkeleton from './skeleton.vue'
 import DashboardSection from './dashboard-section.vue'
@@ -17,6 +16,7 @@ import ReviewInbox from './review-inbox/index.vue'
 import DeckGrid from './deck-grid/index.vue'
 import DeckGridSortOptions, { type SortOption } from './deck-grid/sort-options.vue'
 import AudioReaderSection from './audio-reader-section.vue'
+import DashboardTipCard from './tip-card/index.vue'
 
 const DECK_SORT_COMPARATORS: Record<SortOption, (a: Deck, b: Deck) => number> = {
   custom: (a, b) => (a.rank ?? 0) - (b.rank ?? 0),
@@ -65,8 +65,8 @@ const show_skeleton = computed(() => !decks_data.value)
           @toggle-edit-decks="onToggleEditDecks"
         />
 
-        <div class="mt-6 flex justify-center">
-          <ui-tape>Tip</ui-tape>
+        <div class="mt-6">
+          <dashboard-tip-card />
         </div>
       </template>
 

--- a/src/views/dashboard/skeleton.vue
+++ b/src/views/dashboard/skeleton.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import DashboardShell from './dashboard-shell.vue'
 import DashboardSection from './dashboard-section.vue'
 import DashboardActionsPanelSkeleton from './actions-panel/skeleton.vue'
+import DashboardTipCardSkeleton from './tip-card/skeleton.vue'
 import ReviewInboxSkeleton from './review-inbox/skeleton.vue'
 import DeckGridSkeleton from './deck-grid/skeleton.vue'
 
@@ -18,6 +19,7 @@ onUnmounted(() => (document.documentElement.style.overflow = ''))
     <dashboard-shell>
       <template #left>
         <dashboard-actions-panel-skeleton />
+        <dashboard-tip-card-skeleton />
       </template>
 
       <template #right>

--- a/src/views/dashboard/tip-card/index.vue
+++ b/src/views/dashboard/tip-card/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import UiTape from '@/components/ui-kit/tape.vue'
+import { fadeEnter, fadeLeave } from '@/utils/animations/fade'
 import { useTipRotation } from './use-tip-rotation'
 
 const { t } = useI18n()
@@ -10,7 +11,7 @@ const { tip } = useTipRotation()
 <template>
   <div
     data-testid="dashboard-tip-card"
-    class="mt-6 w-full rounded-4 relative hidden md:flex flex-col items-center gap-2 bg-brown-50 dark:bg-stone-700 px-6 pt-8 pb-6 text-center"
+    class="mt-6 h-47.5 w-full rounded-4 relative hidden md:flex flex-col items-center justify-center gap-2 bg-brown-50 dark:bg-stone-700 px-10 text-center"
   >
     <ui-tape
       data-testid="dashboard-tip-card__tape"
@@ -20,23 +21,26 @@ const { tip } = useTipRotation()
       :label="t('dashboard.tip-card.tape-label')"
     />
 
-    <h3
-      data-testid="dashboard-tip-card__title"
-      class="mt-4 text-brown-700 dark:text-brown-100 text-xl"
-    >
-      {{ t(tip.title_key) }}
-    </h3>
+    <Transition :css="false" @enter="fadeEnter" @leave="fadeLeave">
+      <div
+        :key="tip.id"
+        data-testid="dashboard-tip-card__content"
+        class="absolute inset-0 flex flex-col items-center justify-center gap-2 px-10"
+      >
+        <h3
+          data-testid="dashboard-tip-card__title"
+          class="text-brown-700 dark:text-brown-100 text-xl"
+        >
+          {{ t(tip.title_key) }}
+        </h3>
 
-    <div
-      data-testid="dashboard-tip-card__divider"
-      aria-hidden="true"
-      class="text-brown-700 dark:text-stone-100"
-    >
-      ―
-    </div>
-
-    <p data-testid="dashboard-tip-card__body" class="text-brown-500 dark:text-brown-300 text-base">
-      {{ t(tip.body_key) }}
-    </p>
+        <p
+          data-testid="dashboard-tip-card__body"
+          class="text-brown-500 dark:text-brown-300 text-base"
+        >
+          {{ t(tip.body_key) }}
+        </p>
+      </div>
+    </Transition>
   </div>
 </template>

--- a/src/views/dashboard/tip-card/index.vue
+++ b/src/views/dashboard/tip-card/index.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import UiTape from '@/components/ui-kit/tape.vue'
+import { useTipRotation } from './use-tip-rotation'
+
+const { t } = useI18n()
+const { tip } = useTipRotation()
+</script>
+
+<template>
+  <div
+    data-testid="dashboard-tip-card"
+    class="rounded-4 relative flex flex-col items-center gap-2 bg-brown-50 dark:bg-stone-700 px-6 pt-8 pb-6 text-center"
+  >
+    <ui-tape
+      data-testid="dashboard-tip-card__tape"
+      data-theme="yellow-500"
+      data-theme-dark="yellow-700"
+      class="absolute -top-4 rotate-3 w-40 bgx-leaf"
+      :label="t('dashboard.tip-card.tape-label')"
+    />
+
+    <h3
+      data-testid="dashboard-tip-card__title"
+      class="mt-4 text-brown-700 dark:text-brown-100 text-xl"
+    >
+      {{ t(tip.title_key) }}
+    </h3>
+
+    <div
+      data-testid="dashboard-tip-card__divider"
+      aria-hidden="true"
+      class="text-brown-700 dark:text-stone-100"
+    >
+      ―
+    </div>
+
+    <p data-testid="dashboard-tip-card__body" class="text-brown-500 dark:text-brown-300 text-base">
+      {{ t(tip.body_key) }}
+    </p>
+  </div>
+</template>

--- a/src/views/dashboard/tip-card/index.vue
+++ b/src/views/dashboard/tip-card/index.vue
@@ -10,7 +10,7 @@ const { tip } = useTipRotation()
 <template>
   <div
     data-testid="dashboard-tip-card"
-    class="rounded-4 relative flex flex-col items-center gap-2 bg-brown-50 dark:bg-stone-700 px-6 pt-8 pb-6 text-center"
+    class="mt-6 w-full rounded-4 relative hidden md:flex flex-col items-center gap-2 bg-brown-50 dark:bg-stone-700 px-6 pt-8 pb-6 text-center"
   >
     <ui-tape
       data-testid="dashboard-tip-card__tape"

--- a/src/views/dashboard/tip-card/skeleton.vue
+++ b/src/views/dashboard/tip-card/skeleton.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     data-testid="dashboard-tip-card-skeleton"
-    class="mt-6 w-full rounded-4 relative hidden md:flex flex-col items-center gap-3 bg-brown-200 dark:bg-stone-700 px-6 pt-8 pb-6"
+    class="mt-6 h-47.5 w-full rounded-4 relative hidden md:flex flex-col items-center justify-center gap-3 bg-brown-200 dark:bg-stone-700 px-10"
   >
     <div
       data-testid="dashboard-tip-card-skeleton__tape"
@@ -9,11 +9,11 @@
     ></div>
 
     <div
-      class="mt-4 h-6 w-24 bg-brown-300 dark:bg-stone-900 rounded-2 animate-pulse bgx-diagonal-stripes bgx-size-15 bgx-opacity-40 bgx-color-(--color-brown-50) dark:bgx-color-(--color-grey-700)"
+      class="h-6 w-24 bg-brown-300 dark:bg-stone-900 rounded-2 animate-pulse bgx-diagonal-stripes bgx-size-15 bgx-opacity-40 bgx-color-(--color-brown-50) dark:bgx-color-(--color-grey-700)"
     ></div>
 
     <div
-      class="h-24 w-full max-w-80 bg-brown-300 dark:bg-stone-900 rounded-2 animate-pulse bgx-diagonal-stripes bgx-size-15 bgx-opacity-40 bgx-color-(--color-brown-50) dark:bgx-color-(--color-grey-700)"
+      class="h-10 w-full max-w-80 bg-brown-300 dark:bg-stone-900 rounded-2 animate-pulse bgx-diagonal-stripes bgx-size-15 bgx-opacity-40 bgx-color-(--color-brown-50) dark:bgx-color-(--color-grey-700)"
     ></div>
   </div>
 </template>

--- a/src/views/dashboard/tip-card/skeleton.vue
+++ b/src/views/dashboard/tip-card/skeleton.vue
@@ -1,0 +1,19 @@
+<template>
+  <div
+    data-testid="dashboard-tip-card-skeleton"
+    class="mt-6 w-full rounded-4 relative hidden md:flex flex-col items-center gap-3 bg-brown-200 dark:bg-stone-700 px-6 pt-8 pb-6"
+  >
+    <div
+      data-testid="dashboard-tip-card-skeleton__tape"
+      class="absolute -top-4 rotate-3 h-9 w-40 rounded-1 bg-brown-300 dark:bg-stone-900 animate-pulse bgx-diagonal-stripes bgx-size-15 bgx-opacity-40 bgx-color-(--color-brown-50) dark:bgx-color-(--color-grey-700)"
+    ></div>
+
+    <div
+      class="mt-4 h-6 w-24 bg-brown-300 dark:bg-stone-900 rounded-2 animate-pulse bgx-diagonal-stripes bgx-size-15 bgx-opacity-40 bgx-color-(--color-brown-50) dark:bgx-color-(--color-grey-700)"
+    ></div>
+
+    <div
+      class="h-24 w-full max-w-80 bg-brown-300 dark:bg-stone-900 rounded-2 animate-pulse bgx-diagonal-stripes bgx-size-15 bgx-opacity-40 bgx-color-(--color-brown-50) dark:bgx-color-(--color-grey-700)"
+    ></div>
+  </div>
+</template>

--- a/src/views/dashboard/tip-card/use-tip-rotation.ts
+++ b/src/views/dashboard/tip-card/use-tip-rotation.ts
@@ -1,7 +1,7 @@
 import { computed, onBeforeUnmount, ref } from 'vue'
 import { TIPS } from '@/utils/tips/catalog'
 
-const ROTATE_INTERVAL_MS = 15000
+const ROTATE_INTERVAL_MS = 30000
 
 export function useTipRotation() {
   const index = ref(Math.floor(Math.random() * TIPS.length))

--- a/src/views/dashboard/tip-card/use-tip-rotation.ts
+++ b/src/views/dashboard/tip-card/use-tip-rotation.ts
@@ -1,0 +1,21 @@
+import { computed, onBeforeUnmount, ref } from 'vue'
+import { TIPS } from '@/utils/tips/catalog'
+
+const ROTATE_INTERVAL_MS = 15000
+
+export function useTipRotation() {
+  const index = ref(Math.floor(Math.random() * TIPS.length))
+
+  const timer =
+    TIPS.length > 1
+      ? setInterval(() => {
+          index.value = (index.value + 1) % TIPS.length
+        }, ROTATE_INTERVAL_MS)
+      : undefined
+
+  onBeforeUnmount(() => clearInterval(timer))
+
+  const tip = computed(() => TIPS[index.value])
+
+  return { tip }
+}

--- a/tests/integration/components/ui-kit/tape.test.js
+++ b/tests/integration/components/ui-kit/tape.test.js
@@ -1,0 +1,16 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+
+import UiTape from '@/components/ui-kit/tape.vue'
+
+describe('ui-kit/tape', () => {
+  test('renders the label when passed', () => {
+    const wrapper = mount(UiTape, { props: { label: 'Tip' } })
+    expect(wrapper.find('[data-testid="ui-kit-tape__label"]').text()).toBe('Tip')
+  })
+
+  test('renders nothing in the label slot when label is omitted', () => {
+    const wrapper = mount(UiTape)
+    expect(wrapper.find('[data-testid="ui-kit-tape__label"]').exists()).toBe(false)
+  })
+})

--- a/tests/integration/views/dashboard/index.test.js
+++ b/tests/integration/views/dashboard/index.test.js
@@ -153,6 +153,11 @@ const AudioReaderSectionStub = defineComponent({
   }
 })
 
+const DashboardTipCardStub = defineComponent({
+  name: 'DashboardTipCard',
+  setup: () => () => h('div', { 'data-testid': 'dashboard-tip-card-stub' })
+})
+
 const DashboardMobileFooterStub = defineComponent({
   name: 'DashboardMobileFooter',
   props: ['due_decks', 'editing_decks'],
@@ -191,6 +196,7 @@ function mountDashboard() {
         DeckGrid: DeckGridStub,
         DeckGridSortOptions: DeckGridSortOptionsStub,
         AudioReaderSection: AudioReaderSectionStub,
+        DashboardTipCard: DashboardTipCardStub,
         DashboardMobileFooter: DashboardMobileFooterStub
       }
     }
@@ -388,6 +394,15 @@ describe('DashboardIndex — skeleton gating [obligation]', () => {
     expect(noticeErrorMock).toHaveBeenCalledWith("Couldn't load your decks. Please try again.")
     expect(wrapper.find('[data-testid="dashboard-skeleton-stub"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="dashboard"]').exists()).toBe(false)
+  })
+})
+
+describe('DashboardIndex — left column layout', () => {
+  test('renders dashboard-tip-card below dashboard-actions-panel in the left slot', () => {
+    const wrapper = mountDashboard()
+    const left = wrapper.find('[data-testid="dashboard-shell"]')
+    expect(left.find('[data-testid="dashboard-actions-panel"]').exists()).toBe(true)
+    expect(left.find('[data-testid="dashboard-tip-card-stub"]').exists()).toBe(true)
   })
 })
 

--- a/tests/integration/views/dashboard/skeleton.test.js
+++ b/tests/integration/views/dashboard/skeleton.test.js
@@ -53,9 +53,10 @@ describe('DashboardSkeleton (views/dashboard/skeleton.vue)', () => {
     expect(wrapper.find('[data-testid="dashboard-skeleton"]').exists()).toBe(true)
   })
 
-  test('includes DashboardActionsPanelSkeleton in the left column', () => {
+  test('includes DashboardActionsPanelSkeleton and DashboardTipCardSkeleton in the left column', () => {
     const wrapper = mountSkeleton()
     expect(wrapper.find('[data-testid="actions-panel-skeleton-stub"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="dashboard-tip-card-skeleton"]').exists()).toBe(true)
   })
 
   test('includes ReviewInboxSkeleton and DeckGridSkeleton in the right column', () => {

--- a/tests/integration/views/dashboard/tip-card/index.test.js
+++ b/tests/integration/views/dashboard/tip-card/index.test.js
@@ -1,0 +1,61 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { shallowMount } from '@vue/test-utils'
+
+vi.mock('gsap', () => ({
+  gsap: {
+    fromTo: vi.fn((_el, _from, to) => to?.onComplete?.()),
+    to: vi.fn((_el, opts) => opts?.onComplete?.())
+  }
+}))
+
+import DashboardTipCard from '@/views/dashboard/tip-card/index.vue'
+import { TIPS } from '@/utils/tips/catalog'
+
+beforeEach(() => {
+  vi.spyOn(Math, 'random')
+})
+
+afterEach(() => {
+  Math.random.mockRestore()
+})
+
+describe('DashboardTipCard', () => {
+  test('renders the title and body for the tip useTipRotation currently points to (not hardcoded to TIPS[0])', () => {
+    // Force a non-first tip so the assertion only passes if the component
+    // reads the live tip from the composable rather than TIPS[0].
+    Math.random.mockReturnValue(0.9)
+    const expected_index = Math.floor(0.9 * TIPS.length)
+    const expected_tip = TIPS[expected_index]
+
+    const wrapper = shallowMount(DashboardTipCard)
+
+    expect(wrapper.find('[data-testid="dashboard-tip-card__title"]').text()).toBe(
+      wrapper.vm.$t(expected_tip.title_key)
+    )
+    expect(wrapper.find('[data-testid="dashboard-tip-card__body"]').text()).toBe(
+      wrapper.vm.$t(expected_tip.body_key)
+    )
+    expect(expected_index).not.toBe(0)
+  })
+
+  test('renders the title and body matching the first tip when the composable points to index 0', () => {
+    Math.random.mockReturnValue(0)
+    const expected_tip = TIPS[0]
+
+    const wrapper = shallowMount(DashboardTipCard)
+
+    expect(wrapper.find('[data-testid="dashboard-tip-card__title"]').text()).toBe(
+      wrapper.vm.$t(expected_tip.title_key)
+    )
+    expect(wrapper.find('[data-testid="dashboard-tip-card__body"]').text()).toBe(
+      wrapper.vm.$t(expected_tip.body_key)
+    )
+  })
+
+  test('passes the translated tape-label to the tape component', () => {
+    Math.random.mockReturnValue(0)
+    const wrapper = shallowMount(DashboardTipCard)
+    const tape = wrapper.findComponent({ name: 'UiTape' })
+    expect(tape.props('label')).toBe(wrapper.vm.$t('dashboard.tip-card.tape-label'))
+  })
+})

--- a/tests/integration/views/dashboard/tip-card/skeleton.test.js
+++ b/tests/integration/views/dashboard/tip-card/skeleton.test.js
@@ -1,0 +1,11 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+
+import DashboardTipCardSkeleton from '@/views/dashboard/tip-card/skeleton.vue'
+
+describe('DashboardTipCardSkeleton', () => {
+  test('renders the root with data-testid="dashboard-tip-card-skeleton"', () => {
+    const wrapper = mount(DashboardTipCardSkeleton)
+    expect(wrapper.find('[data-testid="dashboard-tip-card-skeleton"]').exists()).toBe(true)
+  })
+})

--- a/tests/unit/utils/tips/catalog.test.js
+++ b/tests/unit/utils/tips/catalog.test.js
@@ -1,0 +1,18 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { TIPS } from '@/utils/tips/catalog'
+
+describe('tips catalog', () => {
+  test('every tip has non-empty id, category, title_key, and body_key', () => {
+    for (const tip of TIPS) {
+      expect(tip.id).toBeTruthy()
+      expect(tip.category).toBeTruthy()
+      expect(tip.title_key).toBeTruthy()
+      expect(tip.body_key).toBeTruthy()
+    }
+  })
+
+  test('tip ids are unique', () => {
+    const ids = TIPS.map((tip) => tip.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/tests/unit/views/dashboard/tip-card/use-tip-rotation.test.js
+++ b/tests/unit/views/dashboard/tip-card/use-tip-rotation.test.js
@@ -1,0 +1,145 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { createApp } from 'vue'
+
+// ── Helper: mount a minimal Vue app so onBeforeUnmount can fire ───────────────
+
+function withSetup(composable) {
+  let result
+  const app = createApp({
+    setup() {
+      result = composable()
+      return () => null
+    }
+  })
+  app.mount(document.createElement('div'))
+  return [result, app]
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetModules()
+})
+
+// ── Random starting index ──────────────────────────────────────────────────────
+
+describe('useTipRotation — random starting index', () => {
+  test('starting tip is always a valid TIPS member when Math.random returns 0', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const { useTipRotation } = await import('@/views/dashboard/tip-card/use-tip-rotation')
+    const { TIPS } = await import('@/utils/tips/catalog')
+
+    const [result, app] = withSetup(useTipRotation)
+    expect(TIPS).toContainEqual(result.tip.value)
+    app.unmount()
+    Math.random.mockRestore()
+  })
+
+  test('starting tip is always a valid TIPS member when Math.random returns near 1', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.9999)
+    const { useTipRotation } = await import('@/views/dashboard/tip-card/use-tip-rotation')
+    const { TIPS } = await import('@/utils/tips/catalog')
+
+    const [result, app] = withSetup(useTipRotation)
+    expect(TIPS).toContainEqual(result.tip.value)
+    app.unmount()
+    Math.random.mockRestore()
+  })
+
+  test('starting tip is always a valid TIPS member for a mid-range Math.random value', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const { useTipRotation } = await import('@/views/dashboard/tip-card/use-tip-rotation')
+    const { TIPS } = await import('@/utils/tips/catalog')
+
+    const [result, app] = withSetup(useTipRotation)
+    expect(TIPS).toContainEqual(result.tip.value)
+    app.unmount()
+    Math.random.mockRestore()
+  })
+})
+
+// ── Rotation over time ────────────────────────────────────────────────────────
+
+describe('useTipRotation — rotation interval', () => {
+  test('advances to the next tip every 30s and wraps back to the start', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const { useTipRotation } = await import('@/views/dashboard/tip-card/use-tip-rotation')
+    const { TIPS } = await import('@/utils/tips/catalog')
+
+    const [result, app] = withSetup(useTipRotation)
+    expect(result.tip.value).toEqual(TIPS[0])
+
+    for (let i = 1; i < TIPS.length; i++) {
+      vi.advanceTimersByTime(30000)
+      expect(result.tip.value).toEqual(TIPS[i])
+    }
+
+    // One more tick wraps back to the first tip
+    vi.advanceTimersByTime(30000)
+    expect(result.tip.value).toEqual(TIPS[0])
+
+    app.unmount()
+    Math.random.mockRestore()
+  })
+})
+
+// ── Guard against short catalogs ──────────────────────────────────────────────
+
+describe('useTipRotation — TIPS.length guard', () => {
+  test('does not create a timer and does not throw for a 1-item catalog', async () => {
+    vi.doMock('@/utils/tips/catalog', () => ({
+      TIPS: [{ id: 'only', category: 'sound', title_key: 't', body_key: 'b' }]
+    }))
+    const setIntervalSpy = vi.spyOn(global, 'setInterval')
+    const { useTipRotation } = await import('@/views/dashboard/tip-card/use-tip-rotation')
+
+    expect(() => {
+      const [, app] = withSetup(useTipRotation)
+      app.unmount()
+    }).not.toThrow()
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+
+    setIntervalSpy.mockRestore()
+    vi.doUnmock('@/utils/tips/catalog')
+  })
+
+  test('does not create a timer and does not throw for a 0-item catalog', async () => {
+    vi.doMock('@/utils/tips/catalog', () => ({ TIPS: [] }))
+    const setIntervalSpy = vi.spyOn(global, 'setInterval')
+    const { useTipRotation } = await import('@/views/dashboard/tip-card/use-tip-rotation')
+
+    expect(() => {
+      const [, app] = withSetup(useTipRotation)
+      app.unmount()
+    }).not.toThrow()
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+
+    setIntervalSpy.mockRestore()
+    vi.doUnmock('@/utils/tips/catalog')
+  })
+})
+
+// ── Cleanup on unmount ─────────────────────────────────────────────────────────
+
+describe('useTipRotation — clears interval on unmount', () => {
+  test('tip index does not change after unmount, even if timers keep advancing', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const { useTipRotation } = await import('@/views/dashboard/tip-card/use-tip-rotation')
+    const { TIPS } = await import('@/utils/tips/catalog')
+
+    const [result, app] = withSetup(useTipRotation)
+    vi.advanceTimersByTime(30000)
+    expect(result.tip.value).toEqual(TIPS[1])
+
+    app.unmount()
+    const tipAtUnmount = result.tip.value
+
+    vi.advanceTimersByTime(30000 * 5)
+    expect(result.tip.value).toEqual(tipAtUnmount)
+
+    Math.random.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary

Adds a new `UiTape` primitive and a rotating tip card below the dashboard actions panel, backed by a small typed catalog (`src/utils/tips`) so a future standalone tips app can browse/filter the same data by category. Also includes a minor actions-panel study-button theme tweak and an unrelated fork-dev skill fix already on the branch.