### PR TITLE
TARO-207: Close modals, clear query cache, and reset phone state on logout

### DIFF
--- a/src/composables/modal.ts
+++ b/src/composables/modal.ts
@@ -135,5 +135,16 @@ export function useModal() {
     if (top) close(top.id)
   }
 
-  return { open, pop, modal_stack }
+  return { open, pop, closeAll, modal_stack }
+}
+
+/**
+ * Close every open modal at once, resolving each pending `response` promise so
+ * awaiting callers don't hang. Operates on the module-level `modal_stack`, so
+ * it can be called outside component setup (e.g. from the session store's
+ * logout teardown).
+ */
+export function closeAll() {
+  modal_stack.value.forEach((entry) => entry.resolve())
+  modal_stack.value = []
 }

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -28,13 +28,18 @@ import {
 import { useRouter } from 'vue-router'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useQueryCache } from '@pinia/colada'
 import logger from '@/utils/logger'
 import { useNoticeStore } from '@/stores/notice-store'
+import { useTaroPhoneStore } from '@/stores/taro-phone'
+import { closeAll as closeAllModals } from '@/composables/modal'
 
 export const useSessionStore = defineStore('sessionStore', () => {
   const router = useRouter()
   const { t } = useI18n()
   const notice = useNoticeStore()
+  const queryCache = useQueryCache()
+  const taroPhone = useTaroPhoneStore()
 
   const user = ref<User | undefined>(undefined)
   const loading_count = ref(0)
@@ -180,8 +185,22 @@ export const useSessionStore = defineStore('sessionStore', () => {
     user.value = (await getUser()) ?? undefined
   }
 
+  // Single teardown funnel for both logout() and forceLogout(): clears auth
+  // identity, then fans out to every bit of state that would otherwise leak
+  // into the next session or the logged-out surface. The audio engine is left
+  // running — logged-out surfaces still need sound.
   function reset() {
     user.value = undefined
+
+    closeAllModals()
+    clearQueryCache()
+    taroPhone.reset()
+  }
+
+  /** Drop every entry from the Pinia Colada cache so stale data can't carry
+   * over into the next login (Colada has no wholesale clear, so remove each). */
+  function clearQueryCache() {
+    queryCache.getEntries().forEach((entry) => queryCache.remove(entry))
   }
 
   function startLoading(): void {

--- a/src/stores/taro-phone.ts
+++ b/src/stores/taro-phone.ts
@@ -31,6 +31,14 @@ export const useTaroPhoneStore = defineStore('taro-phone', () => {
     })
   }
 
+  /** Reset the phone to its logged-out baseline so no stale open state leaks
+   * into the next session (e.g. firing a close sfx on the first click). */
+  function reset() {
+    is_open.value = false
+    was_hidden_for_app_modal.value = false
+    notifications.value = {}
+  }
+
   function notify(app_id: string, count: number) {
     notifications.value = { ...notifications.value, [app_id]: count }
   }
@@ -47,6 +55,7 @@ export const useTaroPhoneStore = defineStore('taro-phone', () => {
     open,
     close,
     openApp,
+    reset,
     notify,
     clearNotification
   }

--- a/tests/integration/views/welcome/index.test.js
+++ b/tests/integration/views/welcome/index.test.js
@@ -28,7 +28,8 @@ vi.mock('@/sfx/bus', () => ({
 
 vi.mock('@/composables/modal', () => ({
   useModal: () => ({ open: mocks.modalOpen }),
-  useModalRequestClose: () => {}
+  useModalRequestClose: () => {},
+  closeAll: () => {}
 }))
 
 // `useSessionStore()` calls `useI18n()` internally, which requires an active

--- a/tests/unit/composables/modal.test.js
+++ b/tests/unit/composables/modal.test.js
@@ -3,6 +3,7 @@ import { defineComponent, h } from 'vue'
 import { mount } from '@vue/test-utils'
 import {
   useModal,
+  closeAll,
   useModalRequestClose,
   useModalAfterEnter,
   resolveModalAfterEnter,
@@ -173,6 +174,36 @@ describe('useModal', () => {
       close()
 
       await expect(response).resolves.toBeUndefined()
+    })
+  })
+
+  describe('closeAll', () => {
+    test('empties the modal_stack', () => {
+      const { open, modal_stack } = useModal()
+      open(FakeComponent)
+      open(FakeComponent)
+
+      closeAll()
+
+      expect(modal_stack.value).toHaveLength(0)
+    })
+
+    test('resolves every pending response promise so awaiting callers do not hang', async () => {
+      const { open } = useModal()
+      const first = open(FakeComponent)
+      const second = open(FakeComponent)
+
+      closeAll()
+
+      await expect(first.response).resolves.toBeUndefined()
+      await expect(second.response).resolves.toBeUndefined()
+    })
+
+    test('is a no-op when the stack is already empty', () => {
+      const { modal_stack } = useModal()
+
+      expect(() => closeAll()).not.toThrow()
+      expect(modal_stack.value).toHaveLength(0)
     })
   })
 

--- a/tests/unit/stores/session.test.js
+++ b/tests/unit/stores/session.test.js
@@ -44,8 +44,17 @@ const { mockOnSignedOut, mockIsAuthError } = vi.hoisted(() => ({
   mockIsAuthError: vi.fn()
 }))
 
+const { mockQueryCache, mockCloseAllModals, mockTaroPhoneReset } = vi.hoisted(() => ({
+  mockQueryCache: { getEntries: vi.fn(() => []), remove: vi.fn() },
+  mockCloseAllModals: vi.fn(),
+  mockTaroPhoneReset: vi.fn()
+}))
+
 vi.mock('@/stores/notice-store', () => ({ useNoticeStore: () => mockNotice }))
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }))
+vi.mock('@pinia/colada', () => ({ useQueryCache: () => mockQueryCache }))
+vi.mock('@/composables/modal', () => ({ closeAll: mockCloseAllModals }))
+vi.mock('@/stores/taro-phone', () => ({ useTaroPhoneStore: () => ({ reset: mockTaroPhoneReset }) }))
 
 vi.mock('@/api/session', () => ({
   getSession: mockGetSession,
@@ -94,6 +103,11 @@ beforeEach(() => {
   mockOnSignedOut.mockReset()
   mockOnSignedOut.mockImplementation(() => vi.fn())
   mockIsAuthError.mockReset()
+  mockQueryCache.getEntries.mockReset()
+  mockQueryCache.getEntries.mockReturnValue([])
+  mockQueryCache.remove.mockReset()
+  mockCloseAllModals.mockReset()
+  mockTaroPhoneReset.mockReset()
 })
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -242,6 +256,35 @@ describe('useSessionStore', () => {
       expect(mockNotice.error).toHaveBeenCalledWith('session.logout-error')
       expect(store.user).toEqual(user)
       expect(mockPush).not.toHaveBeenCalledWith({ name: 'welcome' })
+    })
+
+    test('runs the full teardown — closes modals, clears the query cache, resets the phone [obligation]', async () => {
+      const user = { id: 'u1', aud: 'authenticated' }
+      mockGetSession.mockResolvedValueOnce({ user })
+      mockLogout.mockResolvedValueOnce(undefined)
+      mockQueryCache.getEntries.mockReturnValueOnce(['entry-a', 'entry-b'])
+      const store = useSessionStore()
+      await store.restoreSession()
+
+      await store.logout()
+
+      expect(mockCloseAllModals).toHaveBeenCalledOnce()
+      expect(mockQueryCache.remove).toHaveBeenCalledWith('entry-a')
+      expect(mockQueryCache.remove).toHaveBeenCalledWith('entry-b')
+      expect(mockTaroPhoneReset).toHaveBeenCalledOnce()
+    })
+
+    test('does NOT run teardown when supaLogout rejects (no reset reached) [obligation]', async () => {
+      const user = { id: 'u1', aud: 'authenticated' }
+      mockGetSession.mockResolvedValueOnce({ user })
+      mockLogout.mockRejectedValueOnce(new Error('network down'))
+      const store = useSessionStore()
+      await store.restoreSession()
+
+      await store.logout()
+
+      expect(mockCloseAllModals).not.toHaveBeenCalled()
+      expect(mockTaroPhoneReset).not.toHaveBeenCalled()
     })
   })
 
@@ -471,6 +514,23 @@ describe('useSessionStore', () => {
       options.onDismiss()
 
       expect(mockPush).toHaveBeenCalledWith({ name: 'welcome' })
+    })
+
+    test('forced session-loss runs the same teardown as logout [obligation]', async () => {
+      const user = { id: 'u1', aud: 'authenticated' }
+      mockGetSession.mockResolvedValueOnce({ user })
+      mockIsAuthError.mockReturnValueOnce(true)
+      mockLogout.mockResolvedValueOnce(undefined)
+      mockQueryCache.getEntries.mockReturnValueOnce(['entry-a'])
+      const store = useSessionStore()
+      await store.restoreSession()
+
+      store.handleAuthError({ status: 401 })
+      await Promise.resolve()
+
+      expect(mockCloseAllModals).toHaveBeenCalledOnce()
+      expect(mockQueryCache.remove).toHaveBeenCalledWith('entry-a')
+      expect(mockTaroPhoneReset).toHaveBeenCalledOnce()
     })
   })
 

--- a/tests/unit/stores/taro-phone.test.js
+++ b/tests/unit/stores/taro-phone.test.js
@@ -97,6 +97,42 @@ describe('useTaroPhoneStore — openApp idempotency', () => {
   })
 })
 
