### PR TITLE
chore(work): parallel worktree subagents in batch mode

### DIFF
--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work
-description: Execute groomed Notion Task Board tickets. Two modes. `/work pair [ID]` works one Ready ticket interactively in this session — backend teaching on, you approve every change, tests left untouched — then opens a PR. `/work batch [--count N] [--p0…]` pulls Queued tickets assigned to a model (Fable/Opus/Sonnet), works each sequentially via a subagent pinned to that model, runs the update-tests skill, and opens a PR via prepare-pr. Both claim the ticket to In Progress first and stop at an open PR (Review) — never merge. Trigger on `/work`, "work the board", "work a ticket".
+description: Execute groomed Notion Task Board tickets. Two modes. `/work pair [ID]` works one Ready ticket interactively in this session — backend teaching on, you approve every change, tests left untouched — then opens a PR. `/work batch [--count N] [--p0…]` pulls up to N Queued tickets assigned to a model (Fable/Opus/Sonnet) and works them in parallel — one worktree-isolated subagent per ticket, each pinned to that ticket's model, each writing its own tests. Subagents report back to this session (the orchestrator), which organizes the branches into non-conflicting, CI-passing PRs. Both claim the ticket to In Progress first and stop at an open PR (Review) — never merge. Trigger on `/work`, "work the board", "work a ticket".
 allowed-tools: Read, Edit, Write, Grep, Glob, Bash, Agent, Skill, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page
 argument-hint: 'pair [<ID>] | batch [--count N] [--p0|--p1|--p2|--p3]'
 arguments:
@@ -9,12 +9,12 @@ arguments:
   - name: batch
     description: Autonomous mode — work Queued tickets assigned to a model, sequentially, each ending in a PR.
   - name: --count N
-    description: batch only — max tickets to work this run (default 1).
+    description: batch only — how many tickets to work in parallel this run, one worktree-isolated subagent each (default 1).
   - name: --p0|--p1|--p2|--p3
     description: batch only — restrict to this priority.
   - name: <ID>
     description: pair only — the specific ticket to work.
-lastUpdated: 2026-07-20T00:00:00Z
+lastUpdated: 2026-07-21T00:00:00Z
 ---
 
 ## What this skill does
@@ -24,15 +24,15 @@ review. It never merges and never marks a ticket `Done` — you close the loop.
 
 Two modes, chosen by the first arg. They differ deliberately:
 
-|                 | `pair`                           | `batch`                            |
-| --------------- | -------------------------------- | ---------------------------------- |
-| Source lane     | `Status = Ready`                 | `Status = Queued`                  |
-| Model           | **this session's** model         | each ticket's **`Assignee`** model |
-| Execution       | interactive, in-session          | sequential subagent per ticket     |
-| Backend persona | **on** (teaching)                | **off**                            |
-| Your approval   | **every change**                 | none — you review the PR           |
-| Tests           | **left untouched** (golden rule) | **`update-tests` skill runs**      |
-| Ends at         | open PR → `Review`               | open PR → `Review`                 |
+|                 | `pair`                           | `batch`                               |
+| --------------- | -------------------------------- | ------------------------------------- |
+| Source lane     | `Status = Ready`                 | `Status = Queued`                     |
+| Model           | **this session's** model         | each ticket's **`Assignee`** model    |
+| Execution       | interactive, in-session          | parallel subagents, one worktree each |
+| Backend persona | **on** (teaching)                | **off**                               |
+| Your approval   | **every change**                 | none — you review the PR              |
+| Tests           | **left untouched** (golden rule) | each subagent writes its own          |
+| Ends at         | open PR → `Review`               | open PR → `Review`                    |
 
 ## Board constants
 
@@ -69,7 +69,10 @@ ticket's `Assignee`).
 
 ## Mode: `batch [--count N] [--p0…]`
 
-Autonomous. Sequential (one ticket fully done before the next — no parallel worktrees for now).
+Autonomous. **Parallel** — up to `N` tickets are worked at once, each by its own subagent in its
+own git worktree. This session is the **orchestrator**: it claims the tickets, fans out the
+subagents, then organizes the branches they hand back into clean, passing PRs. The orchestrator
+never edits ticket code itself.
 
 1. **SELECT**
 
