### PR TITLE
TARO-224: Fix missing indeterminate radio dash icon

### DIFF
--- a/src/components/ui-kit/radio.vue
+++ b/src/components/ui-kit/radio.vue
@@ -35,7 +35,7 @@ const onClick = tap(undefined, {
     v-sfx="{ hover: sfx.hover, focus: sfx.focus, blur: sfx.blur, debounce: sfx.debounce }"
     @click="onClick"
   >
-    <ui-icon v-if="checked" class="text-white" src="check" />
-    <ui-icon v-if="intermediate" src="minus" />
+    <ui-icon v-if="checked" class="size-5 text-white" src="check" />
+    <ui-icon v-if="intermediate" class="size-5" src="subtract" />
   </div>
 </template>

--- a/tests/integration/components/ui-kit/radio.test.js
+++ b/tests/integration/components/ui-kit/radio.test.js
@@ -59,23 +59,23 @@ describe('UiRadio', () => {
 
   // ── intermediate state ─────────────────────────────────────────────────────
 
-  test('renders minus icon when intermediate=true', () => {
+  test('renders subtract (dash) icon when intermediate=true', () => {
     const wrapper = mountRadio({ checked: false, intermediate: true })
     const icons = wrapper.findAllComponents({ name: 'UiIcon' })
-    expect(icons.some((c) => c.props('src') === 'minus')).toBe(true)
+    expect(icons.some((c) => c.props('src') === 'subtract')).toBe(true)
   })
 
-  test('does not render minus icon when intermediate is not set', () => {
+  test('does not render subtract icon when intermediate is not set', () => {
     const wrapper = mountRadio({ checked: false })
     const icons = wrapper.findAllComponents({ name: 'UiIcon' })
-    expect(icons.some((c) => c.props('src') === 'minus')).toBe(false)
+    expect(icons.some((c) => c.props('src') === 'subtract')).toBe(false)
   })
 
-  test('can show both check and minus icons simultaneously', () => {
+  test('can show both check and subtract icons simultaneously', () => {
     const wrapper = mountRadio({ checked: true, intermediate: true })
     const icons = wrapper.findAllComponents({ name: 'UiIcon' })
     expect(icons.some((c) => c.props('src') === 'check')).toBe(true)
-    expect(icons.some((c) => c.props('src') === 'minus')).toBe(true)
+    expect(icons.some((c) => c.props('src') === 'subtract')).toBe(true)
   })
 
   // ── click ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
[TARO-224](https://app.notion.com/p/3a40953c224c81248e6ef26a1d3bce5f)

## Summary

The radio primitive's indeterminate state referenced a `minus` icon that doesn't resolve — it hit the missing-icon warning fallthrough (`logger.warn('Missing icon: minus')`) so no dash rendered. The real asset is `subtract.svg`. Points the icon at `subtract` and gives both icons an explicit `size-5` (same root cause as the check-icon bug #219).

## Changes

- `ui-kit/radio.vue` — indeterminate icon `src="minus"` → `src="subtract"`; added explicit `size-5` to both the check and subtract icons.
- Updated the radio integration tests to assert the `subtract` icon (via `UiIcon` `src` prop, no class assertions).

## Test plan

- [ ] Indeterminate radio (`intermediate` true) shows a dash indicator.
- [ ] No `Missing icon` warning in the console.