### PR TITLE
TARO-172: Card editor follows the breakpoint on resize

### DIFF
--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -78,7 +78,7 @@ const { t } = useI18n()
       <p
         v-if="deck?.card_count !== undefined"
         data-testid="deck-thumbnail__card-count"
-        class="absolute -top-4 right-0 bg-element-strong p-1 px-2 rounded-t-3 rounded-bl-3 text-base text-center text-ink-muted opacity-0 pointer-fine:group-hover/tappable:opacity-100"
+        class="absolute -top-4 right-0 bg-element-soft p-1 px-2 rounded-t-3 rounded-bl-3 text-base text-center text-ink opacity-0 pointer-fine:group-hover/tappable:opacity-100"
       >
         {{ t('deck-thumbnail.card-count-label', deck.card_count) }}
       </p>

--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -131,6 +131,7 @@ defineExpose({ focusEditor, hasFocusWithin })
   <div
     ref="list-item-card"
     data-testid="list-item-card"
+    :data-client-id="card.client_id"
     class="flex w-full flex-col justify-center gap-6 md:flex-row"
     @focusin="onFocusIn"
     @focusout="onFocusOut"

--- a/src/views/deck/composables/editor-breakpoint-sync.ts
+++ b/src/views/deck/composables/editor-breakpoint-sync.ts
@@ -1,0 +1,57 @@
+import { watch } from 'vue'
+import { useMatchMedia } from '@/composables/ui/media-query'
+import type { CardListController } from './list-controller'
+import type { DeckViewShell } from './view-shell'
+import type { MobileCardEditor } from '../mobile-editor/use-mobile-card-editor'
+
+/**
+ * Keep the active card-editing surface aligned with the viewport. Desktop edit
+ * mode and the mobile dock editor are two faces of one intent, picked once at
+ * open time; resizing across the `md` breakpoint would otherwise strand the user
+ * in the surface that no longer fits. On each cross this tears down the current
+ * surface and opens the other on the same card. The unsaved staged card is a
+ * temp already living in `all_cards`, so it survives the swap either way.
+ *
+ * @param shell - The deck-view shell; owns desktop `mode`.
+ * @param editor - The card-list controller; its `pending_focus_client_id` queues
+ *   a desktop row for autofocus so grow lands on the right card.
+ * @param mobile_editor - The mobile dock editor; the cursor into `all_cards`.
+ */
+export function useEditorBreakpointSync(
+  shell: DeckViewShell,
+  editor: CardListController,
+  mobile_editor: MobileCardEditor
+) {
+  const is_mobile = useMatchMedia('w<md')
+
+  // Which desktop editor row currently holds DOM focus. Desktop edit tracks no
+  // "current card" of its own, so focus is the only signal for which card the
+  // user is on when the viewport shrinks out from under them.
+  function focusedDesktopClientId(): string | undefined {
+    const row = document.activeElement?.closest('[data-testid="list-item-card"]')
+    return (row as HTMLElement | null)?.dataset.clientId
+  }
+
+  // Desktop edit → mobile dock editor. Land on the focused card, falling back to
+  // a just-staged card awaiting focus, then to the first card (`open_at`'s
+  // default). No-op unless the desktop editor is actually open.
+  function shrinkToMobile() {
+    if (shell.mode.value !== 'edit') return
+
+    const target = focusedDesktopClientId() ?? editor.pending_focus_client_id.value ?? undefined
+    shell.exitMode()
+    mobile_editor.open_at(target)
+  }
+
+  // Mobile dock editor → desktop edit. Enter edit mode with the cursor's card
+  // queued for autofocus, so the desktop list lands on and reveals the same card.
+  function growToDesktop() {
+    if (!mobile_editor.is_open.value) return
+
+    editor.pending_focus_client_id.value = mobile_editor.current.value?.client_id ?? null
+    mobile_editor.close()
+    shell.setMode('edit')
+  }
+
+  watch(is_mobile, (mobile) => (mobile ? shrinkToMobile() : growToDesktop()))
+}

--- a/src/views/deck/composables/editor-breakpoint-sync.ts
+++ b/src/views/deck/composables/editor-breakpoint-sync.ts
@@ -1,5 +1,5 @@
 import { watch } from 'vue'
-import { useMatchMedia } from '@/composables/ui/media-query'
+import { useEditorSurface } from './editor-surface'
 import type { CardListController } from './list-controller'
 import type { DeckViewShell } from './view-shell'
 import type { MobileCardEditor } from '../mobile-editor/use-mobile-card-editor'
