### PR TITLE
TARO-40: Dismiss alert/prompt on backdrop click as cancel

### DIFF
--- a/src/components/ui-kit/alert.vue
+++ b/src/components/ui-kit/alert.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { TYPE_SFX, type SoundKey } from '@/sfx/config'
 import { emitSfx } from '@/sfx/bus'
-import { type ModalCloseFn } from '@/composables/modal'
+import { type ModalCloseFn, useModalRequestClose } from '@/composables/modal'
 import { nextDepth, provideDepth, useAmbientDepth } from '@/composables/ui/depth'
 
 export type AlertType = 'warn' | 'info'
@@ -31,6 +31,8 @@ const confirm_btn = useTemplateRef('confirm_btn')
 const cancelText = computed(() => cancelLabel ?? t('ui-kit.alert.cancel'))
 const confirmText = computed(() => confirmLabel ?? t('ui-kit.alert.continue'))
 
+useModalRequestClose(onCancel)
+
 onMounted(() => cancel_btn.value?.focus())
 
 function onCancel() {
@@ -53,53 +55,47 @@ function onKeydown(e: KeyboardEvent) {
 
 <template>
   <div
-    data-testid="ui-kit-alert-container"
-    class="absolute inset-0 flex items-center justify-center"
+    data-testid="ui-kit-alert"
+    :data-depth="depth"
+    class="rounded-2 shadow-lg flex w-115 max-w-115 flex-col bg-float"
+    :class="`ui-kit-alert--${type ?? 'warn'}`"
   >
+    <div data-testid="ui-kit-alert__body" class="flex flex-col gap-2 p-10">
+      <h1 class="text-ink text-3xl">{{ title ?? t('ui-kit.alert.title-default') }}</h1>
+      <p class="text-ink-muted">{{ message ?? t('ui-kit.alert.message-default') }}</p>
+    </div>
+
     <div
-      data-testid="ui-kit-alert"
-      :data-depth="depth"
-      class="rounded-2 shadow-lg flex w-115 max-w-115 flex-col bg-float"
-      :class="`ui-kit-alert--${type ?? 'warn'}`"
-      v-bind="$attrs"
+      data-testid="ui-kit-alert__actions"
+      class="border-below divide-below flex w-full divide-x border-t"
+      @keydown="onKeydown"
     >
-      <div data-testid="ui-kit-alert__body" class="flex flex-col gap-2 p-10">
-        <h1 class="text-ink text-3xl">{{ title ?? t('ui-kit.alert.title-default') }}</h1>
-        <p class="text-ink-muted">{{ message ?? t('ui-kit.alert.message-default') }}</p>
-      </div>
-
-      <div
-        data-testid="ui-kit-alert__actions"
-        class="border-below divide-below flex w-full divide-x border-t"
-        @keydown="onKeydown"
+      <button
+        ref="cancel_btn"
+        data-testid="ui-kit-alert__cancel"
+        class="ui-kit-alert__cancel group"
+        @click="onCancel"
+        v-sfx="{ hover: TYPE_SFX }"
       >
-        <button
-          ref="cancel_btn"
-          data-testid="ui-kit-alert__cancel"
-          class="ui-kit-alert__cancel group"
-          @click="onCancel"
-          v-sfx="{ hover: TYPE_SFX }"
-        >
-          {{ cancelText }}
-          <div class="ui-kit-alert__hover-effect group-hover:opacity-100! group-focus:opacity-100!">
-            <span>{{ cancelText }}</span>
-          </div>
-        </button>
+        {{ cancelText }}
+        <div class="ui-kit-alert__hover-effect group-hover:opacity-100! group-focus:opacity-100!">
+          <span>{{ cancelText }}</span>
+        </div>
+      </button>
 
-        <button
-          v-if="confirmLabel"
-          ref="confirm_btn"
-          data-testid="ui-kit-alert__confirm"
-          class="ui-kit-alert__confirm group"
-          @click="onConfirm"
-          v-sfx="{ hover: TYPE_SFX }"
-        >
-          {{ confirmText }}
-          <div class="ui-kit-alert__hover-effect group-hover:opacity-100! group-focus:opacity-100!">
-            <span>{{ confirmText }}</span>
-          </div>
-        </button>
-      </div>
+      <button
+        v-if="confirmLabel"
+        ref="confirm_btn"
+        data-testid="ui-kit-alert__confirm"
+        class="ui-kit-alert__confirm group"
+        @click="onConfirm"
+        v-sfx="{ hover: TYPE_SFX }"
+      >
+        {{ confirmText }}
+        <div class="ui-kit-alert__hover-effect group-hover:opacity-100! group-focus:opacity-100!">
+          <span>{{ confirmText }}</span>
+        </div>
+      </button>
     </div>
   </div>
 </template>

--- a/src/components/ui-kit/prompt.vue
+++ b/src/components/ui-kit/prompt.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiInput from '@/components/ui-kit/input.vue'
-import { type ModalCloseFn } from '@/composables/modal'
+import { type ModalCloseFn, useModalRequestClose } from '@/composables/modal'
 import { nextDepth, provideDepth, useAmbientDepth } from '@/composables/ui/depth'
 import { emitSfx } from '@/sfx/bus'
 import { type SoundKey } from '@/sfx/config'
@@ -48,6 +48,8 @@ const error = computed(() => {
   return t('ui-kit.prompt.required-error')
 })
 
+useModalRequestClose(onCancel)
+
 onMounted(() => root.value?.querySelector('input')?.focus())
 
 function onConfirm() {
@@ -66,48 +68,42 @@ function onCancel() {
 
 <template>
   <div
-    data-testid="ui-kit-prompt-container"
-    class="absolute inset-0 flex items-center justify-center"
+    ref="root"
+    data-testid="ui-kit-prompt"
+    :data-depth="depth"
+    class="rounded-2 shadow-lg flex w-115 max-w-115 flex-col gap-6 bg-surface p-10"
   >
-    <div
-      ref="root"
-      data-testid="ui-kit-prompt"
-      :data-depth="depth"
-      class="rounded-2 shadow-lg flex w-115 max-w-115 flex-col gap-6 bg-surface p-10"
-      v-bind="$attrs"
-    >
-      <div data-testid="ui-kit-prompt__body" class="flex flex-col gap-2">
-        <h1 class="text-3xl text-ink">{{ title }}</h1>
-        <p v-if="message" class="text-base text-ink-muted">{{ message }}</p>
-      </div>
+    <div data-testid="ui-kit-prompt__body" class="flex flex-col gap-2">
+      <h1 class="text-3xl text-ink">{{ title }}</h1>
+      <p v-if="message" class="text-base text-ink-muted">{{ message }}</p>
+    </div>
 
-      <ui-input
-        v-model:value="value"
-        data-testid="ui-kit-prompt__input"
-        size="base"
-        :label="label"
-        :placeholder="placeholder"
-        :max-length="maxLength"
-        :error="error"
-        @keydown.enter="onConfirm"
-        @input="dirty = true"
-      />
+    <ui-input
+      v-model:value="value"
+      data-testid="ui-kit-prompt__input"
+      size="base"
+      :label="label"
+      :placeholder="placeholder"
+      :max-length="maxLength"
+      :error="error"
+      @keydown.enter="onConfirm"
+      @input="dirty = true"
+    />
 
-      <div data-testid="ui-kit-prompt__actions" class="flex justify-end gap-2">
-        <ui-button neutral data-testid="ui-kit-prompt__cancel" variant="ghost" @press="onCancel">
-          {{ cancelLabel ?? t('ui-kit.prompt.cancel') }}
-        </ui-button>
+    <div data-testid="ui-kit-prompt__actions" class="flex justify-end gap-2">
+      <ui-button neutral data-testid="ui-kit-prompt__cancel" variant="ghost" @press="onCancel">
+        {{ cancelLabel ?? t('ui-kit.prompt.cancel') }}
+      </ui-button>
 
-        <ui-button
-          data-testid="ui-kit-prompt__confirm"
-          data-palette="success"
-          :disabled="!trimmed"
-          click-when-disabled
-          @press="onConfirm"
-        >
-          {{ confirmLabel }}
-        </ui-button>
-      </div>
+      <ui-button
+        data-testid="ui-kit-prompt__confirm"
+        data-palette="success"
+        :disabled="!trimmed"
+        click-when-disabled
+        @press="onConfirm"
+      >
+        {{ confirmLabel }}
+      </ui-button>
     </div>
   </div>
 </template>

--- a/tests/integration/components/ui-kit/alert.test.js
+++ b/tests/integration/components/ui-kit/alert.test.js
@@ -1,0 +1,90 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import UiAlert from '@/components/ui-kit/alert.vue'
+import { MODAL_ID_KEY, request_close_handlers } from '@/composables/modal'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+
+// ── Mount helper ──────────────────────────────────────────────────────────────
+
+// The alert renders only the box — the modal host owns the backdrop and routes
+// backdrop-click / esc through the handler the alert registers via
+// useModalRequestClose. Provide a MODAL_ID_KEY so that registration happens.
+function makeWrapper(props = {}, { modalId = 'test-alert' } = {}) {
+  const close = vi.fn()
+  const wrapper = mount(UiAlert, {
+    props: {
+      close,
+      ...props
+    },
+    attachTo: document.body,
+    global: {
+      directives: { sfx: {} },
+      provide: { [MODAL_ID_KEY]: modalId }
+    }
+  })
+  return { wrapper, close, modalId }
+}
+
+function cancelButton(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-alert__cancel"]')
+}
+
+function confirmButton(wrapper) {
+  return wrapper.find('[data-testid="ui-kit-alert__confirm"]')
+}
+
+beforeEach(() => {
+  mockEmitSfx.mockClear()
+  request_close_handlers.clear()
+  document.body.innerHTML = ''
+})
+
+// ── cancel ────────────────────────────────────────────────────────────────────
+
+describe('UiAlert — cancel [obligation]', () => {
+  test('cancel resolves false [obligation]', async () => {
+    const { wrapper, close } = makeWrapper()
+
+    await cancelButton(wrapper).trigger('click')
+
+    expect(close).toHaveBeenCalledWith(false)
+  })
+})
+
+// ── confirm ───────────────────────────────────────────────────────────────────
+
+describe('UiAlert — confirm [obligation]', () => {
+  test('confirm resolves true [obligation]', async () => {
+    const { wrapper, close } = makeWrapper({ confirmLabel: 'Delete it' })
+
+    await confirmButton(wrapper).trigger('click')
+
+    expect(close).toHaveBeenCalledWith(true)
+  })
+})
+
+// ── dismissal via modal machinery ─────────────────────────────────────────────
+
+describe('UiAlert — request-close dismissal [obligation]', () => {
+  test('registers a request-close handler (backdrop click / esc) that resolves false, like cancel — never confirm [obligation]', () => {
+    const { close, modalId } = makeWrapper({ confirmLabel: 'Delete it' })
+
+    // The modal host invokes this handler on backdrop click or esc.
+    request_close_handlers.get(modalId)()
+
+    expect(close).toHaveBeenCalledWith(false)
+  })
+
+  test('clicking inside the alert box does not close it [obligation]', async () => {
+    const { wrapper, close } = makeWrapper({ confirmLabel: 'Delete it' })
+
+    await wrapper.find('[data-testid="ui-kit-alert"]').trigger('click')
+
+    expect(close).not.toHaveBeenCalled()
+  })
+})

--- a/tests/integration/components/ui-kit/prompt.test.js
+++ b/tests/integration/components/ui-kit/prompt.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
 import UiPrompt from '@/components/ui-kit/prompt.vue'
+import { MODAL_ID_KEY, request_close_handlers } from '@/composables/modal'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
@@ -24,7 +25,10 @@ vi.mock('@/composables/ui/media-query', () => ({
 
 // ── Mount helper ──────────────────────────────────────────────────────────────
 
-function makeWrapper(props = {}) {
+// The prompt renders only the box — the modal host owns the backdrop and routes
+// backdrop-click / esc through the handler the prompt registers via
+// useModalRequestClose. Provide a MODAL_ID_KEY so that registration happens.
+function makeWrapper(props = {}, { modalId = 'test-prompt' } = {}) {
   const close = vi.fn()
   const wrapper = mount(UiPrompt, {
     props: {
@@ -35,10 +39,11 @@ function makeWrapper(props = {}) {
     },
     attachTo: document.body,
     global: {
-      directives: { sfx: {} }
+      directives: { sfx: {} },
+      provide: { [MODAL_ID_KEY]: modalId }
     }
   })
-  return { wrapper, close }
+  return { wrapper, close, modalId }
 }
 
 function input(wrapper) {
@@ -61,6 +66,7 @@ function errorTooltipText() {
 
 beforeEach(() => {
   mockEmitSfx.mockClear()
+  request_close_handlers.clear()
   document.body.innerHTML = ''
 })
 
@@ -187,6 +193,27 @@ describe('UiPrompt — cancel', () => {
     await cancelButton(wrapper).trigger('click')
 
     expect(close).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── dismissal via modal machinery ─────────────────────────────────────────────
+
+describe('UiPrompt — request-close dismissal [obligation]', () => {
+  test('registers a request-close handler (backdrop click / esc) that resolves undefined, like cancel [obligation]', () => {
+    const { close, modalId } = makeWrapper()
+
+    // The modal host invokes this handler on backdrop click or esc.
+    request_close_handlers.get(modalId)()
+
+    expect(close).toHaveBeenCalledWith(undefined)
+  })
+
+  test('clicking inside the prompt box does not close it [obligation]', async () => {
+    const { wrapper, close } = makeWrapper()
+
+    await wrapper.find('[data-testid="ui-kit-prompt"]').trigger('click')
+
+    expect(close).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
[TARO-40](https://app.notion.com/3640953c224c80af8df5f5e29af527a2)

## Summary

Clicking outside the alert or prompt box now dismisses it as a cancel (`false` for alert, `undefined` for prompt), matching standard modal behavior.

The root cause was redundant structure: `alert.vue` and `prompt.vue` each rendered their own full-viewport container that duplicated the modal host's centering and — because the host marks the component `pointer-events-auto` — swallowed every click before it could reach the host backdrop, so backdrop clicks did nothing. Rather than patch over it with a component-level `@click.self`, this drops the redundant container so the box itself is the root and lets the modal machinery own dismissal: the host's backdrop click / wrapper `@click.self` invoke the handler each component already registers via `useModalRequestClose(onCancel)`. Esc runs through the same path. Host attrs (`pointer-events-auto`, `data-modal-mode`) inherit onto the box via default `inheritAttrs`.