### PR TITLE
TARO-41: Play close sound on every alert and prompt dismissal

### DIFF
--- a/src/composables/alert.ts
+++ b/src/composables/alert.ts
@@ -10,6 +10,7 @@ type AlertArgs = {
   cancelLabel?: string
   backdrop?: boolean
   openAudio?: SoundKey
+  closeAudio?: SoundKey
   cancelAudio?: SoundKey
   confirmAudio?: SoundKey
 }
@@ -29,17 +30,20 @@ export function useAlert() {
     const {
       backdrop,
       openAudio = 'etc_woodblock_stuck',
+      closeAudio = 'pop_up_close',
       cancelAudio = 'digi_powerdown',
       ...props
     } = args ?? {}
 
     emitSfx(openAudio)
 
-    return modal.open(alert, {
+    const result = modal.open(alert, {
       mode: 'popup',
       backdrop: backdrop ?? true,
       props: { type, cancelAudio, ...props }
     })
+    result.response.then(() => emitSfx(closeAudio))
+    return result
   }
 
   return { warn, info }

--- a/src/composables/prompt.ts
+++ b/src/composables/prompt.ts
@@ -14,6 +14,7 @@ type PromptArgs = {
   maxLength?: number
   backdrop?: boolean
   openAudio?: SoundKey
+  closeAudio?: SoundKey
   cancelAudio?: SoundKey
   confirmAudio?: SoundKey
 }
@@ -40,17 +41,20 @@ export function usePrompt() {
     const {
       backdrop,
       openAudio = 'etc_woodblock_stuck',
+      closeAudio = 'pop_up_close',
       cancelAudio = 'digi_powerdown',
       ...props
     } = args
 
     emitSfx(openAudio)
 
-    return modal.open<string>(prompt, {
+    const result = modal.open<string>(prompt, {
       mode: 'popup',
       backdrop: backdrop ?? true,
       props: { cancelAudio, ...props }
     })
+    result.response.then(() => emitSfx(closeAudio))
+    return result
   }
 
   return { ask }

--- a/tests/unit/composables/prompt.test.js
+++ b/tests/unit/composables/prompt.test.js
@@ -124,4 +124,18 @@ describe('usePrompt — ask()', () => {
       ask({ title: 'Name it', confirmLabel: 'Create' }).response
     ).resolves.toBeUndefined()
   })
+
+  test('emits the default close audio when the modal settles [obligation]', async () => {
+    const { ask } = usePrompt()
+    ask({ title: 'Name it', confirmLabel: 'Create' })
+    await Promise.resolve()
+    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+  })
+
+  test('emits the provided closeAudio when the modal settles', async () => {
+    const { ask } = usePrompt()
+    ask({ title: 'Name it', confirmLabel: 'Create', closeAudio: 'slide_up' })
+    await Promise.resolve()
+    expect(mockEmitSfx).toHaveBeenCalledWith('slide_up')
+  })
 })

--- a/tests/unit/composables/use-alert.test.js
+++ b/tests/unit/composables/use-alert.test.js
@@ -109,6 +109,20 @@ describe('useAlert', () => {
         })
       )
     })
+
+    test('emits the default close audio when the modal settles [obligation]', async () => {
+      const { warn } = useAlert()
+      warn({ title: 'Are you sure?' })
+      await Promise.resolve()
+      expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    })
+
+    test('emits the provided closeAudio when the modal settles', async () => {
+      const { warn } = useAlert()
+      warn({ title: 'x', closeAudio: 'slide_up' })
+      await Promise.resolve()
+      expect(mockEmitSfx).toHaveBeenCalledWith('slide_up')
+    })
   })
 
   describe('info()', () => {


### PR DESCRIPTION
[TARO-41](https://app.notion.com/3640953c224c80d38b84e0ebcbcbb916)

## Summary

Alerts and prompts played an open sound but nothing on close, so backdrop and Esc dismissals were silent. This adds a close sound emitted on every dismissal, mirroring the settings-modal and login-modal pattern.

## Changes

- Add a `closeAudio` option (default `pop_up_close`) to `useAlert` and `usePrompt`, emitted on the settle seam via `result.response.then`.
- Preserve existing per-button confirm/cancel sounds.

## Test plan

- [ ] Dismiss an alert via backdrop click and Esc — close sound plays.
- [ ] Dismiss a prompt via backdrop click and Esc — close sound plays.
- [ ] Confirm/cancel buttons still play their own sounds.