### PR TITLE
TARO-20: Add Edit action to card grid dropdown

### DIFF
--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -28,20 +28,20 @@ const front_text = ref(card.front_text ?? '')
 const back_text = ref(card.back_text ?? '')
 const save_failed = ref(false)
 
-const { selection, updateCard, card_attributes, claimFocus } = inject(cardEditorKey)!
+const { selection, updateCard, card_attributes, claimFocus, claimGrow } = inject(cardEditorKey)!
 const { is_selecting } = selection
 
 const { flagWindowBlur, consumeWindowRefocus } = useWindowRefocusGuard()
 
-// A card staged by the toolbar's "new card" intent claims its one-shot signal
-// the moment its row mounts: land the user in the front editor ready to type,
-// and reveal the new row with a grow-in (gated here so scroll-mounted rows
-// don't animate).
+// On mount a row claims two independent one-shot signals. Focus: a card staged
+// by the toolbar's "new card" intent, or one reached via the grid's "Edit"
+// action, lands the user in the front editor. Grow-in: only a freshly-added card
+// reveals with the height animation — edit-navigation sets no grow target, so
+// scrolling to an existing card focuses it without animating its height. Both
+// claims are gated so ordinary scroll-mounted rows fire neither.
 onMounted(() => {
-  if (!claimFocus(card.client_id)) return
-
-  focusEditor()
-  if (list_item_card.value) expandListItemIn(list_item_card.value)
+  if (claimFocus(card.client_id)) focusEditor()
+  if (claimGrow(card.client_id) && list_item_card.value) expandListItemIn(list_item_card.value)
 })
 
 // Persist both sides from local state, not just the edited one: the merge base

--- a/src/views/deck/card-editor/list.vue
+++ b/src/views/deck/card-editor/list.vue
@@ -24,7 +24,7 @@ const ROW_PITCH = 407
 const LOAD_MORE_THRESHOLD = 5
 const OVERSCAN = 3
 
-const { list, selection, reorderCard, hasNextPage, isLoading, loadNextPage } =
+const { list, selection, reorderCard, hasNextPage, isLoading, loadNextPage, registerScroller } =
   inject(cardEditorKey)!
 const { all_cards } = list
 
@@ -104,6 +104,20 @@ function onReorderStart(index: number, event: PointerEvent) {
   if (lifted_row) liftListItem(lifted_row)
 }
 
+/**
+ * Map a card's client_id to its row index and scroll it into view — works
+ * for cards outside the current virtual-scroll window (the virtualizer
+ * computes the offset from the fixed row pitch, no measurement needed).
+ * Registered with the controller on mount so `editCard` can reach it without
+ * a template-ref chain through the mode-stack's dynamic panes.
+ */
+function scrollToCard(client_id: string) {
+  const index = all_cards.value.findIndex((c) => c.client_id === client_id)
+  if (index === -1) return
+
+  virtualizer.value.scrollToIndex(index, { align: 'center' })
+}
+
 let resize_observer: ResizeObserver | undefined
 // The sticky toolbar (md+) covers the top of the list; its viewport-space
 // bottom is the inset where drag auto-scroll-up should start.