@@ -22,7 +22,9 @@ export function useEditorBreakpointSync(
   editor: CardListController,
   mobile_editor: MobileCardEditor
 ) {
-  const is_mobile = useMatchMedia('w<md')
+  // Share the deck view's one definition of the mobile-editor breakpoint so the
+  // resize reaction can't drift from the entry points that route to each surface.
+  const { is_mobile } = useEditorSurface()
 
   // Which desktop editor row currently holds DOM focus. Desktop edit tracks no
   // "current card" of its own, so focus is the only signal for which card the

--- a/src/views/deck/composables/index.ts
+++ b/src/views/deck/composables/index.ts
@@ -7,6 +7,7 @@ export { useCardListController, cardEditorKey, type CardListController } from '.
 export { useCardSearch, cardSearchKey, type CardSearch } from './card-search'
 export { useCardEditMenu, type CardEditMenu } from './edit-menu'
 export { useEditorSurface, type EditorSurface } from './editor-surface'
+export { useEditorBreakpointSync } from './editor-breakpoint-sync'
 export { useCardItemOptionsMenu, type CardItemOptionsMenu } from './item-options-menu'
 export { useCardActions, type CardActions } from './actions'
 export { useBulkActions } from './bulk-actions'

--- a/src/views/deck/composables/list-controller.ts
+++ b/src/views/deck/composables/list-controller.ts
@@ -268,6 +268,7 @@ export function useCardListController(opts: Options) {
     newCard,
     reorderCard,
     claimFocus,
+    pending_focus_client_id,
     guardAddCards: limit_gate.guardAddCards,
     handleLimitError: limit_gate.handleLimitError,
     saving,

--- a/src/views/deck/deck-view.vue
+++ b/src/views/deck/deck-view.vue
@@ -17,7 +17,8 @@ import {
   cardEditorKey,
   cardSearchKey,
   useCardListController,
-  useCardSearch
+  useCardSearch,
+  useEditorBreakpointSync
 } from '@/views/deck/composables'
 import { deckViewShellKey, useDeckViewShell } from '@/views/deck/composables/view-shell'
 import { mobileCardEditorKey, useMobileCardEditor } from './mobile-editor/use-mobile-card-editor'
@@ -57,6 +58,8 @@ provide(cardSearchKey, search)
 
 const mobile_editor = useMobileCardEditor(editor)
 provide(mobileCardEditorKey, mobile_editor)
+
+useEditorBreakpointSync(shell, editor, mobile_editor)
 
 const view_state = computed<'loading' | 'empty' | 'ready'>(() => {
   if (editor.list.all_cards.value.length > 0) return 'ready'

--- a/src/views/deck/mobile-editor/use-mobile-card-editor.ts
+++ b/src/views/deck/mobile-editor/use-mobile-card-editor.ts
@@ -35,6 +35,7 @@ export function useMobileCardEditor(controller: CardListController) {
   let close_modal: (() => void) | null = null
 
   const cursor_client_id = ref<string | null>(null)
+  const is_open = ref(false)
   const side = ref<CardSide>('front')
   const image_controls = shallowRef<ImageControls | null>(null)
 
@@ -56,6 +57,7 @@ export function useMobileCardEditor(controller: CardListController) {
 
     cursor_client_id.value = target
     side.value = 'front'
+    is_open.value = true
     emitSfx('snappy_button_3')
 
     if (close_modal) return
@@ -90,6 +92,7 @@ export function useMobileCardEditor(controller: CardListController) {
   // how the modal actually closed (done button, esc, background tap).
   function onClosed() {
     close_modal = null
+    is_open.value = false
     emitSfx('snappy_button_5')
   }
 
@@ -161,6 +164,7 @@ export function useMobileCardEditor(controller: CardListController) {
     cards,
     current,
     index,
+    is_open,
     has_prev,
     has_next,
     has_image,

--- a/tests/unit/views/deck/composables/editor-breakpoint-sync.test.js
+++ b/tests/unit/views/deck/composables/editor-breakpoint-sync.test.js
@@ -1,0 +1,146 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { ref, nextTick } from 'vue'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('@/composables/ui/media-query', () => ({ useMatchMedia: vi.fn() }))
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { useMatchMedia } from '@/composables/ui/media-query'
+import { useEditorBreakpointSync } from '@/views/deck/composables/editor-breakpoint-sync'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeShell(mode = 'edit') {
+  return {
+    mode: ref(mode),
+    exitMode: vi.fn(),
+    setMode: vi.fn()
+  }
+}
+
+function makeEditor(pending = null) {
+  return { pending_focus_client_id: ref(pending) }
+}
+
+function makeMobileEditor({ is_open = false, current = null } = {}) {
+  return {
+    is_open: ref(is_open),
+    current: ref(current),
+    open_at: vi.fn(),
+    close: vi.fn()
+  }
+}
+
+// Focus a fake desktop editor row so `document.activeElement.closest(...)`
+// resolves to a row carrying `client_id`.
+function focusDesktopRow(client_id) {
+  const row = document.createElement('div')
+  row.setAttribute('data-testid', 'list-item-card')
+  row.dataset.clientId = client_id
+
+  const input = document.createElement('input')
+  row.appendChild(input)
+  document.body.appendChild(row)
+  input.focus()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+let is_mobile
+
+beforeEach(() => {
+  is_mobile = ref(false)
+  useMatchMedia.mockReset()
+  useMatchMedia.mockReturnValue(is_mobile)
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('useEditorBreakpointSync — shrink (desktop → mobile)', () => {
+  test('leaves desktop edit and opens the mobile editor on the focused card', async () => {
+    const shell = makeShell('edit')
+    const editor = makeEditor()
+    const mobile = makeMobileEditor()
+    focusDesktopRow('cid-focused')
+
+    useEditorBreakpointSync(shell, editor, mobile)
+    is_mobile.value = true
+    await nextTick()
+
+    expect(shell.exitMode).toHaveBeenCalledOnce()
+    expect(mobile.open_at).toHaveBeenCalledWith('cid-focused')
+  })
+
+  test('falls back to the staged card awaiting focus when nothing is focused', async () => {
+    const shell = makeShell('edit')
+    const editor = makeEditor('cid-staged')
+    const mobile = makeMobileEditor()
+
+    useEditorBreakpointSync(shell, editor, mobile)
+    is_mobile.value = true
+    await nextTick()
+
+    expect(mobile.open_at).toHaveBeenCalledWith('cid-staged')
+  })
+
+  test('opens the mobile editor at its default when no card is focused or staged', async () => {
+    const shell = makeShell('edit')
+    const editor = makeEditor()
+    const mobile = makeMobileEditor()
+
+    useEditorBreakpointSync(shell, editor, mobile)
+    is_mobile.value = true
+    await nextTick()
+
+    expect(mobile.open_at).toHaveBeenCalledWith(undefined)
+  })
+
+  test('does nothing when the desktop editor is not open (mode is view)', async () => {
+    const shell = makeShell('view')
+    const editor = makeEditor()
+    const mobile = makeMobileEditor()
+
+    useEditorBreakpointSync(shell, editor, mobile)
+    is_mobile.value = true
+    await nextTick()
+
+    expect(shell.exitMode).not.toHaveBeenCalled()
+    expect(mobile.open_at).not.toHaveBeenCalled()
+  })
+})
+
+describe('useEditorBreakpointSync — grow (mobile → desktop)', () => {
+  test('closes the mobile editor and enters desktop edit on the cursor card', async () => {
+    is_mobile.value = true
+    const shell = makeShell('view')
+    const editor = makeEditor()
+    const mobile = makeMobileEditor({ is_open: true, current: { client_id: 'cid-cursor' } })
+
+    useEditorBreakpointSync(shell, editor, mobile)
+    is_mobile.value = false
+    await nextTick()
+
+    expect(editor.pending_focus_client_id.value).toBe('cid-cursor')
+    expect(mobile.close).toHaveBeenCalledOnce()
+    expect(shell.setMode).toHaveBeenCalledWith('edit')
+  })
+
+  test('does nothing when the mobile editor is not open', async () => {
+    is_mobile.value = true
+    const shell = makeShell('view')
+    const editor = makeEditor()
+    const mobile = makeMobileEditor({ is_open: false })
+
+    useEditorBreakpointSync(shell, editor, mobile)
+    is_mobile.value = false
+    await nextTick()
+
+    expect(mobile.close).not.toHaveBeenCalled()
+    expect(shell.setMode).not.toHaveBeenCalled()
+    expect(editor.pending_focus_client_id.value).toBeNull()
+  })
+})


### PR DESCRIPTION
[TARO-172](https://app.notion.com/3980953c224c8050afa3fefa0d3bb01b)

## Summary

Resizing across the `md` breakpoint mid-edit no longer strands you in the wrong editor. Crossing the breakpoint now swaps to the correct surface (shrink → mobile dock, grow → desktop edit) on the card you were focused on, preserving any unsaved staged card.

## Changes

- New `useEditorBreakpointSync` composable (wired in `deck-view.vue`) watches `useMatchMedia('w<md')` and, on each cross, tears down the current surface and opens the other on the same card.
- Shrink resolves the focused row via DOM `data-client-id` (added to `list-item-card.vue`), falling back to the staged card then first card; grow queues the mobile cursor card into `pending_focus_client_id`.
- Additive-only touches to `use-mobile-card-editor.ts` (`is_open` ref) and `list-controller.ts` (expose `pending_focus_client_id`).
- Tests covering both directions.