### PR TITLE
TARO-194: Disable Edit Decks control when the deck grid is empty

### DIFF
--- a/src/views/dashboard/actions-panel/index.vue
+++ b/src/views/dashboard/actions-panel/index.vue
@@ -13,9 +13,14 @@ import { useNewDeckAction } from '../composables/new-deck-action'
 type DashboardActionsPanelProps = {
   due_decks: Deck[]
   editing_decks?: boolean
+  has_decks?: boolean
 }
 
-const { due_decks, editing_decks = false } = defineProps<DashboardActionsPanelProps>()
+const {
+  due_decks,
+  editing_decks = false,
+  has_decks = false
+} = defineProps<DashboardActionsPanelProps>()
 
 const emit = defineEmits<{
   'toggle-edit-decks': []
@@ -42,7 +47,8 @@ const deck_entries = computed<OptionsPanelEntry[]>(() => [
       : t('dashboard.actions-panel.edit-decks-label'),
     trailingIcon: editing_decks ? 'stop' : 'pencil',
     selected: editing_decks,
-    selectedPalette: 'yellow'
+    selectedPalette: 'yellow',
+    disabled: !editing_decks && !has_decks
   }
 ])
 

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -66,6 +66,7 @@ const show_skeleton = computed(() => !decks_data.value)
         <dashboard-actions-panel
           :due_decks="due_decks"
           :editing_decks="editing_decks"
+          :has_decks="decks.length > 0"
           @toggle-edit-decks="onToggleEditDecks"
         />
 
@@ -97,6 +98,7 @@ const show_skeleton = computed(() => !decks_data.value)
     <dashboard-mobile-footer
       :due_decks="due_decks"
       :editing_decks="editing_decks"
+      :has_decks="decks.length > 0"
       @toggle-edit-decks="onToggleEditDecks"
     />
   </div>

--- a/src/views/dashboard/mobile-footer/footer-actions.vue
+++ b/src/views/dashboard/mobile-footer/footer-actions.vue
@@ -7,9 +7,14 @@ import { useNewDeckAction } from '../composables/new-deck-action'
 type DashboardFooterActionsProps = {
   due_decks: Deck[]
   editing_decks?: boolean
+  has_decks?: boolean
 }
 
