### PR TITLE
TARO-222: Default card grid to Dense size on mobile

### DIFF
--- a/src/views/deck/composables/view-shell.ts
+++ b/src/views/deck/composables/view-shell.ts
@@ -1,5 +1,6 @@
 import { computed, ref, type InjectionKey } from 'vue'
 import { useLocalRef } from '@/composables/storage/local-ref'
+import { useMatchMedia } from '@/composables/ui/media-query'
 import { emitSfx } from '@/sfx/bus'
 
 export type DeckViewShell = ReturnType<typeof useDeckViewShell>
@@ -27,7 +28,12 @@ export const deckViewShellKey = Symbol('deckViewShell') as InjectionKey<DeckView
  */
 export function useDeckViewShell() {
   const mode = ref<CardEditorMode>('view')
-  const grid_size = useLocalRef<CardGridSize>('deck-grid-size', 'md')
+
+  // First-time default: mobile packs the densest grid (`base`); larger viewports
+  // keep the roomier `md`. Read once at init — `useLocalRef` ignores this default
+  // whenever a stored choice exists, so an explicit prior pick is preserved.
+  const is_mobile = useMatchMedia('w<md').value
+  const grid_size = useLocalRef<CardGridSize>('deck-grid-size', is_mobile ? 'base' : 'md')
   const grid_face = useLocalRef<Exclude<CardSide, 'cover'>>('deck-grid-face', 'front')
   const sort_by = ref<CardSortKey>('default')
 

--- a/tests/unit/composables/card-editor/deck-view-shell.test.js
+++ b/tests/unit/composables/card-editor/deck-view-shell.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
 import { nextTick } from 'vue'
 
 const { emitSfxMock } = vi.hoisted(() => ({ emitSfxMock: vi.fn() }))
@@ -29,6 +29,56 @@ describe('useDeckViewShell', () => {
   test('grid_size defaults to md', () => {
     const shell = useDeckViewShell()
     expect(shell.grid_size.value).toBe('md')
+  })
+
+  // ── grid_size mobile-first default (TARO-222) ──────────────────────────────
+  // The first-time default depends on viewport width via useMatchMedia('w<md').
+  // media-query.ts caches compiled queries at module scope, so each case resets
+  // modules and swaps in a width-specific matchMedia mock before importing.
+
+  describe('grid_size mobile-first default', () => {
+    let realMatchMedia
+
+    beforeEach(() => {
+      realMatchMedia = window.matchMedia
+      vi.resetModules()
+    })
+
+    afterEach(() => {
+      window.matchMedia = realMatchMedia
+    })
+
+    function mockViewport(isMobile) {
+      window.matchMedia = vi.fn(() => ({
+        matches: isMobile,
+        addEventListener: () => {},
+        removeEventListener: () => {}
+      }))
+    }
+
+    async function freshShell() {
+      const { useDeckViewShell: fresh } = await import('@/views/deck/composables/view-shell')
+      return fresh()
+    }
+
+    test('defaults to base (Dense) on mobile with no stored choice', async () => {
+      mockViewport(true)
+      const shell = await freshShell()
+      expect(shell.grid_size.value).toBe('base')
+    })
+
+    test('defaults to md on non-mobile with no stored choice', async () => {
+      mockViewport(false)
+      const shell = await freshShell()
+      expect(shell.grid_size.value).toBe('md')
+    })
+
+    test('a stored choice is not overridden on mobile', async () => {
+      localStorage.setItem('deck-grid-size', JSON.stringify('xl'))
+      mockViewport(true)
+      const shell = await freshShell()
+      expect(shell.grid_size.value).toBe('xl')
+    })
   })
 
   // ── setMode ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
[TARO-222](https://app.notion.com/3a40953c224c8004b84ed1a8f3303536)

## Summary

On mobile (viewport < md) the deck card grid now defaults to the Dense (base) size so more cards fit per row. Larger viewports keep the previous md default. An existing size choice stored in localStorage is preserved.

## Changes

- Default the first-time deck grid size to base (Dense) on mobile, md on larger viewports (`view-shell.ts`)
- Preserve any stored grid-size choice — `useLocalRef` ignores the default when a value already exists

## Test plan

- [ ] On a mobile viewport with no stored preference, deck grid renders at Dense size
- [ ] On a desktop viewport with no stored preference, deck grid renders at md size
- [ ] A previously stored grid-size choice is respected on both viewports