### PR TITLE
TARO-197: Lock down members SELECT RLS to own-row

### DIFF
--- a/supabase/migrations/20260723152007_lockdown_members_select_rls.sql
+++ b/supabase/migrations/20260723152007_lockdown_members_select_rls.sql
@@ -1,11 +1,52 @@
--- Hand-organized declarative schema (by domain). Edit freely — this file is the
--- canonical definition. Run `supabase db diff -f <name>` after editing to
--- produce the migration.
-SET check_function_bodies = false;
+drop policy "Enable read access for all users" on "public"."members";
 
-CREATE FUNCTION public.get_member_decks(p_today_start timestamp with time zone) RETURNS SETOF public.member_deck
-    LANGUAGE sql STABLE
-    AS $$
+set check_function_bodies = off;
+
+create type "public"."member_profile" as ("display_name" text, "description" text, "cover_config" jsonb);
+
+CREATE OR REPLACE FUNCTION public.member_public_profile(p_member_id uuid)
+ RETURNS SETOF public.member_profile
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT m.display_name, m.description, m.cover_config
+  FROM public.members m
+  WHERE m.id = p_member_id;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.feedback_items_with_votes()
+ RETURNS TABLE(id bigint, created_at timestamp with time zone, member_id uuid, member_display_name text, member_avatar text, title text, body text, type public.feedback_type, status public.feedback_status, visibility public.feedback_visibility, vote_count integer, voted_by_me boolean)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT
+    f.id,
+    f.created_at,
+    f.member_id,
+    m.display_name AS member_display_name,
+    m.cover_config->>'avatar' AS member_avatar,
+    f.title,
+    f.body,
+    f.type,
+    f.status,
+    f.visibility,
+    (SELECT count(*)::int FROM public.feedback_votes v WHERE v.feedback_id = f.id) AS vote_count,
+    EXISTS (
+      SELECT 1 FROM public.feedback_votes v
+      WHERE v.feedback_id = f.id AND v.member_id = auth.uid()
+    ) AS voted_by_me
+  FROM public.feedback_items f
+  LEFT JOIN LATERAL public.member_public_profile(f.member_id) m ON true
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_member_decks(p_today_start timestamp with time zone)
+ RETURNS SETOF public.member_deck
+ LANGUAGE sql
+ STABLE
+AS $function$
   SELECT
     d.id,
     d.created_at,
@@ -131,12 +172,16 @@ CREATE FUNCTION public.get_member_decks(p_today_start timestamp with time zone) 
         )
       ) AS remaining_new
   ) AS stats;
-$$;
+$function$
+;
 
 
-ALTER FUNCTION public.get_member_decks(p_today_start timestamp with time zone) OWNER TO postgres;
+  create policy "members can read their own row"
+  on "public"."members"
+  as permissive
+  for select
+  to authenticated
+using ((auth.uid() = id));
 
 
-GRANT ALL ON FUNCTION public.get_member_decks(p_today_start timestamp with time zone) TO anon;
-GRANT ALL ON FUNCTION public.get_member_decks(p_today_start timestamp with time zone) TO authenticated;
-GRANT ALL ON FUNCTION public.get_member_decks(p_today_start timestamp with time zone) TO service_role;
+

--- a/supabase/schemas/20_members.sql
+++ b/supabase/schemas/20_members.sql
@@ -91,13 +91,49 @@ GRANT EXECUTE ON FUNCTION public.is_display_name_available(text) TO anon;
 GRANT EXECUTE ON FUNCTION public.is_display_name_available(text) TO authenticated;
 
 
+-- Narrow, safe read across the members RLS boundary. SELECT on `members` is
+-- restricted to your own row (below), which would blank out other members'
+-- profiles anywhere the app legitimately shows them (feedback author,
+-- public-deck author). This SECURITY DEFINER helper runs as the owner so it can
+-- read any member row, but it only ever projects the public-profile fields —
+-- display_name, description, cover_config (banner/theme/avatar) — never email /
+-- stripe ids / preferences / role / plan. Invoker functions call it via LATERAL
+-- to surface author identity without exposing full rows to arbitrary direct
+-- queries.
+CREATE TYPE public.member_profile AS (
+    display_name text,
+    description text,
+    cover_config jsonb
+);
+
+
+ALTER TYPE public.member_profile OWNER TO postgres;
+
+
+CREATE FUNCTION public.member_public_profile(p_member_id uuid) RETURNS SETOF public.member_profile
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+  SELECT m.display_name, m.description, m.cover_config
+  FROM public.members m
+  WHERE m.id = p_member_id;
+$$;
+
+
+ALTER FUNCTION public.member_public_profile(uuid) OWNER TO postgres;
+
+
+GRANT EXECUTE ON FUNCTION public.member_public_profile(uuid) TO anon;
+GRANT EXECUTE ON FUNCTION public.member_public_profile(uuid) TO authenticated;
+
+
 ALTER TABLE public.members ENABLE ROW LEVEL SECURITY;
 
 
 CREATE POLICY "Enable insert for authenticated users" ON public.members FOR INSERT TO authenticated WITH CHECK ((auth.uid() = id));
 
 
