### PR TITLE
Task board agent tooling, plus deck-settings and theming tweaks

### DIFF
--- a/.claude/context/app-map.md
+++ b/.claude/context/app-map.md
@@ -1,0 +1,158 @@
+# App Map — TaroFlash
+
+> Seed context for the `/groom` agent. Read this **before** forming a hunch about where a
+> raw task lives, so the first grep lands in the right place. Not exhaustive — a starting map.
+> Stack: Vue 3 `<script setup>` + TypeScript, Supabase, Pinia + Pinia Colada. **Feature-colocated**:
+> each view owns its components/composables in nested folders; `use-*.ts` sits next to its owner.
+
+Root: `/Users/chris/Dev/Web/TaroFlash`
+
+---
+
+## Hunch guide — task keyword → where to look
+
+Use this first. Match words in the raw ticket to a starting path, then grep from there.
+
+| Ticket mentions…                                                            | Start in                                                                                                                   |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| card editing, text editor, card face, image on card                         | `src/components/card/`, `src/views/deck/card-editor/` (desktop), `src/views/deck/mobile-editor/` (mobile)                  |
+| mobile editor, "mobile editor still shows", editor on phone                 | `src/views/deck/mobile-editor/`                                                                                            |
+| card grid, reorder cards, select/bulk, search cards                         | `src/views/deck/card-grid/`, `src/views/deck/composables/`                                                                 |
+| study session, rating buttons, fail/nope, session summary, resume           | `src/views/study-session/` (engine in `composables/`)                                                                      |
+| FSRS, review pacing, scheduling, presets, limits                            | `src/views/deck/deck-settings/tab-review-pacing/`, `src/composables/fsrs.ts`, `src/api/review-pacing/`                     |
+| deck settings, deck design, cover, danger zone                              | `src/views/deck/deck-settings/` (tabs: `tab-details/ tab-design/ tab-review-pacing/ tab-review-history/ tab-danger-zone/`) |
+| deck cover, icon/pattern picker, bgx                                        | `src/views/deck/cover-designer/`, `src/utils/cover/`, `src/styles/bg-utils.css`                                            |
+| avatar, member cover                                                        | `src/components/member/` (`avatar-picker-modal.vue`, `avatars.ts`, `cover.ts`)                                             |
+| profile/member settings, account, email/password, subscription, billing     | `src/views/settings/` (tabs), `src/components/billing/`, `src/composables/billing/`, `src/api/billing/`                    |
+| phone, mobile nav, dock, phone apps (darkmode/logout/feedback)              | `src/components/taro-phone/`, `src/stores/taro-phone.ts`, `src/components/mobile-dock/`                                    |
+| dashboard, deck grid (home), review inbox, tips, empty state                | `src/views/dashboard/`                                                                                                     |
+| login, signup, forgot/reset password, google auth, splash, roadmap, pricing | `src/views/welcome/`, `src/composables/auth/`, `src/views/auth/callback.vue`                                               |
+| feedback board / submit                                                     | `src/components/feedback/`, `src/composables/feedback/`, `src/api/feedback/`                                               |
+| audio reader, lessons, transcript, transliterate                            | `src/views/audio-reader/`, `src/composables/audio-reader/`, `src/api/lessons/`, `supabase/functions/transcribe-lesson`     |
+| legal, privacy, terms                                                       | `src/views/privacy-policy.vue`, `src/views/terms-of-service.vue`                                                           |
+| a ui-kit primitive (spinbox, slider, modal, toast, button, input…)          | `src/components/ui-kit/<name>/`; window chrome in `src/components/layout-kit/`                                             |
+| sound / sfx / v-sfx                                                         | `src/sfx/`                                                                                                                 |
+| theme, dark mode, palette, colors                                           | `src/stores/theme.ts`, `src/styles/palettes.gen.css`, `src/utils/palette/`, rule `theming.md`                              |
+| RLS, migration, policy, edge function, cleanup-media, stripe webhook        | `supabase/migrations/`, `supabase/functions/`, rule `supabase.md`                                                          |
+| server-state, cache, query/mutation, invalidation                           | `src/api/<domain>/`, rule `server-state.md`                                                                                |
+| animation, transition, gsap                                                 | `src/utils/animations/`, rule `animations.md`                                                                              |
+| skeleton / loading state                                                    | `*/skeleton.vue`, `src/styles/shimmer.css`, rule `skeleton-loading.md`                                                     |
+
+---
+
+## Routed views (`src/router/index.ts`)
+
+| Route                                   | Component                                                | Feature                                           |
+| --------------------------------------- | -------------------------------------------------------- | ------------------------------------------------- |
+| `/welcome`                              | `views/welcome/index.vue`                                | Splash / marketing / auth landing (public)        |
+| `/privacy`, `/terms`                    | `views/privacy-policy.vue`, `views/terms-of-service.vue` | Legal                                             |
+| `/auth/callback`                        | `views/auth/callback.vue`                                | OAuth / magic-link callback                       |
+| `/`                                     | `views/app-shell/authenticated.vue`                      | Auth-gated shell (nav-bar, route-skeleton)        |
+| `/dashboard`                            | `views/dashboard/index.vue`                              | Home: deck grid, review inbox, tips, audio-reader |
+| `/deck/:id`                             | `views/deck/deck-view.vue`                               | Deck detail: editor/grid, hero, settings, modes   |
+| `/audio-reader/collection/:c/lesson/:l` | `views/audio-reader/lesson/index.vue`                    | Audio reader lesson (gated)                       |
+
+**Study session** (`views/study-session/index.vue`) is **not** a route — launches as an overlay from deck/dashboard.
+
+---
+
+## Feature areas (detail)
+
+- **Card editor — desktop:** `views/deck/card-editor/` (`index/list/list-item/list-item-card/list-item-options`). Render primitives: `components/card/` (`card-face`, `face-editor`, `text-editor`, `face-image-layer`, `image-dropzone`, `card-cover`).
+- **Card editor — mobile:** `views/deck/mobile-editor/` (`editor-stage`, `editor-header`, `editor-controls`, `use-mobile-card-editor.ts`).
+- **Card grid & deck shell:** `views/deck/card-grid/`, `deck-hero/`, `mode-stack.vue`, `mode-toolbar/`, `modes.ts`, `search-bar.vue`, `card-importer.vue`; composables `views/deck/composables/` (actions, bulk-actions, card-search, list-controller, virtual-list, view-shell).
+- **Study session:** engine in `views/study-session/composables/` (`session-engine`, `session-controller`, `session-cards`, `session-persistence`, `session-prefs`, `session-resume`, `card-actions`, `card-edit`); UI in `session-studying/` (rating-buttons simple/advanced, progress), `session-summary/`.
+- **Deck settings:** `views/deck/deck-settings/` — `index.vue`, `pages.ts`, tabs `tab-details/ tab-design/ tab-review-pacing/ tab-review-history/ tab-danger-zone/`.
+- **Member settings:** `views/settings/` — tabs `tab-profile/ tab-app/ tab-account-access/ tab-subscription/ tab-danger-zone/`; `account-access/` (email/password/google), `use-avatar-picker.ts`.
+- **Phone (mobile nav):** `components/taro-phone/` (`taro-phone-base/-sm`, `app-launcher`, `app-shell`, `apps/`), store `stores/taro-phone.ts`, anim `utils/animations/phone.ts`; plus `components/mobile-dock/`.
+- **Dashboard:** `views/dashboard/` — `deck-grid/` (`use-deck-grid`, `use-deck-grid-reorder`), `review-inbox/`, `tip-card/`, `actions-panel/`, `audio-reader-section.vue`, `mobile-footer/`, `composables/` (`new-deck-action`, `deck-options-menu`).
+- **Cover / avatar designer:** deck `views/deck/cover-designer/` + `utils/cover/` (`bindings`, `patterns`, `tokens`, `random`); avatar `components/member/`.
+- **Feedback board:** `components/feedback/`, `composables/feedback/use-feedback-modal.ts`, phone app `taro-phone/apps/feedback-app.vue`, api `src/api/feedback/`.
+- **Login/signup:** `views/welcome/` (`login/ signup/ forgot-password/ reset-password/ splash/ section-features/ section-pricing/ section-roadmap/`), `composables/auth/`.
+- **Billing/subscription:** `components/billing/checkout-modal/`, `composables/billing/`, `api/billing/`. (No standalone "Shop" feature yet — only roadmap copy.)
+- **Audio reader:** `views/audio-reader/`, `composables/audio-reader/`, `api/lessons/`, transcription edge fns.
+
+---
+
+## ui-kit primitives (`src/components/ui-kit/`)
+
+`alert`, `burst`, `button`, `button-group`, `divider`, `dropdown-button/`, `icon`, `image`, `input`, `modal/`, `notice/` (panel+toast), `option-group`, `options-panel/`, `pattern-picker`, `pinned-card`, `popover`, `progress-bar`, `prompt`, `radio`, `scroll-bar`, `select-menu`, `slider`, `spinbox/`, `tabs`, `tag`, `tag-button`, `tape`, `tappable`, `textarea`, `theme-picker`, `toggle`, `tooltip`, `wobble-box`.
+
+**layout-kit** (`src/components/layout-kit/`): `app-window/`, `paged-window/`, `dialog-card/`, `crossfade-resize`, `labeled-section`, `section-list`.
+
+> Convention: import as `Ui<Name>`, template `<ui-name>` (never bare `<name>`).
+
+---
+
+## Composables, stores, api
+
+- **Global composables (`src/composables/`):** `alert`, `can`, `draft`, `fsrs`, `last-deck`, `modal`, `prompt`, `shortcuts`, `use-reorder-drag`; grouped `audio-reader/ auth/ billing/ card/ deck/ feedback/ member/ settings/ storage/ ui/` (ui has the big set: gestures, keyboard, media-query, depth, safe-area, scroll-lock, infinite-scroll, animated-height, press-hold, staged-tap, route-transition, numeric-input, …). Feature-specific `use-*.ts` are **colocated** in views, not here.
+- **Stores (`src/stores/`):** `member` (profile/role), `session` (auth), `theme` (dark/palette), `notice-store` (toasts), `shortcut-store`, `taro-phone`.
+- **`src/api/` topology:** per domain `db/` (raw Supabase builders) → `queries/` (Pinia Colada `useQuery`) → `mutations/` (`useMutation` + `_invalidate.ts`) → `index.ts` barrel. Domains: `billing cards decks feedback lessons media members review-pacing reviews`; plus flat `api/session.ts`.
+- **Styles (`src/styles/`):** `main.css` (entry), `palettes.gen.css` (generated), Tailwind v4 `@utility` layers `bg-utils` (`bgx-*`), `border-utils`, `bevel-utils`, `outline-utils`, `depth`, `shimmer` (skeleton), `mobile-modal-variant`.
+
+---
+
+## Backend (`supabase/`)
+
+- **Migrations:** `supabase/migrations/` (~114 files). Editing rules: `.claude/rules/supabase.md`. Never `db reset`; apply with `supabase migrations up`.
+- **Edge functions (`supabase/functions/`):** `cleanup-media`, `coverage`, `create-subscription`, `manage-subscription`, `stripe-webhook`, `transcribe-lesson`, `translate-term`, `translate-transcript`, `transliterate-transcript`, `_shared/`.
+
+---
+
+## Epics (Notion Epic Board → code area)
+
+`/groom` sets the ticket's **Epic** relation. Active (In Dev / Ready / P0) first; map to code:
+
+| Epic                        | Status       | Code area                                              |
+| --------------------------- | ------------ | ------------------------------------------------------ |
+| Deck/Card Config            | In Dev · P0  | `views/deck/deck-settings/`, `utils/cover/`            |
+| Study Session               | In Dev · P0  | `views/study-session/`                                 |
+| Phone Navigation            | In Dev · P0  | `components/taro-phone/`, `mobile-dock/`               |
+| Member Settings             | In Dev · P0  | `views/settings/`                                      |
+| Login/Signup                | In Dev · P0  | `views/welcome/`, `composables/auth/`                  |
+| Splash Page                 | In Dev · P0  | `views/welcome/splash/`, `section-*/`                  |
+| Dashboard                   | In Dev · P0  | `views/dashboard/`                                     |
+| Permissions                 | In Dev · P0  | `composables/can.ts`, RLS + capability SQL fns         |
+| UI-Kit                      | In Dev · P0  | `components/ui-kit/`, `layout-kit/`                    |
+| Card Images                 | In Dev · P0  | `components/card/` (image layers), `api/media/`        |
+| Community Page              | Backlog · P0 | (not built)                                            |
+| Analytics                   | Backlog · P0 | (not built)                                            |
+| Marketing Email Integration | Backlog · P0 | (not built)                                            |
+| Card Audio Upload           | Backlog · P0 | `api/media/`, sfx/audio                                |
+| Legal                       | Planned · P0 | `views/privacy-policy.vue`, `terms-of-service.vue`     |
+| Security & Compliance       | Planned · P1 | `supabase/` RLS, edge-fn authz                         |
+| Misc Bugs                   | Ready · P1   | (cross-cutting — default bucket for stray bugs)        |
+| Feedback Board              | Ready · P2   | `components/feedback/`, `api/feedback/`                |
+| Export/Import               | Planned · P2 | (not built)                                            |
+| Shortcuts                   | Planned · P2 | `composables/shortcuts.ts`, `stores/shortcut-store.ts` |
+| Tips/Tutorials              | Planned · P2 | `views/dashboard/tip-card/`                            |
+| Global Search               | Backlog · P1 | (not built)                                            |
+| Audio Reader                | Planned · P3 | `views/audio-reader/`, `api/lessons/`                  |
+
+Other backlog epics (P1–P3, mostly unbuilt): Power-Ups, Paperclips, Shop, Metrics & Stamps, Daily Challenges, Card decoration, Theming, Postcard sending, Tips/Deck Ratings, 3rd-party integration, Course Builder, Deck Printing, Favorites, Stickers, Attributions, Study Modes, Competitive Social Play, Realtime Collaborative Study, Verified Content, Offline Mode, Heatmap, Lightning Rounds, Trackable Goals, Card Notes, Avatar Designer, Bulk Find/Replace, Admin Dashboard, Accessibility, Misc Features.
+
+> If no epic fits, `Misc Bugs` (bugs) or `Misc Features` (tasks/stories) are the catch-alls.
+
+---
+
+## Domain glossary
+
+- **FSRS** — Free Spaced Repetition Scheduler; drives review-pacing. `composables/fsrs.ts`, `api/reviews/`.
+- **Review pacing** — per-deck study limits + scheduling (presets, new/review limits). `api/review-pacing/`, `tab-review-pacing/`.
+- **Fractional rank / reorder anchors** — ordering scheme for drag-reorder (fractional-rank strings; `anchor_id` + before/after; temp rows use negative ids). `utils/reorder.ts`, `cards/mutations/move.ts`. (LexoRank-style.)
+- **bgx** — CSS custom-prop system for decorative pattern backgrounds (`--bgx-image/-fill/-opacity/-size`); Tailwind `bgx-*` in `styles/bg-utils.css`, bound in `utils/cover/bindings.ts`. Used for covers.
+- **cover / patterns / tokens** — deck & avatar cover designer domain: `utils/cover/`.
+- **sfx / v-sfx** — sound-effect system. Engine `src/sfx/` (`engine`, `player`, `bus`, `config` with `SOUNDS`/buses `interface`|`hover`). `v-sfx` directive attaches interface sounds; registered in `main.ts`. Button clicks use `:sfx` prop, not direct calls.
+- **phone / taro-phone** — skeuomorphic mobile nav styled as a phone with mini-apps (darkmode, feedback, logout, settings).
+- **app-window / paged-window / dialog-card** — layout-kit window chrome: `app-window` (windowed surface), `paged-window` (multi-page directory nav), `dialog-card` (paged modal w/ header/pager/viewport).
+- **wave/cloud borders** — shaped-edge utilities `wave-bottom-[size]`, `wave-top-[size]`, `cloud-bottom-[size]` in `styles/border-utils.css` (never hand-roll SVG).
+- **audio-reader / lessons** — transcription reading: collections → lessons → word/segment-synced transcript; term popover creates cards.
+
+---
+
+## Conventions (`.claude/rules/`, auto-loaded by path glob)
+
+`architecture` (feature-colocation + api pattern) · `code-style` · `FE-formatting` · `vue-props` · `vue-script-order` · `vue-templates` · `composables` · `css` · `theming` · `animations` · `server-state` (Pinia Colada) · `skeleton-loading` · `study-session-architecture` · `supabase` · `i18n` · `safari-gotchas` · `testing` / `testing-composables` / `testing-pinia`.
+
+> All user-facing strings use i18n (`t('...')`, `src/locales/en-us.json`). Rules carry frontmatter (`paths`) scoping them to globs.

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: groom
+description: Turn raw one-line Notion Task Board tickets into agent-ready specs. Reads the seed app-map, forms a hunch about where each task lives, checks that hunch with you, investigates the codebase, validates its assumptions with you, then drafts a rewritten title + body + fields (Priority/Type/Epic/Assignee) for the whole batch and applies them on your approval — moving each to Ready (pair) or Queued (auto). May propose creating or merging tickets. Trigger on `/groom`, "groom the backlog", "groom tickets".
+allowed-tools: Read, Grep, Glob, Bash, Agent, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page, mcp__notion__notion-create-pages, mcp__notion__notion-search
+argument-hint: '[--p0|--p1|--p2|--p3] [--count N] [<ID> <ID> …]'
+arguments:
+  - name: --p0|--p1|--p2|--p3
+    description: Only groom Backlog tickets of this priority.
+  - name: --count N
+    description: Cap the batch at N tickets (default 10). Ordered Priority → ID.
+  - name: <ID>
+    description: One or more numeric ticket IDs to groom specifically (overrides filters).
+lastUpdated: 2026-07-20T00:00:00Z
+---
+
+## What this skill does
+
+Grooming = converting a raw ticket (a one-line idea) into something an agent can execute
+without guessing. It is a **batched, checkpointed** flow: ~3 interruptions total, not one per
+ticket. You stay in control of scope and never get surprised by a bad hunch.
+
+The output of a groomed ticket:
+
+- a **descriptive title** (replaces the raw one-liner),
+- a **body** filled from the per-Type template (§ Body templates),
+- suggested **Priority / Type / Epic / Assignee**,
+- moved to **`Ready`** (pair) or **`Queued`** (autonomous batch).
+
+Do **not** touch tests. Do **not** write code. This skill only reads code and writes Notion.
+
+## Board constants
+
+- **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`
+- **Epic Board** data source: `collection://2510953c-224c-80b7-9bb0-000b5384a47d`
+- **Fields & vocab:**
+  - `Status`: `Needs More Info` · `Backlog` · `Ready` · `Queued` · `In Progress` · `Blocked` · `Review` · `Done` · `Duplicate`
+  - `Priority`: `⇞P0` · `↑P1` · `↓P2` · `⇟P3`
+  - `Type`: `Bug` · `Task` · `Story`
+  - `Assignee`: `Me` · `Fable` · `Opus` · `Sonnet`
+  - `Epic`: relation to Epic Board (single). `ID`: read-only auto-increment.
+
+## Procedure
+
+### 0. LOAD seed
+
+Read `.claude/context/app-map.md` in full. It is the grounding for every hunch — the
+keyword→path hunch guide and the Epic→code map are the two tables you lean on hardest.
+
+### 1. FETCH
+
+Query the Task Board for the input set:
+
+```sql
+SELECT "userDefined:ID" AS id, "Name", "Type", "Priority", "Epic", url
+FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
+WHERE "Status" = 'Backlog'          -- skips Needs More Info
+ORDER BY "Priority" ASC, "userDefined:ID" ASC
+```
+
+Apply args: `--pN` adds `AND "Priority" = '<glyph>'`; explicit `<ID>`s replace the WHERE with
+`"userDefined:ID" IN (…)` (ignoring the Backlog filter — but warn if a named ticket isn't in
+Backlog). `--count N` caps the batch (default 10). If the batch would exceed the cap, take the
+top N by Priority→ID and tell the user how many were left.
+
+### 2. SELECT
+
+Echo the batch as a compact numbered list (ID · Priority · raw name). If args fully determined
+it, proceed. If ambiguous or oversized, ask which to include before spending investigation time.
+
+--- batched checkpoints below: do all tickets at each stage, then one interruption ---
+
+### 3. HUNCH-ALL ▸ CHECKPOINT 1
+
+For each ticket, from the raw name + app-map alone (no code reads yet), state a one-liner:
+
+> `#141` spinbox step bug → likely `src/components/ui-kit/spinbox/` + review-pacing callers
+> Present all hunches together. **Stop and let the user course-correct the search direction**
+> before you spend time investigating. Cheap to redirect here, expensive later.
+
+### 4. INVESTIGATE
+
+With hunches confirmed, dig into the codebase for the whole batch — grep, read the relevant
+files, confirm where the change lives, note affected files, adjacent patterns, and any rules
+(`.claude/rules/*`) that govern the area. For a large batch, dispatch parallel `Agent` (Explore)
+subagents, one per ticket or per cluster, to keep it fast. Gather: what/where, root cause (bugs),
+affected paths, constraints, open unknowns.
+
+### 5. VALIDATE-ALL ▸ CHECKPOINT 2
+
+Report per ticket: assumptions **confirmed** vs **wrong/surprising**, and any unknowns that need
+your input. **Stop for confirmation or redirect** before drafting. If a ticket is still too thin
+to spec even after investigation, flag it as a → `Needs More Info` candidate here.
+
+### 6. DRAFT-ALL ▸ APPROVE-BATCH
+
+For every ticket, draft in one pass and present together:
+
+- **Title** — descriptive rewrite.
+- **Body** — per-Type template (§ below), filled with what INVESTIGATE found.
+- **Fields** — suggested `Priority`, `Type`, `Epic` (from the Epic→code map), `Assignee` (§ heuristic).
+- **Lane** — `Ready` (pair) or `Queued` (auto). Default `Queued` when the spec is complete and
+  the work is mechanical/low-risk; default `Ready` (pair) when it touches `supabase/`, auth,
+  billing, RLS/security, or is genuinely ambiguous. State which and why in one phrase.
+  **A `Queued` ticket MUST have `Assignee` ∈ {`Fable`,`Opus`,`Sonnet`}** — `/work batch` skips
+  `Me`, so a `Queued` + `Me` ticket would sit unworked forever. If a ticket is heading to `Queued`
+  but you'd assign `Me`, that's a contradiction: either give it a model, or route it to `Ready`.
+- **Proposals** — where warranted: **CREATE** a new ticket (e.g. work discovered that's out of
+  scope), or **MERGE** this ticket into another (name the survivor). Never silently.
+
+Present as an editable batch. The user approves / edits / skips per ticket in one review.
+
+### 7. WRITE
+
+Apply only what was approved, via `notion-update-page` per ticket (and `notion-create-pages` for
+CREATEs):
+
+- set the title, write the body (page content), set `Priority`/`Type`/`Epic`/`Assignee`,
+- set `Status` = `Ready` or `Queued` (or `Needs More Info` for the thin ones).
+- **Refuse to write `Status = Queued` when `Assignee` is `Me` or empty.** Stop and ask the user
+  to pick a model or send it to `Ready` — never write a self-stranding ticket.
+- **Merges:** move the merged-away ticket to `Status = Duplicate`, add a body line linking the
+  survivor, and fold any unique context into the survivor's body.
+  Write sequentially; if a write fails, report which and stop rather than half-applying silently.
+
+### 8. REPORT
+
+Concise tally: `groomed → Ready/Queued (with assignee)`, `created`, `merged → Duplicate`,
+`parked → Needs More Info`, `skipped`. One line each. No prose.
+
+## Body templates
+
+**Bug**
+
+```
+## Repro
+1. …
+## Expected / Actual
+- Expected: …
+- Actual: …
+## Area
+<path(s)> — <root cause if known>
+## Acceptance
+<observable condition proving it's fixed>
+```
+
+**Task / Story**
+
+```
+## Goal
+<what & why, 1–2 lines>
+## Acceptance criteria
+- [ ] …
+## Area
+<path(s)>
+## Constraints / out of scope
+- …
+```
+
+Keep bodies tight — enough for an agent to act, no padding. Follow project i18n rule: any new
+user-facing copy the ticket implies should note the locale key path (`src/locales/en-us.json`).
+
+## Assignee heuristic (suggest, user overrides)
+
+- **`Opus`** — architectural, cross-cutting, ambiguous, or security/backend-sensitive work.
+- **`Sonnet`** — well-scoped feature/bug work with a clear spec.
+- **`Fable`** — mechanical/localized changes (copy, single-component tweaks, icon swaps).
+- **`Me`** — you want to drive it yourself; also the signal that it is **not** auto-eligible
+  (a `Me` ticket is never picked by `/work batch`). Pair-lane tickets are typically `Me` or a
+  model you'll sit with.
+
+## Guardrails
+
+- Only ever touch the Task Board data source above — never any backup/duplicate database.
+- Never change `Status` to an `In Progress`/`Review`/`Done` value here — grooming lands tickets
+  in `Ready`/`Queued`/`Needs More Info`/`Duplicate` only.
+- Priority/Type are the user's inputs: propose changes, never apply them unasked.
+- If unsure whether to merge/create, ask — don't guess destructive board edits.

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -72,11 +72,21 @@ it, proceed. If ambiguous or oversized, ask which to include before spending inv
 
 --- batched checkpoints below: do all tickets at each stage, then one interruption ---
 
