### PR TITLE
TARO-185: Wire the mobile New Card flow

### DIFF
--- a/src/views/deck/card-grid/empty-state.vue
+++ b/src/views/deck/card-grid/empty-state.vue
@@ -2,31 +2,20 @@
 import CardGridSkeleton from './skeleton.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
-import { computed, inject } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useMatchMedia } from '@/composables/ui/media-query'
 import { type CardGridSize } from '@/views/deck/composables/view-shell'
-import { cardEditorKey } from '@/views/deck/composables'
-import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
+import { useEditorSurface } from '@/views/deck/composables'
 
 const { t } = useI18n()
 
-const { newCard } = inject(cardEditorKey)!
-const mobile_editor = inject(mobileCardEditorKey)!
+const surface = useEditorSurface()
 
 // On the narrowest screens the md backdrop cards get cramped — drop to base.
 const is_compact = useMatchMedia('w<sm')
 
-// Mirrors the dock's own breakpoint (mobile-footer's `breakpoint="md"`): below
-// it the mobile editor is the deck's only card-editing surface, so the CTA
-// must stage-and-open through it instead of the desktop mode-stack.
-const is_mobile = useMatchMedia('w<md')
-
 const skeleton_size = computed<CardGridSize>(() => (is_compact.value ? 'base' : 'md'))
-
-function onCreate() {
-  return is_mobile.value ? mobile_editor.openNewCard() : newCard()
-}
 </script>
 
 <template>
