### PR TITLE
Never show button tooltips on touch devices

### DIFF
--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -21,7 +21,6 @@ export type ButtonProps = {
   loading?: boolean
   sfx?: SfxOptions
   fullWidth?: boolean
-  mobileTooltip?: boolean
   // Touch-only tap feedback: on coarse pointers the click is deferred a beat to
   // play the tap (desktop passes straight through). On by default.
   playOnTap?: boolean
@@ -46,7 +45,6 @@ const {
   active = false,
   sfx = {},
   fullWidth = false,
-  mobileTooltip = false,
   playOnTap = true,
   tapAnimate = false,
   disabled = false,
@@ -113,7 +111,6 @@ function onClick(e: MouseEvent) {
     element="button"
     :gap="-6"
     :suppress="!tooltip_active"
-    :static_on_mobile="mobileTooltip"
     data-testid="ui-kit-button"
     class="ui-kit-btn group/btn"
     v-sfx="merged_sfx"

--- a/src/components/ui-kit/tooltip.vue
+++ b/src/components/ui-kit/tooltip.vue
@@ -14,7 +14,6 @@ const {
   element = 'div',
   visible = false,
   suppress = false,
-  static_on_mobile = false,
   theme = 'white',
   theme_dark = 'brown-100',
   max_chars = 32
@@ -26,7 +25,6 @@ const {
   element?: 'div' | 'span' | 'button' | 'label'
   visible?: boolean
   suppress?: boolean
-  static_on_mobile?: boolean
   theme?: string
   theme_dark?: string
   // Wraps the tooltip body at roughly this many characters per line, using
@@ -42,9 +40,10 @@ const is_coarse_pointer = useMatchMedia('coarse')
 
 // gates both DOM mount (v-if) and autoUpdate — keeps unused tooltips out of
 // the DOM entirely so switching modes doesn't pay the cost of mounting N
-// teleported popovers up front
+// teleported popovers up front. Coarse pointers (touch) never show tooltips —
+// there's no hover to trigger them intentionally, only a tap-driven focus.
 const should_show = computed(
-  () => !suppress && (visible || is_active.value || (static_on_mobile && is_coarse_pointer.value))
+  () => !suppress && !is_coarse_pointer.value && (visible || is_active.value)
 )
 
 // Rough heuristic — good enough to tell whether `text` will wrap onto more
@@ -128,11 +127,5 @@ function onPointerLeave(e: PointerEvent) {
 
 .ui-tooltip--visible {
   display: block;
-}
-
-@media (pointer: coarse) {
-  .ui-tooltip--static {
-    display: block;
-  }
 }
 </style>

--- a/src/views/deck/deck-settings/deck-save-button.vue
+++ b/src/views/deck/deck-settings/deck-save-button.vue
@@ -52,7 +52,6 @@ function onReset() {
       size="lg"
       icon-only
       icon-left="refresh"
-      mobile-tooltip
       :sfx="{ press: 'snappy_button_5' }"
       :disabled="!is_dirty"
       click-when-disabled

--- a/src/views/deck/deck-settings/tab-review-pacing/tooltip-row.vue
+++ b/src/views/deck/deck-settings/tab-review-pacing/tooltip-row.vue
@@ -48,7 +48,6 @@ const { t } = useI18n()
         size="sm"
         icon-only
         icon-left="refresh"
-        mobile-tooltip
         :sfx="{ press: 'snappy_button_5' }"
         @press="emit('reset')"
         class="absolute! -right-8"

--- a/src/views/settings/settings-save-button.vue
+++ b/src/views/settings/settings-save-button.vue
@@ -48,7 +48,6 @@ function onReset() {
       size="lg"
       icon-only
       icon-left="refresh"
-      mobile-tooltip
       :sfx="{ press: 'snappy_button_5' }"
       :disabled="!is_dirty"
       click-when-disabled

--- a/tests/integration/components/ui-kit/button.test.js
+++ b/tests/integration/components/ui-kit/button.test.js
@@ -30,7 +30,7 @@ import UiTooltip from '@/components/ui-kit/tooltip.vue'
 const UiTooltipSlotStub = defineComponent({
   name: 'UiTooltip',
   inheritAttrs: false,
-  props: ['element', 'gap', 'suppress', 'static_on_mobile', 'text'],
+  props: ['element', 'gap', 'suppress', 'text'],
   setup(_props, { slots, attrs }) {
     return () => h('button', { ...attrs, 'data-testid': 'ui-kit-button' }, slots.default?.())
   }
@@ -71,16 +71,6 @@ describe('UiButton', () => {
     test('tooltip suppressed when there is no slot content', () => {
       const wrapper = mountButton({ iconOnly: true })
       expect(findTooltip(wrapper).props('suppress')).toBe(true)
-    })
-
-    test('mobileTooltip=true forwards static_on_mobile=true (tap-shows on mobile)', () => {
-      const wrapper = mountButton({ iconOnly: true, mobileTooltip: true }, { default: 'Close' })
-      expect(findTooltip(wrapper).props('static_on_mobile')).toBe(true)
-    })
-
-    test('mobileTooltip=false forwards static_on_mobile=false (hover-only)', () => {
-      const wrapper = mountButton({ iconOnly: true, mobileTooltip: false }, { default: 'Close' })
-      expect(findTooltip(wrapper).props('static_on_mobile')).toBe(false)
     })
 
     test('renders tooltip via element=button (button is the trigger)', () => {


### PR DESCRIPTION
## Summary

- Reset-changes buttons (deck settings, member settings, review-pacing field reset) were passing `mobile-tooltip`, which forced their icon-only tooltip to stay permanently visible on touch devices instead of only showing on hover/focus.
- Removed the `mobileTooltip`/`static_on_mobile` mechanism entirely and made tooltip visibility explicitly gated off on coarse pointers, regardless of trigger.