### PR TITLE
chore(tooling): link Notion ticket in PR body

### DIFF
--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -2,19 +2,22 @@
 name: prepare-pr
 description: Fully autonomous — prepare a branch for PR by committing all pending work, rewriting commit messages into release-notes-friendly Conventional Commits, renaming the branch if it no longer fits the changes, running a lint + type-check gate, drafting a PR title and body, then creating a single PR directly (not a draft) and watching CI until green. Never asks for permission or feedback before the PR opens. Always bundles all branch work — committed AND uncommitted (staged + unstaged) — into exactly one PR. Use when a feature branch is code-complete and ready for review.
 allowed-tools: Read, Edit, Write, Bash, Glob, Grep
-argument-hint: '[--no-watch] [--ticket <ID>]'
+argument-hint: '[--no-watch] [--ticket <ID>] [--ticket-url <URL>]'
 arguments:
   - name: --no-watch
     description: Skip the post-create CI watch + coverage check (Step 10).
   - name: --ticket <ID>
     description: Prefix the PR title with the ticket key `TARO-<ID>` (e.g. `TARO-207: …`). Omit for no prefix.
+  - name: --ticket-url <URL>
+    description: Notion ticket URL. When given alongside `--ticket`, the PR body opens with a `[TARO-<ID>](<URL>)` link line. Omit to render just `TARO-<ID>` text (or nothing if `--ticket` is also absent).
 lastUpdated: 2026-07-20T00:00:00Z
 ---
 
 ## Args
 
 - **`--no-watch`** (optional) — skip the post-create CI watch + coverage check (Step 10). Default behaviour blocks on CI after opening the PR until checks settle, then inspects coverage and writes more tests if it regressed.
-- **`--ticket <ID>`** (optional) — the Notion Task Board ticket ID this PR resolves. When given, the PR **title** is prefixed with `TARO-<ID>: ` (Step 8). This affects only the PR title — commit subjects stay clean (ticket refs still belong in a commit-body `Refs:` trailer, per Notes). Omit to open a PR with no ticket prefix.
+- **`--ticket <ID>`** (optional) — the Notion Task Board ticket ID this PR resolves. When given, the PR **title** is prefixed with `TARO-<ID>: ` and the PR **body** opens with a ticket-link line (Step 8). This affects the PR title and body only — commit subjects stay clean (ticket refs still belong in a commit-body `Refs:` trailer, per Notes). Omit to open a PR with no ticket prefix or link.
+- **`--ticket-url <URL>`** (optional) — the Notion page URL for the ticket. When given with `--ticket`, the body's top line renders as a markdown link `[TARO-<ID>](<URL>)`. Without it, the top line falls back to plain `TARO-<ID>` text. Ignored when `--ticket` is absent.
 
 ## Fully autonomous — no approval gates
 
@@ -237,9 +240,14 @@ Avoid repeating Conventional-Commits prefix in title — GitHub release tooling 
 
 **Ticket prefix (`--ticket <ID>`).** If the skill was invoked with `--ticket <ID>`, prepend the ticket key to the drafted title: `TARO-<ID>: <title>` — e.g. `TARO-207: Close open modals and clear caches on logout`. Prefix only; the rest of the title is derived exactly as above. Do **not** add the prefix when `--ticket` is absent, and never put the ticket key into commit subjects (Notes).
 
-**Body** — structured for skim:
+**Body** — structured for skim. When `--ticket <ID>` is given, the **first line** of the body is the ticket link, followed by a blank line, before the `## Summary` heading:
+
+- with `--ticket-url <URL>`: `[TARO-<ID>](<URL>)`
+- without a URL: plain `TARO-<ID>`
 
 ```md
+[TARO-<ID>](URL)
+
 ## Summary
 
 <1–3 sentence overview of the user-visible outcome and why this PR exists.>
@@ -255,7 +263,7 @@ Avoid repeating Conventional-Commits prefix in title — GitHub release tooling 
 - [ ] ...
 ```
 
-If `.github/pull_request_template.md` exists, use its structure and fill sections.
+Omit the ticket-link line entirely when `--ticket` is absent. If `.github/pull_request_template.md` exists, use its structure and fill sections — still prepend the ticket-link line above the template body when `--ticket` is given.
 
 Keep body tight. One short paragraph + handful of bullets beats wall of text.
 

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -62,9 +62,10 @@ ticket's `Assignee`).
    approval on every change.** If the `Area` touches `supabase/**` (migrations, RPCs, RLS, edge
    functions), the backend teaching persona is **on** — teach as you write per CLAUDE.md. **Do
    not touch tests** — the golden rule holds in pair mode. Follow all `.claude/rules/*`.
-5. **PR** — invoke the **`prepare-pr`** skill with `--ticket <ID>` (the ticket's Notion ID)
-   so the PR title is prefixed `TARO-<ID>:` (commits, conventional messages, lint+type gate,
-   opens one PR, watches CI to green).
+5. **PR** — invoke the **`prepare-pr`** skill with `--ticket <ID> --ticket-url <url>` (the ticket's
+   `TARO-<ID>` number and its Notion page URL) so the PR title is prefixed `TARO-<ID>:` and the body
+   opens with a `[TARO-<ID>](<url>)` link (commits, conventional messages, lint+type gate, opens one
+   PR, watches CI to green).
 6. **HANDOFF** — set the ticket's `Status = Review` and write the PR URL into its body. Stop.
 
 ## Mode: `batch [--count N] [--p0…]`
@@ -117,8 +118,9 @@ Progress`. Drop any that another run already grabbed. Claim before dispatching s
    needs **genuine human judgment** (semantic overlap, incompatible approaches), do **not** guess:
    **raise it** in the final report and set that ticket's `Status = Blocked`.
    d. **OPEN** — for each non-blocked ticket, invoke the **`prepare-pr`** skill with `--ticket
-<ID>` (the Notion ID) → one PR titled `TARO-<ID>: …`. Pass the stack base when the PR is
-   stacked. `prepare-pr` watches CI; **a PR isn't done until it's green.** If CI fails, hand the
+<ID> --ticket-url <url>` (the `TARO-<ID>` number and the ticket's Notion page URL) → one PR titled
+   `TARO-<ID>: …` whose body opens with a `[TARO-<ID>](<url>)` link. Pass the stack base when the PR
+   is stacked. `prepare-pr` watches CI; **a PR isn't done until it's green.** If CI fails, hand the
    failure back to that ticket's subagent (re-dispatch with the failure) to fix in its worktree;
    if it still can't pass after real effort, treat the ticket as stuck.
    e. **HANDOFF** — for each opened, green PR: set `Status = Review`, write the PR URL into the


### PR DESCRIPTION
## Summary

Adds a `--ticket-url` arg to the `prepare-pr` skill so a PR body opens with a `[TARO-<ID>](<url>)` link to the Notion ticket. Threads the URL through both `work` skill invocations (pair + batch).

## Changes

- `prepare-pr`: new optional `--ticket-url <URL>`; body top line renders the ticket link when given (plain `TARO-<ID>` fallback), handled for the PR-template case too.
- `work`: pair Step 5 and batch Step 4d now pass `--ticket <ID> --ticket-url <url>`.