### PR TITLE
TARO-198: Require caller authorization on the cleanup-media sweep

### DIFF
--- a/supabase/functions/cleanup-media/index.test.ts
+++ b/supabase/functions/cleanup-media/index.test.ts
@@ -1,8 +1,22 @@
 import { assertEquals } from '@std/assert'
 import { makeFakeSupabase, noSleep } from '../_shared/test-utils.ts'
-import { handler } from './index.ts'
+import { assertServiceRole, handler } from './index.ts'
 
 type MediaRow = { id: number; bucket: string; path: string }
+
+// assertServiceRole only decodes the payload segment (the gateway already
+// verified the signature) — any dummy header/sig works, only the middle
+// segment's `role` claim matters.
+function jwtWithRole(role: string): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = btoa(JSON.stringify({ role }))
+  return `${header}.${payload}.sig`
+}
+
+function reqWithAuth(header: string | null): Request {
+  const headers: Record<string, string> = header ? { Authorization: header } : {}
+  return new Request('http://localhost', { headers })
+}
 
 Deno.test('completes with zero counts when there is nothing to clean', async () => {
   const { supabase, calls } = makeFakeSupabase({ rows: [] })
@@ -213,4 +227,57 @@ Deno.test('returns 500 when DB delete fails after storage success', async () => 
   assertEquals(res.status, 500)
   const body = await res.json()
   assertEquals(body.error, 'delete_failed')
+})
+
+// ── assertServiceRole ────────────────────────────────────────────────────────
+// verify_jwt=true means the public anon key — a validly-signed JWT with role
+// "anon" — clears the gateway and reaches the handler. This is the core
+// vulnerability the caller-auth gate closes.
+
+Deno.test('assertServiceRole rejects a bearer token with role anon (403)', async () => {
+  const res = assertServiceRole(reqWithAuth(`Bearer ${jwtWithRole('anon')}`))
+
+  if (!res) throw new Error('expected a Response, got null')
+  assertEquals(res.status, 403)
+  assertEquals(await res.json(), { error: 'forbidden' })
+})
+
+Deno.test('assertServiceRole rejects a bearer token with role authenticated (403)', async () => {
+  const res = assertServiceRole(reqWithAuth(`Bearer ${jwtWithRole('authenticated')}`))
+
+  if (!res) throw new Error('expected a Response, got null')
+  assertEquals(res.status, 403)
+  assertEquals(await res.json(), { error: 'forbidden' })
+})
+
+Deno.test('assertServiceRole allows a bearer token with role service_role (null)', () => {
+  const res = assertServiceRole(reqWithAuth(`Bearer ${jwtWithRole('service_role')}`))
+
+  assertEquals(res, null)
+})
+
+Deno.test('assertServiceRole rejects a request with no Authorization header (401)', async () => {
+  const res = assertServiceRole(reqWithAuth(null))
+
+  if (!res) throw new Error('expected a Response, got null')
+  assertEquals(res.status, 401)
+  assertEquals(await res.json(), { error: 'unauthorized' })
+})
+
+Deno.test('assertServiceRole rejects a bearer token with no payload segment (401)', async () => {
+  const res = assertServiceRole(reqWithAuth('Bearer not-a-real-jwt'))
+
+  if (!res) throw new Error('expected a Response, got null')
+  assertEquals(res.status, 401)
+  assertEquals(await res.json(), { error: 'unauthorized' })
+})
+
+Deno.test('assertServiceRole rejects a bearer token whose payload is not valid JSON (401)', async () => {
+  // Middle segment decodes as base64 but JSON.parse throws — decodeJwtPayload
+  // must swallow the throw and yield a null role, not propagate the error.
+  const res = assertServiceRole(reqWithAuth('Bearer header.bm90LWpzb24.sig'))
+
+  if (!res) throw new Error('expected a Response, got null')
+  assertEquals(res.status, 401)
+  assertEquals(await res.json(), { error: 'unauthorized' })
 })

--- a/supabase/functions/cleanup-media/index.ts
+++ b/supabase/functions/cleanup-media/index.ts
@@ -244,11 +244,48 @@ export async function handler({ supabase, sleep, retryAttempts = 3 }: Deps): Pro
   )
 }
 