@@ -116,11 +130,13 @@ onMounted(() => {
   sticky_toolbar = document.querySelector('[data-testid="deck-view__toolbar"]')
   resize_observer = new ResizeObserver(onBodyResize)
   resize_observer.observe(document.body)
+  registerScroller({ scrollToCard })
 })
 
 onBeforeUnmount(() => {
   clearTimeout(resize_timer)
   resize_observer?.disconnect()
+  registerScroller(null)
 })
 
 watchEffect(() => {
@@ -146,6 +162,8 @@ watch(
     lifted_row = null
   }
 )
+
+defineExpose({ scrollToCard })
 </script>
 
 <template>

--- a/src/views/deck/composables/item-options-menu.ts
+++ b/src/views/deck/composables/item-options-menu.ts
@@ -6,17 +6,19 @@ import type { DropdownOption } from '@/components/ui-kit/dropdown-button/index.v
 export type CardItemOptionsMenu = ReturnType<typeof useCardItemOptionsMenu>
 
 /**
- * Per-card options (select / move / delete) shared by the grid item's hover
- * more-menu and the mobile long-press popover so the two entry points never
- * drift. Options are card-agnostic; the acting card id is passed to `onSelect`.
+ * Per-card options (select / move / delete / edit) shared by the grid item's
+ * hover more-menu and the mobile long-press popover so the two entry points
+ * never drift. Options are card-agnostic; the acting card id is passed to
+ * `onSelect`.
  */
 export function useCardItemOptionsMenu() {
   const { t } = useI18n()
-  const { actions } = inject(cardEditorKey)!
+  const { actions, editCard } = inject(cardEditorKey)!
 
   const options = computed<DropdownOption[]>(() => [
     { label: t('deck-view.item-options.select'), value: 'select', icon: 'data-check' },
     { label: t('deck-view.item-options.move'), value: 'move', icon: 'move-item' },
+    { label: t('deck-view.item-options.edit'), value: 'edit', icon: 'edit' },
     { label: t('deck-view.item-options.delete'), value: 'delete', icon: 'delete' }
   ])
 
@@ -25,6 +27,7 @@ export function useCardItemOptionsMenu() {
     if (option.value === 'select') actions.onSelectCard(card_id)
     else if (option.value === 'move') actions.onMoveCards(card_id)
     else if (option.value === 'delete') actions.onDeleteCards(card_id)
+    else if (option.value === 'edit') editCard(card_id)
   }
 
   return { options, onSelect }

--- a/src/views/deck/composables/list-controller.ts
+++ b/src/views/deck/composables/list-controller.ts
@@ -1,4 +1,4 @@
-import { computed, ref, type InjectionKey, type Ref } from 'vue'
+import { computed, ref, shallowRef, type InjectionKey, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useInfiniteScroll } from '@/composables/ui/infinite-scroll'
 import { useCardsInDeckInfiniteQuery } from '@/api/cards'
@@ -71,6 +71,11 @@ export function useCardListController(opts: Options) {
   // client_id of the card last staged via `addCardAtTop`, awaiting autofocus.
   // The matching row claims it on mount (see `claimFocus`) and focuses itself.
   const pending_focus_client_id = ref<string | null>(null)
+
+  // The mounted editor list registers its `scrollToCard` here so `editCard`
+  // can reach it without a template-ref chain through the mode-stack's
+  // dynamic `<component :is>` panes (see list.vue).
+  const list_scroller = shallowRef<{ scrollToCard: (client_id: string) => void } | null>(null)
 
   const card_attributes = computed<DeckCardAttributes>(() => ({
     front: deck_query.data.value?.card_attributes?.front ?? {},
@@ -158,6 +163,28 @@ export function useCardListController(opts: Options) {
     if (pending_focus_client_id.value !== client_id) return false
     pending_focus_client_id.value = null
     return true
+  }
+
+  /** Called by the mounted editor list on mount/unmount to publish its scroller. */
+  function registerScroller(scroller: { scrollToCard: (client_id: string) => void } | null) {
+    list_scroller.value = scroller
+  }
+
+  /**
+   * The grid dropdown's "Edit" intent: switch to edit mode, then scroll the
+   * chosen card into view once the editor pane has mounted. `pending_focus_client_id`
+   * is set first so the row claims focus + plays its grow-in the moment it
+   * mounts inside the virtualizer's window (same one-shot claim `addCardAtTop`
+   * uses), then `scrollToCard` pulls it into that window even when it starts
+   * outside the current virtual-scroll range.
+   */
+  async function editCard(card_id: number) {
+    const entry = list.all_cards.value.find((c) => c.id === card_id)
+    if (!entry) return
+
+    pending_focus_client_id.value = entry.client_id
+    await opts.shell.setMode('edit')
+    list_scroller.value?.scrollToCard(entry.client_id)
   }
 
   /**
@@ -269,6 +296,8 @@ export function useCardListController(opts: Options) {
     reorderCard,
     claimFocus,
     pending_focus_client_id,
+    registerScroller,
+    editCard,
     guardAddCards: limit_gate.guardAddCards,
     handleLimitError: limit_gate.handleLimitError,
     saving,

--- a/src/views/deck/composables/list-controller.ts
+++ b/src/views/deck/composables/list-controller.ts
@@ -72,6 +72,11 @@ export function useCardListController(opts: Options) {
   // The matching row claims it on mount (see `claimFocus`) and focuses itself.
   const pending_focus_client_id = ref<string | null>(null)
 
+  // client_id of a freshly-added card awaiting its grow-in reveal. Set only by
+  // `addCardAtTop` (a brand-new row) — never by `editCard`, which navigates to
+  // an existing card and must not animate its height. Claimed once on mount.
+  const pending_grow_client_id = ref<string | null>(null)
+
   // The mounted editor list registers its `scrollToCard` here so `editCard`
   // can reach it without a template-ref chain through the mode-stack's
   // dynamic `<component :is>` panes (see list.vue).
@@ -118,12 +123,14 @@ export function useCardListController(opts: Options) {
   async function addCardAtTop() {
     if (!(await limit_gate.guardAddCards())) return
 
-    // Stage and record the autofocus target in the same synchronous block:
-    // `list.addCardAtTop` pushes the temp and queues Vue's render, which flushes
-    // before any later microtask. Assigning `pending_focus_client_id` after an
-    // `await` here would lose the race — the row mounts and claims focus before
-    // the target is set.
-    pending_focus_client_id.value = list.addCardAtTop()
+    // Stage and record the autofocus + grow-in targets in the same synchronous
+    // block: `list.addCardAtTop` pushes the temp and queues Vue's render, which
+    // flushes before any later microtask. Assigning these after an `await` here
+    // would lose the race — the row mounts and claims focus before the target is
+    // set.
+    const client_id = list.addCardAtTop()
+    pending_focus_client_id.value = client_id
+    pending_grow_client_id.value = client_id
   }
 
   /**
@@ -165,6 +172,18 @@ export function useCardListController(opts: Options) {
     return true
   }
 
+  /**
+   * One-shot grow-in claim: returns true exactly once, for the freshly-added
+   * card whose `client_id` was staged by `addCardAtTop`. The matching row calls
+   * this on mount and plays its reveal. `editCard` never sets this target, so
+   * navigating to an existing card focuses it without the grow-in.
+   */
+  function claimGrow(client_id: string): boolean {
+    if (pending_grow_client_id.value !== client_id) return false
+    pending_grow_client_id.value = null
+    return true
+  }
+
   /** Called by the mounted editor list on mount/unmount to publish its scroller. */
   function registerScroller(scroller: { scrollToCard: (client_id: string) => void } | null) {
     list_scroller.value = scroller
@@ -172,11 +191,12 @@ export function useCardListController(opts: Options) {
 
   /**
    * The grid dropdown's "Edit" intent: switch to edit mode, then scroll the
-   * chosen card into view once the editor pane has mounted. `pending_focus_client_id`
-   * is set first so the row claims focus + plays its grow-in the moment it
-   * mounts inside the virtualizer's window (same one-shot claim `addCardAtTop`
-   * uses), then `scrollToCard` pulls it into that window even when it starts
-   * outside the current virtual-scroll range.
+   * chosen card into view. The scroll waits on the mode transition settling —
+   * mode-stack owns the window scroll + pane transforms while it slides, so
+   * scrolling earlier lands at the wrong offset. `scrollToCard` pulls the row
+   * into the virtualizer's window even when it starts outside the current range,
+   * and `pending_focus_client_id` lands the editor focus on it — without the
+   * grow-in reveal, which stays reserved for freshly-added cards (`claimGrow`).
    */
   async function editCard(card_id: number) {
     const entry = list.all_cards.value.find((c) => c.id === card_id)
@@ -295,6 +315,7 @@ export function useCardListController(opts: Options) {
     newCard,
     reorderCard,
     claimFocus,
+    claimGrow,
     pending_focus_client_id,
     registerScroller,
     editCard,

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => ({
   updateCardMock: vi.fn(),
   emitSfxMock: vi.fn(),
   claimFocusMock: vi.fn(),
+  claimGrowMock: vi.fn(),
   gsapFromMock: vi.fn()
 }))
 
@@ -71,7 +72,8 @@ function makeProvide({ is_selecting = ref(false) } = {}) {
       selection: { is_selecting },
       updateCard: mocks.updateCardMock,
       card_attributes: { front: {}, back: {} },
-      claimFocus: mocks.claimFocusMock
+      claimFocus: mocks.claimFocusMock,
+      claimGrow: mocks.claimGrowMock
     }
   }
 }
@@ -114,6 +116,8 @@ beforeEach(() => {
   mocks.emitSfxMock.mockReset()
   mocks.claimFocusMock.mockReset()
   mocks.claimFocusMock.mockReturnValue(false)
+  mocks.claimGrowMock.mockReset()
+  mocks.claimGrowMock.mockReturnValue(false)
   mocks.gsapFromMock.mockReset()
   // The runner's window isn't focused, so document.hasFocus() is false and the
   // window-blur guard would swallow every focusout. Simulate a focused window.
@@ -362,18 +366,16 @@ describe('ListItemCard', () => {
     wrapper.unmount()
   })
 
-  // ── onMounted autofocus — claimFocus true branch ──────────────────────────
+  // ── onMounted grow-in — gated on claimGrow, not claimFocus ─────────────────
 
-  test('does NOT run expandListItemIn when claimFocus returns false (scroll-mounted row) [obligation]', () => {
-    mocks.claimFocusMock.mockReturnValue(false)
+  test('does NOT run expandListItemIn when claimGrow returns false (scroll-mounted row) [obligation]', () => {
+    mocks.claimGrowMock.mockReturnValue(false)
     mount({ card: { id: 99, client_id: 'c99' } })
     expect(mocks.gsapFromMock).not.toHaveBeenCalled()
   })
 
-  test('runs expandListItemIn on the root element when claimFocus returns true [obligation]', async () => {
-    mocks.claimFocusMock.mockReturnValue(true)
-    // Use mountWithFocusStubs so the front-input template ref resolves to a
-    // stub exposing focus() so focusEditor() doesn't throw.
+  test('runs expandListItemIn on the root element when claimGrow returns true (freshly-added card) [obligation]', () => {
+    mocks.claimGrowMock.mockReturnValue(true)
     const wrapper = shallowMount(ListItemCard, {
       attachTo: document.body,
       props: { card: makeCard({ id: 77, client_id: 'c77' }) },
@@ -383,6 +385,22 @@ describe('ListItemCard', () => {
       }
     })
     expect(mocks.gsapFromMock).toHaveBeenCalledWith(wrapper.element)
+    wrapper.unmount()
+  })
+
+  test('focuses without the grow-in when claimFocus is true but claimGrow is false (edit navigation) [obligation]', () => {
+    mocks.claimFocusMock.mockReturnValue(true)
+    mocks.claimGrowMock.mockReturnValue(false)
+    const wrapper = shallowMount(ListItemCard, {
+      attachTo: document.body,
+      props: { card: makeCard({ id: 55, client_id: 'c55' }) },
+      global: {
+        stubs: { FaceEditor: FaceEditorStub },
+        provide: makeProvide()
+      }
+    })
+    // Edit-navigation lands focus (claimFocus) but never animates height (no claimGrow).
+    expect(mocks.gsapFromMock).not.toHaveBeenCalled()
     wrapper.unmount()
   })
 

--- a/tests/integration/views/deck/card-editor/list.test.js
+++ b/tests/integration/views/deck/card-editor/list.test.js
@@ -56,7 +56,8 @@ function makeEditor({
   hasNextPage = ref(false),
   isLoading = ref(false),
   loadNextPage = vi.fn(),
-  reorderCard = vi.fn()
+  reorderCard = vi.fn(),
+  registerScroller = vi.fn()
 } = {}) {
   return {
     list: {
@@ -66,7 +67,8 @@ function makeEditor({
     reorderCard,
     hasNextPage,
     isLoading,
-    loadNextPage
+    loadNextPage,
+    registerScroller
   }
 }
 
@@ -74,7 +76,8 @@ function setupVirtualizer({ items, totalSize }) {
   const virtualizer = shallowRef({
     getVirtualItems: () => items,
     getTotalSize: () => totalSize,
-    measure: vi.fn()
+    measure: vi.fn(),
+    scrollToIndex: vi.fn()
   })
   useWindowVirtualizerMock.mockReturnValue(virtualizer)
   return virtualizer
@@ -322,6 +325,54 @@ describe('CardList (list.vue)', () => {
 
     expect(liftMock).toHaveBeenCalledWith(rowEl)
     document.body.removeChild(rowEl)
+  })
+
+  // ── scrollToCard — registered on mount, calls scrollToIndex by client_id ──
+
+  describe('scrollToCard', () => {
+    test('registers a scroller with the controller on mount', () => {
+      const cards = [{ id: 1 }, { id: 2 }]
+      setupVirtualizer({ items: makeVirtualItems([0, 1]), totalSize: 2 * ROW_PITCH })
+      const registerScroller = vi.fn()
+
+      mount({ editor: makeEditor({ cards, registerScroller }) })
+
+      expect(registerScroller).toHaveBeenCalledWith({ scrollToCard: expect.any(Function) })
+    })
+
+    test('unregisters the scroller on unmount', () => {
+      const cards = [{ id: 1 }]
+      setupVirtualizer({ items: makeVirtualItems([0]), totalSize: ROW_PITCH })
+      const registerScroller = vi.fn()
+
+      const wrapper = mount({ editor: makeEditor({ cards, registerScroller }) })
+      wrapper.unmount()
+
+      expect(registerScroller).toHaveBeenLastCalledWith(null)
+    })
+
+    test('maps client_id to its row index and calls virtualizer.scrollToIndex centered', () => {
+      const cards = [{ id: 1 }, { id: 2 }, { id: 3 }]
+      const virtualizer = setupVirtualizer({
+        items: makeVirtualItems([0]),
+        totalSize: 3 * ROW_PITCH
+      })
+
+      const wrapper = mount({ editor: makeEditor({ cards }) })
+      wrapper.vm.scrollToCard('cid-3')
+
+      expect(virtualizer.value.scrollToIndex).toHaveBeenCalledWith(2, { align: 'center' })
+    })
+
+    test('is a no-op when the client_id is not found', () => {
+      const cards = [{ id: 1 }]
+      const virtualizer = setupVirtualizer({ items: makeVirtualItems([0]), totalSize: ROW_PITCH })
+
+      const wrapper = mount({ editor: makeEditor({ cards }) })
+      wrapper.vm.scrollToCard('missing')
+
+      expect(virtualizer.value.scrollToIndex).not.toHaveBeenCalled()
+    })
   })
 
   // ── body-resize debounce → single coalesced measureScrollMargin() ────────

--- a/tests/integration/views/deck/card-grid/grid-item.test.js
+++ b/tests/integration/views/deck/card-grid/grid-item.test.js
@@ -81,6 +81,14 @@ const UiDropdownButtonStub = defineComponent({
               'select',
               (props.options ?? []).find((o) => o.value === 'delete') ?? { value: 'delete' }
             )
+        }),
+        h('button', {
+          'data-testid': 'grid-item-menu-stub__edit',
+          onClick: () =>
+            emit(
+              'select',
+              (props.options ?? []).find((o) => o.value === 'edit') ?? { value: 'edit' }
+            )
         })
       ])
   }
@@ -97,6 +105,7 @@ function makeEditor({ is_selecting = false } = {}) {
       onMoveCards: vi.fn(),
       onDeleteCards: vi.fn()
     },
+    editCard: vi.fn(),
     selection: {
       is_selecting: ref(is_selecting)
     }
@@ -266,6 +275,13 @@ describe('GridItem (card-grid/grid-item.vue)', () => {
     expect(editor.actions.onDeleteCards).toHaveBeenCalledWith(1)
   })
 
+  test('onMenuSelect: edit option routes to editCard with the card id [obligation]', async () => {
+    const editor = makeEditor({ is_selecting: false })
+    const { wrapper } = mountGridItem({ editor })
+    await wrapper.find('[data-testid="grid-item-menu-stub__edit"]').trigger('click')
+    expect(editor.editCard).toHaveBeenCalledWith(1)
+  })
+
   test('onMenuSelect: unknown value is a no-op [obligation]', async () => {
     const editor = makeEditor({ is_selecting: false })
     const { wrapper } = mountGridItem({ editor })
@@ -274,6 +290,7 @@ describe('GridItem (card-grid/grid-item.vue)', () => {
     expect(editor.actions.onSelectCard).not.toHaveBeenCalled()
     expect(editor.actions.onMoveCards).not.toHaveBeenCalled()
     expect(editor.actions.onDeleteCards).not.toHaveBeenCalled()
+    expect(editor.editCard).not.toHaveBeenCalled()
   })
 
   // ── selection guard (non-collapsed selection) [obligation] ─────────────────

--- a/tests/unit/composables/card-editor/card-list-controller.test.js
+++ b/tests/unit/composables/card-editor/card-list-controller.test.js
@@ -389,6 +389,25 @@ describe('useCardListController', () => {
     })
   })
 
+  // ── claimGrow — the reveal target, staged only by addCardAtTop ──────────────
+
+  describe('claimGrow', () => {
+    test('returns true once for a card staged by addCardAtTop (freshly added) [obligation]', async () => {
+      const { addCardAtTop, claimGrow, all_cards } = makeController([makeCard({ id: 100 })])
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      const staged_client_id = all_cards.value[0].client_id
+      expect(claimGrow(staged_client_id)).toBe(true)
+      // One-shot: a second claim returns false
+      expect(claimGrow(staged_client_id)).toBe(false)
+    })
+
+    test('returns false before any addCardAtTop call [obligation]', () => {
+      const { claimGrow } = makeController()
+      expect(claimGrow('some-id')).toBe(false)
+    })
+  })
+
   // ── appendCard / prependCard ───────────────────────────────────────────────
 
   describe('appendCard / prependCard', () => {
@@ -796,6 +815,18 @@ describe('useCardListController', () => {
       expect(setMode).toHaveBeenCalledWith('edit')
       expect(ctrl.claimFocus(client_id)).toBe(true)
       expect(scroller.scrollToCard).toHaveBeenCalledWith(client_id)
+    })
+
+    test('focuses the edited card but stages no grow-in reveal (unlike addCardAtTop) [obligation]', async () => {
+      const setMode = vi.fn().mockResolvedValue(undefined)
+      const ctrl = makeController([makeCard({ id: 1 })], [1], undefined, makeShell({ setMode }))
+      ctrl.registerScroller({ scrollToCard: vi.fn() })
+
+      const client_id = ctrl.list.all_cards.value[0].client_id
+      await ctrl.editCard(1)
+
+      expect(ctrl.claimGrow(client_id)).toBe(false)
+      expect(ctrl.claimFocus(client_id)).toBe(true)
     })
 
     test('is a no-op scroll-wise when no scroller is registered [obligation]', async () => {

--- a/tests/unit/composables/card-editor/card-list-controller.test.js
+++ b/tests/unit/composables/card-editor/card-list-controller.test.js
@@ -774,6 +774,37 @@ describe('useCardListController', () => {
     })
   })
 
+  // ── editCard — grid dropdown's "Edit" intent ─────────────────────────────────
+
+  describe('editCard', () => {
+    test('is a no-op when card_id matches nothing [obligation]', async () => {
+      const setMode = vi.fn().mockResolvedValue(undefined)
+      const ctrl = makeController([makeCard({ id: 1 })], [1], undefined, makeShell({ setMode }))
+      await ctrl.editCard(999)
+      expect(setMode).not.toHaveBeenCalled()
+    })
+
+    test('sets pending_focus_client_id, switches to edit mode, then scrolls [obligation]', async () => {
+      const setMode = vi.fn().mockResolvedValue(undefined)
+      const ctrl = makeController([makeCard({ id: 1 })], [1], undefined, makeShell({ setMode }))
+      const scroller = { scrollToCard: vi.fn() }
+      ctrl.registerScroller(scroller)
+
+      const client_id = ctrl.list.all_cards.value[0].client_id
+      await ctrl.editCard(1)
+
+      expect(setMode).toHaveBeenCalledWith('edit')
+      expect(ctrl.claimFocus(client_id)).toBe(true)
+      expect(scroller.scrollToCard).toHaveBeenCalledWith(client_id)
+    })
+
+    test('is a no-op scroll-wise when no scroller is registered [obligation]', async () => {
+      const setMode = vi.fn().mockResolvedValue(undefined)
+      const ctrl = makeController([makeCard({ id: 1 })], [1], undefined, makeShell({ setMode }))
+      await expect(ctrl.editCard(1)).resolves.toBeUndefined()
+    })
+  })
+
   // ── reorderCard — moves a persisted card to a new slot ───────────────────────
 
   describe('reorderCard', () => {

--- a/tests/unit/views/deck/composables/item-options-menu.test.js
+++ b/tests/unit/views/deck/composables/item-options-menu.test.js
@@ -30,18 +30,19 @@ function makeEditor() {
       onSelectCard: vi.fn(),
       onMoveCards: vi.fn(),
       onDeleteCards: vi.fn()
-    }
+    },
+    editCard: vi.fn()
   }
 }
 
 describe('useCardItemOptionsMenu — options', () => {
-  test('exposes exactly select, move, and delete, in that order', () => {
+  test('exposes exactly select, move, edit, and delete, in that order', () => {
     const editor = makeEditor()
     const [{ options }, app] = withSetup(() => useCardItemOptionsMenu(), {
       provide: { [cardEditorKey]: editor }
     })
 
-    expect(options.value.map((o) => o.value)).toEqual(['select', 'move', 'delete'])
+    expect(options.value.map((o) => o.value)).toEqual(['select', 'move', 'edit', 'delete'])
     app.unmount()
   })
 })
@@ -89,6 +90,21 @@ describe('useCardItemOptionsMenu — onSelect dispatch', () => {
     app.unmount()
   })
 
+  test('edit option calls editCard with the card id', () => {
+    const editor = makeEditor()
+    const [{ onSelect }, app] = withSetup(() => useCardItemOptionsMenu(), {
+      provide: { [cardEditorKey]: editor }
+    })
+
+    onSelect({ label: 'Edit', value: 'edit' }, 5)
+
+    expect(editor.editCard).toHaveBeenCalledWith(5)
+    expect(editor.actions.onSelectCard).not.toHaveBeenCalled()
+    expect(editor.actions.onMoveCards).not.toHaveBeenCalled()
+    expect(editor.actions.onDeleteCards).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
   test('an unknown option value is a no-op', () => {
     const editor = makeEditor()
     const [{ onSelect }, app] = withSetup(() => useCardItemOptionsMenu(), {
@@ -100,6 +116,7 @@ describe('useCardItemOptionsMenu — onSelect dispatch', () => {
     expect(editor.actions.onSelectCard).not.toHaveBeenCalled()
     expect(editor.actions.onMoveCards).not.toHaveBeenCalled()
     expect(editor.actions.onDeleteCards).not.toHaveBeenCalled()
+    expect(editor.editCard).not.toHaveBeenCalled()
     app.unmount()
   })
 })


### PR DESCRIPTION
[TARO-20](https://app.notion.com/3630953c224c804aa1f1fdbe66d4427a)

## Summary

Wires the existing (unused) `deck-view.item-options.edit` i18n key into the per-card options menu on the deck's card grid. Selecting Edit switches to editor mode and scrolls the card into view, even if it's outside the current virtual-scroll window.

## Changes

- Added Edit action to the card grid item options menu
- New `scrollToCard` on the list virtualizer, registered with the controller so it's reachable without a template-ref chain through the mode-stack's dynamic panes
- Edited card claims focus and grows in on mount via `pending_focus_client_id`

## Test plan

- [ ] Open a deck, use the grid item dropdown to Edit a card visible on screen — editor opens, focused
- [ ] Edit a card scrolled out of the virtual-scroll window — list scrolls it into view before opening