### PR TITLE
Scroll deck & settings modal content within a fixed height

### DIFF
--- a/src/components/layout-kit/sheet/mobile-sheet.vue
+++ b/src/components/layout-kit/sheet/mobile-sheet.vue
@@ -140,7 +140,7 @@ provide(mobileSheetOverlayKey, overlay_root)
           </div>
         </slot>
 
-        <div data-testid="mobile-sheet__body" class="h-full">
+        <div data-testid="mobile-sheet__body" class="min-h-0 flex-1">
           <slot></slot>
         </div>
       </div>

--- a/src/components/ui-kit/scroll-bar.vue
+++ b/src/components/ui-kit/scroll-bar.vue
@@ -194,6 +194,8 @@ function isPageTarget(el: HTMLElement) {
     v-show="visible"
     ref="scrollBarRef"
     data-testid="ui-kit-scroll-bar"
+    data-theme="brown-300"
+    data-theme-dark="grey-500"
     :data-min-width="minWidth"
     class="ui-kit-scroll-bar"
     :class="visibilityClass"
@@ -211,8 +213,8 @@ function isPageTarget(el: HTMLElement) {
 
 <style scoped>
 .ui-kit-scroll-bar {
-  --bar-color: var(--color-brown-300);
-  --thumb-color: var(--color-brown-300);
+  --bar-color: var(--theme-primary);
+  --thumb-color: var(--theme-primary);
   --theme-color: var(--color-purple-400);
 
   --transition-dur: 0.05s;

--- a/src/composables/ui/tab-transition.ts
+++ b/src/composables/ui/tab-transition.ts
@@ -9,7 +9,6 @@ export function useTabTransition(
   tab_outlet: Ref<HTMLElement | undefined>
 ) {
   const nav_direction = ref<'forward' | 'back'>('forward')
-  const tab_initial_render = ref(true)
 
   function onTabLeave(el: Element, done: () => void) {
     if (layout_mode.value === 'sheet') {
@@ -20,11 +19,6 @@ export function useTabTransition(
   }
 
   function onTabEnter(el: Element, done: () => void) {
-    if (tab_initial_render.value) {
-      tab_initial_render.value = false
-      done()
-      return
-    }
     if (layout_mode.value === 'sheet') {
       tabSlideEnter(nav_direction, tab_outlet.value)(el, done)
       return

--- a/src/views/deck/deck-settings/index.vue
+++ b/src/views/deck/deck-settings/index.vue
@@ -152,7 +152,8 @@ watch(active_tab, (tab) => {
     data-theme-dark="green-800"
     :data-layout="layout_mode"
     :class="[
-      layout_mode === 'desktop' ? 'w-236! h-181.5' : 'w-full! max-w-205.5 h-181.5',
+      layout_mode === 'desktop' ? 'w-236!' : 'w-full! max-w-205.5',
+      layout_mode !== 'sheet' && 'h-181.5',
       layout_mode === 'sheet'
         ? '[--deck-settings-padding:var(--sheet-px)]'
         : '[--deck-settings-padding:0px]'

--- a/src/views/deck/deck-settings/index.vue
+++ b/src/views/deck/deck-settings/index.vue
@@ -11,6 +11,7 @@ import { useTabTransition } from '@/composables/ui/tab-transition'
 import { useAlert } from '@/composables/alert'
 import { useModalAfterEnter, useModalRequestClose } from '@/composables/modal'
 import DeckPinnedPreview from '@/components/deck/pinned-preview.vue'
+import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
 import TabSheet from '@/components/layout-kit/sheet/tab-sheet.vue'
 import TabDetails from './tab-details/index.vue'
 import TabDesign from './tab-design/index.vue'
@@ -89,14 +90,10 @@ const visible_side = computed(() =>
 
 const tab_component = computed(() => TAB_COMPONENTS[displayed_tab.value])
 
-// Sheet mode goes full-bleed so the animated tab outlet doesn't clip outlines/
-// rings — each tab self-pads via --deck-settings-padding instead. Tablet/desktop
-// keep the container padding so the aside column stays inset.
-const tab_content_class = computed(() =>
-  layout_mode.value === 'sheet'
-    ? 'flex gap-14 h-full items-start'
-    : 'px-(--sheet-px) pb-8 pt-0 flex gap-14 h-full items-start'
-)
+// The content row is always full-bleed: `__main` (the scroll container) owns its
+// own padding and the aside owns its own inset, so floating elements/outlines
+// aren't clipped by the overflow and the sheet-mode tab animation stays clean.
+const tab_content_class = 'flex h-full items-start'
 
 onMounted(async () => {
   if (initial_side) {
@@ -155,7 +152,7 @@ watch(active_tab, (tab) => {
     data-theme-dark="green-800"
     :data-layout="layout_mode"
     :class="[
-      layout_mode === 'desktop' ? 'w-236!' : 'w-full! max-w-205.5',
+      layout_mode === 'desktop' ? 'w-236! h-181.5' : 'w-full! max-w-205.5 h-181.5',
       layout_mode === 'sheet'
         ? '[--deck-settings-padding:var(--sheet-px)]'
         : '[--deck-settings-padding:0px]'
@@ -185,28 +182,43 @@ watch(active_tab, (tab) => {
     </template>
 
     <div
-      ref="tab_outlet"
-      data-testid="deck-settings__main"
-      :class="[
-        'relative flex flex-1 flex-col gap-4 w-full min-w-0',
-        layout_mode === 'sheet' && 'max-w-111 mx-auto overflow-hidden pt-0.5'
-      ]"
+      class="relative flex flex-1 flex-col min-w-0"
+      :class="layout_mode !== 'sheet' && 'max-h-full'"
     >
-      <transition :css="false" mode="out-in" @leave="onTabLeave" @enter="onTabEnter">
-        <component
-          ref="active_tab_ref"
-          :is="tab_component"
-          :key="displayed_tab"
-          @navigate="onNavigate"
-        />
-      </transition>
+      <div
+        ref="tab_outlet"
+        data-testid="deck-settings__main"
+        :class="[
+          'flex flex-col gap-4 w-full',
+          layout_mode === 'sheet'
+            ? 'max-w-111 mx-auto overflow-hidden pt-0.5'
+            : 'min-h-0 flex-1 overflow-y-auto scroll-hidden px-(--sheet-px) pb-8'
+        ]"
+      >
+        <transition :css="false" mode="out-in" @leave="onTabLeave" @enter="onTabEnter">
+          <component
+            ref="active_tab_ref"
+            :is="tab_component"
+            :key="displayed_tab"
+            @navigate="onNavigate"
+          />
+        </transition>
+      </div>
+
+      <scroll-bar
+        v-if="layout_mode !== 'sheet'"
+        data-theme="brown-200"
+        target="[data-testid='deck-settings__main']"
+        class="absolute top-2 bottom-4 right-0"
+      />
     </div>
 
+    <!-- Aside has a bespoke layout so it matches visually with the pinned preview -->
     <deck-aside
       v-if="layout_mode !== 'sheet'"
       data-testid="deck-settings__aside"
-      class="w-78.5 shrink-0 self-end"
-      :class="layout_mode === 'tablet' ? 'pt-66' : 'pt-70'"
+      class="w-92 shrink-0 self-end pb-8"
+      :class="layout_mode === 'tablet' ? 'pt-66 pr-22' : 'pt-70 px-8'"
     />
 
     <template #overlay>

--- a/src/views/settings/index.vue
+++ b/src/views/settings/index.vue
@@ -14,6 +14,7 @@ import { useModalRequestClose } from '@/composables/modal'
 import { useAvatarPicker } from './use-avatar-picker'
 import MemberCard from '@/components/member/member-card.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
+import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
 import TabSheet from '@/components/layout-kit/sheet/tab-sheet.vue'
 import TabProfile from './tab-profile/index.vue'
 import TabSubscription from './tab-subscription/index.vue'
@@ -91,14 +92,10 @@ const header_title = computed(() =>
 
 const tab_component = computed(() => TAB_COMPONENTS[displayed_tab.value])
 
-// Sheet mode goes full-bleed so the animated tab outlet doesn't clip outlines/
-// rings — each tab self-pads via --settings-padding instead. Tablet/desktop keep
-// the container padding so the aside column stays inset.
-const tab_content_class = computed(() =>
-  layout_mode.value === 'sheet'
-    ? 'flex gap-14 h-full items-start'
-    : 'px-(--sheet-px) pb-8 pt-0 flex gap-14 h-full items-start'
-)
+// The content row is always full-bleed: `__main` (the scroll container) owns its
+// own padding and the aside owns its own inset, so floating elements/outlines
+// aren't clipped by the overflow and the sheet-mode tab animation stays clean.
+const tab_content_class = 'flex h-full items-start'
 
 // Open/close sfx live on the modal itself so every callsite (phone launcher,
 // dashboard edit button) sounds identically. Mirrors the deck-settings modal.
@@ -181,28 +178,42 @@ watch(layout_mode, (mode) => {
     </template>
 
     <div
-      ref="tab_outlet"
-      data-testid="settings__main"
-      :class="[
-        'relative flex flex-1 flex-col gap-4 w-full min-w-0',
-        layout_mode === 'sheet' && 'max-w-111 mx-auto overflow-hidden pt-0.5'
-      ]"
+      class="relative flex flex-1 flex-col min-w-0"
+      :class="layout_mode !== 'sheet' && 'max-h-full'"
     >
-      <transition :css="false" mode="out-in" @leave="onTabLeave" @enter="onTabEnter">
-        <component
-          ref="active_tab_ref"
-          :is="tab_component"
-          :key="displayed_tab"
-          @navigate="onNavigate"
-        />
-      </transition>
+      <div
+        ref="tab_outlet"
+        data-testid="settings__main"
+        :class="[
+          'flex flex-col gap-4 w-full',
+          layout_mode === 'sheet'
+            ? 'max-w-111 mx-auto overflow-hidden pt-0.5'
+            : 'min-h-0 flex-1 overflow-y-auto scroll-hidden px-(--sheet-px) pb-8'
+        ]"
+      >
+        <transition :css="false" mode="out-in" @leave="onTabLeave" @enter="onTabEnter">
+          <component
+            ref="active_tab_ref"
+            :is="tab_component"
+            :key="displayed_tab"
+            @navigate="onNavigate"
+          />
+        </transition>
+      </div>
+
+      <scroll-bar
+        v-if="layout_mode !== 'sheet'"
+        target="[data-testid='settings__main']"
+        class="absolute top-2 bottom-2 right-2"
+      />
     </div>
 
+    <!-- Aside has a bespoke layout so it matches visually with the pinned preview -->
     <settings-aside
       v-if="layout_mode !== 'sheet'"
       data-testid="settings__aside"
-      class="w-90 shrink-0 self-end"
-      :class="layout_mode === 'tablet' ? 'pt-56' : 'pt-60'"
+      class="shrink-0 self-end pb-8"
+      :class="layout_mode === 'tablet' ? 'w-110 pt-56 pl-10 pr-26' : 'w-100 pt-60 pl-8 pr-16'"
     />
 
     <template #overlay>

--- a/tests/integration/components/modals/deck-settings/index.test.js
+++ b/tests/integration/components/modals/deck-settings/index.test.js
@@ -751,18 +751,16 @@ describe('DeckSettings — onClose when dirty shows alert', () => {
   })
 })
 
-describe('DeckSettings — tab_initial_render fast-path [obligation]', () => {
-  test('onTabEnter calls done immediately on first render without GSAP tween', async () => {
-    // The GSAP mock fires onComplete synchronously (see gsap mock above), but
-    // the important assertion is that tab_initial_render prevents any slide/fade
-    // call on the very first enter. Since the transition fires internally on
-    // mount, the initial render completes without additional GSAP calls.
-    // Verify: after mount, the tab content is visible (rendered = done() was called).
+describe('DeckSettings — initial tab renders on mount [obligation]', () => {
+  test('tab content is visible after mount (no <transition appear>, so onTabEnter never fires on initial mount)', async () => {
+    // The tab `<transition>` has no `appear` attribute, so `enter` only fires
+    // on a subsequent tab swap, not on the initial mount — the tab content is
+    // simply rendered directly. This guards against re-adding an `appear` (or
+    // an initial-render skip guard in useTabTransition) that would change this.
     setSidebar(false)
     const { wrapper } = makeWrapper({ initial_tab: 'design' })
     await flushPromises()
 
-    // Component is visible — onTabEnter called done() via the fast-path
     expect(wrapper.find('[data-testid="tab-design-stub"]').exists()).toBe(true)
   })
 })

--- a/tests/unit/composables/ui/tab-transition.test.js
+++ b/tests/unit/composables/ui/tab-transition.test.js
@@ -70,10 +70,10 @@ describe('useTabTransition — nav_direction [obligation]', () => {
   })
 })
 
-// ── onTabEnter — initial-render skip ─────────────────────────────────────────
+// ── onTabEnter — regression: first call must animate, not skip ────────────────
 
-describe('useTabTransition — onTabEnter initial-render skip [obligation]', () => {
-  test('first onTabEnter call fires done() immediately without any GSAP animation', () => {
+describe('useTabTransition — onTabEnter does not skip the first call [obligation]', () => {
+  test('first onTabEnter animates (does not skip) — regression for removed initial-render guard', () => {
     const { layout_mode } = makeLayout('sheet')
     const tab_outlet = ref(document.createElement('div'))
     const { onTabEnter } = useTabTransition(layout_mode, tab_outlet)
@@ -81,24 +81,13 @@ describe('useTabTransition — onTabEnter initial-render skip [obligation]', () 
     const done = vi.fn()
     onTabEnter(makeEl(), done)
 
+    // A single call routes straight to the sheet-mode animation — no skip,
+    // no second call required. The removed guard used to freeze __main's
+    // height on tabSlideLeave and never re-run tabSlideEnter to unfreeze it
+    // on the very next enter, clipping content until the user navigated away
+    // and back.
+    expect(mockTabSlideEnter).toHaveBeenCalledOnce()
     expect(done).toHaveBeenCalledOnce()
-    // No animation calls on initial render
-    expect(mockTabSlideEnter).not.toHaveBeenCalled()
-    expect(mockFadeEnter).not.toHaveBeenCalled()
-  })
-
-  test('second onTabEnter call does run the animation (guard is consumed after first call)', () => {
-    const { layout_mode } = makeLayout('tablet')
-    const tab_outlet = ref(document.createElement('div'))
-    const { onTabEnter } = useTabTransition(layout_mode, tab_outlet)
-
-    const done1 = vi.fn()
-    const done2 = vi.fn()
-
-    onTabEnter(makeEl(), done1) // consumed — initial render skip
-    onTabEnter(makeEl(), done2) // now routes through fade (tablet mode)
-
-    expect(mockFadeEnter).toHaveBeenCalledOnce()
   })
 })
 
@@ -111,8 +100,7 @@ describe('useTabTransition — onTabEnter routing [obligation]', () => {
     const { onTabEnter } = useTabTransition(layout_mode, tab_outlet)
 
     const done = vi.fn()
-    onTabEnter(makeEl(), done) // first call — consumed
-    onTabEnter(makeEl(), done) // second call — animates
+    onTabEnter(makeEl(), done)
 
     expect(mockTabSlideEnter).toHaveBeenCalledOnce()
     expect(mockFadeEnter).not.toHaveBeenCalled()
@@ -124,8 +112,7 @@ describe('useTabTransition — onTabEnter routing [obligation]', () => {
     const { onTabEnter } = useTabTransition(layout_mode, tab_outlet)
 
     const done = vi.fn()
-    onTabEnter(makeEl(), done) // first call — consumed
-    onTabEnter(makeEl(), done) // second call — animates
+    onTabEnter(makeEl(), done)
 
     expect(mockFadeEnter).toHaveBeenCalledOnce()
     expect(mockTabSlideEnter).not.toHaveBeenCalled()
@@ -137,8 +124,7 @@ describe('useTabTransition — onTabEnter routing [obligation]', () => {
     const { onTabEnter } = useTabTransition(layout_mode, tab_outlet)
 
     const done = vi.fn()
-    onTabEnter(makeEl(), done) // first call — consumed
-    onTabEnter(makeEl(), done) // second call — animates
+    onTabEnter(makeEl(), done)
 
     expect(mockFadeEnter).toHaveBeenCalledOnce()
     expect(mockTabSlideEnter).not.toHaveBeenCalled()
@@ -201,9 +187,7 @@ describe('useTabTransition — onTabLeave routing [obligation]', () => {
     const tab_outlet = ref(outlet)
     const { onTabEnter, nav_direction } = useTabTransition(layout_mode, tab_outlet)
 
-    const done = vi.fn()
-    onTabEnter(makeEl(), done) // consumed
-    onTabEnter(makeEl(), done) // animates
+    onTabEnter(makeEl(), vi.fn())
 
     expect(mockTabSlideEnter).toHaveBeenCalledWith(nav_direction, outlet)
   })


### PR DESCRIPTION
## Summary

Rework the deck-settings and app-settings tab modals so the content column scrolls internally within a fixed-height modal instead of growing the modal, and fix the mobile/tablet regressions that surfaced along the way (tall tabs that couldn't scroll, and a first tab transition that didn't animate or resize).

## Changes

- **Fixed-height + internal scroll** — each modal gets a fixed height; `__main` becomes the scroll container and owns its own padding, with the content row full-bleed so floating elements/outlines aren't clipped and the sheet tab animation stays clean.
- **mobile-sheet body** takes the remaining space (`flex-1 min-h-0`) so its height excludes the header — corrects the scroll bound for every sheet-based modal.
- **aside** owns its own inset/geometry per layout now the container is full-bleed; the `ui-scroll-bar` overlay targets `__main`.
- **Mobile fix** — the deck modal's fixed height is gated to non-sheet, so on mobile the sheet grows and the modal host scrolls tall tabs (matching app-settings).
- **First-transition fix** — dropped the dead `tab_initial_render` guard in `useTabTransition`; with no `<transition appear>` it never fired on mount and only mis-skipped the first real tab change, leaving `__main`'s frozen height clipping the entering tab.
- Tests realigned to the corrected transition behavior, with a named regression test for the first-transition animation.