### PR TITLE
TARO-193: Truncate long member names in the UI

### DIFF
--- a/src/components/feedback/feedback-card.vue
+++ b/src/components/feedback/feedback-card.vue
@@ -44,8 +44,10 @@ async function onToggleVote() {
         <h2 class="text-ink truncate text-2xl">{{ item.title }}</h2>
         <p
           v-if="item.member_display_name"
+          data-testid="feedback-card__author"
           data-palette="info"
           class="text-(--color-accent) truncate text-base"
+          :title="item.member_display_name"
         >
           {{ item.member_display_name }}
         </p>

--- a/src/components/member/member-badge.vue
+++ b/src/components/member/member-badge.vue
@@ -60,7 +60,11 @@ function onEditAvatar(e: MouseEvent) {
     </div>
 
     <div data-testid="member-badge__info" class="flex flex-col min-w-0 flex-1">
-      <span data-testid="member-badge__name" class="font-semibold text-3xl text-brown-100 truncate">
+      <span
+        data-testid="member-badge__name"
+        class="block font-semibold text-3xl text-brown-100 truncate"
+        :title="displayName"
+      >
         {{ displayName || t('member-badge.name-placeholder') }}
       </span>
       <div data-testid="member-badge__description" class="text-sm text-brown-100 wrap-break-word">

--- a/src/components/member/member-card.vue
+++ b/src/components/member/member-card.vue
@@ -42,7 +42,11 @@ provideDepth(1)
     class="bg-panel rounded-8 border-panel flex w-89 flex-col overflow-hidden border-8 shadow-[-1px_-1px_0_0_var(--color-brown-100)] dark:shadow-[-1px_-1px_0_0_var(--color-grey-900)]"
   >
     <div data-testid="member-card__header" class="flex items-center justify-center px-9 pt-4 pb-1">
-      <h1 class="text-ink text-5xl">
+      <h1
+        data-testid="member-card__name"
+        class="text-ink min-w-0 truncate text-5xl"
+        :title="displayName"
+      >
         {{ displayName || t('member-badge.name-placeholder') }}
       </h1>
     </div>

--- a/src/views/dashboard/actions-panel/index.vue
+++ b/src/views/dashboard/actions-panel/index.vue
@@ -76,7 +76,8 @@ async function onSelect(value: string) {
     <template #header>
       <span
         data-testid="dashboard-actions-panel__header"
-        class="text-(--color-on-accent) text-4xl font-semibold truncate"
+        class="text-(--color-on-accent) block text-4xl font-semibold truncate"
+        :title="member_store.display_name || undefined"
       >
         {{ member_store.display_name || t('member-badge.name-placeholder') }}
       </span>

--- a/tests/integration/components/feedback/feedback-card.test.js
+++ b/tests/integration/components/feedback/feedback-card.test.js
@@ -76,6 +76,18 @@ describe('FeedbackCard — content', () => {
     expect(wrapper.find('[data-testid="feedback-card__heading"]').text()).toContain('Bob')
   })
 
+  test('exposes the full member_display_name via title on the author element', () => {
+    const wrapper = mountCard({ member_display_name: 'An Extremely Long Member Display Name' })
+    expect(wrapper.find('[data-testid="feedback-card__author"]').attributes('title')).toBe(
+      'An Extremely Long Member Display Name'
+    )
+  })
+
+  test('does not render the author element when member_display_name is absent', () => {
+    const wrapper = mountCard({ member_display_name: null })
+    expect(wrapper.find('[data-testid="feedback-card__author"]').exists()).toBe(false)
+  })
+
   test('renders body when present', () => {
     const wrapper = mountCard({ body: 'Some body text' })
     expect(wrapper.find('[data-testid="feedback-card__content"]').text()).toContain(

--- a/tests/integration/components/member/member-badge.test.js
+++ b/tests/integration/components/member/member-badge.test.js
@@ -132,6 +132,22 @@ describe('MemberBadge', () => {
     })
   })
 
+  // ── name truncation title ──────────────────────────────────────────────────
+
+  describe('name truncation title', () => {
+    test('exposes the full displayName via the title attribute', () => {
+      const wrapper = mountBadge({ displayName: 'An Extremely Long Member Display Name' })
+      expect(wrapper.find('[data-testid="member-badge__name"]').attributes('title')).toBe(
+        'An Extremely Long Member Display Name'
+      )
+    })
+
+    test('omits the title attribute when displayName is absent', () => {
+      const wrapper = mountBadge()
+      expect(wrapper.find('[data-testid="member-badge__name"]').attributes('title')).toBeUndefined()
+    })
+  })
+
   // ── cover bindings ─────────────────────────────────────────────────────────
 
   describe('cover bindings via memberCoverBindings', () => {

--- a/tests/integration/components/member/member-card.test.js
+++ b/tests/integration/components/member/member-card.test.js
@@ -113,6 +113,22 @@ describe('MemberCard', () => {
     )
   })
 
+  // ── name truncation title ──────────────────────────────────────────────────
+
+  describe('name truncation title', () => {
+    test('exposes the full displayName via the title attribute', () => {
+      const wrapper = mountCard({ displayName: 'An Extremely Long Member Display Name' })
+      expect(wrapper.find('[data-testid="member-card__name"]').attributes('title')).toBe(
+        'An Extremely Long Member Display Name'
+      )
+    })
+
+    test('omits the title attribute when displayName is absent', () => {
+      const wrapper = mountCard()
+      expect(wrapper.find('[data-testid="member-card__name"]').attributes('title')).toBeUndefined()
+    })
+  })
+
   // ── editable / edit-avatar [obligation] ────────────────────────────────────
 
   describe('editable [obligation]', () => {

--- a/tests/integration/views/dashboard/actions-panel/index.test.js
+++ b/tests/integration/views/dashboard/actions-panel/index.test.js
@@ -115,6 +115,13 @@ describe('DashboardActionsPanel — header', () => {
     const wrapper = mount()
     expect(wrapper.find('[data-testid="dashboard-actions-panel__header"]').text()).toBe('Ada')
   })
+
+  test('exposes the full display name via the title attribute', () => {
+    const wrapper = mount()
+    expect(
+      wrapper.find('[data-testid="dashboard-actions-panel__header"]').attributes('title')
+    ).toBe('Ada')
+  })
 })
 
 describe('DashboardActionsPanel — study button', () => {


### PR DESCRIPTION
[TARO-193](https://app.notion.com/p/39d0953c224c80eb9c9ccfc4ba258bf7)

## Summary

Over-long member display names now visually truncate with an ellipsis at every render site, so a long name can never break layout. The full name stays available via the `title` attribute on hover. Purely presentational — the stored `display_name` and its UNIQUE constraint are untouched (no backend change).

## Changes

- `member-card.vue` — h1 name: `min-w-0 truncate` + `:title` + `data-testid`.
- `member-badge.vue` — name span: added `block` (inline span wasn't clipping) + `:title`.
- `feedback-card.vue` — author line: `:title` + `data-testid`.
- `dashboard/actions-panel` header — added `block` + `:title`.
- Grep confirmed these are the only 4 member-name render sites; the ticket's speculated "deck author from decks-with-stats" doesn't exist in the codebase (no deck author is fetched/rendered), so nothing to do there.

## Test plan

- [ ] Long member name truncates with ellipsis on member card, member badge, feedback author, and dashboard header.
- [ ] Hovering shows the full name via `title`.
- [ ] Stored value / signup unchanged.