### PR TITLE
TARO-214: Reword the Daily Limits subheader copy

### DIFF
--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -620,7 +620,7 @@
   "deck.settings-modal.review-pacing.default-preset-label": "Default",
   "deck.settings-modal.review-pacing.general-heading": "General",
   "deck.settings-modal.review-pacing.limits-heading": "Daily Limits",
-  "deck.settings-modal.review-pacing.limits-description": "How much this deck puts in front of you each day.",
+  "deck.settings-modal.review-pacing.limits-description": "Cap how many cards you review and learn each day.",
   "deck.settings-modal.review-pacing.advanced-hide-tooltip": "Hide advanced settings",
   "deck.settings-modal.review-pacing.advanced-label": "Advanced",
   "deck.settings-modal.review-pacing.advanced-toggle": "View Advanced Settings",


### PR DESCRIPTION
[TARO-214](https://app.notion.com/p/3a40953c224c80c99d8bdd625c6f9880)

## Summary

Clearer copy for the "Daily Limits" section subheader in a deck's review-pacing settings.

## Changes

- `deck.settings-modal.review-pacing.limits-description`: "How much this deck puts in front of you each day." → "Cap how many cards you review and learn each day."

## Test plan

- [ ] Open a deck's review-pacing settings → Daily Limits subheader reads the new copy.