-CREATE POLICY "Enable read access for all users" ON public.members FOR SELECT USING (true);
+CREATE POLICY "members can read their own row" ON public.members FOR SELECT TO authenticated USING ((auth.uid() = id));
 
 
 CREATE POLICY "admins can update any member" ON public.members FOR UPDATE TO authenticated USING (public.can_manage_members()) WITH CHECK (public.can_manage_members());

--- a/supabase/schemas/90_feedback.sql
+++ b/supabase/schemas/90_feedback.sql
@@ -109,7 +109,7 @@ CREATE FUNCTION public.feedback_items_with_votes() RETURNS TABLE(id bigint, crea
       WHERE v.feedback_id = f.id AND v.member_id = auth.uid()
     ) AS voted_by_me
   FROM public.feedback_items f
-  LEFT JOIN public.members m ON m.id = f.member_id
+  LEFT JOIN LATERAL public.member_public_profile(f.member_id) m ON true
 $$;
 
 

--- a/supabase/tests/00001_rls_members.sql
+++ b/supabase/tests/00001_rls_members.sql
@@ -1,14 +1,20 @@
 -- =============================================================================
 -- RLS tests: members table
 --
---   SELECT: anyone can read any member profile (public directory)
+--   SELECT: locked down to own-row only (20260723152007_lockdown_members_select_rls)
+--     - authenticated: only your own row, never another member's row
+--       (email / stripe ids / preferences are sensitive columns on this table)
+--     - anon: zero rows — anon was dropped from the SELECT policy entirely
+--     - cross-member reads for public-facing UI (feedback author, public-deck
+--       author) go through the narrow member_public_profile() definer helper
+--       instead, which projects only display_name/description/cover_config
 --   INSERT: you can only insert a row where id = your auth.uid()
 --   UPDATE: you can only update your own row
 -- =============================================================================
 
 BEGIN;
 
-SELECT plan(6);
+SELECT plan(10);
 
 -- ── Setup (as postgres superuser) ─────────────────────────────────────────────
 
@@ -20,11 +26,27 @@ SELECT tests.create_user('22222222-2222-2222-2222-222222222222'::uuid, 'bob');
 SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
 SET LOCAL role = 'authenticated';
 
