### PR TITLE
TARO-225: Refresh stale study-session architecture rule doc

### DIFF
--- a/.claude/rules/study-session-architecture.md
+++ b/.claude/rules/study-session-architecture.md
@@ -1,13 +1,22 @@
 ---
 title: Study Session Architecture
-lastUpdated: 2026-05-17T00:00:00Z
+lastUpdated: 2026-07-21T00:00:00Z
 paths:
-  - 'src/composables/study-session/**'
-  - 'src/composables/modals/use-study-modal.ts'
-  - 'src/components/modals/study-session/**'
+  - 'src/views/study-session/**'
 ---
 
 # Study Session Architecture
 
-- [`study-session-modals`](../docs/study-session-modals.md) — entry point, modal wiring, card flow in `session-flashcard.vue`
-- [`study-session-composables`](../docs/study-session-composables.md) — core vs flashcard layer, `DeckConfig`, FSRS
+The whole feature lives under `src/views/study-session/`.
+
+- `index.vue` — entry point (routed view). Resolves the deck(s), calls `provideStudySessionController`.
+- `composables/session-controller.ts` — composition root. Wires deck resolution, the engine, card edit/preview/actions, persistence, and prefs; provides the result via inject so `index.vue`, the header, and `session-studying/` share one instance.
+- `composables/session-engine.ts` — deck-blind state machine owning the lifecycle, FSRS queue, card sides, and per-card scheduling. Knows nothing about decks beyond each card's `deck_id`, handed to injected `schedulerFor` / `startingSideFor` callbacks.
+- `composables/` also holds supporting seams: `session-cards.ts` (fetch/seed), `session-persistence.ts` (sessionStorage restore), `session-prefs.ts`, `session-resume.ts`, `card-preview.ts`, `card-edit.ts`, `card-actions.ts`, `cover-carousel.ts`, `study-modal.ts`.
+- `deck-resolution.ts` — per-deck scheduler/starting-side/shuffle lookups, provided to the engine.
+- `session-studying/` — active-study UI (card stage, rating buttons, progress, edit footer).
+- `session-summary/` — post-session summary and stat aggregation.
+
+## Lifecycle
+
+Single source: `SessionState` in `session-engine.ts` — `loading -> cover -> studying -> summary`. The engine owns the transitions; `is_cover` and `display_side` derive from it.


### PR DESCRIPTION
[TARO-225](https://app.notion.com/p/3a40953c224c8177a64eca10e0e3ad06)

## Summary

The `study-session-architecture` rule doc pointed at folders/paths that no longer exist (`src/composables/study-session/**`, `src/composables/modals/use-study-modal.ts`, `src/components/modals/study-session/**`), misleading agents working in that feature. This refreshes it to reflect the current structure.

## Changes

- Replaced stale `paths` frontmatter with `src/views/study-session/**` — where the feature now lives entirely.
- Verified and documented the real structure: composition root `composables/session-controller.ts` (provides for `index.vue`/header/`session-studying/`), deck-blind engine `composables/session-engine.ts`, and the `SessionState` lifecycle `loading → cover → studying → summary`.
- Dropped two links to companion docs (`.claude/docs/study-session-modals.md` / `study-session-composables.md`) that are themselves badly stale; replaced with an inline structure summary rather than pointing at misleading docs.

## Test plan

- [ ] Docs-only change — no code/tests affected. Confirm the paths and structure in the rule doc match `src/views/study-session/`.