### PR TITLE
Full-bleed settings tabs with a tucking card preview

### DIFF
--- a/src/components/deck/pinned-preview.vue
+++ b/src/components/deck/pinned-preview.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import DeckDesignPreview from './deck-design-preview.vue'
 import Card from '@/components/card/index.vue'
-import UiIcon from '@/components/ui-kit/icon.vue'
+import UiPinnedCard from '@/components/ui-kit/pinned-card.vue'
 
 type DeckPinnedPreviewProps = {
   cover: DeckCover
@@ -9,9 +9,10 @@ type DeckPinnedPreviewProps = {
   side: CardSide
   front_text?: string
   back_text?: string
+  tucked?: boolean
 }
 
-const { cover, card_attributes, side, front_text, back_text } =
+const { cover, card_attributes, side, front_text, back_text, tucked } =
   defineProps<DeckPinnedPreviewProps>()
 
 const emit = defineEmits<{
@@ -20,20 +21,15 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div data-testid="deck-pinned-preview" class="relative">
-    <card
-      data-testid="deck-pinned-preview__shadow-card"
-      size="xl"
-      class="absolute! -top-2 right-1"
-      face_classes="bg-white! dark:bg-stone-700!"
-    />
-
-    <div
-      data-testid="deck-pinned-preview__paperclip"
-      class="absolute -top-8 right-15 -translate-x-1/2 z-10 drop-shadow-2xs transition-opacity duration-100 group-data-[tucked=true]:opacity-0"
-    >
-      <ui-icon src="paperclip" class="w-16 h-16 -rotate-186 text-grey-300" />
-    </div>
+  <ui-pinned-card data-testid="deck-pinned-preview" :tucked="tucked">
+    <template #backdrop>
+      <card
+        data-testid="deck-pinned-preview__shadow-card"
+        size="xl"
+        class="absolute! -top-2 right-1"
+        face_classes="bg-white! dark:bg-stone-700!"
+      />
+    </template>
 
     <deck-design-preview
       data-testid="deck-pinned-preview__preview"
@@ -42,8 +38,7 @@ const emit = defineEmits<{
       :side="side"
       :front_text="front_text"
       :back_text="back_text"
-      class="rotate-4 drop-shadow-sm"
       @update:side="emit('update:side', $event)"
     />
-  </div>
+  </ui-pinned-card>
 </template>

--- a/src/components/deck/pinned-preview.vue
+++ b/src/components/deck/pinned-preview.vue
@@ -30,7 +30,7 @@ const emit = defineEmits<{
 
     <div
       data-testid="deck-pinned-preview__paperclip"
-      class="absolute -top-8 right-15 -translate-x-1/2 z-10 drop-shadow-2xs"
+      class="absolute -top-8 right-15 -translate-x-1/2 z-10 drop-shadow-2xs transition-opacity duration-100 group-data-[tucked=true]:opacity-0"
     >
       <ui-icon src="paperclip" class="w-16 h-16 -rotate-186 text-grey-300" />
     </div>

--- a/src/components/layout-kit/sheet/mobile-sheet.vue
+++ b/src/components/layout-kit/sheet/mobile-sheet.vue
@@ -108,7 +108,7 @@ provide(mobileSheetOverlayKey, overlay_root)
       <div
         data-testid="mobile-sheet"
         :data-surface="surface"
-        :class="['relative flex w-full h-full flex-col', body_bg_class]"
+        class="relative flex w-full h-full flex-col"
       >
         <div
           v-if="show_builtin_close"

--- a/src/components/layout-kit/sheet/mobile-sheet.vue
+++ b/src/components/layout-kit/sheet/mobile-sheet.vue
@@ -92,7 +92,7 @@ provide(mobileSheetOverlayKey, overlay_root)
     <div
       ref="overlay_root"
       data-testid="mobile-sheet__overlay"
-      class="absolute inset-0 pointer-events-none z-10"
+      class="absolute inset-0 pointer-events-none z-[var(--sheet-overlay-z,30)]"
     >
       <slot name="overlay"></slot>
     </div>
@@ -111,7 +111,7 @@ provide(mobileSheetOverlayKey, overlay_root)
         <div
           v-if="show_builtin_close"
           data-testid="mobile-sheet__close-slot"
-          class="absolute top-0 p-4 left-0 z-20"
+          class="absolute top-0 p-4 left-0 z-40"
         >
           <ui-button
             :icon-left="close_icon"
@@ -130,7 +130,7 @@ provide(mobileSheetOverlayKey, overlay_root)
             :data-header-border="header_border"
             v-bind="header_bindings"
             :class="[
-              'w-full flex justify-center items-center place-items-center px-(--sheet-px) pt-11.5 pb-14 gap-6 bg-(--theme-primary) text-(--theme-on-primary) relative',
+              'w-full flex justify-center items-center place-items-center px-(--sheet-px) pt-11.5 pb-14 gap-6 bg-(--theme-primary) text-(--theme-on-primary) relative z-10',
               header_border_class
             ]"
           >
@@ -140,7 +140,10 @@ provide(mobileSheetOverlayKey, overlay_root)
           </div>
         </slot>
 
-        <div data-testid="mobile-sheet__body" class="min-h-0 flex-1">
+        <div
+          data-testid="mobile-sheet__body"
+          :class="['relative z-20 min-h-0 flex-1', body_bg_class]"
+        >
           <slot></slot>
         </div>
       </div>

--- a/src/components/layout-kit/sheet/mobile-sheet.vue
+++ b/src/components/layout-kit/sheet/mobile-sheet.vue
@@ -6,6 +6,7 @@ import { mobileSheetOverlayKey } from './mobile-sheet-overlay'
 import {
   SHEET_BODY_BG,
   SHEET_HEADER_BORDER_CLASS,
+  SHEET_HEADER_FILL_CLASS,
   type SheetHeaderBorder,
   type SheetSurface
 } from './sheet-surface'
@@ -57,6 +58,7 @@ const emit = defineEmits<{
 
 const body_bg_class = computed(() => SHEET_BODY_BG[surface])
 const header_border_class = computed(() => SHEET_HEADER_BORDER_CLASS[header_border])
+const header_fill_class = computed(() => SHEET_HEADER_FILL_CLASS[header_border])
 const close_label_text = computed(() => close_label ?? t('mobile-sheet.close-label'))
 
 // The default header owns the close button. A custom `header` slot replaces the
@@ -92,7 +94,7 @@ provide(mobileSheetOverlayKey, overlay_root)
     <div
       ref="overlay_root"
       data-testid="mobile-sheet__overlay"
-      class="absolute inset-0 pointer-events-none z-[var(--sheet-overlay-z,30)]"
+      class="absolute inset-0 pointer-events-none z-(--sheet-overlay-z,30)"
     >
       <slot name="overlay"></slot>
     </div>
@@ -124,21 +126,30 @@ provide(mobileSheetOverlayKey, overlay_root)
           </ui-button>
         </div>
 
-        <slot v-if="showHeader" name="header">
+        <div v-if="showHeader" data-testid="mobile-sheet__header-slot" class="relative">
+          <slot name="header">
+            <div
+              data-testid="mobile-sheet__header"
+              :data-header-border="header_border"
+              v-bind="header_bindings"
+              :class="[
+                'w-full flex justify-center items-center place-items-center px-(--sheet-px) pt-11.5 pb-14 gap-6 bg-(--theme-primary) text-(--theme-on-primary) relative z-10',
+                header_border_class
+              ]"
+            >
+              <slot name="header-content">
+                <h1 class="text-5xl text-white">{{ title }}</h1>
+              </slot>
+            </div>
+          </slot>
+
           <div
-            data-testid="mobile-sheet__header"
-            :data-header-border="header_border"
-            v-bind="header_bindings"
-            :class="[
-              'w-full flex justify-center items-center place-items-center px-(--sheet-px) pt-11.5 pb-14 gap-6 bg-(--theme-primary) text-(--theme-on-primary) relative z-10',
-              header_border_class
-            ]"
-          >
-            <slot name="header-content">
-              <h1 class="text-5xl text-white">{{ title }}</h1>
-            </slot>
-          </div>
-        </slot>
+            v-if="header_fill_class"
+            data-testid="mobile-sheet__header-fill"
+            aria-hidden="true"
+            :class="['absolute inset-0 z-20 pointer-events-none', body_bg_class, header_fill_class]"
+          ></div>
+        </div>
 
         <div
           data-testid="mobile-sheet__body"

--- a/src/components/layout-kit/sheet/sheet-surface.ts
+++ b/src/components/layout-kit/sheet/sheet-surface.ts
@@ -16,3 +16,14 @@ export const SHEET_HEADER_BORDER_CLASS: Record<SheetHeaderBorder, string> = {
   cloud: 'cloud-bottom-[50px]',
   none: ''
 }
+
+// Paints back the strip the header's border mask cuts away, on a layer above
+// the overlay, so a lowered overlay is occluded along the shaped edge rather
+// than the header's straight box bottom. `none` needs no fill — its bottom edge
+// already is the box. `cloud` has no complement utility yet; a cloud-bordered
+// sheet that lowers its overlay will clip on a straight line until it does.
+export const SHEET_HEADER_FILL_CLASS: Record<SheetHeaderBorder, string> = {
+  wave: 'wave-bottom-fill-[50px]',
+  cloud: '',
+  none: ''
+}

--- a/src/components/layout-kit/sheet/tab-sheet.vue
+++ b/src/components/layout-kit/sheet/tab-sheet.vue
@@ -41,7 +41,7 @@ const {
   sidebar_query = 'w>=lg & fine',
   sheet_px,
   hover_sfx = TYPE_SFX,
-  select_sfx = 'select',
+  select_sfx = 'snappy_button_5',
   reselect_sfx = 'digi_powerdown',
   show_back = false
 } = defineProps<TabSheetProps>()

--- a/src/components/ui-kit/pinned-card.vue
+++ b/src/components/ui-kit/pinned-card.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import UiIcon from '@/components/ui-kit/icon.vue'
+
+type UiPinnedCardProps = {
+  tucked?: boolean
+}
+
+const { tucked = false } = defineProps<UiPinnedCardProps>()
+
+defineSlots<{
+  backdrop(): any
+  default(): any
+}>()
+</script>
+
+<template>
+  <div data-testid="ui-pinned-card" class="relative">
+    <slot name="backdrop"></slot>
+
+    <div
+      data-testid="ui-pinned-card__paperclip"
+      :data-tucked="tucked"
+      class="absolute -top-8 right-15 -translate-x-1/2 z-10 drop-shadow-2xs transition-opacity duration-100"
+      :class="tucked && 'opacity-0'"
+    >
+      <ui-icon src="paperclip" class="w-16 h-16 -rotate-186 text-grey-300" />
+    </div>
+
+    <div data-testid="ui-pinned-card__card" class="rotate-4 drop-shadow-sm">
+      <slot></slot>
+    </div>
+  </div>
+</template>

--- a/src/composables/ui/sheet-chrome.ts
+++ b/src/composables/ui/sheet-chrome.ts
@@ -1,0 +1,62 @@
+import { ref, type Ref } from 'vue'
+import { retractAside, restoreAside, snapAside } from '@/utils/animations/aside-retract'
+import {
+  snapPinnedPreview,
+  tuckPinnedPreview,
+  untuckPinnedPreview
+} from '@/utils/animations/preview-tuck'
+
+export type SheetChrome = ReturnType<typeof useSheetChrome>
+
+/**
+ * Drives a tab sheet's surrounding chrome — the pinned card preview and the
+ * form aside — in and out together, so a tab can claim the whole content area.
+ *
+ * `is_tucked` flips at the preview's edge-on midpoint rather than when the
+ * animation starts, so the caller can restack the card behind the content pane
+ * on the one frame where it can't be seen.
+ *
+ * @param preview - the positioned wrapper around the pinned card, not the card itself
+ * @param aside - the aside element sharing the content row with the tab outlet
+ *
+ * @example
+ * const chrome = useSheetChrome(preview_el, aside_el)
+ * await chrome.tuck()
+ */
+export function useSheetChrome(
+  preview: Readonly<Ref<HTMLElement | null | undefined>>,
+  aside: Readonly<Ref<HTMLElement | null | undefined>>
+) {
+  const is_tucked = ref(false)
+
+  /** Flips the preview away and retracts the aside. No-op if already tucked. */
+  async function tuck() {
+    if (is_tucked.value) return
+
+    await Promise.all([
+      preview.value && tuckPinnedPreview(preview.value, () => (is_tucked.value = true)),
+      aside.value && retractAside(aside.value)
+    ])
+    is_tucked.value = true
+  }
+
+  /** Flips the preview back out and restores the aside. No-op if already showing. */
+  async function restore() {
+    if (!is_tucked.value) return
+
+    await Promise.all([
+      preview.value && untuckPinnedPreview(preview.value, () => (is_tucked.value = false)),
+      aside.value && restoreAside(aside.value)
+    ])
+    is_tucked.value = false
+  }
+
+  /** Jumps straight to a pose without animating, for a sheet that opens on a full-bleed tab. */
+  function snap(tucked: boolean) {
+    if (preview.value) snapPinnedPreview(preview.value, tucked)
+    if (aside.value) snapAside(aside.value, tucked)
+    is_tucked.value = tucked
+  }
+
+  return { is_tucked, tuck, restore, snap }
+}

--- a/src/composables/ui/sheet-chrome.ts
+++ b/src/composables/ui/sheet-chrome.ts
@@ -1,4 +1,5 @@
 import { ref, type Ref } from 'vue'
+import { emitSfx } from '@/sfx/bus'
 import { retractAside, restoreAside, snapAside } from '@/utils/animations/aside-retract'
 import {
   snapPinnedPreview,
@@ -33,6 +34,7 @@ export function useSheetChrome(
   async function tuck() {
     if (is_tucked.value) return
 
+    emitSfx('slide_up')
     await Promise.all([
       preview.value && tuckPinnedPreview(preview.value, () => (is_tucked.value = true)),
       aside.value && retractAside(aside.value)
@@ -44,6 +46,7 @@ export function useSheetChrome(
   async function restore() {
     if (!is_tucked.value) return
 
+    emitSfx('slide_up')
     await Promise.all([
       preview.value && untuckPinnedPreview(preview.value, () => (is_tucked.value = false)),
       aside.value && restoreAside(aside.value)

--- a/src/composables/ui/tab-transition.ts
+++ b/src/composables/ui/tab-transition.ts
@@ -22,16 +22,20 @@ export function useTabTransition(
   async function onTabLeave(el: Element, done: () => void) {
     await runLeave(el)
 
-    // Tucking waits for the outgoing tab so the chrome doesn't animate over a
-    // pane that's still fading; untucking rides along with the incoming tab
-    // below, since there's nothing left to collide with.
-    if (is_full_bleed?.()) await chrome?.tuck()
+    // Both directions run here, in the gap between the two tabs. The chrome
+    // takes and gives back the content row's width instantly, and this is the
+    // only moment with no tab mounted for that reflow to shift.
+    await syncChrome()
     done()
   }
 
   function onTabEnter(el: Element, done: () => void) {
-    if (is_full_bleed && !is_full_bleed()) chrome?.restore()
     runEnter(el, done)
+  }
+
+  function syncChrome() {
+    if (!chrome || !is_full_bleed) return
+    return is_full_bleed() ? chrome.tuck() : chrome.restore()
   }
 
   function runLeave(el: Element) {

--- a/src/composables/ui/tab-transition.ts
+++ b/src/composables/ui/tab-transition.ts
@@ -2,23 +2,46 @@ import { ref } from 'vue'
 import type { ComputedRef, Ref } from 'vue'
 import { fadeEnter, fadeLeave } from '@/utils/animations/fade'
 import { tabSlideEnter, tabSlideLeave } from '@/utils/animations/tab-slide'
+import type { SheetChrome } from './sheet-chrome'
 import type { TabModalLayout } from './tab-modal-layout'
+
+type TabTransitionOptions = {
+  chrome?: SheetChrome
+  // True when the tab now displayed wants the full content area. Read lazily
+  // during leave, by which point the incoming tab is already the displayed one.
+  is_full_bleed?: () => boolean
+}
 
 export function useTabTransition(
   layout_mode: ComputedRef<TabModalLayout>,
-  tab_outlet: Ref<HTMLElement | undefined>
+  tab_outlet: Ref<HTMLElement | undefined>,
+  { chrome, is_full_bleed }: TabTransitionOptions = {}
 ) {
   const nav_direction = ref<'forward' | 'back'>('forward')
 
-  function onTabLeave(el: Element, done: () => void) {
-    if (layout_mode.value === 'sheet') {
-      tabSlideLeave(nav_direction, tab_outlet.value)(el, done)
-      return
-    }
-    fadeLeave(el, done)
+  async function onTabLeave(el: Element, done: () => void) {
+    await runLeave(el)
+
+    // Tucking waits for the outgoing tab so the chrome doesn't animate over a
+    // pane that's still fading; untucking rides along with the incoming tab
+    // below, since there's nothing left to collide with.
+    if (is_full_bleed?.()) await chrome?.tuck()
+    done()
   }
 
   function onTabEnter(el: Element, done: () => void) {
+    if (is_full_bleed && !is_full_bleed()) chrome?.restore()
+    runEnter(el, done)
+  }
+
+  function runLeave(el: Element) {
+    return new Promise<void>((resolve) => {
+      if (layout_mode.value === 'sheet') tabSlideLeave(nav_direction, tab_outlet.value)(el, resolve)
+      else fadeLeave(el, resolve)
+    })
+  }
+
+  function runEnter(el: Element, done: () => void) {
     if (layout_mode.value === 'sheet') {
       tabSlideEnter(nav_direction, tab_outlet.value)(el, done)
       return

--- a/src/styles/border-utils.css
+++ b/src/styles/border-utils.css
@@ -28,6 +28,44 @@
   mask: var(--wave-mask);
 }
 
+@utility wave-bottom-fill-* {
+  /* Exact complement of wave-bottom-* at the same size: opaque below the wave
+     line, transparent above it. Share a box with a wave-bottom element and this
+     paints back precisely what that element's mask cut away — so a layer sitting
+     between the two can be occluded along the wave instead of a straight edge.
+     The geometry below is copied from wave-bottom-*; keep the two in sync. */
+  --wave-size: --value([length]);
+  --wave-radius: var(--wave-size);
+  --wave-width: calc(var(--wave-size) * 1.788);
+  --crest-offset: calc(var(--wave-size) * 1.341);
+  --trough-offset: calc(var(--wave-size) * 0.895);
+  --baseline-offset: calc(var(--wave-size) * 0.447);
+  --crest-horizontal-shift: calc(50% - (var(--wave-width) / 2));
+
+  /* Layers composite bottom-up: trough and crest union into the wave, then the
+     full-cover layer XORs against it to invert the result. */
+  --wave-fill-mask:
+    linear-gradient(#000, #000),
+    radial-gradient(
+        var(--wave-radius) at 50% calc(100% - var(--crest-offset)),
+        #000 99%,
+        #0000 101%
+      )
+      var(--crest-horizontal-shift) 0 / var(--wave-width) 100%,
+    radial-gradient(
+        var(--wave-radius) at 50% calc(100% + var(--trough-offset)),
+        #0000 99%,
+        #000 101%
+      )
+      50% round(down, calc(100% - var(--baseline-offset)), 1px) / var(--wave-width)
+      round(down, 100%, 1px) repeat-x;
+
+  -webkit-mask: var(--wave-fill-mask);
+  mask: var(--wave-fill-mask);
+  -webkit-mask-composite: xor, source-over, source-over;
+  mask-composite: exclude, add, add;
+}
+
 @utility wave-top-* {
   --wave-size: --value([length]); /* main control */
   --wave-radius: var(--wave-size);

--- a/src/utils/animations/aside-retract.ts
+++ b/src/utils/animations/aside-retract.ts
@@ -1,6 +1,6 @@
 import { gsap } from 'gsap'
 
-const DURATION = 0.28
+const DURATION = 0.2
 const EASE = 'power2.inOut'
 
 /**

--- a/src/utils/animations/aside-retract.ts
+++ b/src/utils/animations/aside-retract.ts
@@ -1,0 +1,46 @@
+import { gsap } from 'gsap'
+
+const DURATION = 0.28
+const EASE = 'power2.inOut'
+
+/**
+ * Slides the aside out past the right edge while collapsing the track it
+ * occupies, so its `flex-1` sibling reflows to full width as it leaves.
+ * Negative margin does the collapsing — animating `width` would squash the
+ * aside's own contents on the way out.
+ */
+export function retractAside(el: HTMLElement) {
+  return new Promise<void>((resolve) => {
+    gsap.to(el, {
+      xPercent: 100,
+      autoAlpha: 0,
+      marginRight: -el.offsetWidth,
+      duration: DURATION,
+      ease: EASE,
+      onComplete: resolve
+    })
+  })
+}
+
+/** Reverse of {@link retractAside} — slides the aside back in and reclaims its track. */
+export function restoreAside(el: HTMLElement) {
+  return new Promise<void>((resolve) => {
+    gsap.to(el, {
+      xPercent: 0,
+      autoAlpha: 1,
+      marginRight: 0,
+      duration: DURATION,
+      ease: EASE,
+      onComplete: () => {
+        gsap.set(el, { clearProps: 'transform,visibility,opacity,marginRight' })
+        resolve()
+      }
+    })
+  })
+}
+
+/** Drops the aside straight into a pose with no animation, for the initial mount. */
+export function snapAside(el: HTMLElement, retracted: boolean) {
+  if (retracted) gsap.set(el, { xPercent: 100, autoAlpha: 0, marginRight: -el.offsetWidth })
+  else gsap.set(el, { clearProps: 'transform,visibility,opacity,marginRight' })
+}

--- a/src/utils/animations/aside-retract.ts
+++ b/src/utils/animations/aside-retract.ts
@@ -4,31 +4,35 @@ const DURATION = 0.2
 const EASE = 'power2.inOut'
 
 /**
- * Slides the aside out past the right edge while collapsing the track it
- * occupies, so its `flex-1` sibling reflows to full width as it leaves.
- * Negative margin does the collapsing — animating `width` would squash the
- * aside's own contents on the way out.
+ * Slides the aside out past the right edge, where the sheet's overflow clips it.
+ *
+ * The track it occupies collapses instantly rather than over the tween — a
+ * negative margin animated in step with the slide would reflow the sibling tab
+ * content on every frame. An opposing `x` cancels the jump that instant
+ * collapse would otherwise cause, so only the tween moves anything on screen.
+ * Callers are expected to run this while the tab outlet is empty, so the
+ * reflow itself is never seen.
  */
 export function retractAside(el: HTMLElement) {
   return new Promise<void>((resolve) => {
-    gsap.to(el, {
-      xPercent: 100,
-      autoAlpha: 0,
-      marginRight: -el.offsetWidth,
-      duration: DURATION,
-      ease: EASE,
-      onComplete: resolve
-    })
+    const width = el.offsetWidth
+
+    gsap.set(el, { marginRight: -width, x: -width })
+    gsap.to(el, { x: 0, autoAlpha: 0, duration: DURATION, ease: EASE, onComplete: resolve })
   })
 }
 
-/** Reverse of {@link retractAside} — slides the aside back in and reclaims its track. */
+/**
+ * Reverse of {@link retractAside} — slides the aside back in, then hands its
+ * track back. Restoring the margin shifts the aside left by exactly what
+ * dropping the `x` offset shifts it right, so the final swap back into flow
+ * costs no visible movement.
+ */
 export function restoreAside(el: HTMLElement) {
   return new Promise<void>((resolve) => {
     gsap.to(el, {
-      xPercent: 0,
+      x: -el.offsetWidth,
       autoAlpha: 1,
-      marginRight: 0,
       duration: DURATION,
       ease: EASE,
       onComplete: () => {
@@ -41,6 +45,6 @@ export function restoreAside(el: HTMLElement) {
 
 /** Drops the aside straight into a pose with no animation, for the initial mount. */
 export function snapAside(el: HTMLElement, retracted: boolean) {
-  if (retracted) gsap.set(el, { xPercent: 100, autoAlpha: 0, marginRight: -el.offsetWidth })
+  if (retracted) gsap.set(el, { marginRight: -el.offsetWidth, x: 0, autoAlpha: 0 })
   else gsap.set(el, { clearProps: 'transform,visibility,opacity,marginRight' })
 }

--- a/src/utils/animations/preview-tuck.ts
+++ b/src/utils/animations/preview-tuck.ts
@@ -3,14 +3,14 @@ import { gsap } from 'gsap'
 const HALF_TURN_DURATION = 0.14
 const FLIP_PERSPECTIVE = 800
 
-const TUCKED_POSE = { y: -136, scale: 0.78 }
+const TUCKED_POSE = { y: -70, scale: 0.8 }
 const RESTING_POSE = { y: 0, scale: 1 }
 
-type PreviewPose = { y: number; scale: number }
+type PreviewPose = typeof TUCKED_POSE
 
 /**
- * Flips the pinned preview a full turn while it slides up and shrinks away, so
- * it reads as the card tucking in behind the content pane with its top edge
+ * Flips the pinned preview a full turn while it lifts and eases back a touch,
+ * so it reads as the card tucking in behind the content pane with its top edge
  * still poking into the sheet header.
  *
  * @param onEdgeOn - fires at 90°, the frame where the card is edge-on and
@@ -43,7 +43,7 @@ function flipToPose(el: HTMLElement, pose: PreviewPose, onEdgeOn: () => void) {
   tl.to(el, { rotateY: 0, duration: HALF_TURN_DURATION, ease: 'power2.out' })
 
   // The travel runs across both halves rather than after them, so the card is
-  // already moving away as it turns rather than turning then sliding.
+  // already drifting away as it turns rather than turning then sliding.
   tl.to(el, { ...pose, duration: HALF_TURN_DURATION * 2, ease: 'power2.inOut' }, 0)
 
   return new Promise<void>((resolve) => {

--- a/src/utils/animations/preview-tuck.ts
+++ b/src/utils/animations/preview-tuck.ts
@@ -1,9 +1,9 @@
 import { gsap } from 'gsap'
 
-const HALF_TURN_DURATION = 0.14
+const HALF_TURN_DURATION = 0.1
 const FLIP_PERSPECTIVE = 800
 
-const TUCKED_POSE = { y: -70, scale: 0.8 }
+const TUCKED_POSE = { y: -90, scale: 0.85 }
 const RESTING_POSE = { y: 0, scale: 1 }
 
 type PreviewPose = typeof TUCKED_POSE

--- a/src/utils/animations/preview-tuck.ts
+++ b/src/utils/animations/preview-tuck.ts
@@ -1,0 +1,52 @@
+import { gsap } from 'gsap'
+
+const HALF_TURN_DURATION = 0.22
+const FLIP_PERSPECTIVE = 800
+
+const TUCKED_POSE = { y: -136, scale: 0.78 }
+const RESTING_POSE = { y: 0, scale: 1 }
+
+type PreviewPose = { y: number; scale: number }
+
+/**
+ * Flips the pinned preview a full turn while it slides up and shrinks away, so
+ * it reads as the card tucking in behind the content pane with its top edge
+ * still poking into the sheet header.
+ *
+ * @param onEdgeOn - fires at 90°, the frame where the card is edge-on and
+ * invisible, so the caller can swap its stacking layer without a visible pop.
+ */
+export function tuckPinnedPreview(el: HTMLElement, onEdgeOn: () => void) {
+  return flipToPose(el, TUCKED_POSE, onEdgeOn)
+}
+
+/** Reverse of {@link tuckPinnedPreview} — flips the card back out to its resting pose. */
+export function untuckPinnedPreview(el: HTMLElement, onEdgeOn: () => void) {
+  return flipToPose(el, RESTING_POSE, onEdgeOn)
+}
+
+/** Drops the preview straight into a pose with no animation, for the initial mount. */
+export function snapPinnedPreview(el: HTMLElement, tucked: boolean) {
+  if (tucked) gsap.set(el, { ...TUCKED_POSE, transformPerspective: FLIP_PERSPECTIVE })
+  else gsap.set(el, { clearProps: 'transform' })
+}
+
+function flipToPose(el: HTMLElement, pose: PreviewPose, onEdgeOn: () => void) {
+  const tl = gsap.timeline()
+
+  // Perspective has to be baked into the inline transform before the first
+  // rotate, or the opening frame renders as a flat scaleX squish instead of a
+  // turn — same first-flip jank the cover carousel works around.
+  tl.set(el, { transformPerspective: FLIP_PERSPECTIVE })
+  tl.to(el, { rotateY: 90, duration: HALF_TURN_DURATION, ease: 'power2.in', onComplete: onEdgeOn })
+  tl.set(el, { rotateY: -90 })
+  tl.to(el, { rotateY: 0, duration: HALF_TURN_DURATION, ease: 'power2.out' })
+
+  // The travel runs across both halves rather than after them, so the card is
+  // already moving away as it turns rather than turning then sliding.
+  tl.to(el, { ...pose, duration: HALF_TURN_DURATION * 2, ease: 'power2.inOut' }, 0)
+
+  return new Promise<void>((resolve) => {
+    tl.eventCallback('onComplete', resolve)
+  })
+}

--- a/src/utils/animations/preview-tuck.ts
+++ b/src/utils/animations/preview-tuck.ts
@@ -1,6 +1,6 @@
 import { gsap } from 'gsap'
 
-const HALF_TURN_DURATION = 0.22
+const HALF_TURN_DURATION = 0.14
 const FLIP_PERSPECTIVE = 800
 
 const TUCKED_POSE = { y: -136, scale: 0.78 }

--- a/src/views/deck/deck-settings/index.vue
+++ b/src/views/deck/deck-settings/index.vue
@@ -252,7 +252,7 @@ watch(active_tab, (tab) => {
         ref="preview_el"
         data-testid="deck-settings__pinned-preview"
         :data-tucked="chrome.is_tucked.value"
-        class="absolute right-(--sheet-px) top-6"
+        class="group absolute right-(--sheet-px) top-6"
         :class="chrome.is_tucked.value ? 'pointer-events-none' : 'pointer-events-auto'"
       >
         <deck-pinned-preview

--- a/src/views/deck/deck-settings/index.vue
+++ b/src/views/deck/deck-settings/index.vue
@@ -252,13 +252,14 @@ watch(active_tab, (tab) => {
         ref="preview_el"
         data-testid="deck-settings__pinned-preview"
         :data-tucked="chrome.is_tucked.value"
-        class="group absolute right-(--sheet-px) top-6"
+        class="absolute right-(--sheet-px) top-6"
         :class="chrome.is_tucked.value ? 'pointer-events-none' : 'pointer-events-auto'"
       >
         <deck-pinned-preview
           :cover="editor.draft.cover_config"
           :card_attributes="editor.draft.card_attributes"
           :side="visible_side"
+          :tucked="chrome.is_tucked.value"
           :front_text="editor.preview_front_text.value"
           :back_text="editor.preview_back_text.value"
           @update:side="onPreviewSide"

--- a/src/views/deck/deck-settings/index.vue
+++ b/src/views/deck/deck-settings/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, provide, ref, useTemplateRef, watch } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DeckAside from './deck-aside.vue'
 import { deckSettingsLayoutKey, deckSettingsCloseKey } from './layout'
@@ -8,6 +9,7 @@ import { useDeckEditor, deckEditorKey } from '@/composables/deck/editor'
 import { useDeckDangerActions, deckDangerActionsKey } from '@/composables/deck/danger-actions'
 import { useTabModalLayout } from '@/composables/ui/tab-modal-layout'
 import { useTabTransition } from '@/composables/ui/tab-transition'
+import { useSheetChrome } from '@/composables/ui/sheet-chrome'
 import { useAlert } from '@/composables/alert'
 import { useModalAfterEnter, useModalRequestClose } from '@/composables/modal'
 import DeckPinnedPreview from '@/components/deck/pinned-preview.vue'
@@ -59,7 +61,16 @@ provide(deckSettingsCloseKey, close)
 const active_tab = ref<ActiveTab | null>(null)
 const tab_outlet = ref<HTMLElement>()
 
-const { nav_direction, onTabEnter, onTabLeave } = useTabTransition(layout_mode, tab_outlet)
+const preview_el = useTemplateRef<HTMLElement>('preview_el')
+const aside_instance = useTemplateRef<ComponentPublicInstance>('aside_instance')
+const aside_el = computed(() => aside_instance.value?.$el as HTMLElement | undefined)
+
+const chrome = useSheetChrome(preview_el, aside_el)
+
+const { nav_direction, onTabEnter, onTabLeave } = useTabTransition(layout_mode, tab_outlet, {
+  chrome,
+  is_full_bleed: () => is_full_bleed.value
+})
 
 const active_tab_ref = useTemplateRef<{ onChromeBack?: () => boolean }>('active_tab_ref')
 
@@ -93,12 +104,23 @@ const visible_side = computed(() =>
 
 const tab_component = computed(() => TAB_COMPONENTS[displayed_tab.value])
 
+// Sheet mode has no pinned preview or aside to clear away, so full-bleed is a
+// desktop/tablet-only concern.
+const is_full_bleed = computed(
+  () =>
+    layout_mode.value !== 'sheet' && Boolean(TAB_META[displayed_tab.value as TabValue]?.full_bleed)
+)
+
 // The content row is always full-bleed: `__main` (the scroll container) owns its
 // own padding and the aside owns its own inset, so floating elements/outlines
 // aren't clipped by the overflow and the sheet-mode tab animation stays clean.
 const tab_content_class = 'flex h-full items-start'
 
 onMounted(async () => {
+  // Opening straight onto a full-bleed tab starts with the chrome already gone
+  // rather than animating it away in front of the user.
+  if (is_full_bleed.value) chrome.snap(true)
+
   if (initial_side) {
     await after_enter
     editor.setActiveSide(initial_side)
@@ -155,7 +177,8 @@ watch(active_tab, (tab) => {
       layout_mode !== 'sheet' && 'h-181.5',
       layout_mode === 'sheet'
         ? '[--deck-settings-padding:var(--sheet-px)]'
-        : '[--deck-settings-padding:0px]'
+        : '[--deck-settings-padding:0px]',
+      chrome.is_tucked.value && '[--sheet-overlay-z:15]'
     ]"
     :sheet_px="sheet_px"
     :tabs="tabs"
@@ -217,6 +240,7 @@ watch(active_tab, (tab) => {
     <!-- Aside has a bespoke layout so it matches visually with the pinned preview -->
     <deck-aside
       v-if="layout_mode !== 'sheet'"
+      ref="aside_instance"
       data-testid="deck-settings__aside"
       class="w-92 shrink-0 self-end pb-8"
       :class="layout_mode === 'tablet' ? 'pt-66 pr-22' : 'pt-70 px-8'"
@@ -225,8 +249,11 @@ watch(active_tab, (tab) => {
     <template #overlay>
       <div
         v-if="layout_mode !== 'sheet'"
+        ref="preview_el"
         data-testid="deck-settings__pinned-preview"
-        class="pointer-events-auto absolute right-(--sheet-px) top-6"
+        :data-tucked="chrome.is_tucked.value"
+        class="absolute right-(--sheet-px) top-6"
+        :class="chrome.is_tucked.value ? 'pointer-events-none' : 'pointer-events-auto'"
       >
         <deck-pinned-preview
           :cover="editor.draft.cover_config"

--- a/src/views/deck/deck-settings/tab-review-pacing/index.vue
+++ b/src/views/deck/deck-settings/tab-review-pacing/index.vue
@@ -8,12 +8,10 @@ import SectionList from '@/components/layout-kit/section-list.vue'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
 import PacingSection from './pacing-section.vue'
 import { deckEditorKey } from '@/composables/deck/editor'
-import { deckSettingsLayoutKey } from '../layout'
 import DeckSaveButton from '../deck-save-button.vue'
 
 const { t } = useI18n()
 const { draft } = inject(deckEditorKey)!
-const layout_mode = inject(deckSettingsLayoutKey)!
 
 // The draft always carries a seeded value; the getter default only satisfies
 // `DeckConfig`'s optional key.
@@ -62,6 +60,6 @@ const starting_side_options = computed(() =>
 
     <pacing-section class="mt-4" />
 
-    <deck-save-button v-if="layout_mode === 'sheet'" />
+    <deck-save-button />
   </section-list>
 </template>

--- a/src/views/deck/deck-settings/tabs.ts
+++ b/src/views/deck/deck-settings/tabs.ts
@@ -5,10 +5,17 @@ export type TabValue = 'details' | 'design' | 'review-pacing' | 'review-history'
  * bar, the mobile tab-index nav list, and the modal header — so icon/copy
  * can't drift between the three surfaces.
  */
-export const TAB_META: Record<TabValue, { icon: string; labelKey: string }> = {
-  details: { icon: 'text-field', labelKey: 'deck.settings-modal.tab.details' },
-  design: { icon: 'paint-brush', labelKey: 'deck.settings-modal.tab.design' },
-  'review-pacing': { icon: 'card-deck', labelKey: 'deck.settings-modal.tab.review-pacing' },
-  'review-history': { icon: 'schedule', labelKey: 'deck.settings-modal.tab.review-history' },
-  'danger-zone': { icon: 'delete', labelKey: 'deck.settings-modal.tab.danger-zone' }
-}
+export const TAB_META: Record<TabValue, { icon: string; labelKey: string; full_bleed?: boolean }> =
+  {
+    details: { icon: 'text-field', labelKey: 'deck.settings-modal.tab.details' },
+    design: { icon: 'paint-brush', labelKey: 'deck.settings-modal.tab.design' },
+    'review-pacing': {
+      icon: 'card-deck',
+      labelKey: 'deck.settings-modal.tab.review-pacing',
+      // Claims the whole content area: the pinned preview tucks away and the
+      // aside retracts, so this tab carries its own save button.
+      full_bleed: true
+    },
+    'review-history': { icon: 'schedule', labelKey: 'deck.settings-modal.tab.review-history' },
+    'danger-zone': { icon: 'delete', labelKey: 'deck.settings-modal.tab.danger-zone' }
+  }

--- a/src/views/settings/index.vue
+++ b/src/views/settings/index.vue
@@ -13,7 +13,7 @@ import { useAlert } from '@/composables/alert'
 import { useModalRequestClose } from '@/composables/modal'
 import { useAvatarPicker } from './use-avatar-picker'
 import MemberCard from '@/components/member/member-card.vue'
-import UiIcon from '@/components/ui-kit/icon.vue'
+import UiPinnedCard from '@/components/ui-kit/pinned-card.vue'
 import ScrollBar from '@/components/ui-kit/scroll-bar.vue'
 import TabSheet from '@/components/layout-kit/sheet/tab-sheet.vue'
 import TabProfile from './tab-profile/index.vue'
@@ -215,13 +215,7 @@ watch(layout_mode, (mode) => {
         data-testid="settings__pinned-preview"
         class="pointer-events-auto absolute right-(--sheet-px) top-6"
       >
-        <div data-testid="settings__pinned-preview-inner" class="relative">
-          <div
-            data-testid="settings__pinned-preview-paperclip"
-            class="absolute -top-8 right-15 -translate-x-1/2 z-10 drop-shadow-2xs"
-          >
-            <ui-icon src="paperclip" class="w-16 h-16 -rotate-186 text-grey-300" />
-          </div>
+        <ui-pinned-card data-testid="settings__pinned-preview-inner">
           <member-card
             :created-at="editor.created_at.value"
             :display-name="editor.draft.display_name"
@@ -229,10 +223,9 @@ watch(layout_mode, (mode) => {
             :card-title="t('settings.preview.title-fallback')"
             :cover="editor.draft.cover_config"
             editable
-            class="rotate-4 drop-shadow-sm"
             @edit-avatar="onEditAvatar"
           />
-        </div>
+        </ui-pinned-card>
       </div>
     </template>
   </tab-sheet>

--- a/tests/integration/components/deck/pinned-preview.test.js
+++ b/tests/integration/components/deck/pinned-preview.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
-import { shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
 import PinnedPreview from '@/components/deck/pinned-preview.vue'
 
@@ -33,7 +33,7 @@ const baseProps = {
 // ── Factory ───────────────────────────────────────────────────────────────────
 
 function makeWrapper(props = {}) {
-  return shallowMount(PinnedPreview, {
+  return mount(PinnedPreview, {
     props: { ...baseProps, ...props },
     global: {
       stubs: {
@@ -62,9 +62,9 @@ describe('PinnedPreview — rendering', () => {
     expect(wrapper.find('[data-testid="deck-pinned-preview__shadow-card"]').exists()).toBe(true)
   })
 
-  test('renders the paperclip decoration', () => {
+  test('renders the paperclip decoration (owned by ui-pinned-card, forwarded through)', () => {
     const wrapper = makeWrapper()
-    expect(wrapper.find('[data-testid="deck-pinned-preview__paperclip"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="ui-pinned-card__paperclip"]').exists()).toBe(true)
   })
 
   test('renders the deck-design-preview', () => {
@@ -119,5 +119,26 @@ describe('PinnedPreview — update:side emit [obligation]', () => {
 
     expect(wrapper.emitted('update:side')).toBeTruthy()
     expect(wrapper.emitted('update:side')[0]).toEqual(['back'])
+  })
+})
+
+// ── tucked prop forwarding [obligation] ─────────────────────────────────────────
+// The DOM contract moved from an ancestor's `group-data-[tucked=true]` selector
+// to an explicit `tucked` prop on ui-pinned-card — assert PinnedPreview forwards
+// it through, and that the paperclip reflects it via data-tucked.
+
+describe('PinnedPreview — forwards tucked through to ui-pinned-card [obligation]', () => {
+  test('defaults the paperclip data-tucked to false when the prop is omitted', () => {
+    const wrapper = makeWrapper()
+    expect(
+      wrapper.find('[data-testid="ui-pinned-card__paperclip"]').attributes('data-tucked')
+    ).toBe('false')
+  })
+
+  test('forwards tucked=true so the paperclip data-tucked reflects it', () => {
+    const wrapper = makeWrapper({ tucked: true })
+    expect(
+      wrapper.find('[data-testid="ui-pinned-card__paperclip"]').attributes('data-tucked')
+    ).toBe('true')
   })
 })

--- a/tests/integration/components/modals/deck-settings/index.test.js
+++ b/tests/integration/components/modals/deck-settings/index.test.js
@@ -65,7 +65,24 @@ vi.mock('gsap', () => ({
     fromTo: vi.fn((_el, _from, to) => to?.onComplete?.()),
     to: vi.fn((_el, opts) => opts?.onComplete?.()),
     set: vi.fn(),
-    killTweensOf: vi.fn()
+    killTweensOf: vi.fn(),
+    // Chrome tuck/restore drive a gsap.timeline() (preview-tuck.ts) — collapse
+    // it synchronously the same way the `to`/`fromTo` mocks above do, firing
+    // both the mid-timeline onComplete (onEdgeOn) and the final one.
+    timeline: vi.fn(() => {
+      const tl = {
+        set: vi.fn(() => tl),
+        to: vi.fn((_el, opts) => {
+          opts?.onComplete?.()
+          return tl
+        }),
+        eventCallback: vi.fn((_event, cb) => {
+          cb?.()
+          return tl
+        })
+      }
+      return tl
+    })
   }
 }))
 
@@ -766,5 +783,62 @@ describe('DeckSettings — initial tab renders on mount [obligation]', () => {
     await flushPromises()
 
     expect(wrapper.find('[data-testid="tab-design-stub"]').exists()).toBe(true)
+  })
+})
+
+describe('DeckSettings — is_full_bleed is false in sheet layout regardless of TAB_META [obligation]', () => {
+  test('a full-bleed tab (review-pacing) does not claim full-bleed once the layout collapses to a sheet', () => {
+    setSidebar(false)
+    setBelowMd(true)
+    const { wrapper } = makeWrapper({ initial_tab: 'review-pacing' })
+
+    // Sheet mode has no aside or pinned preview to clear away, so full-bleed
+    // is a desktop/tablet-only concern even for a tab whose TAB_META says
+    // full_bleed: true.
+    expect(wrapper.vm.is_full_bleed).toBe(false)
+  })
+
+  test('the same tab does claim full-bleed once the layout is tablet/desktop', () => {
+    setSidebar(false)
+    setBelowMd(false)
+    const { wrapper } = makeWrapper({ initial_tab: 'review-pacing' })
+
+    expect(wrapper.vm.is_full_bleed).toBe(true)
+  })
+})
+
+describe('DeckSettings — opening directly on a full-bleed tab snaps the chrome instead of animating it [obligation]', () => {
+  test('chrome.is_tucked is already true synchronously after mount, with no animation frame needed', () => {
+    setSidebar(false)
+    setBelowMd(false)
+    const { wrapper } = makeWrapper({ initial_tab: 'review-pacing' })
+
+    expect(wrapper.vm.chrome.is_tucked.value).toBe(true)
+  })
+
+  test('opening on a non-full-bleed tab leaves the chrome untucked', () => {
+    setSidebar(false)
+    setBelowMd(false)
+    const { wrapper } = makeWrapper({ initial_tab: 'design' })
+
+    expect(wrapper.vm.chrome.is_tucked.value).toBe(false)
+  })
+
+  test('onTabLeave reads the live is_full_bleed value to decide whether to tuck or restore the chrome', async () => {
+    setSidebar(false)
+    setBelowMd(false)
+    const { wrapper } = makeWrapper({ initial_tab: 'design' })
+    expect(wrapper.vm.chrome.is_tucked.value).toBe(false)
+
+    // Simulate navigating into the full-bleed tab, then drive the transition's
+    // leave hook directly — this is the exact wiring DeckSettings passes to
+    // useTabTransition (`is_full_bleed: () => is_full_bleed.value`).
+    wrapper.vm.active_tab = 'review-pacing'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.is_full_bleed).toBe(true)
+
+    await wrapper.vm.onTabLeave(document.createElement('div'), () => {})
+
+    expect(wrapper.vm.chrome.is_tucked.value).toBe(true)
   })
 })

--- a/tests/integration/components/ui-kit/pinned-card.test.js
+++ b/tests/integration/components/ui-kit/pinned-card.test.js
@@ -1,0 +1,90 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import UiPinnedCard from '@/components/ui-kit/pinned-card.vue'
+
+function makeWrapper(props = {}, slots = {}) {
+  return mount(UiPinnedCard, {
+    props,
+    slots,
+    global: { stubs: { UiIcon: true } }
+  })
+}
+
+describe('UiPinnedCard — structure', () => {
+  test('renders the root container', () => {
+    const wrapper = makeWrapper()
+    expect(wrapper.find('[data-testid="ui-pinned-card"]').exists()).toBe(true)
+  })
+
+  test('renders the card slot wrapper', () => {
+    const wrapper = makeWrapper()
+    expect(wrapper.find('[data-testid="ui-pinned-card__card"]').exists()).toBe(true)
+  })
+
+  test('renders the paperclip decoration', () => {
+    const wrapper = makeWrapper()
+    expect(wrapper.find('[data-testid="ui-pinned-card__paperclip"]').exists()).toBe(true)
+  })
+})
+
+describe('UiPinnedCard — slots', () => {
+  test('renders the backdrop slot ahead of the card slot in document order', () => {
+    const wrapper = makeWrapper(
+      {},
+      {
+        backdrop: '<div data-testid="backdrop-content">back</div>',
+        default: '<div data-testid="card-content">front</div>'
+      }
+    )
+
+    const backdrop = wrapper.find('[data-testid="backdrop-content"]').element
+    const card = wrapper.find('[data-testid="card-content"]').element
+    expect(!!(backdrop.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
+  })
+
+  test('renders default slot content inside the card wrapper', () => {
+    const wrapper = makeWrapper({}, { default: '<div data-testid="card-content">front</div>' })
+    const card_wrapper = wrapper.find('[data-testid="ui-pinned-card__card"]')
+    expect(card_wrapper.find('[data-testid="card-content"]').exists()).toBe(true)
+  })
+
+  test('renders with no backdrop slot content when omitted', () => {
+    const wrapper = makeWrapper({}, { default: '<div>front</div>' })
+    expect(wrapper.find('[data-testid="ui-pinned-card"]').element.children.length).toBeGreaterThan(
+      0
+    )
+  })
+})
+
+// ── tucked prop [obligation] ────────────────────────────────────────────────────
+
+describe('UiPinnedCard — tucked prop reflected on the paperclip [obligation]', () => {
+  test('defaults tucked to false', () => {
+    const wrapper = makeWrapper()
+    expect(
+      wrapper.find('[data-testid="ui-pinned-card__paperclip"]').attributes('data-tucked')
+    ).toBe('false')
+  })
+
+  test('reflects tucked=true on the paperclip data-tucked attribute', () => {
+    const wrapper = makeWrapper({ tucked: true })
+    expect(
+      wrapper.find('[data-testid="ui-pinned-card__paperclip"]').attributes('data-tucked')
+    ).toBe('true')
+  })
+
+  test('reflects tucked=false explicitly', () => {
+    const wrapper = makeWrapper({ tucked: false })
+    expect(
+      wrapper.find('[data-testid="ui-pinned-card__paperclip"]').attributes('data-tucked')
+    ).toBe('false')
+  })
+
+  test('updates data-tucked reactively when the prop changes', async () => {
+    const wrapper = makeWrapper({ tucked: false })
+    await wrapper.setProps({ tucked: true })
+    expect(
+      wrapper.find('[data-testid="ui-pinned-card__paperclip"]').attributes('data-tucked')
+    ).toBe('true')
+  })
+})

--- a/tests/integration/views/deck/deck-settings/tab-review-pacing/index.test.js
+++ b/tests/integration/views/deck/deck-settings/tab-review-pacing/index.test.js
@@ -188,14 +188,18 @@ describe('TabReviewPacing — starting-side option group [obligation]', () => {
   })
 })
 
-describe('TabReviewPacing — deck-save-button gated on layout_mode', () => {
+// [obligation] This tab claims the whole content area, so the aside that used
+// to carry the save button is retracted — the save button now renders
+// unconditionally (it used to be gated on layout_mode === 'sheet'), so there's
+// still a way to save on desktop/tablet.
+describe('TabReviewPacing — renders deck-save-button unconditionally [obligation]', () => {
   test('renders the save button when layout_mode is "sheet"', () => {
     const { wrapper } = makeWrapper({ layout_mode: 'sheet' })
     expect(wrapper.findComponent({ name: 'DeckSaveButton' }).exists()).toBe(true)
   })
 
-  test('omits the save button for other layout modes', () => {
+  test('renders the save button on desktop/tablet layout modes too', () => {
     const { wrapper } = makeWrapper({ layout_mode: 'modal' })
-    expect(wrapper.findComponent({ name: 'DeckSaveButton' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'DeckSaveButton' }).exists()).toBe(true)
   })
 })

--- a/tests/unit/composables/ui/sheet-chrome.test.js
+++ b/tests/unit/composables/ui/sheet-chrome.test.js
@@ -1,0 +1,234 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { ref } from 'vue'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const {
+  mockEmitSfx,
+  mockTuckPreview,
+  mockUntuckPreview,
+  mockSnapPreview,
+  mockRetract,
+  mockRestore,
+  mockSnapAside
+} = vi.hoisted(() => ({
+  mockEmitSfx: vi.fn(),
+  mockTuckPreview: vi.fn((_el, onEdgeOn) => {
+    onEdgeOn()
+    return Promise.resolve()
+  }),
+  mockUntuckPreview: vi.fn((_el, onEdgeOn) => {
+    onEdgeOn()
+    return Promise.resolve()
+  }),
+  mockSnapPreview: vi.fn(),
+  mockRetract: vi.fn(() => Promise.resolve()),
+  mockRestore: vi.fn(() => Promise.resolve()),
+  mockSnapAside: vi.fn()
+}))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+
+vi.mock('@/utils/animations/preview-tuck', () => ({
+  tuckPinnedPreview: mockTuckPreview,
+  untuckPinnedPreview: mockUntuckPreview,
+  snapPinnedPreview: mockSnapPreview
+}))
+
+vi.mock('@/utils/animations/aside-retract', () => ({
+  retractAside: mockRetract,
+  restoreAside: mockRestore,
+  snapAside: mockSnapAside
+}))
+
+import { useSheetChrome } from '@/composables/ui/sheet-chrome'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChrome() {
+  const preview = ref(document.createElement('div'))
+  const aside = ref(document.createElement('div'))
+  return { preview, aside, chrome: useSheetChrome(preview, aside) }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockTuckPreview.mockImplementation((_el, onEdgeOn) => {
+    onEdgeOn()
+    return Promise.resolve()
+  })
+  mockUntuckPreview.mockImplementation((_el, onEdgeOn) => {
+    onEdgeOn()
+    return Promise.resolve()
+  })
+})
+
+// ── is_tucked flips at the onEdgeOn midpoint [obligation] ─────────────────────
+
+describe('useSheetChrome — is_tucked flips at the animation midpoint, not on promise resolution [obligation]', () => {
+  test('tuck(): is_tucked flips true exactly when onEdgeOn fires, before the tween promise resolves', async () => {
+    let edgeCb
+    let resolveAnim
+    mockTuckPreview.mockImplementation((_el, onEdgeOn) => {
+      edgeCb = onEdgeOn
+      return new Promise((resolve) => {
+        resolveAnim = resolve
+      })
+    })
+    const { chrome } = makeChrome()
+
+    const tuckPromise = chrome.tuck()
+    expect(chrome.is_tucked.value).toBe(false)
+
+    edgeCb()
+    expect(chrome.is_tucked.value).toBe(true)
+
+    resolveAnim()
+    await tuckPromise
+    expect(chrome.is_tucked.value).toBe(true)
+  })
+
+  test('restore(): is_tucked flips false exactly when onEdgeOn fires, before the tween promise resolves', async () => {
+    const { chrome } = makeChrome()
+    await chrome.tuck()
+    expect(chrome.is_tucked.value).toBe(true)
+
+    let edgeCb
+    let resolveAnim
+    mockUntuckPreview.mockImplementation((_el, onEdgeOn) => {
+      edgeCb = onEdgeOn
+      return new Promise((resolve) => {
+        resolveAnim = resolve
+      })
+    })
+
+    const restorePromise = chrome.restore()
+    expect(chrome.is_tucked.value).toBe(true)
+
+    edgeCb()
+    expect(chrome.is_tucked.value).toBe(false)
+
+    resolveAnim()
+    await restorePromise
+    expect(chrome.is_tucked.value).toBe(false)
+  })
+})
+
+// ── no-op guards + single sfx emission [obligation] ────────────────────────────
+
+describe('useSheetChrome — tuck/restore are no-ops when already in that state [obligation]', () => {
+  test('tuck() called twice only animates and emits sfx once', async () => {
+    const { chrome } = makeChrome()
+
+    await chrome.tuck()
+    expect(mockEmitSfx).toHaveBeenCalledTimes(1)
+    expect(mockEmitSfx).toHaveBeenCalledWith('slide_up')
+    expect(mockTuckPreview).toHaveBeenCalledTimes(1)
+
+    await chrome.tuck()
+    expect(mockEmitSfx).toHaveBeenCalledTimes(1)
+    expect(mockTuckPreview).toHaveBeenCalledTimes(1)
+    expect(chrome.is_tucked.value).toBe(true)
+  })
+
+  test('restore() called before any tuck() is a silent no-op', async () => {
+    const { chrome } = makeChrome()
+
+    await chrome.restore()
+
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+    expect(mockUntuckPreview).not.toHaveBeenCalled()
+    expect(chrome.is_tucked.value).toBe(false)
+  })
+
+  test('restore() called twice only animates and emits sfx once', async () => {
+    const { chrome } = makeChrome()
+    await chrome.tuck()
+    mockEmitSfx.mockClear()
+
+    await chrome.restore()
+    expect(mockEmitSfx).toHaveBeenCalledTimes(1)
+    expect(mockEmitSfx).toHaveBeenCalledWith('slide_up')
+    expect(mockUntuckPreview).toHaveBeenCalledTimes(1)
+
+    await chrome.restore()
+    expect(mockEmitSfx).toHaveBeenCalledTimes(1)
+    expect(mockUntuckPreview).toHaveBeenCalledTimes(1)
+    expect(chrome.is_tucked.value).toBe(false)
+  })
+})
+
+// ── aside is animated alongside the preview ────────────────────────────────────
+
+describe('useSheetChrome — drives the aside alongside the preview', () => {
+  test('tuck() retracts the aside and restore() restores it', async () => {
+    const { chrome } = makeChrome()
+
+    await chrome.tuck()
+    expect(mockRetract).toHaveBeenCalledTimes(1)
+    expect(mockRestore).not.toHaveBeenCalled()
+
+    await chrome.restore()
+    expect(mockRestore).toHaveBeenCalledTimes(1)
+  })
+
+  test('tuck() skips animating the preview/aside when their refs are null, but still flips is_tucked', async () => {
+    const preview = ref(null)
+    const aside = ref(null)
+    const chrome = useSheetChrome(preview, aside)
+
+    await chrome.tuck()
+
+    expect(mockTuckPreview).not.toHaveBeenCalled()
+    expect(mockRetract).not.toHaveBeenCalled()
+    expect(chrome.is_tucked.value).toBe(true)
+  })
+})
+
+// ── snap ────────────────────────────────────────────────────────────────────────
+
+describe('useSheetChrome — snap jumps straight to a pose with no animation', () => {
+  test('snap(true) sets is_tucked, snaps the preview and aside, and never emits sfx', () => {
+    const { preview, aside, chrome } = makeChrome()
+
+    chrome.snap(true)
+
+    expect(chrome.is_tucked.value).toBe(true)
+    expect(mockSnapPreview).toHaveBeenCalledWith(preview.value, true)
+    expect(mockSnapAside).toHaveBeenCalledWith(aside.value, true)
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+  })
+
+  test('snap(false) sets is_tucked back and snaps both elements to the resting pose', () => {
+    const { preview, aside, chrome } = makeChrome()
+    chrome.snap(true)
+
+    chrome.snap(false)
+
+    expect(chrome.is_tucked.value).toBe(false)
+    expect(mockSnapPreview).toHaveBeenCalledWith(preview.value, false)
+    expect(mockSnapAside).toHaveBeenCalledWith(aside.value, false)
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+  })
+
+  test('snap() is unguarded — it re-applies even when already in that state', () => {
+    const { chrome } = makeChrome()
+
+    chrome.snap(true)
+    chrome.snap(true)
+
+    expect(mockSnapPreview).toHaveBeenCalledTimes(2)
+  })
+
+  test('snap() still flips is_tucked when the preview/aside refs are null', () => {
+    const preview = ref(null)
+    const aside = ref(null)
+    const chrome = useSheetChrome(preview, aside)
+
+    chrome.snap(true)
+
+    expect(chrome.is_tucked.value).toBe(true)
+    expect(mockSnapPreview).not.toHaveBeenCalled()
+    expect(mockSnapAside).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/composables/ui/tab-transition.test.js
+++ b/tests/unit/composables/ui/tab-transition.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { ref, computed } from 'vue'
+import { flushPromises } from '@vue/test-utils'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
@@ -190,5 +191,169 @@ describe('useTabTransition — onTabLeave routing [obligation]', () => {
     onTabEnter(makeEl(), vi.fn())
 
     expect(mockTabSlideEnter).toHaveBeenCalledWith(nav_direction, outlet)
+  })
+})
+
+// ── onTabEnter never touches the chrome [obligation] ───────────────────────────
+// Regression: chrome tuck/restore used to run inside onTabEnter too. Restoring
+// during enter reflowed the content row while the incoming tab was still
+// rendering. The chrome now only moves during leave.
+
+describe('useTabTransition — onTabEnter never touches the chrome [obligation]', () => {
+  function makeChrome() {
+    return { tuck: vi.fn(() => Promise.resolve()), restore: vi.fn(() => Promise.resolve()) }
+  }
+
+  test('does not call chrome.tuck when entering a full-bleed tab', () => {
+    const { layout_mode } = makeLayout('tablet')
+    const tab_outlet = ref(document.createElement('div'))
+    const chrome = makeChrome()
+    const { onTabEnter } = useTabTransition(layout_mode, tab_outlet, {
+      chrome,
+      is_full_bleed: () => true
+    })
+
+    onTabEnter(makeEl(), vi.fn())
+
+    expect(chrome.tuck).not.toHaveBeenCalled()
+    expect(chrome.restore).not.toHaveBeenCalled()
+  })
+
+  test('does not call chrome.restore when entering a non-full-bleed tab', () => {
+    const { layout_mode } = makeLayout('tablet')
+    const tab_outlet = ref(document.createElement('div'))
+    const chrome = makeChrome()
+    const { onTabEnter } = useTabTransition(layout_mode, tab_outlet, {
+      chrome,
+      is_full_bleed: () => false
+    })
+
+    onTabEnter(makeEl(), vi.fn())
+
+    expect(chrome.tuck).not.toHaveBeenCalled()
+    expect(chrome.restore).not.toHaveBeenCalled()
+  })
+
+  test('onTabEnter still calls done, chrome or not', () => {
+    const { layout_mode } = makeLayout('tablet')
+    const tab_outlet = ref(document.createElement('div'))
+    const chrome = makeChrome()
+    const { onTabEnter } = useTabTransition(layout_mode, tab_outlet, {
+      chrome,
+      is_full_bleed: () => true
+    })
+
+    const done = vi.fn()
+    onTabEnter(makeEl(), done)
+
+    expect(done).toHaveBeenCalledOnce()
+  })
+})
+
+// ── onTabLeave awaits the chrome before calling done [obligation] ──────────────
+// Both directions (tuck and restore) run inside onTabLeave, awaited before
+// `done()` fires — the only moment with no tab mounted for the reflow to shift.
+
+describe('useTabTransition — onTabLeave awaits the chrome before calling done [obligation]', () => {
+  test('calls chrome.tuck when leaving into a full-bleed tab, and withholds done until it resolves', async () => {
+    const { layout_mode } = makeLayout('tablet')
+    const tab_outlet = ref(document.createElement('div'))
+    let resolveTuck
+    const chrome = {
+      tuck: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveTuck = resolve
+          })
+      ),
+      restore: vi.fn(() => Promise.resolve())
+    }
+    const { onTabLeave } = useTabTransition(layout_mode, tab_outlet, {
+      chrome,
+      is_full_bleed: () => true
+    })
+
+    const done = vi.fn()
+    onTabLeave(makeEl(), done)
+    await flushPromises()
+
+    expect(chrome.tuck).toHaveBeenCalledOnce()
+    expect(chrome.restore).not.toHaveBeenCalled()
+    expect(done).not.toHaveBeenCalled()
+
+    resolveTuck()
+    await flushPromises()
+
+    expect(done).toHaveBeenCalledOnce()
+  })
+
+  test('calls chrome.restore when leaving into a non-full-bleed tab, and withholds done until it resolves', async () => {
+    const { layout_mode } = makeLayout('tablet')
+    const tab_outlet = ref(document.createElement('div'))
+    let resolveRestore
+    const chrome = {
+      tuck: vi.fn(() => Promise.resolve()),
+      restore: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveRestore = resolve
+          })
+      )
+    }
+    const { onTabLeave } = useTabTransition(layout_mode, tab_outlet, {
+      chrome,
+      is_full_bleed: () => false
+    })
+
+    const done = vi.fn()
+    onTabLeave(makeEl(), done)
+    await flushPromises()
+
+    expect(chrome.restore).toHaveBeenCalledOnce()
+    expect(chrome.tuck).not.toHaveBeenCalled()
+    expect(done).not.toHaveBeenCalled()
+
+    resolveRestore()
+    await flushPromises()
+
+    expect(done).toHaveBeenCalledOnce()
+  })
+
+  test('is_full_bleed is read lazily — reading the value at call time, not construction time', async () => {
+    const { layout_mode } = makeLayout('tablet')
+    const tab_outlet = ref(document.createElement('div'))
+    const chrome = { tuck: vi.fn(() => Promise.resolve()), restore: vi.fn(() => Promise.resolve()) }
+    let full_bleed = false
+    const { onTabLeave } = useTabTransition(layout_mode, tab_outlet, {
+      chrome,
+      is_full_bleed: () => full_bleed
+    })
+
+    full_bleed = true
+    await onTabLeave(makeEl(), vi.fn())
+
+    expect(chrome.tuck).toHaveBeenCalledOnce()
+    expect(chrome.restore).not.toHaveBeenCalled()
+  })
+
+  test('without chrome/is_full_bleed configured, onTabLeave still resolves and calls done', async () => {
+    const { layout_mode } = makeLayout('tablet')
+    const tab_outlet = ref(document.createElement('div'))
+    const { onTabLeave } = useTabTransition(layout_mode, tab_outlet)
+
+    const done = vi.fn()
+    await onTabLeave(makeEl(), done)
+
+    expect(done).toHaveBeenCalledOnce()
+  })
+
+  test('onTabLeave returns a promise (async), unlike onTabEnter', () => {
+    const { layout_mode } = makeLayout('tablet')
+    const tab_outlet = ref(document.createElement('div'))
+    const { onTabLeave } = useTabTransition(layout_mode, tab_outlet)
+
+    const result = onTabLeave(makeEl(), vi.fn())
+
+    expect(result).toBeInstanceOf(Promise)
   })
 })

--- a/tests/unit/utils/animations/aside-retract.test.js
+++ b/tests/unit/utils/animations/aside-retract.test.js
@@ -1,0 +1,121 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+const { mockSet, mockTo } = vi.hoisted(() => ({
+  mockSet: vi.fn(),
+  mockTo: vi.fn((_el, opts) => opts.onComplete?.())
+}))
+
+vi.mock('gsap', () => ({
+  gsap: { set: mockSet, to: mockTo }
+}))
+
+import { retractAside, restoreAside, snapAside } from '@/utils/animations/aside-retract'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockTo.mockImplementation((_el, opts) => opts.onComplete?.())
+})
+
+function elWithWidth(width) {
+  const el = document.createElement('div')
+  Object.defineProperty(el, 'offsetWidth', { value: width, configurable: true })
+  return el
+}
+
+// ── margin collapses instantly, never tweens [obligation] ──────────────────────
+
+describe('retractAside — the negative margin is set instantly, never tweened [obligation]', () => {
+  test('applies marginRight via gsap.set, not gsap.to', async () => {
+    const el = elWithWidth(120)
+    await retractAside(el)
+
+    expect(mockSet).toHaveBeenCalledWith(el, { marginRight: -120, x: -120 })
+  })
+
+  test('the tween only animates x/opacity — marginRight never appears in a gsap.to call', async () => {
+    const el = elWithWidth(120)
+    await retractAside(el)
+
+    for (const [, opts] of mockTo.mock.calls) {
+      expect(opts).not.toHaveProperty('marginRight')
+    }
+    expect(mockTo).toHaveBeenCalledWith(el, expect.objectContaining({ x: 0, autoAlpha: 0 }))
+  })
+
+  test('resolves once the tween completes', async () => {
+    let resolveTween
+    mockTo.mockImplementation((_el, opts) => {
+      resolveTween = () => opts.onComplete()
+    })
+    const el = elWithWidth(80)
+
+    let resolved = false
+    retractAside(el).then(() => (resolved = true))
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    resolveTween()
+    await Promise.resolve()
+    expect(resolved).toBe(true)
+  })
+})
+
+describe('restoreAside — reverse of retractAside, margin restored instantly at the end [obligation]', () => {
+  test('tweens x back in and opacity to 1, without touching marginRight in the tween', async () => {
+    const el = elWithWidth(100)
+    await restoreAside(el)
+
+    const [, opts] = mockTo.mock.calls[0]
+    expect(opts).not.toHaveProperty('marginRight')
+    expect(opts).toMatchObject({ x: -100, autoAlpha: 1 })
+  })
+
+  test('clears the margin/transform/visibility/opacity via gsap.set once the tween completes', async () => {
+    const el = elWithWidth(100)
+    await restoreAside(el)
+
+    expect(mockSet).toHaveBeenCalledWith(el, {
+      clearProps: 'transform,visibility,opacity,marginRight'
+    })
+  })
+
+  test('resolves only after the clearProps set runs', async () => {
+    let resolveTween
+    mockTo.mockImplementation((_el, opts) => {
+      resolveTween = () => opts.onComplete()
+    })
+    const el = elWithWidth(60)
+
+    let resolved = false
+    restoreAside(el).then(() => (resolved = true))
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    resolveTween()
+    await Promise.resolve()
+    expect(resolved).toBe(true)
+    expect(mockSet).toHaveBeenCalledWith(
+      el,
+      expect.objectContaining({ clearProps: expect.any(String) })
+    )
+  })
+})
+
+describe('snapAside — jumps straight to a pose with no animation', () => {
+  test('retracted=true sets the collapsed margin, zero x offset, and hides it', () => {
+    const el = elWithWidth(90)
+    snapAside(el, true)
+
+    expect(mockSet).toHaveBeenCalledWith(el, { marginRight: -90, x: 0, autoAlpha: 0 })
+    expect(mockTo).not.toHaveBeenCalled()
+  })
+
+  test('retracted=false clears every prop this module ever sets', () => {
+    const el = elWithWidth(90)
+    snapAside(el, false)
+
+    expect(mockSet).toHaveBeenCalledWith(el, {
+      clearProps: 'transform,visibility,opacity,marginRight'
+    })
+  })
+})

--- a/tests/unit/utils/animations/preview-tuck.test.js
+++ b/tests/unit/utils/animations/preview-tuck.test.js
@@ -1,0 +1,148 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+// ── Hoisted gsap mock ──────────────────────────────────────────────────────────
+// Each `gsap.timeline()` call gets its own fake timeline so tests can inspect
+// exactly which tween carries which onComplete, and fire completion manually
+// rather than have it auto-resolve like the simpler `gsap.to` mocks elsewhere.
+
+const { mockGsapSet, makeTimeline, timelines } = vi.hoisted(() => {
+  const timelines = []
+  function makeTimeline() {
+    const calls = { set: [], to: [] }
+    let onCompleteCb
+    const tl = {
+      set: (...args) => {
+        calls.set.push(args)
+        return tl
+      },
+      to: (...args) => {
+        calls.to.push(args)
+        return tl
+      },
+      eventCallback: (event, cb) => {
+        if (event === 'onComplete') onCompleteCb = cb
+        return tl
+      },
+      calls,
+      fireOnComplete: () => onCompleteCb?.()
+    }
+    timelines.push(tl)
+    return tl
+  }
+  return { mockGsapSet: vi.fn(), makeTimeline, timelines }
+})
+
+vi.mock('gsap', () => ({
+  gsap: {
+    timeline: () => makeTimeline(),
+    set: mockGsapSet
+  }
+}))
+
+import {
+  tuckPinnedPreview,
+  untuckPinnedPreview,
+  snapPinnedPreview
+} from '@/utils/animations/preview-tuck'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  timelines.length = 0
+})
+
+function el() {
+  return document.createElement('div')
+}
+
+// ── onEdgeOn fires at the 90° midpoint, not at completion [obligation] ────────
+
+describe('tuckPinnedPreview / untuckPinnedPreview — onEdgeOn fires at the 90° midpoint [obligation]', () => {
+  test('tuckPinnedPreview wires onEdgeOn as the onComplete of the first half-turn tween only', () => {
+    const onEdgeOn = vi.fn()
+    tuckPinnedPreview(el(), onEdgeOn)
+
+    const tl = timelines[0]
+    // First .to() is the 0deg -> 90deg half turn.
+    expect(tl.calls.to[0][1].onComplete).toBe(onEdgeOn)
+    // The remaining tweens (90->0 turn, pose travel) must not also fire it.
+    expect(tl.calls.to[1][1]?.onComplete).toBeUndefined()
+    expect(tl.calls.to[2][1]?.onComplete).toBeUndefined()
+  })
+
+  test('onEdgeOn firing does not resolve the returned promise — only the full timeline completing does', async () => {
+    const onEdgeOn = vi.fn()
+    let resolved = false
+    tuckPinnedPreview(el(), onEdgeOn).then(() => (resolved = true))
+
+    const tl = timelines[0]
+    tl.calls.to[0][1].onComplete()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onEdgeOn).toHaveBeenCalledOnce()
+    expect(resolved).toBe(false)
+
+    tl.fireOnComplete()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(resolved).toBe(true)
+  })
+
+  test('untuckPinnedPreview wires onEdgeOn the same way as tuckPinnedPreview', () => {
+    const onEdgeOn = vi.fn()
+    untuckPinnedPreview(el(), onEdgeOn)
+
+    const tl = timelines[0]
+    expect(tl.calls.to[0][1].onComplete).toBe(onEdgeOn)
+  })
+})
+
+// ── pose targets ────────────────────────────────────────────────────────────────
+
+describe('tuckPinnedPreview / untuckPinnedPreview — pose targets', () => {
+  test('tuckPinnedPreview travels to the tucked pose (lifted + scaled down)', () => {
+    tuckPinnedPreview(el(), vi.fn())
+    const tl = timelines[0]
+    const [, poseOpts, position] = tl.calls.to[2]
+
+    expect(poseOpts).toMatchObject({ y: -90, scale: 0.85 })
+    expect(position).toBe(0)
+  })
+
+  test('untuckPinnedPreview travels back to the resting pose', () => {
+    untuckPinnedPreview(el(), vi.fn())
+    const tl = timelines[0]
+    const [, poseOpts] = tl.calls.to[2]
+
+    expect(poseOpts).toMatchObject({ y: 0, scale: 1 })
+  })
+
+  test('bakes transformPerspective before the first rotate', () => {
+    tuckPinnedPreview(el(), vi.fn())
+    const tl = timelines[0]
+    expect(tl.calls.set[0][1]).toMatchObject({ transformPerspective: 800 })
+  })
+})
+
+// ── snapPinnedPreview ────────────────────────────────────────────────────────────
+
+describe('snapPinnedPreview — jumps straight to a pose with no animation', () => {
+  test('tucked=true sets the tucked pose + perspective directly, without a timeline', () => {
+    const target = el()
+    snapPinnedPreview(target, true)
+
+    expect(mockGsapSet).toHaveBeenCalledWith(
+      target,
+      expect.objectContaining({ y: -90, scale: 0.85, transformPerspective: 800 })
+    )
+    expect(timelines).toHaveLength(0)
+  })
+
+  test('tucked=false clears the transform back to its natural state', () => {
+    const target = el()
+    snapPinnedPreview(target, false)
+
+    expect(mockGsapSet).toHaveBeenCalledWith(target, { clearProps: 'transform' })
+  })
+})


### PR DESCRIPTION
## Summary

A deck-settings tab can now claim the whole content area. Switching to one flips the pinned card preview away behind the content pane — its top edge still showing in the header — and retracts the form aside. Review Settings is the first tab to use it.

## Changes

- `full_bleed` flag on `TAB_META` drives the behaviour per tab; Review Settings opts in and now carries its own save button, since the aside's is retracted.
- `useSheetChrome` owns the tuck/restore choreography, sequenced by `useTabTransition` around the existing out-in tab swap. Both live in `composables/ui/`, so app settings can adopt the same behaviour by setting a flag and passing two refs.
- `mobile-sheet` gained explicit z-layers and a `--sheet-overlay-z` hook, letting a caller drop the overlay between the header and the content pane.
- New `wave-bottom-fill-*` utility — the exact complement of `wave-bottom-*` — so the lowered card is occluded along the header's wave rather than a straight box edge.
- `UiPinnedCard` extracted from the deck preview and adopted by app settings, replacing a duplicated paperclip/tilt block and an ancestor-selector coupling with a `tucked` prop.