--- Test 1: Alice can see all member profiles
-SELECT ok(
-  (SELECT count(*) FROM public.members) >= 2,
-  'Alice can see all member profiles'
+-- Test 1: Alice sees only her own row, not Bob's.
+SELECT results_eq(
+  $$ SELECT id FROM public.members $$,
+  $$ VALUES ('11111111-1111-1111-1111-111111111111'::uuid) $$,
+  'Alice can only read her own member row (Bob''s row is not returned) [obligation]'
 );
+
+-- Test 1b: anon gets zero rows from a direct members SELECT.
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims(NULL);
+SET LOCAL role = 'anon';
+
+SELECT is(
+  (SELECT count(*)::int FROM public.members),
+  0,
+  'anon reading members directly gets zero rows [obligation]'
+);
+
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+SET LOCAL role = 'authenticated';
 
 -- Test 2: Alice can update her own profile
 SELECT lives_ok(
@@ -90,6 +112,55 @@ SELECT isnt(
   'Hacked by Bob',
   'Bob cannot update Alice''s profile'
 );
+
+
+-- ── member_public_profile(): the sanctioned cross-member read ────────────────
+
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims(NULL);
+UPDATE public.members
+SET description = 'Bob''s public bio',
+    cover_config = '{"theme": "blue-500"}'::jsonb
+WHERE id = '22222222-2222-2222-2222-222222222222';
+
+-- Test 7: return shape is exactly display_name, description, cover_config —
+-- never email/stripe/preferences/role/plan.
+SELECT bag_eq(
+  $$ SELECT attname
+     FROM pg_attribute
+     WHERE attrelid = 'public.member_profile'::regclass
+       AND attnum > 0
+       AND NOT attisdropped $$,
+  $$ VALUES ('display_name'), ('description'), ('cover_config') $$,
+  'member_profile type exposes only display_name/description/cover_config [obligation]'
+);
+
+-- Test 8: authenticated caller (Alice) gets Bob's public profile via the helper.
+SELECT tests.set_claims('11111111-1111-1111-1111-111111111111'::uuid);
+SET LOCAL role = 'authenticated';
+
+SELECT results_eq(
+  $$ SELECT display_name, description, cover_config
+     FROM public.member_public_profile('22222222-2222-2222-2222-222222222222'::uuid) $$,
+  $$ VALUES ('bob'::text, 'Bob''s public bio'::text, '{"theme": "blue-500"}'::jsonb) $$,
+  'authenticated member_public_profile(other_id) returns the other member''s display_name/description/cover_config [obligation]'
+);
+
+-- Test 9: anon can also call member_public_profile — public-deck author names
+-- must still render for logged-out visitors.
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims(NULL);
+SET LOCAL role = 'anon';
+
+SELECT results_eq(
+  $$ SELECT display_name, description, cover_config
+     FROM public.member_public_profile('22222222-2222-2222-2222-222222222222'::uuid) $$,
+  $$ VALUES ('bob'::text, 'Bob''s public bio'::text, '{"theme": "blue-500"}'::jsonb) $$,
+  'anon member_public_profile(other_id) returns the other member''s profile [obligation]'
+);
+
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims(NULL);
 
 
 SELECT * FROM finish();

--- a/supabase/tests/00009_decks_with_stats.sql
+++ b/supabase/tests/00009_decks_with_stats.sql
@@ -12,7 +12,7 @@
 
 BEGIN;
 
-SELECT plan(9);
+SELECT plan(10);
 
 -- ── Test: function returns the exact columns the FE consumes ─────────────────
 -- get_member_decks now RETURNS SETOF public.member_deck (a composite type)
@@ -137,6 +137,16 @@ SELECT is(
   (SELECT count(*) FROM public.cards_with_images WHERE id = 1100)::int,
   1,
   'Bob can still see Alice''s public deck card via cards_with_images'
+);
+
+-- Test 9: Bob sees a non-null member_display_name for Alice's public deck
+-- (101) through get_member_decks — the members SELECT RLS lockdown means
+-- get_member_decks can't read Alice's row directly anymore, so this exercises
+-- the member_public_profile() LATERAL join that backfills it.
+SELECT is(
+  (SELECT member_display_name FROM public.get_member_decks(date_trunc('day', now())) WHERE id = 101),
+  'alice_stats',
+  'get_member_decks surfaces member_display_name for another member''s public deck [obligation]'
 );
 
 


### PR DESCRIPTION
[TARO-197](https://app.notion.com/p/39e0953c224c802b8080e132738cf02e)

## Summary

The `members` SELECT RLS policy used `USING (true)` with no role clause, so **anon and every authenticated user could read every member's `email`, Stripe customer/subscription IDs, and preferences**. This tightens member reads to your own row, and routes the legitimate cross-member reads (feedback author, public-deck author) through a narrow `SECURITY DEFINER` helper that only ever exposes public-profile fields.

## Changes

- **RLS lockdown** — `members` SELECT is now `TO authenticated USING (auth.uid() = id)`; `anon` is dropped from direct member reads entirely.
- **`member_public_profile(uuid)` helper** — a `SECURITY DEFINER` function returning a new `member_profile` composite type (`display_name`, `description`, `cover_config`) — never email / Stripe / preferences / role / plan. Executable by `anon` + `authenticated` so public-deck author names still render logged-out.
- **`feedback_items_with_votes` / `get_member_decks`** — swap their direct `members` join for `LEFT JOIN LATERAL member_public_profile(...)`. Both stay `SECURITY INVOKER`, so table RLS still scopes their deck/card/review reads (a wholesale definer flip would have bypassed that and leaked every user's private decks — deliberately avoided).
- **pgTAP** — own-row-only + anon-zero-rows on the table, helper return-shape lock + cross-member reads (authenticated & anon), and public-deck author name via the LATERAL join. All 316 assertions green.

## Test plan

- [ ] `supabase test db` green (316 assertions)
- [ ] A logged-in user can still edit their own profile; cannot read another member's email/billing via a direct `members` query
- [ ] Feedback board shows author names/avatars; public-deck cards show author names (logged in and out)