+> **Checkpoint reporting voice (CHECKPOINT 1 & 2).** Report to the user in **product terms** —
+> describe where a thing sits in the **UI** and what the user experiences ("the edit-decks
+> control on the dashboard", "the popup after Google sign-up", "the red error under the name
+> field"). Do **not** surface filepaths, component/composable names, function names, or symbols
+> in the checkpoint report — the user thinks in screens and flows, not the file tree. Filepaths
+> still belong in the drafted ticket **body** (§ 6, agent-facing), just never in the
+> user-facing checkpoint summaries. When a hunch is fundamentally about a location in code,
+> translate it to the screen/flow the user would recognise.
+
 ### 3. HUNCH-ALL ▸ CHECKPOINT 1
 
-For each ticket, from the raw name + app-map alone (no code reads yet), state a one-liner:
+For each ticket, from the raw name + app-map alone (no code reads yet), state a one-liner in
+product terms — the screen/flow it lives in and what the user sees, not the path:
 
-> `#141` spinbox step bug → likely `src/components/ui-kit/spinbox/` + review-pacing callers
+> `#141` spinbox step bug → likely the number steppers in deck review-pacing settings
 > Present all hunches together. **Stop and let the user course-correct the search direction**
 > before you spend time investigating. Cheap to redirect here, expensive later.
 
@@ -90,16 +100,22 @@ affected paths, constraints, open unknowns.
 
 ### 5. VALIDATE-ALL ▸ CHECKPOINT 2
 
-Report per ticket: assumptions **confirmed** vs **wrong/surprising**, and any unknowns that need
-your input. **Stop for confirmation or redirect** before drafting. If a ticket is still too thin
-to spec even after investigation, flag it as a → `Needs More Info` candidate here.
+Report per ticket, **in product terms** (see reporting-voice note above — screens and flows, no
+filepaths or symbol names): assumptions **confirmed** vs **wrong/surprising**, and any unknowns
+that need your input. Separate the "clean, ready to spec" tickets from the ones that need a
+decision, and for each decision state the user-facing choice plainly (what changes on screen,
+what the trade-off is) rather than the implementation fork. **Stop for confirmation or redirect**
+before drafting. If a ticket is still too thin to spec even after investigation, flag it as a →
+`Needs More Info` candidate here.
 
 ### 6. DRAFT-ALL ▸ APPROVE-BATCH
 
-For every ticket, draft in one pass and present together:
+For every ticket, draft the full body in one pass (per-Type template § below), but **present a
+compact summary** — do not dump full bodies into the review. Per ticket show:
 
 - **Title** — descriptive rewrite.
-- **Body** — per-Type template (§ below), filled with what INVESTIGATE found.
+- **Description summary** — a **single line** (≤1 line) capturing the product intent. The full
+  **Product description** and **Technical notes** live in the drafted body, not the review.
 - **Fields** — suggested `Priority`, `Type`, `Epic` (from the Epic→code map), `Assignee` (§ heuristic).
 - **Lane** — `Ready` (pair) or `Queued` (auto). Default `Queued` when the spec is complete and
   the work is mechanical/low-risk; default `Ready` (pair) when it touches `supabase/`, auth,
@@ -132,31 +148,40 @@ Concise tally: `groomed → Ready/Queued (with assignee)`, `created`, `merged �
 
 ## Body templates
 
+Every body carries two named sections: **Product description** (what the user experiences and
+why, in plain product terms — no filepaths) and **Technical notes** (the agent-facing detail:
+paths, root cause, approach, constraints/out-of-scope, rules, i18n key paths). The description
+summary shown at CHECKPOINT/DRAFT review is a one-line distillation of Product description.
+
 **Bug**
 
 ```
+## Product description
+<1–3 lines: what the user sees/experiences and why it's wrong, product terms>
 ## Repro
 1. …
 ## Expected / Actual
 - Expected: …
 - Actual: …
-## Area
-<path(s)> — <root cause if known>
 ## Acceptance
 <observable condition proving it's fixed>
+## Technical notes
+- Area: <path(s)> — <root cause if known>
+- Approach: <where the fix lives / how>
+- Constraints & rules: <.claude/rules/*, i18n key path, gotchas>
 ```
 
 **Task / Story**
 
 ```
-## Goal
-<what & why, 1–2 lines>
+## Product description
+<what & why for the user, product terms>
 ## Acceptance criteria
 - [ ] …
-## Area
-<path(s)>
-## Constraints / out of scope
-- …
+## Technical notes
+- Area: <path(s)>
+- Approach: <how / where>
+- Constraints & out of scope: <…, rules, i18n key path>
 ```
 
 Keep bodies tight — enough for an agent to act, no padding. Follow project i18n rule: any new

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -51,16 +51,19 @@ keyword→path hunch guide and the Epic→code map are the two tables you lean o
 Query the Task Board for the input set:
 
 ```sql
-SELECT "userDefined:ID" AS id, "Name", "Type", "Priority", "Epic", url
+SELECT "userDefined:ID" AS id, "Name", "Type", "Priority", "Epic", "Assignee", url
 FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
-WHERE "Status" = 'Backlog'          -- skips Needs More Info
+WHERE "Status" = 'Backlog'                         -- skips every other lane (Needs More Info, Icebox, …)
+  AND ("Assignee" IS NULL OR "Assignee" <> 'Me')   -- Me on a backlog ticket = hands off, don't groom
 ORDER BY "Priority" ASC, "userDefined:ID" ASC
 ```
 
-Apply args: `--pN` adds `AND "Priority" = '<glyph>'`; explicit `<ID>`s replace the WHERE with
-`"userDefined:ID" IN (…)` (ignoring the Backlog filter — but warn if a named ticket isn't in
-Backlog). `--count N` caps the batch (default 10). If the batch would exceed the cap, take the
-top N by Priority→ID and tell the user how many were left.
+`Assignee = Me` on a Backlog ticket is the user's "I'll handle this myself — don't groom" signal;
+never auto-pull it. Apply args: `--pN` adds `AND "Priority" = '<glyph>'`; explicit `<ID>`s replace
+the WHERE with `"userDefined:ID" IN (…)` (overriding both the Backlog and the `Me` filter, since
+naming a ticket is deliberate — but warn if a named ticket isn't in Backlog or is assigned `Me`).
+`--count N` caps the batch (default 10). If the batch would exceed the cap, take the top N by
+Priority→ID and tell the user how many were left.
 
 ### 2. SELECT
 

--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -2,16 +2,19 @@
 name: prepare-pr
 description: Fully autonomous — prepare a branch for PR by committing all pending work, rewriting commit messages into release-notes-friendly Conventional Commits, renaming the branch if it no longer fits the changes, running a lint + type-check gate, drafting a PR title and body, then creating a single PR directly (not a draft) and watching CI until green. Never asks for permission or feedback before the PR opens. Always bundles all branch work — committed AND uncommitted (staged + unstaged) — into exactly one PR. Use when a feature branch is code-complete and ready for review.
 allowed-tools: Read, Edit, Write, Bash, Glob, Grep
-argument-hint: '[--no-watch]'
+argument-hint: '[--no-watch] [--ticket <ID>]'
 arguments:
   - name: --no-watch
     description: Skip the post-create CI watch + coverage check (Step 10).
-lastUpdated: 2026-07-03T00:00:00Z
+  - name: --ticket <ID>
+    description: Prefix the PR title with the ticket key `TARO-<ID>` (e.g. `TARO-207: …`). Omit for no prefix.
+lastUpdated: 2026-07-20T00:00:00Z
 ---
 
 ## Args
 
 - **`--no-watch`** (optional) — skip the post-create CI watch + coverage check (Step 10). Default behaviour blocks on CI after opening the PR until checks settle, then inspects coverage and writes more tests if it regressed.
+- **`--ticket <ID>`** (optional) — the Notion Task Board ticket ID this PR resolves. When given, the PR **title** is prefixed with `TARO-<ID>: ` (Step 8). This affects only the PR title — commit subjects stay clean (ticket refs still belong in a commit-body `Refs:` trailer, per Notes). Omit to open a PR with no ticket prefix.
 
 ## Fully autonomous — no approval gates
 
@@ -231,6 +234,8 @@ Examples:
 - `Study session inline editing and architecture cleanup` (multiple commits, mixed types)
 
 Avoid repeating Conventional-Commits prefix in title — GitHub release tooling reads commit subjects, not PR titles, and humans don't need `feat(study-session):` twice.
+
+**Ticket prefix (`--ticket <ID>`).** If the skill was invoked with `--ticket <ID>`, prepend the ticket key to the drafted title: `TARO-<ID>: <title>` — e.g. `TARO-207: Close open modals and clear caches on logout`. Prefix only; the rest of the title is derived exactly as above. Do **not** add the prefix when `--ticket` is absent, and never put the ticket key into commit subjects (Notes).
 
 **Body** — structured for skim:
 

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -62,7 +62,8 @@ ticket's `Assignee`).
    approval on every change.** If the `Area` touches `supabase/**` (migrations, RPCs, RLS, edge
    functions), the backend teaching persona is **on** — teach as you write per CLAUDE.md. **Do
    not touch tests** — the golden rule holds in pair mode. Follow all `.claude/rules/*`.
-5. **PR** — invoke the **`prepare-pr`** skill (commits, conventional messages, lint+type gate,
+5. **PR** — invoke the **`prepare-pr`** skill with `--ticket <ID>` (the ticket's Notion ID)
+   so the PR title is prefixed `TARO-<ID>:` (commits, conventional messages, lint+type gate,
    opens one PR, watches CI to green).
 6. **HANDOFF** — set the ticket's `Status = Review` and write the PR URL into its body. Stop.
 
@@ -91,7 +92,8 @@ Autonomous. Sequential (one ticket fully done before the next — no parallel wo
    It reports back what it changed + the branch name.
    c. **TESTS** — invoke the **`update-tests`** skill for the changes (this is the explicit ask
    that overrides the golden rule — batch mode owns its tests).
-   d. **PR** — invoke the **`prepare-pr`** skill → one PR, CI watched to green.
+   d. **PR** — invoke the **`prepare-pr`** skill with `--ticket <ID>` (the ticket's Notion ID)
+   → one PR titled `TARO-<ID>: …`, CI watched to green.
    e. **HANDOFF** — set `Status = Review`, write the PR URL into the ticket body.
    f. **If stuck** — subagent can't satisfy acceptance, the gate won't pass after real effort, or
    a blocking unknown surfaces: set `Status = Blocked`, write a one-line reason + what's needed

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: work
+description: Execute groomed Notion Task Board tickets. Two modes. `/work pair [ID]` works one Ready ticket interactively in this session — backend teaching on, you approve every change, tests left untouched — then opens a PR. `/work batch [--count N] [--p0…]` pulls Queued tickets assigned to a model (Fable/Opus/Sonnet), works each sequentially via a subagent pinned to that model, runs the update-tests skill, and opens a PR via prepare-pr. Both claim the ticket to In Progress first and stop at an open PR (Review) — never merge. Trigger on `/work`, "work the board", "work a ticket".
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash, Agent, Skill, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page
+argument-hint: 'pair [<ID>] | batch [--count N] [--p0|--p1|--p2|--p3]'
+arguments:
+  - name: pair
+    description: Interactive mode — work one Ready ticket with you in this session. Optional ID; else top Priority→ID.
+  - name: batch
+    description: Autonomous mode — work Queued tickets assigned to a model, sequentially, each ending in a PR.
+  - name: --count N
+    description: batch only — max tickets to work this run (default 1).
+  - name: --p0|--p1|--p2|--p3
+    description: batch only — restrict to this priority.
+  - name: <ID>
+    description: pair only — the specific ticket to work.
+lastUpdated: 2026-07-20T00:00:00Z
+---
+
+## What this skill does
+
+Pulls a groomed ticket off the board, does the work, and lands it at an **open PR** for your
+review. It never merges and never marks a ticket `Done` — you close the loop.
+
+Two modes, chosen by the first arg. They differ deliberately:
+
+|                 | `pair`                           | `batch`                            |
+| --------------- | -------------------------------- | ---------------------------------- |
+| Source lane     | `Status = Ready`                 | `Status = Queued`                  |
+| Model           | **this session's** model         | each ticket's **`Assignee`** model |
+| Execution       | interactive, in-session          | sequential subagent per ticket     |
+| Backend persona | **on** (teaching)                | **off**                            |
+| Your approval   | **every change**                 | none — you review the PR           |
+| Tests           | **left untouched** (golden rule) | **`update-tests` skill runs**      |
+| Ends at         | open PR → `Review`               | open PR → `Review`                 |
+
+## Board constants
+
+- **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`
+- `Status` lanes this skill uses: pulls from `Ready`/`Queued`; claims to `In Progress`; lands at
+  `Review`; parks stuck work at `Blocked`. Never sets `Done`/`Duplicate`.
+- `Assignee`: `Me` · `Fable` · `Opus` · `Sonnet`. `Me` is **never** batch-eligible.
+
+## Claim protocol (both modes, per ticket)
+
+Before touching any code, **claim atomically**: `notion-update-page` set `Status = In Progress`.
+Re-query first — if the ticket is no longer in its source lane (someone/another run grabbed it),
+skip it. This is what stops two runs colliding on the same ticket.
+
+---
+
+## Mode: `pair [ID]`
+
+Interactive, in **this** session, using **whatever model the session is running** (ignore the
+ticket's `Assignee`).
+
+1. **SELECT** — `Status = Ready`. If an ID is given, take it; else the top `Priority → ID`.
+   Fetch its full page (title + body). Echo what you're about to work.
+2. **CLAIM** → `In Progress`.
+3. **BRANCH** — conventional branch off `master` matching the ticket (`fix/…`, `feat/…`).
+4. **IMPLEMENT — together.** Work through the acceptance criteria in small steps. **Pause for
+   approval on every change.** If the `Area` touches `supabase/**` (migrations, RPCs, RLS, edge
+   functions), the backend teaching persona is **on** — teach as you write per CLAUDE.md. **Do
+   not touch tests** — the golden rule holds in pair mode. Follow all `.claude/rules/*`.
+5. **PR** — invoke the **`prepare-pr`** skill (commits, conventional messages, lint+type gate,
+   opens one PR, watches CI to green).
+6. **HANDOFF** — set the ticket's `Status = Review` and write the PR URL into its body. Stop.
+
+## Mode: `batch [--count N] [--p0…]`
+
+Autonomous. Sequential (one ticket fully done before the next — no parallel worktrees for now).
+
+1. **SELECT**
+
+   ```sql
+   SELECT "userDefined:ID" AS id, "Name", "Priority", "Assignee", url
+   FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
+   WHERE "Status" = 'Queued' AND "Assignee" IN ('Fable','Opus','Sonnet')
+   ORDER BY "Priority" ASC, "userDefined:ID" ASC
+   ```
+
+   `--pN` adds a priority filter; `--count N` caps (default 1). Tickets with `Assignee = Me` are
+   skipped by the query — never batch them. Echo the plan (ID · priority · assignee) before starting.
+
+2. **Per ticket, sequentially:**
+   a. **CLAIM** → `In Progress` (re-check it's still `Queued` first; skip if not).
+   b. **IMPLEMENT via a model-pinned subagent.** Dispatch one `Agent` (`agentType: general-purpose`,
+   `model:` = the ticket's `Assignee` lowercased → `fable`/`opus`/`sonnet`) with the ticket's
+   title + body + acceptance criteria. The subagent: branches off `master`, implements to the
+   acceptance criteria, follows `.claude/rules/*`. **No backend teaching persona** in batch.
+   It reports back what it changed + the branch name.
+   c. **TESTS** — invoke the **`update-tests`** skill for the changes (this is the explicit ask
+   that overrides the golden rule — batch mode owns its tests).
+   d. **PR** — invoke the **`prepare-pr`** skill → one PR, CI watched to green.
+   e. **HANDOFF** — set `Status = Review`, write the PR URL into the ticket body.
+   f. **If stuck** — subagent can't satisfy acceptance, the gate won't pass after real effort, or
+   a blocking unknown surfaces: set `Status = Blocked`, write a one-line reason + what's needed
+   into the body, and move to the next ticket. Don't silently fail or leave it `In Progress`.
+
+3. **REPORT** — tally: worked → `Review` (with PR links), `Blocked` (with reasons), skipped.
+
+## Guardrails
+
+- Only ever touch the Task Board data source above — never a backup/duplicate database.
+- **Always stop at an open PR.** Never merge, never set `Done`. That's the user's call in `Review`.
+- Claim before coding; re-check the lane to avoid double-work.
+- Batch never runs the backend teaching persona and never works a `Me` ticket. Pair never touches
+  tests. These are the mode contracts — don't cross them.
+- One PR per ticket (via `prepare-pr`). Don't batch multiple tickets into a single PR.

--- a/src/components/ui-kit/spinbox/index.vue
+++ b/src/components/ui-kit/spinbox/index.vue
@@ -102,7 +102,7 @@ function increment() {
           type="text"
           inputmode="numeric"
           data-testid="ui-kit-spinbox__input"
-          class="text-center tabular-nums text-ink bg-transparent outline-none text-base px-2 w-12"
+          class="text-center tabular-nums text-ink bg-transparent outline-none text-lg px-2 w-12"
           :value="display_value"
           :step="step"
           @beforeinput="onBeforeInput"

--- a/src/styles/depth.css
+++ b/src/styles/depth.css
@@ -196,6 +196,20 @@
   --color-element-strong: var(--color-stone-800);
 }
 
+/* Depth 2 holds the depth 1 lighter-pop in light (brown-100/brown-300) — a
+ * raised surface is light enough that brown-100 reads on brown-500 too. */
+[data-depth='2'] {
+  --color-element: var(--color-brown-100);
+  --color-element-strong: var(--color-brown-300);
+  --color-element-soft: var(--color-brown-300);
+}
+[data-mode='dark'] [data-depth='2'],
+[data-mode='dark'][data-depth='2'] {
+  --color-element: var(--color-stone-800);
+  --color-element-strong: var(--color-stone-900);
+  --color-element-soft: var(--color-stone-700);
+}
+
 /* Fixed media surfaces, never depth-derived: the flashcard (white/stone-700)
  * and the avatar mat (brown-100/stone-700, tuned once for user avatars). */
 :root[data-mode='dark'] {

--- a/src/views/deck/deck-settings/tab-review-pacing/general-section.vue
+++ b/src/views/deck/deck-settings/tab-review-pacing/general-section.vue
@@ -5,9 +5,12 @@ import UiToggle from '@/components/ui-kit/toggle.vue'
 import UiOptionGroup from '@/components/ui-kit/option-group.vue'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
 import { deckEditorKey } from '@/composables/deck/editor'
+import { useMatchMedia } from '@/composables/ui/media-query'
 
 const { t } = useI18n()
 const { draft } = inject(deckEditorKey)!
+
+const is_coarse = useMatchMedia('coarse')
 
 // The draft always carries a seeded value; the getter default only satisfies
 // `DeckConfig`'s optional key.
@@ -47,6 +50,7 @@ const starting_side_options = computed(() =>
         data-testid="tab-review-pacing__starting-side-options"
         v-model:value="starting_side"
         :options="starting_side_options"
+        :size="is_coarse ? 'base' : 'sm'"
       />
     </div>
   </labeled-section>

--- a/tests/integration/views/deck/deck-settings/tab-review-pacing/general-section.test.js
+++ b/tests/integration/views/deck/deck-settings/tab-review-pacing/general-section.test.js
@@ -1,8 +1,21 @@
-import { describe, test, expect } from 'vite-plus/test'
+import { describe, test, expect, vi } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
-import { defineComponent, h, reactive, useAttrs } from 'vue'
+import { defineComponent, h, reactive, ref, useAttrs } from 'vue'
 import { deckEditorKey } from '@/composables/deck/editor'
 import GeneralSection from '@/views/deck/deck-settings/tab-review-pacing/general-section.vue'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+// mockIsCoarse is a plain container so it can be assigned inside vi.hoisted
+// (where Vue's `ref` is not yet importable). Tests mutate `.ref`.
+const { mockIsCoarse } = vi.hoisted(() => {
+  const mockIsCoarse = { ref: null }
+  return { mockIsCoarse }
+})
+
+vi.mock('@/composables/ui/media-query', () => ({
+  useMatchMedia: vi.fn(() => mockIsCoarse.ref)
+}))
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
@@ -61,7 +74,8 @@ const OptionGroupStub = defineComponent({
 
 // ── Fixture ───────────────────────────────────────────────────────────────────
 
-function makeWrapper({ config: configOverrides = {} } = {}) {
+function makeWrapper({ config: configOverrides = {}, coarse = false } = {}) {
+  mockIsCoarse.ref = ref(coarse)
   const draft = reactive({ study_config: { shuffle: false, ...configOverrides } })
   const wrapper = mount(GeneralSection, {
     global: {
@@ -125,5 +139,17 @@ describe('GeneralSection — starting-side option group [obligation]', () => {
   test('renders the starting-side row wrapper', () => {
     const { wrapper } = makeWrapper()
     expect(wrapper.find('[data-testid="tab-review-pacing__starting-side"]').exists()).toBe(true)
+  })
+
+  test('passes size="base" to the option group on a coarse pointer [obligation]', () => {
+    const { wrapper } = makeWrapper({ coarse: true })
+    const group = wrapper.find('[data-testid="tab-review-pacing__starting-side-options"]')
+    expect(group.attributes('size')).toBe('base')
+  })
+
+  test('passes size="sm" to the option group on a fine pointer [obligation]', () => {
+    const { wrapper } = makeWrapper({ coarse: false })
+    const group = wrapper.find('[data-testid="tab-review-pacing__starting-side-options"]')
+    expect(group.attributes('size')).toBe('sm')
   })
 })


### PR DESCRIPTION
## Summary

Adds the Notion Task Board agent workflow (`/groom` + `/work` skills, seed app-map) for turning raw tickets into agent-ready specs and executing them. Also bundles a few small UI drive-bys committed on this branch: spinbox font size, depth-2 theming tokens, and a coarse-pointer sizing tweak for the Starting Side selector.

## Changes

**Task-board tooling**
- Add `/groom` and `/work` skills + seed `app-map.md` context
- Exclude `Assignee=Me` from groom's backlog fetch
- Groom checkpoints use product terms; `TARO-<id>` PR-title prefix support in prepare-pr

**UI / theming**
- `fix(spinbox)`: input base font size to 16px
- `feat(theming)`: `--color-element` variants at depth 2 (light + dark)
- `feat(deck-settings)`: Starting Side selector renders `size="base"` on coarse pointers, `sm` on fine, with tests