-const { due_decks, editing_decks = false } = defineProps<DashboardFooterActionsProps>()
+const {
+  due_decks,
+  editing_decks = false,
+  has_decks = false
+} = defineProps<DashboardFooterActionsProps>()
 
 const emit = defineEmits<{
   'toggle-edit-decks': []
@@ -75,6 +80,7 @@ function onStudyAll() {
       icon-left="pencil"
       variant="ghost"
       size="lg"
+      :disabled="!has_decks"
       @press="emit('toggle-edit-decks')"
     >
       {{ t('dashboard.mobile-footer.edit-decks-label') }}

--- a/src/views/dashboard/mobile-footer/index.vue
+++ b/src/views/dashboard/mobile-footer/index.vue
@@ -5,6 +5,7 @@ import FooterActions from './footer-actions.vue'
 type DashboardMobileFooterProps = {
   due_decks: Deck[]
   editing_decks?: boolean
+  has_decks?: boolean
 }
 
 defineProps<DashboardMobileFooterProps>()
@@ -19,6 +20,7 @@ const emit = defineEmits<{
     <footer-actions
       :due_decks="due_decks"
       :editing_decks="editing_decks"
+      :has_decks="has_decks"
       @toggle-edit-decks="emit('toggle-edit-decks')"
     />
   </mobile-dock>

--- a/tests/integration/views/dashboard/actions-panel/index.test.js
+++ b/tests/integration/views/dashboard/actions-panel/index.test.js
@@ -87,9 +87,9 @@ function wrapper_entry(wrapper) {
   return entries.find((e) => e.value === 'edit-decks')
 }
 
-function mount(due_decks = [], editing_decks = false) {
+function mount(due_decks = [], editing_decks = false, has_decks = false) {
   return shallowMount(DashboardActionsPanel, {
-    props: { due_decks, editing_decks },
+    props: { due_decks, editing_decks, has_decks },
     global: {
       stubs: {
         DashboardActionsPanelShell: DashboardActionsPanelShellStub,
@@ -227,6 +227,23 @@ describe('DashboardActionsPanel — edit-decks entry reflects editing_decks stat
     const editing = wrapper_entry(mount([], true))
     expect(editing.selected).toBe(true)
     expect(editing.selectedPalette).toBe('yellow')
+  })
+})
+
+describe('DashboardActionsPanel — edit-decks entry disabled when no decks', () => {
+  test('is disabled when has_decks is false and not editing', () => {
+    const entry = wrapper_entry(mount([], false, false))
+    expect(entry.disabled).toBe(true)
+  })
+
+  test('is enabled when has_decks is true and not editing', () => {
+    const entry = wrapper_entry(mount([], false, true))
+    expect(entry.disabled).toBe(false)
+  })
+
+  test('done-editing state is never disabled, even with no decks', () => {
+    const entry = wrapper_entry(mount([], true, false))
+    expect(entry.disabled).toBe(false)
   })
 })
 

--- a/tests/integration/views/dashboard/mobile-footer/footer-actions.test.js
+++ b/tests/integration/views/dashboard/mobile-footer/footer-actions.test.js
@@ -102,11 +102,35 @@ describe('DashboardFooterActions', () => {
     })
 
     test('emits toggle-edit-decks on press', async () => {
-      const wrapper = mountFooterActions()
+      const wrapper = mountFooterActions({ has_decks: true })
 
       await wrapper.find('[data-testid="dashboard-footer-actions__edit-decks"]').trigger('click')
 
       expect(wrapper.emitted('toggle-edit-decks')).toHaveLength(1)
+    })
+
+    test('is disabled when has_decks is false and not editing', () => {
+      const wrapper = mountFooterActions({ editing_decks: false, has_decks: false })
+
+      expect(
+        wrapper.find('[data-testid="dashboard-footer-actions__edit-decks"]').attributes('disabled')
+      ).not.toBeUndefined()
+    })
+
+    test('is enabled when has_decks is true and not editing', () => {
+      const wrapper = mountFooterActions({ editing_decks: false, has_decks: true })
+
+      expect(
+        wrapper.find('[data-testid="dashboard-footer-actions__edit-decks"]').attributes('disabled')
+      ).toBeUndefined()
+    })
+
+    test('done-editing state is never disabled, even with no decks', () => {
+      const wrapper = mountFooterActions({ editing_decks: true, has_decks: false })
+
+      expect(
+        wrapper.find('[data-testid="dashboard-footer-actions__edit-decks"]').attributes('disabled')
+      ).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
[TARO-194](https://app.notion.com/p/39d0953c224c80419bdbf248fa028a69)

## Summary

When the deck grid is empty there's nothing to reorder, so the "Edit Decks" control is now disabled until at least one deck exists. Applies to both the desktop actions panel and the mobile footer. The "Done editing" state is never disabled, so you can always exit edit mode.

## Changes

- Thread a `has_decks` prop (`decks.length > 0`, from already-loaded data — no extra fetch) from `dashboard/index.vue` into the actions panel and mobile footer.
- Desktop actions-panel "Edit Decks" entry disabled via `disabled: !editing_decks && !has_decks`.
- Mobile footer applies `:disabled="!has_decks"` only on the edit (pencil) branch, never the done (stop) branch.
- Opacity-only disabled treatment (no `cursor-not-allowed`), per project rule.

## Test plan

- [ ] With zero decks, Edit Decks is disabled on desktop and mobile.
- [ ] With ≥1 deck, Edit Decks is enabled on both.
- [ ] While editing, the Done state is always tappable regardless of deck count.