@@ -57,7 +46,7 @@ function onCreate() {
           data-testid="card-grid-empty__create-button"
           data-palette="brand"
           icon-left="card-add"
-          @press="onCreate"
+          @press="surface.openNewCard"
         >
           {{ t('deck-view.empty-state.create-button') }}
         </ui-button>

--- a/src/views/deck/card-grid/empty-state.vue
+++ b/src/views/deck/card-grid/empty-state.vue
@@ -7,14 +7,26 @@ import { useI18n } from 'vue-i18n'
 import { useMatchMedia } from '@/composables/ui/media-query'
 import { type CardGridSize } from '@/views/deck/composables/view-shell'
 import { cardEditorKey } from '@/views/deck/composables'
+import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
 
 const { t } = useI18n()
 
 const { newCard } = inject(cardEditorKey)!
+const mobile_editor = inject(mobileCardEditorKey)!
 
 // On the narrowest screens the md backdrop cards get cramped — drop to base.
 const is_compact = useMatchMedia('w<sm')
+
+// Mirrors the dock's own breakpoint (mobile-footer's `breakpoint="md"`): below
+// it the mobile editor is the deck's only card-editing surface, so the CTA
+// must stage-and-open through it instead of the desktop mode-stack.
+const is_mobile = useMatchMedia('w<md')
+
 const skeleton_size = computed<CardGridSize>(() => (is_compact.value ? 'base' : 'md'))
+
+function onCreate() {
+  return is_mobile.value ? mobile_editor.openNewCard() : newCard()
+}
 </script>
 
 <template>
@@ -45,7 +57,7 @@ const skeleton_size = computed<CardGridSize>(() => (is_compact.value ? 'base' : 
           data-testid="card-grid-empty__create-button"
           data-palette="brand"
           icon-left="card-add"
-          @press="newCard"
+          @press="onCreate"
         >
           {{ t('deck-view.empty-state.create-button') }}
         </ui-button>

--- a/src/views/deck/card-grid/grid-item.vue
+++ b/src/views/deck/card-grid/grid-item.vue
@@ -11,17 +11,15 @@ import { usePressHold } from '@/composables/ui/press-hold'
 import {
   cardEditorKey,
   useCardItemOptionsMenu,
+  useEditorSurface,
   type CardWithClientId
 } from '@/views/deck/composables'
-import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
-import { useMatchMedia } from '@/composables/ui/media-query'
 
 const { actions, selection } = inject(cardEditorKey)!
 const { onSelectCard } = actions
 const { is_selecting } = selection
 
-const mobile_editor = inject(mobileCardEditorKey, null)
-const is_mobile = useMatchMedia('w<md')
+const surface = useEditorSurface()
 
 const { options: menu_options, onSelect: onMenuOptionSelect } = useCardItemOptionsMenu()
 const dropdown = useTemplateRef<InstanceType<typeof UiDropdownButton>>('dropdown')
@@ -66,11 +64,9 @@ function onCardClick() {
   }
 
   // Below md the grid is read-only — a tap opens the focused dock editor on
-  // this card instead of flipping it in place.
-  if (is_mobile.value) {
-    mobile_editor?.open_at(card.client_id)
-    return
-  }
+  // this card instead of flipping it in place. openCard handles that and
+  // returns true; at md+ it returns false and we flip in place below.
+  if (surface.openCard(card.client_id)) return
 
   // A click that ends a drag-selection of the card's text shouldn't also flip.
   // A plain click collapses the selection on mousedown, so this only catches

--- a/src/views/deck/composables/edit-menu.ts
+++ b/src/views/deck/composables/edit-menu.ts
@@ -2,10 +2,9 @@ import { computed, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { cardEditorKey } from './list-controller'
 import { deckViewShellKey } from './view-shell'
-import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
+import { useEditorSurface } from './editor-surface'
 import { useDeckSettingsModal } from '@/composables/deck/settings-modal'
 import { useDeckQuery } from '@/api/decks'
-import { useMatchMedia } from '@/composables/ui/media-query'
 import type { DropdownOption } from '@/components/ui-kit/dropdown-button/index.vue'
 
 export type CardEditMenu = ReturnType<typeof useCardEditMenu>
@@ -25,9 +24,8 @@ export function useCardEditMenu() {
   const { t } = useI18n()
   const editor = inject(cardEditorKey, null)
   const shell = inject(deckViewShellKey, null)
-  const mobile_editor = inject(mobileCardEditorKey, null)
+  const surface = useEditorSurface()
   const settings = useDeckSettingsModal()
-  const is_mobile = useMatchMedia('w<md')
 
   const deck_query = useDeckQuery(() => editor?.deck_id ?? -1)
 
@@ -55,16 +53,10 @@ export function useCardEditMenu() {
     }
   ])
 
-  /** Enter editing: the dock editor below md, desktop edit mode at md+. */
-  function startEditing() {
-    if (is_mobile.value) mobile_editor?.open_at()
-    else shell?.toggleMode('edit')
-  }
-
   /** Primary button behaviour: stop the active mode first, else start editing. */
   function primaryAction() {
     if (is_rearranging.value) shell?.toggleRearrange()
-    else startEditing()
+    else surface.startEditing()
   }
 
   function openAppearance() {
@@ -74,11 +66,18 @@ export function useCardEditMenu() {
 
   /** Dispatch a chosen menu option. `edit` only appears in trigger-only menus. */
   function onSelect(option: DropdownOption) {
-    if (option.value === 'edit') startEditing()
+    if (option.value === 'edit') surface.startEditing()
     else if (option.value === 'select') editor?.actions.onSelectCard()
     else if (option.value === 'rearrange') shell?.toggleRearrange()
     else if (option.value === 'appearance') openAppearance()
   }
 
-  return { options, is_editing, is_rearranging, startEditing, primaryAction, onSelect }
+  return {
+    options,
+    is_editing,
+    is_rearranging,
+    startEditing: surface.startEditing,
+    primaryAction,
+    onSelect
+  }
 }

--- a/src/views/deck/composables/editor-surface.ts
+++ b/src/views/deck/composables/editor-surface.ts
@@ -1,0 +1,53 @@
+import { inject } from 'vue'
+import { useMatchMedia } from '@/composables/ui/media-query'
+import { cardEditorKey } from './list-controller'
+import { deckViewShellKey } from './view-shell'
+import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
+
+export type EditorSurface = ReturnType<typeof useEditorSurface>
+
+/**
+ * Single source of truth for *which* card-editing surface the deck view uses at
+ * the current viewport. Below the `md` breakpoint the mobile dock editor is the
+ * deck's only editing surface; at md+ it's the desktop mode-stack. Every entry
+ * point — empty-state CTA, mobile dock button, edit menu, card tap — routes
+ * through here so the breakpoint and the surface choice can never drift apart.
+ *
+ * @example
+ * const surface = useEditorSurface()
+ * surface.openNewCard()            // stage + open on the fitting surface
+ * if (surface.openCard(id)) return // mobile handled it; desktop falls through
+ */
+export function useEditorSurface() {
+  const editor = inject(cardEditorKey, null)
+  const shell = inject(deckViewShellKey, null)
+  const mobile_editor = inject(mobileCardEditorKey, null)
+
+  const is_mobile = useMatchMedia('w<md')
+
+  /** Stage a fresh card and open it on the surface that fits the viewport. */
+  function openNewCard() {
+    if (is_mobile.value) mobile_editor?.openNewCard()
+    else editor?.newCard()
+  }
+
+  /** Enter editing: the dock editor below md, desktop edit mode at md+. */
+  function startEditing() {
+    if (is_mobile.value) mobile_editor?.open_at()
+    else shell?.toggleMode('edit')
+  }
+
+  /**
+   * Open an existing card. Below md this routes to the dock editor and returns
+   * `true`; at md+ it returns `false` so the caller keeps its in-place behaviour
+   * (e.g. flip the card).
+   */
+  function openCard(client_id: string): boolean {
+    if (!is_mobile.value) return false
+
+    mobile_editor?.open_at(client_id)
+    return true
+  }
+
+  return { is_mobile, openNewCard, startEditing, openCard }
+}

--- a/src/views/deck/composables/index.ts
+++ b/src/views/deck/composables/index.ts
@@ -6,6 +6,7 @@
 export { useCardListController, cardEditorKey, type CardListController } from './list-controller'
 export { useCardSearch, cardSearchKey, type CardSearch } from './card-search'
 export { useCardEditMenu, type CardEditMenu } from './edit-menu'
+export { useEditorSurface, type EditorSurface } from './editor-surface'
 export { useCardItemOptionsMenu, type CardItemOptionsMenu } from './item-options-menu'
 export { useCardActions, type CardActions } from './actions'
 export { useBulkActions } from './bulk-actions'

--- a/src/views/deck/mobile-editor/use-mobile-card-editor.ts
+++ b/src/views/deck/mobile-editor/use-mobile-card-editor.ts
@@ -71,6 +71,21 @@ export function useMobileCardEditor(controller: CardListController) {
     close_modal?.()
   }
 
+  /**
+   * The mobile "new card" intent: stage a fresh temp card through the shared
+   * controller (gated on the plan cap, same as the desktop toolbar) and open
+   * the mobile editor focused on it. Shared by the empty-state CTA and the
+   * dock's new-card button at phone width, so staging + opening stays in one
+   * place. No-op when the cap blocks staging — `addCard` already surfaced the
+   * upgrade alert.
+   */
+  async function openNewCard() {
+    const client_id = await controller.addCard()
+    if (!client_id) return
+
+    open_at(client_id)
+  }
+
   // Called by the modal wrapper's onUnmounted so state stays in sync no matter
   // how the modal actually closed (done button, esc, background tap).
   function onClosed() {
@@ -153,6 +168,7 @@ export function useMobileCardEditor(controller: CardListController) {
     card_attributes: controller.card_attributes,
     saving: controller.saving,
     open_at,
+    openNewCard,
     close,
     onClosed,
     flip,

--- a/src/views/deck/mobile-footer/footer-actions.vue
+++ b/src/views/deck/mobile-footer/footer-actions.vue
@@ -5,14 +5,13 @@ import UiDropdownButton, {
 } from '@/components/ui-kit/dropdown-button/index.vue'
 import { computed, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useCardEditMenu } from '@/views/deck/composables'
+import { useCardEditMenu, useEditorSurface } from '@/views/deck/composables'
 import { deckViewShellKey } from '@/views/deck/composables/view-shell'
-import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
 
 const { t } = useI18n()
 
 const shell = inject(deckViewShellKey)!
-const mobile_editor = inject(mobileCardEditorKey)!
+const surface = useEditorSurface()
 const menu = useCardEditMenu()
 
 // Trigger-only here, so the edit action that lives in the desktop primary button
@@ -59,7 +58,7 @@ const edit_options = computed<DropdownOption[]>(() => [
       variant="ghost"
       full-width
       size="lg"
-      @press="mobile_editor.openNewCard()"
+      @press="surface.openNewCard"
     >
       {{ t('deck-view.mobile-footer.new-card') }}
     </ui-button>

--- a/src/views/deck/mobile-footer/footer-actions.vue
+++ b/src/views/deck/mobile-footer/footer-actions.vue
@@ -7,10 +7,12 @@ import { computed, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useCardEditMenu } from '@/views/deck/composables'
 import { deckViewShellKey } from '@/views/deck/composables/view-shell'
+import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
 
 const { t } = useI18n()
 
 const shell = inject(deckViewShellKey)!
+const mobile_editor = inject(mobileCardEditorKey)!
 const menu = useCardEditMenu()
 
 // Trigger-only here, so the edit action that lives in the desktop primary button
@@ -57,6 +59,7 @@ const edit_options = computed<DropdownOption[]>(() => [
       variant="ghost"
       full-width
       size="lg"
+      @press="mobile_editor.openNewCard()"
     >
       {{ t('deck-view.mobile-footer.new-card') }}
     </ui-button>

--- a/tests/integration/views/deck/card-grid/empty-state.test.js
+++ b/tests/integration/views/deck/card-grid/empty-state.test.js
@@ -3,6 +3,7 @@ import { shallowMount } from '@vue/test-utils'
 import { defineComponent, h, ref } from 'vue'
 import CardGridEmpty from '@/views/deck/card-grid/empty-state.vue'
 import { cardEditorKey } from '@/views/deck/composables/list-controller'
+import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
 
 // ── Module-level mocks ────────────────────────────────────────────────────────
 
@@ -64,12 +65,24 @@ function makeEditor({ newCard } = {}) {
   return { newCard: newCard ?? vi.fn() }
 }
 
-function mount({ editor, isCompact = false } = {}) {
-  // isCompact=true simulates w<sm matching (base skeleton size), false = md
-  matchMediaMock.mockReturnValue(ref(isCompact))
+function makeMobileEditor({ openNewCard } = {}) {
+  return { openNewCard: openNewCard ?? vi.fn() }
+}
+
+function mount({ editor, mobileEditor, isCompact = false, isMobile = false } = {}) {
+  // isCompact drives w<sm (base vs md skeleton size); isMobile drives w<md
+  // (desktop mode-stack vs mobile editor for the create button).
+  matchMediaMock.mockImplementation((token) => {
+    if (token === 'w<sm') return ref(isCompact)
+    if (token === 'w<md') return ref(isMobile)
+    return ref(false)
+  })
   return shallowMount(CardGridEmpty, {
     global: {
-      provide: { [cardEditorKey]: editor ?? makeEditor() },
+      provide: {
+        [cardEditorKey]: editor ?? makeEditor(),
+        [mobileCardEditorKey]: mobileEditor ?? makeMobileEditor()
+      },
       stubs: {
         CardGridSkeleton: CardGridSkeletonStub,
         UiButton: UiButtonStub,
@@ -140,13 +153,32 @@ describe('CardGridEmpty (card-grid/empty-state.vue)', () => {
     expect(skeleton.attributes('data-size')).toBe('base')
   })
 
-  // ── newCard wired to create button [obligation] ───────────────────────────
+  // ── create button — desktop vs mobile [obligation] ────────────────────────
 
-  test('clicking the create button calls newCard from the injected editor [obligation]', async () => {
+  test('clicking the create button calls newCard (desktop editor) at desktop width [obligation]', async () => {
     const newCard = vi.fn()
-    const wrapper = mount({ editor: makeEditor({ newCard }) })
+    const openNewCard = vi.fn()
+    const wrapper = mount({
+      isMobile: false,
+      editor: makeEditor({ newCard }),
+      mobileEditor: makeMobileEditor({ openNewCard })
+    })
     await wrapper.find('[data-testid="card-grid-empty__create-button"]').trigger('click')
     expect(newCard).toHaveBeenCalledOnce()
+    expect(openNewCard).not.toHaveBeenCalled()
+  })
+
+  test('clicking the create button calls mobile_editor.openNewCard at phone width [obligation]', async () => {
+    const newCard = vi.fn()
+    const openNewCard = vi.fn()
+    const wrapper = mount({
+      isMobile: true,
+      editor: makeEditor({ newCard }),
+      mobileEditor: makeMobileEditor({ openNewCard })
+    })
+    await wrapper.find('[data-testid="card-grid-empty__create-button"]').trigger('click')
+    expect(openNewCard).toHaveBeenCalledOnce()
+    expect(newCard).not.toHaveBeenCalled()
   })
 
   // ── heading uses i18n key [obligation] ────────────────────────────────────

--- a/tests/integration/views/deck/mobile-footer/footer-actions.test.js
+++ b/tests/integration/views/deck/mobile-footer/footer-actions.test.js
@@ -54,8 +54,12 @@ function makeMobileEditor() {
   return { openNewCard: vi.fn() }
 }
 
-function mountFooterActions(shell = makeShell(), mobile_editor = makeMobileEditor()) {
-  mockUseMatchMedia.mockReturnValue(ref(false))
+function mountFooterActions(
+  shell = makeShell(),
+  mobile_editor = makeMobileEditor(),
+  is_mobile = false
+) {
+  mockUseMatchMedia.mockReturnValue(ref(is_mobile))
   return shallowMount(FooterActions, {
     global: {
       stubs: { UiButton: UiButtonStub },
@@ -118,9 +122,9 @@ describe('mobile-footer/footer-actions', () => {
     expect(shell.toggleRearrange).toHaveBeenCalledOnce()
   })
 
-  test('pressing the new-card button calls mobile_editor.openNewCard [obligation]', async () => {
+  test('pressing the new-card button opens a new card on the mobile surface [obligation]', async () => {
     const mobile_editor = makeMobileEditor()
-    const wrapper = mountFooterActions(makeShell({ is_rearranging: false }), mobile_editor)
+    const wrapper = mountFooterActions(makeShell({ is_rearranging: false }), mobile_editor, true)
     await wrapper.find('[data-testid="deck-footer-actions__new-card"]').trigger('click')
     expect(mobile_editor.openNewCard).toHaveBeenCalledOnce()
   })

--- a/tests/integration/views/deck/mobile-footer/footer-actions.test.js
+++ b/tests/integration/views/deck/mobile-footer/footer-actions.test.js
@@ -25,6 +25,7 @@ vi.mock('@/composables/deck/settings-modal', () => ({
 
 import FooterActions from '@/views/deck/mobile-footer/footer-actions.vue'
 import { deckViewShellKey } from '@/views/deck/composables/view-shell'
+import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
 
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
@@ -49,12 +50,16 @@ function makeShell({ is_rearranging = false } = {}) {
   }
 }
 
-function mountFooterActions(shell = makeShell()) {
+function makeMobileEditor() {
+  return { openNewCard: vi.fn() }
+}
+
+function mountFooterActions(shell = makeShell(), mobile_editor = makeMobileEditor()) {
   mockUseMatchMedia.mockReturnValue(ref(false))
   return shallowMount(FooterActions, {
     global: {
       stubs: { UiButton: UiButtonStub },
-      provide: { [deckViewShellKey]: shell }
+      provide: { [deckViewShellKey]: shell, [mobileCardEditorKey]: mobile_editor }
     }
   })
 }
@@ -111,6 +116,13 @@ describe('mobile-footer/footer-actions', () => {
     const wrapper = mountFooterActions(shell)
     await wrapper.find('[data-testid="deck-footer-actions__stop-rearranging"]').trigger('click')
     expect(shell.toggleRearrange).toHaveBeenCalledOnce()
+  })
+
+  test('pressing the new-card button calls mobile_editor.openNewCard [obligation]', async () => {
+    const mobile_editor = makeMobileEditor()
+    const wrapper = mountFooterActions(makeShell({ is_rearranging: false }), mobile_editor)
+    await wrapper.find('[data-testid="deck-footer-actions__new-card"]').trigger('click')
+    expect(mobile_editor.openNewCard).toHaveBeenCalledOnce()
   })
 
   // ── edit menu ───────────────────────────────────────────────────────────────

--- a/tests/unit/views/deck/composables/use-editor-surface.test.js
+++ b/tests/unit/views/deck/composables/use-editor-surface.test.js
@@ -1,0 +1,146 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { createApp, ref } from 'vue'
+import { config } from '@vue/test-utils'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const { mockUseMatchMedia } = vi.hoisted(() => ({ mockUseMatchMedia: vi.fn() }))
+vi.mock('@/composables/ui/media-query', () => ({
+  useMatchMedia: mockUseMatchMedia
+}))
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { useEditorSurface } from '@/views/deck/composables/editor-surface'
+import { cardEditorKey } from '@/views/deck/composables/list-controller'
+import { deckViewShellKey } from '@/views/deck/composables/view-shell'
+import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-editor'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function withSetup(composable, { provide } = {}) {
+  let result
+  const app = createApp({
+    setup() {
+      result = composable()
+      return () => {}
+    }
+  })
+  for (const plugin of config.global.plugins ?? []) app.use(plugin)
+  if (provide) {
+    const keys = [...Object.keys(provide), ...Object.getOwnPropertySymbols(provide)]
+    for (const k of keys) app.provide(k, provide[k])
+  }
+  app.mount(document.createElement('div'))
+  return [result, app]
+}
+
+function makeEditor() {
+  return { newCard: vi.fn() }
+}
+
+function makeShell() {
+  return { toggleMode: vi.fn() }
+}
+
+function makeMobileEditor() {
+  return { openNewCard: vi.fn(), open_at: vi.fn() }
+}
+
+/** Mount useEditorSurface at the given viewport with all three surfaces provided. */
+function mountSurface({ is_mobile = false } = {}) {
+  mockUseMatchMedia.mockReturnValue(ref(is_mobile))
+  const editor = makeEditor()
+  const shell = makeShell()
+  const mobile_editor = makeMobileEditor()
+  const [surface, app] = withSetup(() => useEditorSurface(), {
+    provide: {
+      [cardEditorKey]: editor,
+      [deckViewShellKey]: shell,
+      [mobileCardEditorKey]: mobile_editor
+    }
+  })
+  return { surface, editor, shell, mobile_editor, app }
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+let active
+
+afterEach(() => {
+  active?.unmount()
+  active = null
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  mockUseMatchMedia.mockReturnValue(ref(false))
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useEditorSurface', () => {
+  test('keys off the "w<md" breakpoint token [obligation]', () => {
+    const ctx = mountSurface()
+    active = ctx.app
+    expect(mockUseMatchMedia).toHaveBeenCalledWith('w<md')
+  })
+
+  // ── openNewCard ─────────────────────────────────────────────────────────────
+
+  describe('openNewCard', () => {
+    test('routes to the desktop editor at md+ [obligation]', () => {
+      const ctx = mountSurface({ is_mobile: false })
+      active = ctx.app
+      ctx.surface.openNewCard()
+      expect(ctx.editor.newCard).toHaveBeenCalledOnce()
+      expect(ctx.mobile_editor.openNewCard).not.toHaveBeenCalled()
+    })
+
+    test('routes to the mobile dock editor below md [obligation]', () => {
+      const ctx = mountSurface({ is_mobile: true })
+      active = ctx.app
+      ctx.surface.openNewCard()
+      expect(ctx.mobile_editor.openNewCard).toHaveBeenCalledOnce()
+      expect(ctx.editor.newCard).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── startEditing ────────────────────────────────────────────────────────────
+
+  describe('startEditing', () => {
+    test('toggles desktop edit mode at md+ [obligation]', () => {
+      const ctx = mountSurface({ is_mobile: false })
+      active = ctx.app
+      ctx.surface.startEditing()
+      expect(ctx.shell.toggleMode).toHaveBeenCalledWith('edit')
+      expect(ctx.mobile_editor.open_at).not.toHaveBeenCalled()
+    })
+
+    test('opens the dock editor below md [obligation]', () => {
+      const ctx = mountSurface({ is_mobile: true })
+      active = ctx.app
+      ctx.surface.startEditing()
+      expect(ctx.mobile_editor.open_at).toHaveBeenCalledOnce()
+      expect(ctx.shell.toggleMode).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── openCard ────────────────────────────────────────────────────────────────
+
+  describe('openCard', () => {
+    test('returns false and does not open the dock at md+ [obligation]', () => {
+      const ctx = mountSurface({ is_mobile: false })
+      active = ctx.app
+      expect(ctx.surface.openCard('c1')).toBe(false)
+      expect(ctx.mobile_editor.open_at).not.toHaveBeenCalled()
+    })
+
+    test('opens the dock on the given card and returns true below md [obligation]', () => {
+      const ctx = mountSurface({ is_mobile: true })
+      active = ctx.app
+      expect(ctx.surface.openCard('c1')).toBe(true)
+      expect(ctx.mobile_editor.open_at).toHaveBeenCalledWith('c1')
+    })
+  })
+})

--- a/tests/unit/views/deck/mobile-editor/use-mobile-card-editor.test.js
+++ b/tests/unit/views/deck/mobile-editor/use-mobile-card-editor.test.js
@@ -45,11 +45,13 @@ function makeController(cards = []) {
   const updateCard = vi.fn().mockResolvedValue(undefined)
   const onMoveCards = vi.fn().mockResolvedValue(undefined)
   const onDeleteCards = vi.fn().mockResolvedValue(undefined)
+  const addCard = vi.fn().mockResolvedValue(undefined)
   return {
     list: { all_cards },
     card_attributes: { front: {}, back: {} },
     saving: ref(false),
     updateCard,
+    addCard,
     actions: { onMoveCards, onDeleteCards }
   }
 }
@@ -152,6 +154,29 @@ describe('useMobileCardEditor — open_at [obligation]', () => {
     editor.open_at('cid-1')
 
     expect(mockOpen).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('useMobileCardEditor — openNewCard [obligation]', () => {
+  test('openNewCard stages via controller.addCard and opens the editor on the returned client_id [obligation]', async () => {
+    const card = makeCard({ client_id: 'cid-new' })
+    const { editor, controller } = makeEditor([card])
+    controller.addCard.mockResolvedValue('cid-new')
+
+    await editor.openNewCard()
+
+    expect(controller.addCard).toHaveBeenCalledOnce()
+    expect(editor.current.value?.client_id).toBe('cid-new')
+    expect(mockOpen).toHaveBeenCalledOnce()
+  })
+
+  test('openNewCard is a no-op when addCard stages nothing (plan cap gated) [obligation]', async () => {
+    const { editor, controller } = makeEditor([])
+    controller.addCard.mockResolvedValue(undefined)
+
+    await editor.openNewCard()
+
+    expect(mockOpen).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
[TARO-185](https://app.notion.com/39c0953c224c80a59353c2675cb075b0)

## Summary

Fixes both broken mobile "New Card" entry points: the empty-deck CTA opened the desktop editor at phone width, and the bottom-dock button did nothing. Both now stage a fresh card and open the mobile editor on it. (Absorbs #186.)

## Changes

- Added `openNewCard()` to `useMobileCardEditor` — stages via the list controller (plan-cap gated, same as desktop) then `open_at(client_id)`.
- `empty-state.vue` branches on `useMatchMedia('w<md')`: mobile → `openNewCard()`, desktop → existing `newCard()`.
- `footer-actions.vue` dock button now wired to `openNewCard()`.
- Tests for both entry points + the stage/cap flow.