### PR TITLE
Fix daily caps ignored in study sessions (stale RPC overloads)

### DIFF
--- a/supabase/migrations/20260716000008_drop-stale-study-session-cards-overload.sql
+++ b/supabase/migrations/20260716000008_drop-stale-study-session-cards-overload.sql
@@ -1,0 +1,149 @@
+-- Two overloads of get_study_session_cards exist:
+--   (bigint, timestamptz, boolean) — created 20260502 when p_today_start was
+--     added (that migration DROPped the 2-arg original). Still reads daily
+--     caps from decks.study_config, which no longer carries them since
+--     20260716000004 → caps resolve NULL → unlimited.
+--   (bigint, boolean) — accidentally created as a NEW overload by 20260707's
+--     CREATE OR REPLACE (it assumed the 2-arg signature still existed) and
+--     again by 20260716000007. Has the cap fix + interleave/overdue ordering,
+--     but the FE passes p_today_start so PostgREST never resolves to it.
+--
+-- Consolidate: drop both, recreate a single 3-arg function with the resolved
+-- caps body from 20260716000007, counting today's usage from p_today_start
+-- (the member's local midnight, FE-supplied) instead of UTC midnight — the
+-- same day boundary get_member_decks uses for the inbox due counts.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.get_study_session_cards(bigint, timestamptz, boolean);
+DROP FUNCTION IF EXISTS public.get_study_session_cards(bigint, boolean);
+
+CREATE FUNCTION public.get_study_session_cards(
+  p_deck_id      bigint,
+  p_today_start  timestamptz,
+  p_study_all    boolean DEFAULT false
+)
+RETURNS SETOF public.cards_with_images
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+AS $$
+DECLARE
+  v_max_total       int;
+  v_max_new         int;
+  v_used_total      int;
+  v_used_new        int;
+  v_remaining_total int;
+  v_remaining_new   int;
+  v_new_available   int;
+  v_new_take        int;
+  v_review_take     int;
+BEGIN
+  -- study_all bypasses caps + due filter — return every card in rank order.
+  IF p_study_all THEN
+    RETURN QUERY
+    SELECT cwi.*
+    FROM public.cards_with_images cwi
+    WHERE cwi.deck_id = p_deck_id
+    ORDER BY cwi.rank;
+    RETURN;
+  END IF;
+
+  -- Read caps. NULL = unlimited. Same override -> preset -> system ladder
+  -- as get_member_decks: a linked preset's own NULL means "that preset says
+  -- unlimited", which is why this checks "is a preset linked" (dp/p present)
+  -- rather than COALESCE-ing straight through a possibly-NULL preset value.
+  SELECT
+    CASE
+      WHEN dp.has_max_reviews_override THEN dp.max_reviews_per_day_override
+      WHEN p.id IS NOT NULL THEN p.max_reviews_per_day
+      ELSE sys.max_reviews_per_day
+    END,
+    CASE
+      WHEN dp.has_max_new_override THEN dp.max_new_per_day_override
+      WHEN p.id IS NOT NULL THEN p.max_new_per_day
+      ELSE sys.max_new_per_day
+    END
+  INTO v_max_total, v_max_new
+  FROM public.decks d
+  LEFT JOIN public.deck_review_pacing dp ON dp.deck_id = d.id
+  LEFT JOIN public.review_pacing_presets p ON p.id = dp.review_pacing_preset_id
+  CROSS JOIN (
+    SELECT max_reviews_per_day, max_new_per_day
+    FROM public.review_pacing_presets
+    WHERE is_system
+    LIMIT 1
+  ) sys
+  WHERE d.id = p_deck_id;
+
+  -- Today's usage: distinct cards reviewed since the member's local midnight.
+  SELECT
+    count(DISTINCT rl.card_id)::int,
+    count(DISTINCT rl.card_id) FILTER (WHERE rl.state = 0)::int
+  INTO v_used_total, v_used_new
+  FROM public.review_logs rl
+  JOIN public.cards c ON c.id = rl.card_id
+  WHERE c.deck_id = p_deck_id
+    AND rl.review >= p_today_start;
+
+  -- Remaining budget. NULL cap → sentinel large int meaning unlimited.
+  v_remaining_total := GREATEST(0, COALESCE(v_max_total - v_used_total, 2147483647));
+  v_remaining_new   := GREATEST(0, COALESCE(v_max_new   - v_used_new,   2147483647));
+
+  -- How many new cards exist in this deck (no review row yet).
+  SELECT count(*)::int
+  INTO v_new_available
+  FROM public.cards c
+  LEFT JOIN public.reviews r ON r.card_id = c.id
+  WHERE c.deck_id = p_deck_id
+    AND r.id IS NULL;
+
+  -- New cards drawn first for budget purposes; review cards fill the rest.
+  -- (This only decides *how many* of each — final ordering interleaves them.)
+  v_new_take    := LEAST(v_new_available, v_remaining_new, v_remaining_total);
+  v_review_take := GREATEST(0, v_remaining_total - v_new_take);
+
+  RETURN QUERY
+  WITH new_queue AS (
+    -- row_number() OVER (ORDER BY c.rank) numbers each row 1..v_new_take in
+    -- rank order, without collapsing rows the way an aggregate would.
+    SELECT c.id, 1 AS bucket, row_number() OVER (ORDER BY c.rank) AS rn
+    FROM public.cards c
+    LEFT JOIN public.reviews r ON r.card_id = c.id
+    WHERE c.deck_id = p_deck_id
+      AND r.id IS NULL
+    ORDER BY c.rank
+    LIMIT v_new_take
+  ),
+  review_queue AS (
+    -- Most-overdue-first: order by due ASC (oldest due date = most overdue),
+    -- not rank. rank only breaks ties between cards due at the same instant.
+    SELECT c.id, 2 AS bucket, row_number() OVER (ORDER BY r.due ASC, c.rank) AS rn
+    FROM public.cards c
+    JOIN public.reviews r ON r.card_id = c.id
+    WHERE c.deck_id = p_deck_id
+      AND r.due <= now()
+    ORDER BY r.due ASC, c.rank
+    LIMIT v_review_take
+  ),
+  queue AS (
+    -- Proportional interleave: each bucket's row gets a key in (0, 1] based
+    -- on its position within that bucket alone (e.g. new card 2 of 5 → 0.3).
+    -- Sorting all rows by that shared key spreads new cards evenly through
+    -- the review cards instead of grouping all of one bucket before the other.
+    SELECT id, bucket, (rn - 0.5) / NULLIF(v_new_take, 0) AS interleave_key
+    FROM new_queue
+    UNION ALL
+    SELECT id, bucket, (rn - 0.5) / NULLIF(v_review_take, 0) AS interleave_key
+    FROM review_queue
+  )
+  SELECT cwi.*
+  FROM public.cards_with_images cwi
+  JOIN queue q ON q.id = cwi.id
+  ORDER BY q.interleave_key, q.bucket;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_study_session_cards(bigint, timestamptz, boolean) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260716000009_drop-stale-save-review-overload.sql
+++ b/supabase/migrations/20260716000009_drop-stale-save-review-overload.sql
@@ -1,0 +1,20 @@
+-- Same overload-drift class as 20260716000008, second instance: the original
+-- 16-arg save_review from 20260411000007 was orphaned when 20260411000009
+-- grew the arg list (p_card_state) via CREATE OR REPLACE — which, with a
+-- different argument list, creates a NEW overload instead of replacing.
+-- 20260707000001 correctly DROP-first'd, but targeted only the 17-arg
+-- intermediate, so the 16-arg original still lingers.
+--
+-- Harmless today (PostgREST resolves the FE's 18 named args to the live
+-- 18-arg function only), but it's a landmine for positional SQL callers and
+-- trips the no-duplicate-overloads guard in supabase/tests. Drop it.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.save_review(
+  bigint, timestamp with time zone, real, real, smallint, smallint, smallint,
+  smallint, timestamp with time zone, smallint, smallint,
+  timestamp with time zone, real, real, smallint, timestamp with time zone
+);
+
+COMMIT;

--- a/supabase/tests/00005_rpc_functions.sql
+++ b/supabase/tests/00005_rpc_functions.sql
@@ -54,10 +54,11 @@ SELECT lives_ok(
       p_stability := 2.5, p_difficulty := 5.0,
       p_elapsed_days := 0::smallint, p_scheduled_days := 1::smallint,
       p_reps := 1::smallint, p_lapses := 0::smallint,
-      p_last_review := now(),
+      p_last_review := now(), p_card_state := 0::smallint,
       p_rating := 3::smallint, p_state := 0::smallint,
       p_log_due := now(), p_log_stability := 0.0, p_log_difficulty := 0.0,
-      p_log_scheduled_days := 0::smallint, p_review := now()
+      p_log_scheduled_days := 0::smallint, p_review := now(),
+      p_learning_steps := 0::smallint
     )
   $$,
   'Alice can save a review for her own card'
@@ -90,10 +91,11 @@ SELECT throws_ok(
       p_stability := 2.5, p_difficulty := 5.0,
       p_elapsed_days := 0::smallint, p_scheduled_days := 1::smallint,
       p_reps := 1::smallint, p_lapses := 0::smallint,
-      p_last_review := now(),
+      p_last_review := now(), p_card_state := 0::smallint,
       p_rating := 3::smallint, p_state := 0::smallint,
       p_log_due := now(), p_log_stability := 0.0, p_log_difficulty := 0.0,
-      p_log_scheduled_days := 0::smallint, p_review := now()
+      p_log_scheduled_days := 0::smallint, p_review := now(),
+      p_learning_steps := 0::smallint
     )
   $$,
   'Card not found or not owned by user',

--- a/supabase/tests/00012_study_session_cards.sql
+++ b/supabase/tests/00012_study_session_cards.sql
@@ -16,7 +16,7 @@
 
 BEGIN;
 
-SELECT plan(14);
+SELECT plan(15);
 
 -- ── Setup ─────────────────────────────────────────────────────────────────────
 SELECT tests.create_user('11111111-1111-1111-1111-111111111111'::uuid, 'alice_caps');
@@ -92,7 +92,7 @@ SELECT is(
 -- overdue review card first, then the new card, then the second review card:
 -- [1002, 1000, 1003].
 SELECT results_eq(
-  $$ SELECT id FROM public.get_study_session_cards(100) $$,
+  $$ SELECT id FROM public.get_study_session_cards(100, date_trunc('day', now())) $$,
   $$ VALUES (1002::bigint), (1000::bigint), (1003::bigint) $$,
   'queue: 1 new card + due reviews up to total cap, resolved via deck_review_pacing [obligation]'
 );
@@ -132,7 +132,7 @@ SELECT is(
 -- skips 1001 (new budget exhausted: 1 used, max 1). Returns 2 due reviews:
 -- [1002, 1003] up to remaining total budget = 2.
 SELECT results_eq(
-  $$ SELECT id FROM public.get_study_session_cards(100) $$,
+  $$ SELECT id FROM public.get_study_session_cards(100, date_trunc('day', now())) $$,
   $$ VALUES (1002::bigint), (1003::bigint) $$,
   'queue respects exhausted new-card budget and remaining total budget'
 );
@@ -140,7 +140,7 @@ SELECT results_eq(
 -- Test 9: p_study_all = true returns every card in deck regardless of caps,
 -- in rank order.
 SELECT results_eq(
-  $$ SELECT id FROM public.get_study_session_cards(100, true) $$,
+  $$ SELECT id FROM public.get_study_session_cards(100, date_trunc('day', now()), true) $$,
   $$ VALUES (1000::bigint), (1001::bigint), (1002::bigint), (1003::bigint), (1004::bigint) $$,
   'p_study_all bypasses caps and returns all cards in rank order'
 );
@@ -161,6 +161,17 @@ SELECT is(
   'p_today_start in the future restores due_count to the unclamped cap'
 );
 
+-- Test 9c [obligation]: get_study_session_cards scopes today's usage by
+-- p_today_start too — the same day boundary as get_member_decks, so the inbox
+-- count and the session queue can never disagree. With a future p_today_start
+-- the logged review of 1000 no longer counts: full budget restored, new_take
+-- = 1 (1001), review_take = 2 (1002, 1003), interleaved [1002, 1001, 1003].
+SELECT results_eq(
+  $$ SELECT id FROM public.get_study_session_cards(100, now() + interval '1 day') $$,
+  $$ VALUES (1002::bigint), (1001::bigint), (1003::bigint) $$,
+  'p_today_start scopes the usage window in get_study_session_cards [obligation]'
+);
+
 
 -- ── Act as Bob — RLS scoping ──────────────────────────────────────────────────
 SET LOCAL role = 'postgres';
@@ -177,7 +188,7 @@ SELECT is(
 -- Test 11: Bob's RPC call against Alice's deck returns no rows (his own
 -- claims scope cards/reviews — the function runs as invoker so RLS applies).
 SELECT is(
-  (SELECT count(*) FROM public.get_study_session_cards(100))::int,
+  (SELECT count(*) FROM public.get_study_session_cards(100, date_trunc('day', now())))::int,
   0,
   'security_invoker: Bob''s call to get_study_session_cards on Alice''s deck returns 0 rows'
 );
@@ -202,7 +213,7 @@ SELECT 1200 + gs, 102, 'Q' || gs, 'A' || gs, gs * 1000
 FROM generate_series(1, 5) AS gs;
 
 SELECT is(
-  (SELECT count(*) FROM public.get_study_session_cards(102))::int,
+  (SELECT count(*) FROM public.get_study_session_cards(102, date_trunc('day', now())))::int,
   5,
   'get_study_session_cards resolves an unbounded linked-preset cap (NULL), not the system default [obligation]'
 );

--- a/supabase/tests/00029_function_overload_guard.sql
+++ b/supabase/tests/00029_function_overload_guard.sql
@@ -1,0 +1,63 @@
+-- =============================================================================
+-- Function overload drift guard
+--
+-- CREATE OR REPLACE FUNCTION only replaces a function whose argument list
+-- matches EXACTLY — with a changed arg list it silently creates a second
+-- overload. PostgREST then resolves RPC calls by the named args the client
+-- sends, so the FE can end up pinned to a stale overload while migrations
+-- keep "updating" a function it never calls. This happened twice:
+--   * get_study_session_cards — stale 3-arg overload served sessions with no
+--     daily caps after 20260716000004 (fixed in 20260716000008)
+--   * save_review — orphaned 16-arg original lingered since 20260411000009
+--     (dropped in 20260716000009)
+--
+-- Guards:
+--   1. No public function has more than one overload. If you intentionally
+--      add an overload, exempt it explicitly in the query below.
+--   2. The signatures the FE actually sends (named RPC args) exist verbatim,
+--      so a signature-changing migration that forgets DROP-first turns CI red
+--      here instead of silently forking.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(3);
+
+-- Test 1: every public function name maps to exactly one overload.
+SELECT is_empty(
+  $$
+  SELECT p.proname || ': ' || string_agg(pg_get_function_identity_arguments(p.oid), ' | ')
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+  GROUP BY p.proname
+  HAVING count(*) > 1
+  $$,
+  'no public function has multiple overloads (DROP the old signature before CREATE-ing a new one)'
+);
+
+-- Test 2: get_study_session_cards exists with the exact signature the FE
+-- calls (src/api/cards/db/study-session-cards.ts).
+SELECT has_function(
+  'public',
+  'get_study_session_cards',
+  ARRAY['bigint', 'timestamp with time zone', 'boolean'],
+  'get_study_session_cards has the (p_deck_id, p_today_start, p_study_all) signature the FE sends'
+);
+
+-- Test 3: save_review exists with the exact 18-arg signature the FE calls
+-- (src/api/reviews/db/index.ts).
+SELECT has_function(
+  'public',
+  'save_review',
+  ARRAY[
+    'bigint', 'timestamp with time zone', 'real', 'real', 'smallint',
+    'smallint', 'smallint', 'smallint', 'timestamp with time zone',
+    'smallint', 'smallint', 'smallint', 'timestamp with time zone', 'real',
+    'real', 'smallint', 'timestamp with time zone', 'smallint'
+  ],
+  'save_review has the 18-arg signature (incl. p_card_state + p_learning_steps) the FE sends'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,4 +1,10 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
 export type Database = {
   graphql_public: {
@@ -64,19 +70,70 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'cards_deck_id_fkey'
-            columns: ['deck_id']
+            foreignKeyName: "cards_deck_id_fkey"
+            columns: ["deck_id"]
             isOneToOne: false
-            referencedRelation: 'decks'
-            referencedColumns: ['id']
+            referencedRelation: "decks"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'cards_member_id_fkey'
-            columns: ['member_id']
+            foreignKeyName: "cards_member_id_fkey"
+            columns: ["member_id"]
             isOneToOne: false
-            referencedRelation: 'members'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      deck_review_pacing: {
+        Row: {
+          deck_id: number
+          desired_retention_override: number | null
+          has_max_new_override: boolean
+          has_max_reviews_override: boolean
+          learning_steps_override: string[] | null
+          max_new_per_day_override: number | null
+          max_reviews_per_day_override: number | null
+          relearning_steps_override: string[] | null
+          review_pacing_preset_id: number | null
+        }
+        Insert: {
+          deck_id: number
+          desired_retention_override?: number | null
+          has_max_new_override?: boolean
+          has_max_reviews_override?: boolean
+          learning_steps_override?: string[] | null
+          max_new_per_day_override?: number | null
+          max_reviews_per_day_override?: number | null
+          relearning_steps_override?: string[] | null
+          review_pacing_preset_id?: number | null
+        }
+        Update: {
+          deck_id?: number
+          desired_retention_override?: number | null
+          has_max_new_override?: boolean
+          has_max_reviews_override?: boolean
+          learning_steps_override?: string[] | null
+          max_new_per_day_override?: number | null
+          max_reviews_per_day_override?: number | null
+          relearning_steps_override?: string[] | null
+          review_pacing_preset_id?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "deck_review_pacing_deck_id_fkey"
+            columns: ["deck_id"]
+            isOneToOne: true
+            referencedRelation: "decks"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "deck_review_pacing_review_pacing_preset_id_fkey"
+            columns: ["review_pacing_preset_id"]
+            isOneToOne: false
+            referencedRelation: "review_pacing_presets"
+            referencedColumns: ["id"]
+          },
         ]
       }
       decks: {
@@ -127,12 +184,86 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'decks_member_id_fkey'
-            columns: ['member_id']
+            foreignKeyName: "decks_member_id_fkey"
+            columns: ["member_id"]
             isOneToOne: false
-            referencedRelation: 'members'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      feedback_items: {
+        Row: {
+          body: string | null
+          created_at: string
+          id: number
+          member_id: string
+          status: Database["public"]["Enums"]["feedback_status"]
+          title: string
+          type: Database["public"]["Enums"]["feedback_type"]
+          visibility: Database["public"]["Enums"]["feedback_visibility"]
+        }
+        Insert: {
+          body?: string | null
+          created_at?: string
+          id?: number
+          member_id: string
+          status?: Database["public"]["Enums"]["feedback_status"]
+          title: string
+          type: Database["public"]["Enums"]["feedback_type"]
+          visibility?: Database["public"]["Enums"]["feedback_visibility"]
+        }
+        Update: {
+          body?: string | null
+          created_at?: string
+          id?: number
+          member_id?: string
+          status?: Database["public"]["Enums"]["feedback_status"]
+          title?: string
+          type?: Database["public"]["Enums"]["feedback_type"]
+          visibility?: Database["public"]["Enums"]["feedback_visibility"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "feedback_items_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      feedback_votes: {
+        Row: {
+          created_at: string
+          feedback_id: number
+          member_id: string
+        }
+        Insert: {
+          created_at?: string
+          feedback_id: number
+          member_id: string
+        }
+        Update: {
+          created_at?: string
+          feedback_id?: number
+          member_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "feedback_votes_feedback_id_fkey"
+            columns: ["feedback_id"]
+            isOneToOne: false
+            referencedRelation: "feedback_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "feedback_votes_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
         ]
       }
       lesson_collections: {
@@ -165,19 +296,19 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'lesson_collections_last_lesson_id_fkey'
-            columns: ['last_lesson_id']
+            foreignKeyName: "lesson_collections_last_lesson_id_fkey"
+            columns: ["last_lesson_id"]
             isOneToOne: false
-            referencedRelation: 'lessons'
-            referencedColumns: ['id']
+            referencedRelation: "lessons"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'lesson_collections_member_id_fkey'
-            columns: ['member_id']
+            foreignKeyName: "lesson_collections_member_id_fkey"
+            columns: ["member_id"]
             isOneToOne: false
-            referencedRelation: 'members'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
         ]
       }
       lessons: {
@@ -237,26 +368,26 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'lessons_collection_id_fkey'
-            columns: ['collection_id']
+            foreignKeyName: "lessons_collection_id_fkey"
+            columns: ["collection_id"]
             isOneToOne: false
-            referencedRelation: 'lesson_collections'
-            referencedColumns: ['id']
+            referencedRelation: "lesson_collections"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'lessons_collection_id_fkey'
-            columns: ['collection_id']
+            foreignKeyName: "lessons_collection_id_fkey"
+            columns: ["collection_id"]
             isOneToOne: false
-            referencedRelation: 'lesson_collections_with_counts'
-            referencedColumns: ['id']
+            referencedRelation: "lesson_collections_with_counts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'lessons_member_id_fkey'
-            columns: ['member_id']
+            foreignKeyName: "lessons_member_id_fkey"
+            columns: ["member_id"]
             isOneToOne: false
-            referencedRelation: 'members'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
         ]
       }
       media: {
@@ -270,7 +401,7 @@ export type Database = {
           lesson_id: number | null
           member_id: string | null
           path: string
-          slot: Database['public']['Enums']['media_slot'] | null
+          slot: Database["public"]["Enums"]["media_slot"] | null
         }
         Insert: {
           bucket: string
@@ -282,7 +413,7 @@ export type Database = {
           lesson_id?: number | null
           member_id?: string | null
           path: string
-          slot?: Database['public']['Enums']['media_slot'] | null
+          slot?: Database["public"]["Enums"]["media_slot"] | null
         }
         Update: {
           bucket?: string
@@ -294,37 +425,37 @@ export type Database = {
           lesson_id?: number | null
           member_id?: string | null
           path?: string
-          slot?: Database['public']['Enums']['media_slot'] | null
+          slot?: Database["public"]["Enums"]["media_slot"] | null
         }
         Relationships: [
           {
-            foreignKeyName: 'media_card_id_fkey'
-            columns: ['card_id']
+            foreignKeyName: "media_card_id_fkey"
+            columns: ["card_id"]
             isOneToOne: false
-            referencedRelation: 'cards'
-            referencedColumns: ['id']
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'media_card_id_fkey'
-            columns: ['card_id']
+            foreignKeyName: "media_card_id_fkey"
+            columns: ["card_id"]
             isOneToOne: false
-            referencedRelation: 'cards_with_images'
-            referencedColumns: ['id']
+            referencedRelation: "cards_with_images"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'media_deck_id_fkey'
-            columns: ['deck_id']
+            foreignKeyName: "media_deck_id_fkey"
+            columns: ["deck_id"]
             isOneToOne: false
-            referencedRelation: 'decks'
-            referencedColumns: ['id']
+            referencedRelation: "decks"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'media_lesson_id_fkey'
-            columns: ['lesson_id']
+            foreignKeyName: "media_lesson_id_fkey"
+            columns: ["lesson_id"]
             isOneToOne: false
-            referencedRelation: 'lessons'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "lessons"
+            referencedColumns: ["id"]
+          },
         ]
       }
       members: {
@@ -338,7 +469,7 @@ export type Database = {
           id: string
           plan: string
           preferences: Json
-          role: Database['public']['Enums']['member_role']
+          role: Database["public"]["Enums"]["member_role"]
           stripe_customer_id: string | null
           stripe_subscription_id: string | null
         }
@@ -352,7 +483,7 @@ export type Database = {
           id: string
           plan?: string
           preferences?: Json
-          role?: Database['public']['Enums']['member_role']
+          role?: Database["public"]["Enums"]["member_role"]
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null
         }
@@ -366,18 +497,18 @@ export type Database = {
           id?: string
           plan?: string
           preferences?: Json
-          role?: Database['public']['Enums']['member_role']
+          role?: Database["public"]["Enums"]["member_role"]
           stripe_customer_id?: string | null
           stripe_subscription_id?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: 'members_plan_fkey'
-            columns: ['plan']
+            foreignKeyName: "members_plan_fkey"
+            columns: ["plan"]
             isOneToOne: false
-            referencedRelation: 'plans'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "plans"
+            referencedColumns: ["id"]
+          },
         ]
       }
       plans: {
@@ -428,19 +559,19 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'purchases_item_id_fkey'
-            columns: ['item_id']
+            foreignKeyName: "purchases_item_id_fkey"
+            columns: ["item_id"]
             isOneToOne: false
-            referencedRelation: 'shop_items'
-            referencedColumns: ['id']
+            referencedRelation: "shop_items"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'purchases_member_id_fkey'
-            columns: ['member_id']
+            foreignKeyName: "purchases_member_id_fkey"
+            columns: ["member_id"]
             isOneToOne: false
-            referencedRelation: 'members'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
         ]
       }
       review_logs: {
@@ -485,26 +616,73 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'review_logs_card_id_fkey'
-            columns: ['card_id']
+            foreignKeyName: "review_logs_card_id_fkey"
+            columns: ["card_id"]
             isOneToOne: false
-            referencedRelation: 'cards'
-            referencedColumns: ['id']
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'review_logs_card_id_fkey'
-            columns: ['card_id']
+            foreignKeyName: "review_logs_card_id_fkey"
+            columns: ["card_id"]
             isOneToOne: false
-            referencedRelation: 'cards_with_images'
-            referencedColumns: ['id']
+            referencedRelation: "cards_with_images"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'review_logs_member_id_fkey'
-            columns: ['member_id']
+            foreignKeyName: "review_logs_member_id_fkey"
+            columns: ["member_id"]
             isOneToOne: false
-            referencedRelation: 'members'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      review_pacing_presets: {
+        Row: {
+          created_at: string
+          desired_retention: number
+          id: number
+          is_system: boolean
+          learning_steps: string[]
+          max_new_per_day: number | null
+          max_reviews_per_day: number | null
+          member_id: string | null
+          name: string
+          relearning_steps: string[]
+        }
+        Insert: {
+          created_at?: string
+          desired_retention: number
+          id?: number
+          is_system?: boolean
+          learning_steps: string[]
+          max_new_per_day?: number | null
+          max_reviews_per_day?: number | null
+          member_id?: string | null
+          name: string
+          relearning_steps: string[]
+        }
+        Update: {
+          created_at?: string
+          desired_retention?: number
+          id?: number
+          is_system?: boolean
+          learning_steps?: string[]
+          max_new_per_day?: number | null
+          max_reviews_per_day?: number | null
+          member_id?: string | null
+          name?: string
+          relearning_steps?: string[]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "review_pacing_presets_member_id_fkey"
+            columns: ["member_id"]
+            isOneToOne: false
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
         ]
       }
       reviews: {
@@ -558,31 +736,31 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'reviews_card_id_fkey'
-            columns: ['card_id']
+            foreignKeyName: "reviews_card_id_fkey"
+            columns: ["card_id"]
             isOneToOne: true
-            referencedRelation: 'cards'
-            referencedColumns: ['id']
+            referencedRelation: "cards"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'reviews_card_id_fkey'
-            columns: ['card_id']
+            foreignKeyName: "reviews_card_id_fkey"
+            columns: ["card_id"]
             isOneToOne: true
-            referencedRelation: 'cards_with_images'
-            referencedColumns: ['id']
+            referencedRelation: "cards_with_images"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'reviews_member_id_fkey'
-            columns: ['member_id']
+            foreignKeyName: "reviews_member_id_fkey"
+            columns: ["member_id"]
             isOneToOne: false
-            referencedRelation: 'members'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
         ]
       }
       shop_items: {
         Row: {
-          category: Database['public']['Enums']['shop_category'] | null
+          category: Database["public"]["Enums"]["shop_category"] | null
           description: string | null
           id: number
           item_key: string | null
@@ -590,7 +768,7 @@ export type Database = {
           price: number | null
         }
         Insert: {
-          category?: Database['public']['Enums']['shop_category'] | null
+          category?: Database["public"]["Enums"]["shop_category"] | null
           description?: string | null
           id?: number
           item_key?: string | null
@@ -598,7 +776,7 @@ export type Database = {
           price?: number | null
         }
         Update: {
-          category?: Database['public']['Enums']['shop_category'] | null
+          category?: Database["public"]["Enums"]["shop_category"] | null
           description?: string | null
           id?: number
           item_key?: string | null
@@ -627,19 +805,19 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'cards_deck_id_fkey'
-            columns: ['deck_id']
+            foreignKeyName: "cards_deck_id_fkey"
+            columns: ["deck_id"]
             isOneToOne: false
-            referencedRelation: 'decks'
-            referencedColumns: ['id']
+            referencedRelation: "decks"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'cards_member_id_fkey'
-            columns: ['member_id']
+            foreignKeyName: "cards_member_id_fkey"
+            columns: ["member_id"]
             isOneToOne: false
-            referencedRelation: 'members'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
         ]
       }
       lesson_collections_with_counts: {
@@ -675,19 +853,19 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'lesson_collections_last_lesson_id_fkey'
-            columns: ['last_lesson_id']
+            foreignKeyName: "lesson_collections_last_lesson_id_fkey"
+            columns: ["last_lesson_id"]
             isOneToOne: false
-            referencedRelation: 'lessons'
-            referencedColumns: ['id']
+            referencedRelation: "lessons"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'lesson_collections_member_id_fkey'
-            columns: ['member_id']
+            foreignKeyName: "lesson_collections_member_id_fkey"
+            columns: ["member_id"]
             isOneToOne: false
-            referencedRelation: 'members'
-            referencedColumns: ['id']
-          }
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
         ]
       }
     }
@@ -699,7 +877,7 @@ export type Database = {
       auth_plan: { Args: never; Returns: string }
       auth_role: {
         Args: never
-        Returns: Database['public']['Enums']['member_role']
+        Returns: Database["public"]["Enums"]["member_role"]
       }
       bulk_insert_cards_in_deck: {
         Args: { p_cards: Json; p_deck_id: number }
@@ -715,12 +893,15 @@ export type Database = {
           updated_at: string | null
         }[]
         SetofOptions: {
-          from: '*'
-          to: 'cards'
+          from: "*"
+          to: "cards"
           isOneToOne: false
           isSetofReturn: true
         }
       }
+      can_manage_members: { Args: never; Returns: boolean }
+      can_moderate_feedback: { Args: never; Returns: boolean }
+      can_read_lesson_audio: { Args: never; Returns: boolean }
       card_rank_between: {
         Args: {
           p_deck_id: number
@@ -757,8 +938,8 @@ export type Database = {
           updated_at: string
         }
         SetofOptions: {
-          from: '*'
-          to: 'lessons'
+          from: "*"
+          to: "lessons"
           isOneToOne: true
           isSetofReturn: false
         }
@@ -771,29 +952,6 @@ export type Database = {
         }
         Returns: number
       }
-      decks_with_stats: {
-        Args: { p_today_start: string }
-        Returns: {
-          card_attributes: Json
-          card_count: number
-          cover_config: Json
-          created_at: string
-          description: string
-          due_count: number
-          has_image: boolean
-          id: number
-          is_public: boolean
-          member_display_name: string
-          member_id: string
-          new_reviewed_today_count: number
-          rank: number
-          reviewed_today_count: number
-          study_config: Json
-          tags: string[]
-          title: string
-          updated_at: string
-        }[]
-      }
       delete_cards_in_deck: {
         Args: { p_deck_id: number; p_except_ids: number[] }
         Returns: number
@@ -802,6 +960,23 @@ export type Database = {
       enforce_deck_card_limit: {
         Args: { p_adding: number; p_deck_id: number }
         Returns: undefined
+      }
+      feedback_items_with_votes: {
+        Args: never
+        Returns: {
+          body: string
+          created_at: string
+          id: number
+          member_avatar: string
+          member_display_name: string
+          member_id: string
+          status: Database["public"]["Enums"]["feedback_status"]
+          title: string
+          type: Database["public"]["Enums"]["feedback_type"]
+          visibility: Database["public"]["Enums"]["feedback_visibility"]
+          vote_count: number
+          voted_by_me: boolean
+        }[]
       }
       find_orphan_storage_objects: {
         Args: { p_limit?: number; p_older_than?: string }
@@ -849,59 +1024,70 @@ export type Database = {
           term: string
         }[]
       }
-      get_study_session_cards:
-        | {
-            Args: { p_deck_id: number; p_study_all?: boolean }
-            Returns: {
-              back_image_bucket: string | null
-              back_image_path: string | null
-              back_text: string | null
-              created_at: string | null
-              deck_id: number | null
-              front_image_bucket: string | null
-              front_image_path: string | null
-              front_text: string | null
-              id: number | null
-              is_duplicate: boolean | null
-              member_id: string | null
-              rank: number | null
-              updated_at: string | null
-            }[]
-            SetofOptions: {
-              from: '*'
-              to: 'cards_with_images'
-              isOneToOne: false
-              isSetofReturn: true
-            }
-          }
-        | {
-            Args: {
-              p_deck_id: number
-              p_study_all?: boolean
-              p_today_start: string
-            }
-            Returns: {
-              back_image_bucket: string | null
-              back_image_path: string | null
-              back_text: string | null
-              created_at: string | null
-              deck_id: number | null
-              front_image_bucket: string | null
-              front_image_path: string | null
-              front_text: string | null
-              id: number | null
-              is_duplicate: boolean | null
-              member_id: string | null
-              rank: number | null
-              updated_at: string | null
-            }[]
-            SetofOptions: {
-              from: '*'
-              to: 'cards_with_images'
-              isOneToOne: false
-              isSetofReturn: true
-            }
-          }
+      get_member_decks: {
+        Args: { p_today_start: string }
+        Returns: {
+          card_attributes: Json
+          card_count: number
+          cover_config: Json
+          created_at: string
+          description: string
+          desired_retention: number
+          desired_retention_override: number
+          due_count: number
+          has_image: boolean
+          has_max_new_override: boolean
+          has_max_reviews_override: boolean
+          id: number
+          is_public: boolean
+          learning_steps: string[]
+          learning_steps_override: string[]
+          max_new_per_day: number
+          max_new_per_day_override: number
+          max_reviews_per_day: number
+          max_reviews_per_day_override: number
+          member_display_name: string
+          member_id: string
+          new_reviewed_today_count: number
+          rank: number
+          relearning_steps: string[]
+          relearning_steps_override: string[]
+          review_pacing_preset_id: number
+          reviewed_today_count: number
+          study_config: Json
+          tags: string[]
+          title: string
+          updated_at: string
+        }[]
+      }
+      get_study_session_cards: {
+        Args: {
+          p_deck_id: number
+          p_study_all?: boolean
+          p_today_start: string
+        }
+        Returns: {
+          back_image_bucket: string | null
+          back_image_path: string | null
+          back_text: string | null
+          created_at: string | null
+          deck_id: number | null
+          front_image_bucket: string | null
+          front_image_path: string | null
+          front_text: string | null
+          id: number | null
+          is_duplicate: boolean | null
+          member_id: string | null
+          rank: number | null
+          updated_at: string | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "cards_with_images"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
       insert_card_at: {
         Args: {
           p_anchor_id: number
@@ -956,6 +1142,58 @@ export type Database = {
         }[]
       }
       reset_deck_reviews: { Args: { p_deck_id: number }; Returns: undefined }
+      save_deck: {
+        Args: {
+          p_card_attributes: Json
+          p_cover_config: Json
+          p_deck_id: number
+          p_description: string
+          p_desired_retention_override: number
+          p_has_max_new_override: boolean
+          p_has_max_reviews_override: boolean
+          p_is_public: boolean
+          p_learning_steps_override: string[]
+          p_max_new_per_day_override: number
+          p_max_reviews_per_day_override: number
+          p_relearning_steps_override: string[]
+          p_review_pacing_preset_id: number
+          p_study_config: Json
+          p_title: string
+        }
+        Returns: {
+          card_attributes: Json
+          card_count: number
+          cover_config: Json
+          created_at: string
+          description: string
+          desired_retention: number
+          desired_retention_override: number
+          due_count: number
+          has_image: boolean
+          has_max_new_override: boolean
+          has_max_reviews_override: boolean
+          id: number
+          is_public: boolean
+          learning_steps: string[]
+          learning_steps_override: string[]
+          max_new_per_day: number
+          max_new_per_day_override: number
+          max_reviews_per_day: number
+          max_reviews_per_day_override: number
+          member_display_name: string
+          member_id: string
+          new_reviewed_today_count: number
+          rank: number
+          relearning_steps: string[]
+          relearning_steps_override: string[]
+          review_pacing_preset_id: number
+          reviewed_today_count: number
+          study_config: Json
+          tags: string[]
+          title: string
+          updated_at: string
+        }[]
+      }
       save_review:
         | {
             Args: {
@@ -1001,12 +1239,65 @@ export type Database = {
             }
             Returns: undefined
           }
+      submit_feedback: {
+        Args: {
+          p_body: string
+          p_title: string
+          p_type: Database["public"]["Enums"]["feedback_type"]
+        }
+        Returns: {
+          body: string | null
+          created_at: string
+          id: number
+          member_id: string
+          status: Database["public"]["Enums"]["feedback_status"]
+          title: string
+          type: Database["public"]["Enums"]["feedback_type"]
+          visibility: Database["public"]["Enums"]["feedback_visibility"]
+        }
+        SetofOptions: {
+          from: "*"
+          to: "feedback_items"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
+      toggle_feedback_vote: {
+        Args: { p_feedback_id: number }
+        Returns: boolean
+      }
+      update_feedback_item: {
+        Args: {
+          p_feedback_id: number
+          p_status: Database["public"]["Enums"]["feedback_status"]
+          p_visibility: Database["public"]["Enums"]["feedback_visibility"]
+        }
+        Returns: {
+          body: string | null
+          created_at: string
+          id: number
+          member_id: string
+          status: Database["public"]["Enums"]["feedback_status"]
+          title: string
+          type: Database["public"]["Enums"]["feedback_type"]
+          visibility: Database["public"]["Enums"]["feedback_visibility"]
+        }
+        SetofOptions: {
+          from: "*"
+          to: "feedback_items"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
     }
     Enums: {
-      card_state: 'new' | 'learning' | 'young' | 'mature' | 'relearn'
-      media_slot: 'card_front' | 'card_back'
-      member_role: 'user' | 'moderator' | 'admin'
-      shop_category: 'power_ups' | 'stationary'
+      card_state: "new" | "learning" | "young" | "mature" | "relearn"
+      feedback_status: "new" | "accepted" | "rejected" | "in-progress" | "done"
+      feedback_type: "idea" | "bug" | "other"
+      feedback_visibility: "public" | "internal"
+      media_slot: "card_front" | "card_back"
+      member_role: "user" | "moderator" | "admin"
+      shop_category: "power_ups" | "stationary"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1014,31 +1305,33 @@ export type Database = {
   }
 }
 
-type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
-    : never = never
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
-    ? (DefaultSchema['Tables'] & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -1047,23 +1340,23 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-    : never = never
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -1072,23 +1365,23 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-    : never = never
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -1097,48 +1390,52 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
-    : never = never
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
-    : never = never
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
 export const Constants = {
   graphql_public: {
-    Enums: {}
+    Enums: {},
   },
   public: {
     Enums: {
-      card_state: ['new', 'learning', 'young', 'mature', 'relearn'],
-      media_slot: ['card_front', 'card_back'],
-      member_role: ['user', 'moderator', 'admin'],
-      shop_category: ['power_ups', 'stationary']
-    }
-  }
+      card_state: ["new", "learning", "young", "mature", "relearn"],
+      feedback_status: ["new", "accepted", "rejected", "in-progress", "done"],
+      feedback_type: ["idea", "bug", "other"],
+      feedback_visibility: ["public", "internal"],
+      media_slot: ["card_front", "card_back"],
+      member_role: ["user", "moderator", "admin"],
+      shop_category: ["power_ups", "stationary"],
+    },
+  },
 } as const
+

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1194,51 +1194,29 @@ export type Database = {
           updated_at: string
         }[]
       }
-      save_review:
-        | {
-            Args: {
-              p_card_id: number
-              p_card_state: number
-              p_difficulty: number
-              p_due: string
-              p_elapsed_days: number
-              p_lapses: number
-              p_last_review: string
-              p_learning_steps?: number
-              p_log_difficulty: number
-              p_log_due: string
-              p_log_scheduled_days: number
-              p_log_stability: number
-              p_rating: number
-              p_reps: number
-              p_review: string
-              p_scheduled_days: number
-              p_stability: number
-              p_state: number
-            }
-            Returns: undefined
-          }
-        | {
-            Args: {
-              p_card_id: number
-              p_difficulty: number
-              p_due: string
-              p_elapsed_days: number
-              p_lapses: number
-              p_last_review: string
-              p_log_difficulty: number
-              p_log_due: string
-              p_log_scheduled_days: number
-              p_log_stability: number
-              p_rating: number
-              p_reps: number
-              p_review: string
-              p_scheduled_days: number
-              p_stability: number
-              p_state: number
-            }
-            Returns: undefined
-          }
+      save_review: {
+        Args: {
+          p_card_id: number
+          p_card_state: number
+          p_difficulty: number
+          p_due: string
+          p_elapsed_days: number
+          p_lapses: number
+          p_last_review: string
+          p_learning_steps?: number
+          p_log_difficulty: number
+          p_log_due: string
+          p_log_scheduled_days: number
+          p_log_stability: number
+          p_rating: number
+          p_reps: number
+          p_review: string
+          p_scheduled_days: number
+          p_stability: number
+          p_state: number
+        }
+        Returns: undefined
+      }
       submit_feedback: {
         Args: {
           p_body: string


### PR DESCRIPTION
## Summary

Study sessions pulled every card in a deck because the FE's `get_study_session_cards` call was resolving to a stale Postgres overload: `CREATE OR REPLACE FUNCTION` with a changed argument list creates a *new* overload instead of replacing, so the cap fix (and the 20260707 interleave/overdue-ordering work) landed on a 2-arg function the app never calls, while the live 3-arg one still read caps from `decks.study_config` — empty since the pacing refactor.

- Consolidate `get_study_session_cards` to a single 3-arg function with the resolved-cap ladder, counting today's usage from `p_today_start` (local midnight, same boundary as the inbox's `get_member_decks`) instead of UTC midnight.
- Drop the orphaned 16-arg `save_review` overload (same drift class, dormant since April).
- Add a pgTAP guard: no public function may have multiple overloads, and the exact signatures the FE sends must exist — future signature-changing migrations that forget DROP-first turn CI red.
- Point existing pgTAP tests at the live signatures (they had been exercising the dead overloads, which is why the suite stayed green through the breakage) and regenerate `types/supabase.ts` (was stale since before the feedback board).