+// ── reset — logout teardown [obligation] ──────────────────────────────────────
+
+describe('useTaroPhoneStore — reset', () => {
+  test('closes the phone so no stale open state leaks into the next session', () => {
+    const store = useTaroPhoneStore()
+    store.open()
+
+    store.reset()
+
+    expect(store.is_open).toBe(false)
+  })
+
+  test('clears notifications', () => {
+    const store = useTaroPhoneStore()
+    store.notify('settings', 3)
+    store.notify('feedback', 2)
+
+    store.reset()
+
+    expect(store.notification_count).toBe(0)
+  })
+
+  test('clears the app-modal hide flag so a stale finally cannot reopen the phone', async () => {
+    const store = useTaroPhoneStore()
+    store.open()
+    const deferred = makeDeferredResult()
+    store.openApp(deferred)
+
+    store.reset()
+    deferred.resolve(undefined)
+    await flushPromises()
+
+    expect(store.is_open).toBe(false)
+  })
+})
+
 // ── notify / clearNotification / notification_count ───────────────────────────
 
 describe('useTaroPhoneStore — notifications', () => {


### PR DESCRIPTION
[TARO-207](https://app.notion.com/p/3a20953c224c800eb6d6f8eda530f79b)

## Summary

On logout (and forced session-loss) several bits of state leaked into the next session: open modals stayed visible, the server-state query cache persisted, and stale taro-phone open state fired the phone close sound on the next click. This adds a single logout-teardown seam at `session.reset()` — the shared funnel for both `logout()` and `forceLogout()` — that tears all three down. The audio engine is left intact so logged-out surfaces keep their sound.

## Changes

- `modal.ts`: new module-level `closeAll()` that closes every open modal and resolves each pending `response` promise so awaiting callers don't hang.
- `session.reset()`: fans out to `closeAll()`, a full Pinia Colada cache clear (`queryCache.getEntries().forEach(remove)`), and a taro-phone state reset.
- `taro-phone.ts`: new `reset()` clearing `is_open`, `was_hidden_for_app_modal`, and `notifications`.
- `forceLogout`'s "session expired" notice is a notice-store notice (not a modal), so `closeAll()` correctly leaves it standing.

## Test plan

- [ ] Open a modal, log out → modal is gone on the welcome screen.
- [ ] Log out then log back in → no stale cached data carries over.
- [ ] Open the taro-phone, log out, click around → no phone close sound; audio still works.
- [ ] Both intentional logout and forced session-loss run the same teardown.