@@ -80,26 +83,54 @@ Autonomous. Sequential (one ticket fully done before the next — no parallel wo
    ORDER BY "Priority" ASC, "userDefined:ID" ASC
    ```
 
-   `--pN` adds a priority filter; `--count N` caps (default 1). Tickets with `Assignee = Me` are
-   skipped by the query — never batch them. Echo the plan (ID · priority · assignee) before starting.
+   `--pN` adds a priority filter; `--count N` sets **how many tickets to work in parallel** (default
+   1). Take the top `N` rows. Tickets with `Assignee = Me` are skipped by the query — never batch
+   them. Echo the plan (ID · priority · assignee) before starting.
 
-2. **Per ticket, sequentially:**
-   a. **CLAIM** → `In Progress` (re-check it's still `Queued` first; skip if not).
-   b. **IMPLEMENT via a model-pinned subagent.** Dispatch one `Agent` (`agentType: general-purpose`,
-   `model:` = the ticket's `Assignee` lowercased → `fable`/`opus`/`sonnet`) with the ticket's
-   title + body + acceptance criteria. The subagent: branches off `master`, implements to the
-   acceptance criteria, follows `.claude/rules/*`. **No backend teaching persona** in batch.
-   It reports back what it changed + the branch name.
-   c. **TESTS** — invoke the **`update-tests`** skill for the changes (this is the explicit ask
-   that overrides the golden rule — batch mode owns its tests).
-   d. **PR** — invoke the **`prepare-pr`** skill with `--ticket <ID>` (the ticket's Notion ID)
-   → one PR titled `TARO-<ID>: …`, CI watched to green.
-   e. **HANDOFF** — set `Status = Review`, write the PR URL into the ticket body.
-   f. **If stuck** — subagent can't satisfy acceptance, the gate won't pass after real effort, or
-   a blocking unknown surfaces: set `Status = Blocked`, write a one-line reason + what's needed
-   into the body, and move to the next ticket. Don't silently fail or leave it `In Progress`.
+2. **CLAIM ALL** — for each selected ticket, re-check it's still `Queued` and set `Status = In
+Progress`. Drop any that another run already grabbed. Claim before dispatching so parallel runs
+   don't collide.
 
-3. **REPORT** — tally: worked → `Review` (with PR links), `Blocked` (with reasons), skipped.
+3. **FAN OUT — one subagent per ticket, in parallel.** Dispatch all subagents in a single message
+   (multiple `Agent` calls) so they run concurrently. Each `Agent`:
+   - `agentType: general-purpose`, `isolation: worktree` (its own worktree — they edit files in
+     parallel and must not collide), `model:` = the ticket's `Assignee` lowercased →
+     `fable`/`opus`/`sonnet`.
+   - Prompt carries the ticket's title + body + acceptance criteria and instructs the subagent to:
+     branch off `master` with a conventional name, implement to the acceptance criteria, follow
+     `.claude/rules/*`, **write its own tests** — new coverage for what it added and fixes for any
+     tests its change broke (it does **not** invoke `update-tests`), and run the gate
+     (`vp check` + `vp test`) green in its worktree.
+   - **No backend teaching persona** in batch.
+   - It **reports back** to the orchestrator: branch name, a summary of what changed, the file
+     paths it touched, and gate status (pass/fail + any unresolved failure).
+
+4. **ORCHESTRATE PRs** — once subagents report, turn their branches into PRs. One PR per ticket:
+   a. **GATE CHECK** — if a subagent reported a failing/unfinished gate, don't open its PR; treat
+   the ticket as stuck (step 5).
+   b. **CONFLICT CHECK** — for each finished branch, verify it merges cleanly into current
+   `master` (`git merge-tree` / dry-run merge). Then test-merge **every pair** of finished batch
+   branches against each other to catch cross-PR conflicts (two subagents touching the same code).
+   c. **RESOLVE** — a branch that's clean vs master and vs its peers gets a PR **based off
+   `master`**. When two branches conflict but the overlap is mechanical, **stack** the dependent
+   PR on the other (base its branch on the peer's branch) so it merges cleanly. When a conflict
+   needs **genuine human judgment** (semantic overlap, incompatible approaches), do **not** guess:
+   **raise it** in the final report and set that ticket's `Status = Blocked`.
+   d. **OPEN** — for each non-blocked ticket, invoke the **`prepare-pr`** skill with `--ticket
+<ID>` (the Notion ID) → one PR titled `TARO-<ID>: …`. Pass the stack base when the PR is
+   stacked. `prepare-pr` watches CI; **a PR isn't done until it's green.** If CI fails, hand the
+   failure back to that ticket's subagent (re-dispatch with the failure) to fix in its worktree;
+   if it still can't pass after real effort, treat the ticket as stuck.
+   e. **HANDOFF** — for each opened, green PR: set `Status = Review`, write the PR URL into the
+   ticket body.
+
+5. **STUCK / BLOCKED** — a ticket is stuck when its subagent can't satisfy acceptance, its gate or
+   CI won't pass after real effort, or a conflict needs human resolution. Set `Status = Blocked`,
+   write a one-line reason + what's needed into the body, and leave its branch/worktree in place
+   for the human. Never silently fail or leave a ticket stranded in `In Progress`.
+
+6. **REPORT** — tally: worked → `Review` (with PR links, noting any stacked pairs), `Blocked`
+   (with reasons + which need human conflict resolution), skipped.
 
 ## Guardrails
 
@@ -109,3 +140,7 @@ Autonomous. Sequential (one ticket fully done before the next — no parallel wo
 - Batch never runs the backend teaching persona and never works a `Me` ticket. Pair never touches
   tests. These are the mode contracts — don't cross them.
 - One PR per ticket (via `prepare-pr`). Don't batch multiple tickets into a single PR.
+- In batch, the orchestrator (this session) never edits ticket code — subagents do, each in its
+  own worktree. Batch subagents write their own tests; batch does **not** invoke `update-tests`.
+- Every batch PR must merge cleanly (vs `master` and vs the other batch PRs) and be CI-green before
+  handoff. A conflict needing human judgment → raise it + `Blocked`; never guess a resolution.


### PR DESCRIPTION
## Summary

Reworks `/work batch` to run tickets in parallel instead of sequentially.

- `--count N` now sets how many tickets are worked **in parallel**, one worktree-isolated subagent per ticket, each pinned to the ticket's `Assignee` model.
- Subagents **write their own tests** (new coverage + fix broken) — batch no longer invokes `update-tests`.
- Subagents report branches back to this session (the **orchestrator**), which never edits ticket code itself.
- Orchestrator conflict-checks each branch vs `master` and pairwise vs the other batch branches: clean → PR off master, mechanical overlap → stacked PR, genuine human-judgment conflict → raised + ticket moved to `Blocked`.
- Every batch PR must merge cleanly and be CI-green before handoff to `Review`.

Pair mode is unchanged.