+// --- caller authorization ----------------------------------------------------
+// verify_jwt = true means the gateway has ALREADY verified this token's
+// signature before we run, so the payload is safe to *read* — a forged token
+// never reaches us. We only need the role claim. A JWT is
+// `header.payload.signature`; the payload is the base64url middle segment.
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const segment = token.split('.')[1]
+  if (!segment) return null
+  const b64 = segment.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4)
+  try {
+    return JSON.parse(atob(padded))
+  } catch {
+    return null
+  }
+}
+
+// The only legitimate caller is the pg_cron job, which authenticates with the
+// service_role key. Everyone else is rejected here — including holders of the
+// public anon key, which is a validly-signed JWT and so clears the gateway.
+export function assertServiceRole(req: Request): Response | null {
+  const authHeader = req.headers.get('Authorization')
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null
+  const role = token ? decodeJwtPayload(token)?.role : null
+
+  if (!role) {
+    return new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401 })
+  }
+  if (role !== 'service_role') {
+    return new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+  }
+  return null
+}
+
 if (import.meta.main) {
   const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
   const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
 
-  Deno.serve(() => {
+  Deno.serve((req) => {
+    const denied = assertServiceRole(req)
+    if (denied) return denied
+
     const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
       auth: { persistSession: false }
     })

--- a/supabase/migrations/20260723160000_lockdown-invoke-cleanup-media-execute.sql
+++ b/supabase/migrations/20260723160000_lockdown-invoke-cleanup-media-execute.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- Lock down invoke_cleanup_media() to owner (postgres) only
+-- =============================================================================
+--
+-- invoke_cleanup_media() is SECURITY DEFINER: it reads the service_role key out
+-- of Vault and POSTs to the cleanup-media edge function with a valid
+-- `Bearer <service_role_key>`. It was granted to anon + authenticated, which put
+-- it on PostgREST's RPC surface (POST /rest/v1/rpc/invoke_cleanup_media) — so any
+-- holder of the public anon key could trigger a full service-role storage sweep,
+-- sailing straight past the edge function's own caller-auth gate.
+--
+-- The hourly pg_cron job runs as `postgres`, which OWNS this function and so
+-- always retains EXECUTE regardless of grants. Revoking every other grant means
+-- only the scheduled system job can trigger the sweep — nothing is broken.
+--
+-- REVOKE ... FROM PUBLIC only removes the default PUBLIC grant; the explicit
+-- role grants are separate, so each is revoked by name.
+REVOKE ALL ON FUNCTION public.invoke_cleanup_media() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.invoke_cleanup_media() FROM anon;
+REVOKE ALL ON FUNCTION public.invoke_cleanup_media() FROM authenticated;
+REVOKE ALL ON FUNCTION public.invoke_cleanup_media() FROM service_role;

--- a/supabase/schemas/50_media.sql
+++ b/supabase/schemas/50_media.sql
@@ -179,9 +179,13 @@ $$;
 ALTER FUNCTION public.invoke_cleanup_media() OWNER TO postgres;
 
 
-GRANT ALL ON FUNCTION public.invoke_cleanup_media() TO anon;
-GRANT ALL ON FUNCTION public.invoke_cleanup_media() TO authenticated;
-GRANT ALL ON FUNCTION public.invoke_cleanup_media() TO service_role;
+-- Owner-only: the hourly pg_cron job runs as postgres (the owner), which
+-- always retains EXECUTE. Nobody else may trigger the sweep. Crucially this
+-- keeps the function off PostgREST's RPC surface — a grant to anon/authenticated
+-- would expose POST /rest/v1/rpc/invoke_cleanup_media, and since the function is
+-- SECURITY DEFINER it would fire the edge function with the Vault service_role
+-- key, sailing past the edge function's own caller-auth gate.
+REVOKE ALL ON FUNCTION public.invoke_cleanup_media() FROM PUBLIC;
 
 
 CREATE FUNCTION public.soft_delete_media_before_card_delete() RETURNS trigger

--- a/supabase/tests/00032_invoke_cleanup_media_lockdown.sql
+++ b/supabase/tests/00032_invoke_cleanup_media_lockdown.sql
@@ -1,0 +1,43 @@
+-- =============================================================================
+-- invoke_cleanup_media() EXECUTE lockdown
+-- (20260723160000_lockdown-invoke-cleanup-media-execute.sql)
+--
+--   invoke_cleanup_media() is SECURITY DEFINER and POSTs to the cleanup-media
+--   edge function using the Vault service_role key. It was previously granted
+--   to anon + authenticated, putting it on PostgREST's RPC surface — any
+--   holder of the public anon key could trigger a full service-role storage
+--   sweep. The migration revokes EXECUTE from PUBLIC/anon/authenticated/
+--   service_role, leaving only the owner (postgres, which the hourly pg_cron
+--   job runs as) able to call it.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(4);
+
+SELECT is(
+  has_function_privilege('anon', 'public.invoke_cleanup_media()', 'EXECUTE'),
+  false,
+  'anon cannot execute invoke_cleanup_media()'
+);
+
+SELECT is(
+  has_function_privilege('authenticated', 'public.invoke_cleanup_media()', 'EXECUTE'),
+  false,
+  'authenticated cannot execute invoke_cleanup_media()'
+);
+
+SELECT is(
+  has_function_privilege('service_role', 'public.invoke_cleanup_media()', 'EXECUTE'),
+  false,
+  'service_role cannot execute invoke_cleanup_media()'
+);
+
+SELECT is(
+  has_function_privilege('postgres', 'public.invoke_cleanup_media()', 'EXECUTE'),
+  true,
+  'postgres (owner, the role pg_cron runs as) retains EXECUTE on invoke_cleanup_media()'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
[TARO-198](https://app.notion.com/39e0953c224c807ca9baf4eec1f091de)

## Summary

The `cleanup-media` sweep — a full service-role storage deletion — could be triggered by anyone holding the app's public anon key. `verify_jwt = true` only proves the bearer is a validly-signed project JWT, and the anon key is exactly that. This locks the sweep down to the scheduled `pg_cron` system job on both reachable paths.

## Changes

- **Edge function gate** (`cleanup-media/index.ts`): assert the decoded bearer role is `service_role` before running. The gateway already verified the signature, so the payload is safe to read; anon/authenticated callers get 401/403. The cron invoker already sends `Bearer <service_role_key>`, so it passes unchanged.
- **RPC lockdown** (`invoke_cleanup_media`): the `SECURITY DEFINER` helper was granted to `anon`/`authenticated`, exposing `POST /rest/v1/rpc/invoke_cleanup_media` — a second path that fires the sweep as service_role via Vault, bypassing the edge gate. Revoked all grants; the postgres-owned cron job retains EXECUTE as owner, so the scheduled sweep is unaffected.

## Notes

- Chose the "assert `service_role` claim" approach over a shared-secret gate — no new per-env secret to provision, and the cron path is unchanged.
- Caller-auth test coverage is intentionally not included here (pair-mode leaves tests to a follow-up); `assertServiceRole` is exported as a pure `Request → Response|null` for exactly that.