### PR TITLE
docs(corpus): domain-knowledge corpus + hazard-hunting Archivist

### DIFF
--- a/.claude/agents/archivist.md
+++ b/.claude/agents/archivist.md
@@ -1,0 +1,73 @@
+---
+name: archivist
+description: Keeps the corpus/ domain-knowledge docs honest. Runs per-commit (headless, via the post-commit git hook) to review a single commit's diff, update any corpus topic a change made stale, and surface newly-exposed system holes. Baseline action is to do nothing.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+---
+
+You are **the Archivist**. You maintain `corpus/` — TaroFlash's reader-first,
+plain-language docs of high-level domain & system logic.
+
+**Your charter is `corpus/CONTRIBUTING.md`. Read it first, every run.** It is the
+source of truth for what the corpus is, its shape, its voice, the callout/hazard
+conventions, and your authority. What follows is only your per-commit operating
+loop.
+
+## What you're invoked with
+
+A single commit SHA just landed. Inspect it:
+
+```
+git show <SHA>
+```
+
+## Your loop
+
+1. **Read the charter** (`corpus/CONTRIBUTING.md`) and skim `corpus/map.md` so you
+   know the current topics and ids.
+2. **Apply the altitude gate.** Ask only: did this commit cross the domain /
+   system line — change a stated invariant, introduce a new domain concept, retire
+   one, or **newly expose a system hole**? Implementation detail (refactors,
+   bugfixes, component tweaks, renames, styling, tests) is beneath your line.
+3. **Almost always, the answer is no. Then do nothing and exit** — no commit, no
+   output beyond a one-line "nothing corpus-worthy" note. This is the expected
+   outcome and a success. You are allergic to churn.
+4. **When something did cross the line**, act with the smallest change that makes
+   the record true again:
+   - Correct the stale line in the affected topic (not the whole section).
+   - Add a topic only for a genuinely new domain area with no home.
+   - If the change **exposed a hazard**, elevate it: set `hazard: true` in the
+     topic's frontmatter and add a `> [!HAZARD]` block per the charter.
+   - If you changed any `hazard:` flag or hazard block, regenerate
+     `corpus/hazards.md` and the relevant `_map.md` / `map.md` lines to match.
+
+## Hard rules
+
+- **Advisory, never blocking.** You never fail the commit or the build. You only
+  edit `corpus/` and report.
+- **Isolate your work.** Commit ONLY `corpus/` files, with an explicit pathspec so
+  you never touch the user's staged index or their unrelated working changes:
+
+  ```
+  git commit -m "docs(corpus): <what changed> [archivist]" -- corpus/<files...>
+  ```
+
+  Every commit message MUST contain the literal tag `[archivist]` and touch only
+  paths under `corpus/`. (The git hook uses both facts to avoid re-triggering you —
+  break either and you cause an infinite loop.)
+
+- **Never** `git add -A`, never stage or commit anything outside `corpus/`, never
+  amend or rewrite existing commits, never push.
+- **New hazards: flag, don't file.** You have no reliable Notion access here. When
+  you add a new hazard, record it in the commit body as a line beginning
+  `NEW HAZARD:` (topic id + one-line summary) so a human files the backlog ticket.
+  Do not attempt to reach Notion or any MCP.
+- **Match the exemplars' voice** (`corpus/authz/permissions.md`,
+  `corpus/media/media.md`): open cold, one idea per beat, callouts that add (never
+  restate), plain declarative present tense. When in doubt, change less.
+
+## Output
+
+End with one short line: either `nothing corpus-worthy in <SHA>`, or a summary of
+the topic(s) you touched and any `NEW HAZARD:` you flagged. Keep it terse — this
+goes to a log, not a person watching.

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,49 @@
+# Git hooks
+
+Tracked git hooks for this repo. Activated by pointing git at this directory:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+Run that once per clone (it's a local git setting, not carried in the repo).
+
+## `post-commit` — the Archivist
+
+Runs [the Archivist agent](../.claude/agents/archivist.md) after each commit to
+keep the [`corpus/`](../corpus/) domain-knowledge docs honest. See
+[`corpus/CONTRIBUTING.md`](../corpus/CONTRIBUTING.md) for what the corpus and the
+Archivist are.
+
+**How it works**
+
+1. `post-commit` runs a cheap synchronous pre-filter, then detaches
+   `archivist-review.sh` so your commit returns immediately.
+2. The worker runs `claude -p --agent archivist` headlessly over the commit's
+   diff. Baseline outcome is **do nothing** — most commits produce no change.
+3. When a commit crosses the domain/system line, the Archivist makes the smallest
+   corpus edit that fixes the record and commits it **on its own**, isolated:
+   a `corpus/`-only commit tagged `[archivist]`. It never blocks, never touches
+   your staged index, never pushes.
+
+**It stays quiet unless a change is domain-level.** Two loop guards and a
+relevance pre-filter keep it from re-triggering on its own output or waking for
+implementation-only commits:
+
+- skips any commit whose message contains `[archivist]`;
+- skips commits touching only `corpus/`;
+- skips commits that don't touch `supabase/schemas|functions|migrations` or
+  `src/api|views|composables|stores|styles`;
+- skips merges, rebases, and concurrent runs (`.git/archivist.lock`).
+
+**New hazards** are flagged, not filed: the Archivist writes a `NEW HAZARD:` line
+into its commit body (Notion isn't reachable headlessly). Grep the log or its
+commits and file the backlog ticket yourself.
+
+**Log:** `.git/archivist.log`.
+
+**Config / opt-out**
+
+- `ARCHIVIST_DISABLE=1` on a commit skips the Archivist for that commit.
+- `ARCHIVIST_MODEL=<model>` overrides the model (default `sonnet`).
+- Disable entirely: `git config --unset core.hooksPath`.

--- a/.githooks/archivist-review.sh
+++ b/.githooks/archivist-review.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# Detached Archivist worker. Runs the headless agent over one commit's diff.
+# Bounded, non-interactive, autonomous. Output goes to .git/archivist.log.
+
+SHA="$1"
+REPO_ROOT="$2"
+[ -n "$SHA" ] && [ -n "$REPO_ROOT" ] || exit 0
+cd "$REPO_ROOT" || exit 0
+
+LOCK="$REPO_ROOT/.git/archivist.lock"
+LOG="$REPO_ROOT/.git/archivist.log"
+
+# Take the lock; always release it.
+echo "$SHA" > "$LOCK"
+trap 'rm -f "$LOCK"' EXIT INT TERM
+
+printf '\n=== [archivist] %s reviewing %s ===\n' "$(git log -1 --pretty=%cI "$SHA")" "$SHA" >> "$LOG"
+
+PROMPT="A commit just landed: $SHA. Run your per-commit corpus review on it, per your charter. Inspect it with \`git show $SHA\`, apply the altitude gate, and act — staying silent if nothing crosses the domain line."
+
+# --agent archivist         : load .claude/agents/archivist.md
+# --dangerously-skip-permissions : no human is present to approve; the agent's
+#                             tool allowlist + system prompt are the guardrails.
+# timeout                   : a stuck run must never linger.
+timeout 900 claude -p "$PROMPT" \
+  --agent archivist \
+  --model "${ARCHIVIST_MODEL:-sonnet}" \
+  --dangerously-skip-permissions \
+  >> "$LOG" 2>&1
+
+status=$?
+[ "$status" -eq 0 ] || echo "[archivist] run for $SHA exited $status" >> "$LOG"
+exit 0

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+# Archivist per-commit trigger.
+#
+# Cheap, synchronous pre-filter → detaches the real review so the commit returns
+# immediately. Must be fast and must never fail the commit. See ./README.md.
+
+HOOK_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+# No claude CLI → nothing to run.
+command -v claude >/dev/null 2>&1 || exit 0
+
+# Opt-out escape hatch.
+[ "${ARCHIVIST_DISABLE:-}" = "1" ] && exit 0
+
+# Skip merge commits (2+ parents) and rebase/cherry-pick storms.
+git rev-parse -q --verify HEAD^2 >/dev/null 2>&1 && exit 0
+[ -d "$REPO_ROOT/.git/rebase-merge" ] || [ -d "$REPO_ROOT/.git/rebase-apply" ] && exit 0
+
+SHA="$(git rev-parse HEAD 2>/dev/null)" || exit 0
+MSG="$(git log -1 --pretty=%B "$SHA" 2>/dev/null)"
+
+# Loop guard #1: never react to the Archivist's own commits.
+case "$MSG" in *"[archivist]"*) exit 0 ;; esac
+
+CHANGED="$(git diff-tree --no-commit-id --name-only -r "$SHA" 2>/dev/null)"
+[ -z "$CHANGED" ] && exit 0
+
+# Loop guard #2: skip commits that touch ONLY corpus/ (the Archivist's output).
+printf '%s\n' "$CHANGED" | grep -qvE '^corpus/' || exit 0
+
+# Relevance pre-filter: only wake for domain-relevant paths. This is the cheap
+# half of the "do nothing" baseline — no model call when a change obviously
+# can't cross the domain line. The agent still applies the real altitude gate.
+printf '%s\n' "$CHANGED" | grep -qE \
+  '^(supabase/schemas/|supabase/functions/|supabase/migrations/|src/api/|src/views/|src/composables/|src/stores/|src/styles/)' \
+  || exit 0
+
+# Concurrency guard: one review at a time; a later commit's run subsumes a skip.
+[ -e "$REPO_ROOT/.git/archivist.lock" ] && exit 0
+
+# Detach the heavy review; the commit returns now.
+nohup sh "$HOOK_DIR/archivist-review.sh" "$SHA" "$REPO_ROOT" >/dev/null 2>&1 &
+exit 0

--- a/corpus/CONTRIBUTING.md
+++ b/corpus/CONTRIBUTING.md
@@ -1,0 +1,201 @@
+# The Corpus
+
+High-level **domain & system logic** for TaroFlash, in plain language — the
+durable truths about how the system behaves, written once so both humans and
+agents can rely on them.
+
+This is **not** the reference docs (`docs/`). Those document _how the code
+works_ — API signatures, composable internals, component props — at
+implementation altitude. The corpus sits above that line: _what is true about
+the system_, in domain words a non-engineer can follow.
+
+The two never overlap. When a topic here needs a code detail, it links out to
+`docs/` rather than restating it.
+
+Its real job is not to list facts — it is to **make the non-obvious obvious**:
+to surface the hazards, the silent assumptions, and the traps a reader would
+otherwise only find by getting burned.
+
+---
+
+## Who maintains it: the Archivist
+
+The Archivist keeps the corpus honest. Its charter, in tension on purpose:
+
+- **Baseline action is to do nothing.** Most code changes touch no topic here.
+  That is the expected outcome, not a failure. It is allergic to churn.
+- **…except hazards, which it hunts.** Surfacing a system hole is the single
+  most valuable thing the Archivist does, and the main exception to "do
+  nothing." See [Hazards](#hazards).
+
+### The altitude gate
+
+The Archivist only acts when a change crosses the **domain / system line** — a
+new invariant, a changed behavior, a retired concept, or a newly-exposed hazard.
+This altitude _is_ the churn control; there is no line budget.
+
+- Refactors, bugfixes, renames, component tweaks → **zero** corpus changes.
+- A changed system invariant or a new hazard → **one** focused edit.
+
+### Authority
+
+- **Correct** — fix anything a change made false. Smallest edit that does it:
+  change the stale line, not the section.
+- **Add** — create a new topic only when a change introduces a genuinely new
+  domain area with no existing home.
+- **Clarify** — sharpen accurate-but-muddy text, but only for a genuine
+  improvement: a topic that conflated two things gets split, a vague invariant
+  gets stated precisely. Cosmetic rewording is not clarification. If you can't
+  name what got clearer, don't touch it.
+- **Elevate** — when a change exposes a hazard, surface it (add or promote a
+  hazard block). This is the one place the Archivist is expected to be
+  aggressive.
+- **Never** — reword correct prose for taste, restructure for its own sake, add
+  examples, or document implementation detail.
+
+### Overflow — isolate, don't inline
+
+When a real change is large (a new domain area, a topic splitting in two), the
+Archivist makes it — but **isolated**: its own commit, scoped to `corpus/`,
+never mixed into a code commit. You review or drop it as one unit.
+
+---
+
+## The shape
+
+One **topic** per file — a subsystem you'd sit down to understand (Media,
+Permissions), not a single atomic fact. A topic carries enough surrounding
+context that any one idea in it is graspable without hunting elsewhere.
+
+```
+corpus/
+  map.md                  root index — every topic, one line each
+  hazards.md              generated — every topic tagged `hazard: true`, gathered
+  <domain>/
+    _map.md               domain index
+    <topic-id>.md         one topic
+```
+
+### Topic frontmatter
+
+```markdown
+---
+id: <stable-slug>     permanent deep-link handle; agents cite this, not the path
+domain: <domain>
+status: current       current | deprecated
+hazard: false         true if this topic documents a system hole (see Hazards)
+related: [<id>, <id>]
+updated: YYYY-MM-DD
+---
+```
+
+- **`id` is permanent.** Rename the file freely; never change a shipped `id` —
+  it is the address agents and deep-links depend on.
+- **`[[id]]` links** reference other topics by id. A link to an id that doesn't
+  exist yet is fine — it marks a topic worth writing.
+
+### Structure — loose, but with a spine
+
+Not a rigid skeleton. The order that reads well and skims well:
+
+1. **Standfirst** — one plain sentence: what this is, in domain words.
+2. **Lead** — the mental model, in consumable beats (see Authoring).
+3. **Hazard block(s)** — if the topic has a system hole, surfaced high, before
+   the detail.
+4. **Sections** — plain headings (no arbitrary numbering — numbers imply a rank
+   that isn't real). Order by importance, not by sequence.
+5. **What this isn't** — the boundaries, so topics don't bleed into each other.
+6. **Related** — links to adjacent topics.
+
+---
+
+## Authoring — write for a reader who's deciding whether to keep reading
+
+Every rule below was learned by watching a real reader bounce off a draft.
+
+- **Open cold.** The top must land for someone who knows nothing — plain words,
+  concrete nouns. _Earn_ technical terms by grounding them first; never lead
+  with jargon. ("A little note that says 'this card uses that file'" before ever
+  saying "reference index.")
+- **One idea per beat, space between beats.** Break dense paragraphs into short
+  lines and small lists. Whitespace is the primary tool; bullets are the backup.
+  A wall of prose at a decision point loses the reader.
+- **Declarative, present tense.** "Media moves through three states." Not "we
+  decided to make media…". Fact first, context second or omitted.
+- **Show, don't lecture.** A concrete walkthrough (the dashboard returns your 5
+  decks, then every deck) beats an abstract statement of the rule.
+
+### Callouts
+
+A tinted, boxed aside. **A callout earns its box only by adding something the
+prose doesn't** — never by restating it. A restating callout is pure noise; cut
+it. Callouts interrupt prose one at a time where they bite; they never stack in
+a row. Zero per section is common and fine.
+
+Pick the type per topic from this fixed palette (consistent color = consistent
+meaning):
+
+| Type        | Source syntax | Color | Use for                                     |
+| ----------- | ------------- | ----- | ------------------------------------------- |
+| `Rule`      | `> [!RULE]`   | green | a hard constraint you'd otherwise get wrong |
+| `Watch out` | `> [!WATCH]`  | amber | a gotcha or footgun in normal use           |
+| `Note`      | `> [!NOTE]`   | teal  | a useful non-obvious aside                  |
+
+Written as blockquote alerts; the interface renders each keyword to its styled
+block. For a full-blown system hole, don't use a callout — use a **hazard
+block** (`> [!HAZARD]`, see below).
+
+### Diagrams
+
+Diagram only what a picture genuinely beats a sentence at — flow, structure,
+blast radius, before/after. Author it as **text** (Mermaid, or a plain HTML
+table for before/after) so it stays diffable and an agent can update it. Zero
+diagrams is the common case; one load-bearing diagram beats three decorative
+ones. If a diagram would just re-draw a sentence, skip it.
+
+---
+
+## Hazards
+
+A **hazard** is a place where the obvious assumption is quietly wrong and it
+costs you. It is a different _class_ of thing than a fact or a rule, and it gets
+elevated treatment so a reader — or an agent about to touch that area — cannot
+miss it.
+
+### The tell — how the Archivist finds them
+
+- **A benefit whose flip-side is dangerous.** The property that makes something
+  convenient is often the exact property that makes it a trap. (Capabilities let
+  you "change a rule in one place" — which is _why_ widening one ripples into
+  every query that leaned on it.) Whenever you write down a benefit, ask what its
+  flip-side breaks.
+- **A silent assumption.** Code that works only because something elsewhere
+  stays a certain way, without saying so. When that thing moves, the code breaks
+  quietly.
+- **"Works in testing, wrong in production."** A shortcut that passes today
+  because conditions happen to line up.
+
+### How a hazard is presented
+
+- A **hazard block** surfaced high in the topic (right after the lead, before
+  the ordinary sections), stating the trap in one strong line + the flip-side
+  framing + a link to the deep walkthrough.
+- The topic's frontmatter sets **`hazard: true`**. The root **`hazards.md`** is
+  generated from that tag — one place to review every known system hole across
+  all domains. Never hand-maintain that index; tag the topic and let it gather.
+
+### The Archivist actively hunts
+
+On any domain-level change, the Archivist explicitly looks for benefit/flip-side
+traps and silent-assumption breaks, and elevates what it finds. This overrides
+"do nothing" — a surfaced hazard is worth the churn every time.
+
+---
+
+## How agents use the corpus
+
+- **Planning** — read `map.md`, pull the relevant topics, plan within them.
+  Check `hazards.md` for landmines in the area being touched.
+- **Verifying an edit** — check the diff against the touched topic. A diff that
+  contradicts a stated invariant is a bug. A diff that _changes_ one, or exposes
+  a new hazard, is the Archivist's trigger to update the corpus.

--- a/corpus/architecture/_map.md
+++ b/corpus/architecture/_map.md
@@ -1,0 +1,5 @@
+# architecture
+
+Cross-cutting system logic — how data flows and stays in sync.
+
+- [[data-flow]] — server data is a named cache; a write owns marking its own data stale ⚠️

--- a/corpus/architecture/data-flow.md
+++ b/corpus/architecture/data-flow.md
@@ -1,0 +1,127 @@
+---
+id: data-flow
+domain: architecture
+status: current
+hazard: true
+related: [permissions, cards]
+updated: 2026-07-23
+---
+
+# Data flow
+
+How data from the server gets onto the screen, how a change gets back to the
+server, and who is responsible for keeping the two in sync.
+
+Almost everything on screen is a copy. The real decks, cards, and reviews live on
+the server; the app keeps a local copy so it doesn't have to re-ask for the same
+thing on every render.
+
+That local copy is a **cache**. Two jobs run against it, and only two:
+
+1. **Reading** fills the cache — ask for the dashboard's decks, and the answer is
+   remembered under a name so the next screen that wants the same thing gets it
+   for free.
+2. **Writing** changes the server — save a review, move a card — and then has to
+   admit that some of what's in the cache is now out of date.
+
+The cache doesn't refresh itself. Something has to say "the decks I remembered are
+stale now." Getting that _something_ right — always, and in exactly one place — is
+what this topic is about.
+
+> [!HAZARD] **A write that succeeds but forgets to mark the right thing stale leaves the screen showing old data — and nothing anywhere reports an error.**
+> The convenience below is that a caller never thinks about the cache. The flip
+> side is that when the cache _does_ drift, there's no error to chase and no clue
+> at the call site: the save worked, the server is correct, and the screen quietly
+> keeps the pre-save copy. A wrong or missing staleness mark fails silent.
+> [See who owns the mark ↓](#a-write-owns-its-aftermath)
+
+## Two kinds of state, kept apart
+
+Not everything on screen is a copy of the server.
+
+- **Server data** — decks, cards, reviews, members, the shop — is fetched and
+  cached. It can go stale, so it's the thing that needs refreshing.
+- **Local-only state** — who's signed in, the current theme, which modal is open —
+  is never on the server to begin with. It can't go stale; it just _is_.
+
+These live in separate stores and never mix. The rest of this topic is only about
+the first kind. Local state has none of these hazards because there's no server
+copy to fall out of sync with.
+
+## Reading fills the cache by name
+
+Every read is asked for under a stable name — "the dashboard's decks," "this
+deck's cards." The answer is filed under that name.
+
+Ask twice and the second ask is instant: the cache already has it. That's the
+whole point of the copy.
+
+The name is also the handle a write uses later to say "throw that one out." So the
+names aren't decoration — they're the vocabulary the two jobs use to talk about
+the same data.
+
+## A write owns its aftermath
+
+Here's the rule that makes the whole thing hang together: **a write is responsible
+for marking stale whatever it just changed.** Not the button that triggered it.
+Not the screen. The write itself.
+
+Save a review, and the save is what says "the decks are stale now" — because the
+save is the only thing that knows a review just landed. The screen that called it
+stays dumb: it asks for the save and moves on, trusting that anything affected will
+refresh on its own.
+
+> [!RULE]
+> The caller never refreshes the cache after a write. It calls the write and
+> stops. If a screen finds itself invalidating something a mutation already
+> changed, that's a bug — the responsibility got split, and now two places have to
+> stay in agreement or the cache drifts.
+
+Why put it there and nowhere else? Because a single write can touch data three
+unrelated screens are showing. If each caller had to remember which names to
+refresh, they'd disagree — one refreshes the deck list, another forgets the card
+count — and the copies drift apart. Keeping it with the write means the answer is
+written down once, next to the thing that knows it.
+
+> [!WATCH]
+> This cuts the other way too. A brand-new write that _forgets_ to mark anything
+> stale looks completely fine in review — it saves, it returns, no error. The
+> staleness is invisible until someone notices the screen didn't move. There's no
+> compiler and no test failure standing guard here; the discipline is the only
+> thing holding it.
+
+## Refreshing narrowly, never wholesale
+
+Marking stale is always aimed. A write names the specific things it disturbed —
+this deck, these cards — and leaves the rest of the cache untouched.
+
+Clearing the whole cache would "work" in that nothing stays stale, but it throws
+away every other screen's remembered data for no reason, and the next render
+re-fetches all of it. Aim is what keeps the copy worth keeping.
+
+## Permission checks refresh themselves
+
+One kind of question runs constantly against this data: _is this person allowed to
+do this?_ Those checks read live state — the member's plan, their role, how many
+decks they own — and that state is itself cached server data.
+
+So the checks are wired to re-answer on their own the moment their inputs change.
+Buy a subscription, and every "is this a paid feature?" question flips without
+anyone re-asking it. The check isn't a one-time verdict; it's a standing
+subscription to the answer. The [[permissions]] topic covers what those checks
+protect and why the screen's answer is only ever a hint.
+
+## What this isn't
+
+- **Not access control.** Whether an answer is _allowed_ to reach you is
+  [[permissions]]'s job. This is about how the answer travels and stays fresh once
+  it's permitted.
+- **Not the write rules.** _What_ a given write is allowed to do — cards only
+  written through the server so ranks stay correct — is its own topic; this is
+  only about what happens to the cache afterward.
+- **Not the cache mechanics.** Query-key shapes, the invalidation contract table,
+  and how a mutation is wired are code detail — the reference docs cover those.
+
+## Related
+
+[[permissions]] · [[cards]]

--- a/corpus/authz/_map.md
+++ b/corpus/authz/_map.md
@@ -1,0 +1,5 @@
+# authz
+
+How the system decides who's allowed to do what.
+
+- [[permissions]] — named `can_` checks, server-is-the-boundary, and the widen-once ripple ⚠️ hazard

--- a/corpus/authz/permissions.md
+++ b/corpus/authz/permissions.md
@@ -1,0 +1,100 @@
+---
+id: permissions
+domain: authz
+status: current
+hazard: true
+related: [media]
+updated: 2026-07-23
+---
+
+# Permissions
+
+How the app decides who's allowed to do what — and why the real answer always
+comes from the server, never the screen.
+
+Every guarded action — removing a member, moderating feedback, opening the audio
+reader — comes down to one question: _is this person allowed to do this?_
+
+Each permission has a single home: a small, named check like
+`can_manage_members`. Change who's allowed, and you change it in that one place.
+
+That check gets asked in two very different spots:
+
+1. The **screen** asks it — to decide what to show or hide.
+2. The **server** asks it again — to decide what's actually allowed to happen.
+
+Only the server's answer counts. What the screen does with it is a courtesy — it
+keeps people from reaching for buttons they can't use.
+
+> [!HAZARD] **Widen a permission, and every query that was leaning on the old, tighter rule silently widens with it — including screens you forgot were leaning on it.**
+> This is the flip side of the "change it in one place" convenience below. The
+> same wiring that updates every screen at once will also ripple a loosened rule
+> into queries you never meant to touch — turning an ordinary dashboard into a
+> firehose. A screen that must stay narrow has to scope _itself_; the permission
+> can't do it for you.
+> [See exactly how it happens ↓](#the-flip-side-widen-once-ripple-everywhere)
+
+## One check per permission
+
+A permission isn't scattered across the code as "is this an admin?" tests. It's
+collected into one named check that describes _what it unlocks_ —
+`can_manage_members`, `can_moderate_feedback`, `can_read_lesson_audio`.
+
+Everywhere that permission matters asks that one check by name. So when the rule
+changes, the change happens once, and every screen and server call that asks
+picks it up for free.
+
+> [!RULE]
+> Name a permission for the thing it unlocks, never for who happens to have it
+> today — `can_manage_members`, not `is_admin`. Roles come and go; the thing
+> you're protecting stays put.
+
+## The screen is only a hint
+
+On the screen, a permission decides what you _see_ — a hidden button, a
+greyed-out control. That's a nicety, so people aren't offered things they can't
+do. It is never what keeps anything safe.
+
+> [!WATCH]
+> Hiding a button is not protection. If the server doesn't check the same
+> permission again, a determined person just calls the action directly and it
+> works. The screen's check is courtesy; the server's is the lock.
+
+## The flip side: widen once, ripple everywhere
+
+The permission that guards _who may see a deck_ isn't only checked on admin
+screens. It also quietly scopes ordinary ones. The dashboard just asks for "all
+decks" and trusts the permission to trim that down to the ones you belong to:
+
+`select * from decks` → your 5 decks
+
+Now an admin moderation tool ships, and the rule is loosened to "a deck you
+belong to _— or any deck, if you're an admin._" Nobody touched the dashboard. But
+its query was leaning on the old, tighter rule — so for an admin, that same
+untouched query now returns **every deck on the platform.**
+
+| The rule says…                                  | The dashboard's unchanged query returns… |
+| ----------------------------------------------- | ---------------------------------------- |
+| a deck you belong to                            | ✅ your 5 decks                          |
+| …or any deck, if you're an admin                | ⚠️ **every deck on the platform**        |
+| the dashboard scopes _itself_: `where i_belong` | ✅ your 5 decks — whatever the rule says |
+
+Same query all three times. Only the last row is safe on its own.
+
+That's the trade for the one-place convenience above: change a rule once and it
+lands everywhere — the screens you meant _and_ the ones you forgot were trusting
+it. The permission's job is to get the **ceiling** right. Only the query can get
+the **screen** right.
+
+## What this isn't
+
+- **Not the list of roles.** Which roles exist and who holds them is its own
+  topic — this is about what a permission _does_.
+- **Not billing.** Whether a feature is paid rides on the member's plan — a
+  related but separate kind of check.
+- **Not the SQL.** How a check is written and wired into the database and edge
+  functions is code detail — the reference docs cover that.
+
+## Related
+
+[[media]]

--- a/corpus/cards/_map.md
+++ b/corpus/cards/_map.md
@@ -1,0 +1,5 @@
+# cards
+
+The question-and-answer units people study.
+
+- [[cards]] — front/back units; server-picked ordering number; duplicates flagged not blocked ⚠️

--- a/corpus/cards/cards.md
+++ b/corpus/cards/cards.md
@@ -1,0 +1,107 @@
+---
+id: cards
+domain: cards
+status: current
+hazard: true
+related: [media, permissions]
+updated: 2026-07-23
+---
+
+# Cards
+
+The question-and-answer units people study — how a card comes to exist, how its
+deck keeps every card in order, and when two of them count as the same.
+
+A card is two pieces of text: a **front** and a **back**, sitting inside a deck.
+
+Every deck keeps its cards in a deliberate order. That order isn't stored as
+"card #1, card #2" — it's a single **number** carried by each card, and cards
+sort from smallest number to largest.
+
+The trick that makes reordering cheap: to slip a new card _between_ two others,
+the deck picks a number halfway between its neighbours'. There's always room for
+one more in the gap — until the gap grows too small to split, at which point the
+whole deck is quietly renumbered with fresh spacing and the insert retries.
+
+A card comes into being in one of two ways:
+
+1. **Placed** — dropped in _before_ or _after_ a card you point at.
+2. **Bulk-added** — a stack of cards appended to the end of the deck at once.
+
+Either way, the number that fixes its place is chosen by the **server**, never
+the app.
+
+> [!HAZARD] **A card's ordering number is trustworthy only because every create goes through one door — the table itself will accept any number you hand it.**
+> Cards are owned rows, and the database happily lets a signed-in person insert
+> their own. That openness is the convenience — it's also the flip side: nothing
+> in the table forces the ordering number to be server-picked, so a card created
+> by a raw insert can carry a made-up number that collides with a neighbour or
+> lands in the wrong spot, silently corrupting the deck's order and skipping the
+> per-deck cap along the way. The guarantee lives in the discipline of routing
+> every create through the two functions, not in the schema.
+> [See why there's only one door ↓](#every-card-comes-in-through-one-door)
+
+## Order is a number, not a position
+
+The ordering number is fractional on purpose. Insert between two cards and the
+deck takes the midpoint of their numbers; insert at the end and it takes the
+last number plus a step; the first card in an empty deck starts at a round base.
+
+Because the number is fractional, an insert almost never has to touch any other
+card — it just claims the space in the gap.
+
+Almost never. Repeatedly inserting into the _same_ gap eventually leaves no room
+between two neighbours. When that happens the deck **renumbers** every card with
+wide, even spacing and the insert tries again. The order the reader sees never
+changes — only the underlying numbers do.
+
+> [!NOTE]
+> Rank assignment is serialized per deck: two people adding to the same deck at
+> the same instant take turns, so they can't both claim the same gap and land on
+> the same number.
+
+## Every card comes in through one door
+
+Placing a card and bulk-adding cards are the _only_ two ways to create one. Both
+run on the server, and both do three things the app can't safely do itself:
+compute the ordering number, take the per-deck turn-taking lock, and check the
+deck hasn't hit its card ceiling.
+
+> [!RULE]
+> A card is never created by writing straight to the cards table from the app.
+> Creation always goes through the placing or bulk-adding path — that's the only
+> place the ordering number is computed correctly. Editing an _existing_ card's
+> text is a different matter and writes directly; the one-door rule is about
+> _bringing a card into being_, where the number has to be earned.
+
+The ceiling is set by the owner's plan. A free plan caps how many cards a deck
+may hold; adding past the cap fails fast, before anything is written, and the
+app surfaces it as an upgrade prompt rather than a generic error.
+
+## Duplicates are flagged, never blocked
+
+A deck can hold two identical cards. Nothing stops it — instead, each card
+_knows_ whether it has a twin, and the deck can quietly mark the ones that do.
+
+A card counts as a duplicate only when **both** its sides are filled in **and**
+both sides match another card in the same deck.
+
+> [!RULE]
+> Both conditions are required together, not either one. Two cards that share
+> only a front — or only a back — are _not_ duplicates. Two cards that are both
+> blank are _not_ duplicates. Only a full front-and-back match, both sides
+> non-empty, counts. The check is per deck; the same pair in two decks is fine.
+
+## What this isn't
+
+- **Not the study schedule.** When a card is next due and how well it's known is
+  its review state, driven by the spaced-repetition algorithm — its own concern.
+- **Not the images.** Pictures attached to a card's front or back live and die by
+  their own rules — [[media]].
+- **Not access control.** Who may read or change a card is [[permissions]]'s job.
+- **Not the SQL.** The ordering functions, indexes, and the duplicate-flag view
+  are code detail — the reference docs cover those.
+
+## Related
+
+[[media]] · [[permissions]]

--- a/corpus/decks/_map.md
+++ b/corpus/decks/_map.md
@@ -1,0 +1,5 @@
+# decks
+
+A member's boxes of cards — ownership, sharing, and due counts.
+
+- [[decks]] — one owner, one public/private switch; public means read-only, not shared study ⚠️

--- a/corpus/decks/decks.md
+++ b/corpus/decks/decks.md
@@ -1,0 +1,113 @@
+---
+id: decks
+domain: decks
+status: current
+hazard: true
+related: [permissions, scheduling, cards]
+updated: 2026-07-23
+---
+
+# Decks
+
+A deck is one person's box of cards — who it belongs to, who's allowed to see it,
+and how the dashboard counts what's due in it today.
+
+Every deck belongs to exactly one member. That owner is stamped on the deck the
+moment it's created, and never changes hands.
+
+A deck is private by default. The owner can flip a single switch to make it
+public.
+
+1. **Private** — only the owner can see it.
+2. **Public** — anyone can see it.
+
+There is no third thing. No "members of a deck," no per-deck roles, no invites to
+a private deck. A deck has one owner and one public/private switch — that is the
+entire sharing model.
+
+The dashboard asks for _your_ decks and shows each one with a count of the cards
+due today.
+
+> [!HAZARD] **Making a deck public lets other people _read_ it — never _study_ it.**
+> "Public" sounds like "shared, and everyone builds their own progress on it." It
+> isn't. Recording a review is gated to the card's owner, and the progress table
+> holds exactly **one** row per card for the whole platform — not one per viewer.
+> So a public deck is a browse-only copy: there is nowhere to put a second
+> person's study state, and the system quietly assumes every card is studied by
+> exactly one person. The day someone wants shared study, the data model can't
+> hold it.
+> [See why below ↓](#public-means-look-not-study)
+
+## Every deck has exactly one owner
+
+Ownership isn't something the client sends — it's stamped by the database on
+insert, always to the person making the request. A caller can't hand a deck to
+someone else, or forge one under another member's name.
+
+That owner is the deck's whole identity for access: create, rename, delete,
+change cards, study it — all of it is the owner's alone.
+
+> [!RULE]
+> Owning the deck is what unlocks studying it. Recording a review requires that
+> the card belongs to you, so a deck you don't own is never one you can build
+> progress on — public or not.
+
+## Public means look, not study
+
+Flipping a deck public widens exactly one thing: who can _see_ it. It does not
+create members, grant roles, or let anyone else record progress.
+
+Two facts lock this in:
+
+- Writing a review is refused unless the card is yours.
+- There is room for only one progress row per card, ever — the table is unique on
+  the card alone, not on card-plus-person.
+
+So a public deck is a read-only exhibit. A visitor can page through the cards;
+they cannot turn it into a studyable deck of their own. If they want that, they'd
+need their own copy.
+
+> [!NOTE]
+> This is why the dashboard's due count is only ever meaningful for decks you
+> own — they're the only decks you can actually study down to zero.
+
+## The dashboard lists your decks with a due count
+
+The dashboard shows the decks you own, each with a live count of cards due today.
+
+Under the hood it asks for a broader set than that — everything the access rules
+let you see — and then narrows the list to your own decks itself. Why it must do
+that narrowing, rather than trusting the rules to do it, is [[permissions]]'s
+story, not this one.
+
+The due count isn't stored; it's computed fresh on every read. For each deck the
+server tallies the brand-new cards and the cards whose next review has come due,
+then trims that by the deck's daily pacing caps — the same math the study session
+itself uses, so the number on the card matches the session you're about to start.
+The caps and the scheduling behind "due" belong to [[scheduling]].
+
+> [!WATCH]
+> The count depends on _when your day starts_ — the client passes its own local
+> day boundary. Two people in different time zones can open the same deck and see
+> different due counts, and neither is wrong.
+
+## How many decks you can make
+
+A deck isn't free to create without limit. Each member's plan sets a ceiling, and
+a new deck is refused once that ceiling is reached. Raising the ceiling is a
+billing matter — the deck itself doesn't know or care which plan paid for it.
+
+## What this isn't
+
+- **Not the cards.** What's _inside_ a deck — the card records, their order, how
+  they're written — is [[cards]]'s topic.
+- **Not scheduling.** What "due" means, how the daily caps work, and how a review
+  reschedules a card live in [[scheduling]].
+- **Not the access plumbing.** How the see-it rule is enforced, and why the
+  dashboard scopes itself, is [[permissions]].
+- **Not the SQL.** Table columns, the read RPC, rank ordering, and the pacing
+  resolver are code detail — the reference docs cover those.
+
+## Related
+
+[[permissions]] · [[scheduling]] · [[cards]]

--- a/corpus/feedback/_map.md
+++ b/corpus/feedback/_map.md
@@ -1,0 +1,5 @@
+# feedback
+
+The public feedback wall — submissions, votes, moderation.
+
+- [[feedback]] — a curated public wall; posts stay hidden until a moderator publishes them ⚠️

--- a/corpus/feedback/feedback.md
+++ b/corpus/feedback/feedback.md
@@ -1,0 +1,106 @@
+---
+id: feedback
+domain: feedback
+status: current
+hazard: true
+related: [permissions]
+updated: 2026-07-23
+---
+
+# Feedback
+
+A public wall where members post ideas and bug reports, vote on each other's,
+and watch the good ones get picked up.
+
+Anyone signed in can open the board and read what's there.
+
+Two things a member can do to a post:
+
+1. **Add their own** — a title, and an optional bit more.
+2. **Vote for someone else's** — a heart they can add or take back at any time.
+
+A smaller group — the moderators — can do a third thing: decide which posts the
+wall shows, and mark where each one stands.
+
+> [!HAZARD] **A new submission does not land on the wall. It waits, unseen, until a moderator lets it through.**
+> Posting feels finished — the member gets a "thanks, submitted" and the box
+> closes. But every fresh post starts _hidden_, and the wall only ever shows the
+> ones a moderator has published. So the obvious assumption — "I posted it, it's
+> on the board now" — is quietly false. The post is real and saved; it is simply
+> invisible to everyone (its own author included) until someone moderates it.
+> Nothing tells the member that. [See how a post gets published ↓](#a-post-earns-its-place)
+
+## What a post carries
+
+Every post remembers who wrote it, a title, and an optional body. Alongside that
+it carries three things the writer never sets:
+
+- **A kind** — idea, bug, or other. The submit box doesn't ask; a moderator sorts
+  it later.
+- **A standing** — where it is in its life: new, accepted, rejected, in progress,
+  or done.
+- **Whether it's shown** — public (on the wall) or held back. Held back is the
+  starting point.
+
+The member fills in the words. Everything that governs _whether and how the post
+appears_ is a moderator's call.
+
+## A post earns its place
+
+A post's journey is short but gated:
+
+`written` → `held back (the default)` → _a moderator publishes it_ → `on the wall`
+
+A moderator is the only one who can flip a post to public, and the same action
+lets them set its standing — accepted, in progress, done, and so on. Until that
+happens the post exists but shows to no one on the board.
+
+This is deliberate. The wall is a curated shortlist, not a raw inbox.
+
+## Voting is a live toggle
+
+A heart is a switch, not a tally you add to. Tap once to back a post, tap again
+to take it back — a member's vote counts exactly once or not at all.
+
+The count everyone sees is the server's, always. The heart flips the instant
+it's tapped so it feels immediate, but if the server disagrees the display
+snaps back to the true count.
+
+> [!NOTE]
+> Voting is the one feedback action with no gate beyond being signed in — any
+> member can back any published post. Writing a post and moderating one are the
+> guarded actions; voting is open.
+
+## Who sees which posts
+
+The rule underneath the wall lets three kinds of reader through: anyone, for a
+**published** post; its **author**, for their own held-back post; and a
+**moderator**, for _everything_.
+
+That last clause is a widened rule — and the board leans on it at its peril. The
+wall itself must still ask only for published posts, or a moderator opening the
+ordinary board would pull the entire hidden backlog onto it. The wall gets that
+narrowing right by scoping its own request, not by trusting the rule to stay
+tight. This is the [[permissions]] "widen once, ripple everywhere" trap in the
+wild — the moderator's wider reach silently widens any query that forgot to
+scope itself.
+
+> [!RULE]
+> "Moderator" here is a named permission — the thing that unlocks moderation, not
+> a check for who happens to be an admin today. Publishing, restanding, and
+> reading the hidden backlog all ask that one permission by name. See
+> [[permissions]] for why it lives in exactly one place.
+
+## What this isn't
+
+- **Not roles.** Who counts as a moderator, and how that's decided, is
+  [[permissions]]'s business — this topic only cares that _a_ moderator gate
+  exists.
+- **Not a support inbox.** A post is a public idea or bug on a shared wall, not a
+  private ticket routed to a person.
+- **Not the wiring.** Tables, policies, the vote toggle's internals, and the
+  publish call are code detail — the reference docs cover those.
+
+## Related
+
+[[permissions]]

--- a/corpus/hazards.md
+++ b/corpus/hazards.md
@@ -1,0 +1,32 @@
+# Hazards
+
+Every known **system hole** across the corpus, gathered in one place. A hazard is
+somewhere the obvious assumption is quietly wrong and it costs you.
+
+> **Generated — do not hand-edit.** This list is built from every topic with
+> `hazard: true` in its frontmatter. To add or change an entry, edit the topic;
+> to review before touching an area, read this. See
+> [CONTRIBUTING → Hazards](./CONTRIBUTING.md#hazards).
+
+Check this before planning or verifying work in an area — an agent about to touch
+a domain reads its hazards first.
+
+---
+
+### Widening a permission ripples everywhere
+
+**[[permissions]]** · authz
+
+Loosen one `can_` rule and every query that was leaning on the old, tighter rule
+silently widens too — including ordinary screens you forgot were trusting it. The
+flip side of the "change it in one place" convenience. A screen that must stay
+narrow has to scope itself; the permission can't.
+
+### A file lives or dies by its notes, not the bucket
+
+**[[media]]** · media
+
+The hourly cleanup treats any file with no live note pointing at it as garbage.
+That makes the note the file's lifeline: delete a shared file directly and you
+break every other card using it; leave a file in a media bucket untracked and the
+next sweep eats it. Touch these buckets only through the notes.

--- a/corpus/hazards.md
+++ b/corpus/hazards.md
@@ -3,30 +3,114 @@
 Every known **system hole** across the corpus, gathered in one place. A hazard is
 somewhere the obvious assumption is quietly wrong and it costs you.
 
-> **Generated — do not hand-edit.** This list is built from every topic with
-> `hazard: true` in its frontmatter. To add or change an entry, edit the topic;
-> to review before touching an area, read this. See
-> [CONTRIBUTING → Hazards](./CONTRIBUTING.md#hazards).
+> **Generated — do not hand-edit.** Built from every topic with `hazard: true` in
+> its frontmatter. To add or change an entry, edit the topic; to review before
+> touching an area, read this. See [CONTRIBUTING → Hazards](./CONTRIBUTING.md#hazards).
 
-Check this before planning or verifying work in an area — an agent about to touch
-a domain reads its hazards first.
+Roughly ordered by blast radius — data loss and silent corruption first, design
+ceilings and footguns last.
 
 ---
+
+### A failed review save is silently abandoned
+
+**[[study]]** · study
+
+A card is marked reviewed locally the instant it's rated — before the async save
+runs. If the save fails, the card is already logged as done; the offered "refresh"
+rebuilds it as already-reviewed and never retries. The review is lost and the
+card's server schedule stays stale.
+
+### The stall-reaper strands healthy long-running jobs
+
+**[[audio-generation]]** · media
+
+A stuck job and a slow-but-alive job look identical. The 10-minute sweep that
+rescues genuinely-dead chains also reaps a step that legitimately runs long — and
+its late write lands on an already-`failed` row the chain trigger won't re-fire,
+stranding completed work. (Retry must also clear the half-built transcript, or
+transcription appends onto it.)
+
+### Card ordering integrity lives in RPC discipline, not the schema
+
+**[[cards]]** · cards
+
+The cards table accepts any ordering number a signed-in owner hands it — no
+server-enforced default or uniqueness. Integrity holds only because every create
+routes through the two RPCs; a raw insert can collide/misorder and skip the
+per-deck cap, silently corrupting deck order.
+
+### The ownership stamp is empty under a backend job
+
+**[[members]]** · members
+
+Ownership is stamped from `auth.uid()`, which is NULL under the service-role
+client (which also bypasses RLS). A privileged job's insert either fails loudly on
+a NOT-NULL owner column, or silently lands an unreachable, orphaned row on a
+nullable one — past the isolation wall that would have caught it.
 
 ### Widening a permission ripples everywhere
 
 **[[permissions]]** · authz
 
-Loosen one `can_` rule and every query that was leaning on the old, tighter rule
-silently widens too — including ordinary screens you forgot were trusting it. The
-flip side of the "change it in one place" convenience. A screen that must stay
-narrow has to scope itself; the permission can't.
+Loosen one `can_` rule and every query leaning on the old, tighter rule silently
+widens too — including ordinary screens you forgot were trusting it. A screen that
+must stay narrow has to scope itself; the permission can't.
 
 ### A file lives or dies by its notes, not the bucket
 
 **[[media]]** · media
 
 The hourly cleanup treats any file with no live note pointing at it as garbage.
-That makes the note the file's lifeline: delete a shared file directly and you
-break every other card using it; leave a file in a media bucket untracked and the
-next sweep eats it. Touch these buckets only through the notes.
+Delete a shared file directly and you break every other card using it; leave a
+file in a media bucket untracked and the next sweep eats it.
+
+### The client is the source of scheduling truth
+
+**[[scheduling]]** · scheduling
+
+FSRS runs on the device; the server only stores what the client computed and never
+recomputes or checks it. A stale app, a different algorithm version, or two devices
+reviewing the same card can quietly write schedules under different math — and the
+database can't tell.
+
+### A forgotten cache invalidation fails silent
+
+**[[data-flow]]** · architecture
+
+A write that succeeds but forgets to mark the right cache entry stale leaves the
+screen showing old data — no error, no clue at the call site. The "callers never
+touch the cache" convenience means drift has no guard but discipline.
+
+### A pin that matches the preset silently detaches
+
+**[[pacing]]** · pacing
+
+A dial is "pinned" purely because its key is present in the override bag — value is
+never compared to the preset. Pin a dial to the preset's own value and it looks
+identical, but it has detached: later preset edits move every deck except that one.
+
+### An out-of-set color renders bare, with no error
+
+**[[theming]]** · theming
+
+The color set is closed — the root reset wipes every default shade and re-adds only
+curated ones. Reach for a color outside it (a leftover default class, a token typo)
+and it resolves to nothing: no fallback, no warning, an element rendered bare.
+
+### Public means read-only — the model holds one studier per card
+
+**[[decks]]** · decks
+
+"Public" grants read visibility only. Recording a review is gated to the card's
+owner, and the progress table holds exactly one row per card platform-wide — so
+there is nowhere to store a second viewer's study state. Shared study can't be
+expressed in the current model.
+
+### A submitted post is hidden until a moderator publishes it
+
+**[[feedback]]** · feedback
+
+Every fresh post starts held back and the wall shows only published ones — so "I
+posted it, it's on the board" is quietly false, even to the author. The board is a
+curated shortlist, not a raw inbox; nothing tells the member.

--- a/corpus/map.md
+++ b/corpus/map.md
@@ -1,0 +1,13 @@
+# Corpus Map
+
+Root index of every topic. One line each: `[[id]] — hook`.
+See [CONTRIBUTING](./CONTRIBUTING.md) for how the corpus works, and
+[hazards](./hazards.md) for every known system hole in one place.
+
+## authz
+
+- [[permissions]] — named `can_` checks; the server is the real boundary; widening one ripples everywhere ⚠️
+
+## media
+
+- [[media]] — files vs. the notes that keep them alive; reuse; lazy hourly cleanup ⚠️

--- a/corpus/map.md
+++ b/corpus/map.md
@@ -1,13 +1,50 @@
 # Corpus Map
 
-Root index of every topic. One line each: `[[id]] — hook`.
-See [CONTRIBUTING](./CONTRIBUTING.md) for how the corpus works, and
-[hazards](./hazards.md) for every known system hole in one place.
+Root index of every topic. One line each: `[[id]] — hook`. ⚠️ marks a topic that
+documents a [system hole](./hazards.md).
+See [CONTRIBUTING](./CONTRIBUTING.md) for how the corpus works.
 
 ## authz
 
 - [[permissions]] — named `can_` checks; the server is the real boundary; widening one ripples everywhere ⚠️
 
+## cards
+
+- [[cards]] — front/back units; server-picked ordering number; duplicates flagged not blocked ⚠️
+
+## decks
+
+- [[decks]] — one owner, one public/private switch; public means read-only, not shared study ⚠️
+
+## feedback
+
+- [[feedback]] — a curated public wall; posts stay hidden until a moderator publishes them ⚠️
+
 ## media
 
-- [[media]] — files vs. the notes that keep them alive; reuse; lazy hourly cleanup ⚠️
+- [[media]] — files vs. the notes that keep them alive; lazy hourly cleanup ⚠️
+- [[audio-generation]] — a durable step-chain turns a lesson recording into a transcript ⚠️
+
+## members
+
+- [[members]] — the account behind everything; ownership stamped from whoever's asking ⚠️
+
+## pacing
+
+- [[pacing]] — per-deck dials; follow a preset or pin a dial; a pin is presence, not difference ⚠️
+
+## scheduling
+
+- [[scheduling]] — FSRS decides when each card returns; the math runs on the client, not the server ⚠️
+
+## study
+
+- [[study]] — the session run over a merged pile; reviews save as you go ⚠️
+
+## theming
+
+- [[theming]] — colors are roles, not shades; three switches reslot the whole screen ⚠️
+
+## architecture
+
+- [[data-flow]] — server data is a named cache; a write owns marking its own data stale ⚠️

--- a/corpus/media/_map.md
+++ b/corpus/media/_map.md
@@ -1,0 +1,5 @@
+# media
+
+How uploaded images and audio are tracked, reused, and cleaned up.
+
+- [[media]] — files vs. the notes that track them; reuse, and the hourly cleanup ⚠️ hazard

--- a/corpus/media/_map.md
+++ b/corpus/media/_map.md
@@ -1,5 +1,6 @@
 # media
 
-How uploaded images and audio are tracked, reused, and cleaned up.
+How uploaded images and audio are tracked, reused, cleaned up, and turned into lessons.
 
-- [[media]] — files vs. the notes that track them; reuse, and the hourly cleanup ⚠️ hazard
+- [[media]] — files vs. the notes that keep them alive; reuse; lazy hourly cleanup ⚠️
+- [[audio-generation]] — a durable step-chain turns a lesson recording into a transcript ⚠️

--- a/corpus/media/audio-generation.md
+++ b/corpus/media/audio-generation.md
@@ -1,0 +1,115 @@
+---
+id: audio-generation
+domain: media
+status: current
+hazard: true
+related: [media]
+updated: 2026-07-23
+---
+
+# Audio generation
+
+Turning a recorded lesson — a talk, a chapter of a book — into a readable,
+follow-along transcript: the words, their timings, chapter breaks, translations,
+and pronunciation readings.
+
+Upload an hour of audio and the work can't happen in one go. It's too much for a
+single machine to finish before it's cut off.
+
+So the job is broken into small steps, and the lesson itself remembers where it
+is between them:
+
+1. Each step does **one small piece** of work and writes the result back onto
+   the lesson.
+2. That write **wakes the next step**, which reads where things stand and does
+   the next piece.
+
+The lesson carries a status through this — _processing_ while the chain runs,
+_ready_ when it finishes, _failed_ if a step gives up. A reader only sees the
+finished thing.
+
+> [!HAZARD] **A stuck job and a slow-but-healthy job look identical — so the safety net that rescues the first will strangle the second.**
+> Nothing watches a step from the inside. The only sign a lesson is still alive
+> is that it wrote something recently; go quiet for ten minutes and a background
+> sweep declares it dead and marks it failed. That's what rescues a job whose
+> chain truly broke — but it's the same clock, and a step that legitimately runs
+> long trips it while still working. Worse, that step's late result lands on a
+> row already marked failed, where nothing will pick the chain back up: real work
+> completed, then stranded.
+> [See how the sweep decides ↓](#the-sweep-is-the-backstop)
+
+## The chain moves one step at a time
+
+The steps run in a fixed order: transcribe the words, find the chapters,
+translate the sentences, add the readings, done.
+
+No single machine holds the whole job. Each step wakes, reads the lesson to see
+which step is due, does exactly that one piece, and writes it back. That write is
+what fires the next step. The last step marks the lesson _ready_ and the chain
+stops.
+
+The long steps are split finer still. A big upload is cut into overlapping
+slices before it's ever sent, and transcribing chews through **one slice per
+wake**. Translating and adding readings work through the sentences a batch at a
+time the same way. So no single wake ever tries to swallow the whole lesson.
+
+> [!NOTE]
+> The split happens on the uploader's own device before anything is sent — the
+> audio arrives already carved into ordered slices with a map of where each one
+> belongs in the timeline. A short file skips this and travels as one slice.
+
+## The sweep is the backstop
+
+If a step is lost — the machine dies, the wake-up never arrives — the lesson
+would otherwise sit in _processing_ forever. A sweep runs every minute, finds
+lessons that have been quiet too long, and marks them failed so the reader stops
+waiting on a ghost.
+
+"Quiet too long" is the whole judgment: the sweep can't see inside a running
+step, only when the lesson last wrote. Every step writes as it finishes its
+slice, and that write doubles as a heartbeat. The entire arrangement leans on one
+unstated promise — **that one slice always finishes well inside the deadline.**
+Size the slices wrong, or hand a step an unusually heavy one, and a perfectly
+healthy job gets reaped mid-breath.
+
+## Restarting means starting from scratch
+
+A failed lesson can be retried. The audio is still stored, so a retry doesn't
+re-upload — it resets the lesson to the very first step and lets the chain run
+again.
+
+The reset has to wipe the half-built transcript first, and this is not optional.
+Transcribing **appends** each slice onto what's already there. Point it at a
+lesson that already holds half a transcript and it stitches the new work onto the
+old — silently doubling content instead of resuming cleanly.
+
+> [!WATCH]
+> There's no "resume from where it died." The only safe restart is a full reset
+> to step one with the transcript cleared. A reaped lesson still carries its
+> half-finished transcript; whatever restarts it owns clearing that first, or the
+> next run builds on garbage.
+
+## Enrichment is allowed to come up short
+
+Only the transcript is load-bearing. Chapters, translations, and readings are
+enrichments — each step tries, and if it can't, it moves on rather than failing
+the whole lesson. A book with no clear chapter breaks simply gets one chapter; a
+sentence the translator chokes on is left untranslated. The reader still opens.
+
+The words themselves are the exception. If transcription fails, there's nothing
+to read, and the lesson fails outright.
+
+## What this isn't
+
+- **Not storage or cleanup.** Where the audio file lives, how it's shared, and
+  when it's swept away is [[media]]'s job — this is only how the transcript is
+  produced.
+- **Not who may run it.** Whether a member is allowed to generate or read lesson
+  audio is a permission check, a separate concern.
+- **Not the model wiring.** Which model does which step, the slice sizes, the
+  deadline, and how the steps signal each other are code detail — the reference
+  docs cover those.
+
+## Related
+
+[[media]]

--- a/corpus/media/media.md
+++ b/corpus/media/media.md
@@ -1,0 +1,87 @@
+---
+id: media
+domain: media
+status: current
+hazard: true
+related: [permissions, card-writes-via-rpc]
+updated: 2026-07-23
+---
+
+# Media
+
+The images and audio people attach to cards, decks, and lessons — how they're
+stored, reused, and eventually cleaned up.
+
+Add an image to a card and two things happen:
+
+1. **The file is saved** to storage.
+2. **A note is written** that says _"this card uses that file."_
+
+The file and the note are kept separate on purpose.
+
+Because the same image can be reused on many cards, one shared file can have
+several notes pointing at it.
+
+So a file is never thrown away the moment a card stops using it. It stays until
+_nothing_ — no card, deck, or lesson — points to it. Then a background cleanup
+job quietly removes it.
+
+> [!HAZARD] **A file lives or dies by its notes — not by the bucket it sits in.**
+> The cleanup job decides a file is garbage the instant no live note points at
+> it. That makes the note the file's lifeline, with a blade on each side: delete
+> a _shared_ file directly and you yank it out from under every other card still
+> using it; drop a file into a media bucket _without_ writing a note and the next
+> hourly sweep quietly eats it. Anything that touches these buckets goes through
+> the notes, never around them.
+> [See how cleanup decides ↓](#cleanup-happens-later)
+
+## The record
+
+Each note ties one file to one thing that uses it — a card slot, a deck, or a
+lesson — and remembers who owns it. Ownership matters: a person can only ever
+reach their own files, never anyone else's.
+
+> [!RULE]
+> A card slot holds **one** image at a time. Drop a new image on a slot that
+> already has one and the old note is quietly retired — you never end up with two
+> live images fighting over the same spot.
+
+## One file, many uses
+
+Reuse the same image on ten cards and there's still just _one_ file — with ten
+separate notes, one per card.
+
+That's the whole reason cleanup can't be instant. When one card lets go of an
+image, all that changed is that card's note. Nine other cards may still be using
+the same file.
+
+So a file is only safe to remove once **every** note pointing at it is gone — a
+judgment made across all the notes at once, never from one on its own.
+
+## Cleanup happens later
+
+Deleting a card, deck, lesson, or member retires its notes right away. A separate
+cleanup job runs once an hour, finds files that no note points to anymore, and
+removes them in batches.
+
+> [!WATCH]
+> Deleting a card doesn't free its image on the spot. The file sits untouched
+> until the next hourly sweep — so don't write code that assumes the storage is
+> reclaimed the instant something is deleted.
+
+The job leaves brand-new files alone for a short grace window, so an image that's
+mid-upload isn't swept away before its note is written. This job is the _only_
+thing that ever deletes a file.
+
+## What this isn't
+
+- **Not access control.** Who may _read_ a file is [[permissions]]'s job, not the
+  lifecycle's.
+- **Not generation.** How audio gets transcribed or images made lives in its own
+  topic.
+- **Not the SQL.** Bucket provisioning, indexes, triggers, and cron wiring are
+  code detail — the reference docs cover those.
+
+## Related
+
+[[permissions]] · [[card-writes-via-rpc]]

--- a/corpus/media/media.md
+++ b/corpus/media/media.md
@@ -3,7 +3,7 @@ id: media
 domain: media
 status: current
 hazard: true
-related: [permissions, card-writes-via-rpc]
+related: [permissions, cards]
 updated: 2026-07-23
 ---
 
@@ -77,11 +77,11 @@ thing that ever deletes a file.
 
 - **Not access control.** Who may _read_ a file is [[permissions]]'s job, not the
   lifecycle's.
-- **Not generation.** How audio gets transcribed or images made lives in its own
-  topic.
+- **Not generation.** How audio gets transcribed into a lesson lives in its own
+  topic — [[audio-generation]].
 - **Not the SQL.** Bucket provisioning, indexes, triggers, and cron wiring are
   code detail — the reference docs cover those.
 
 ## Related
 
-[[permissions]] · [[card-writes-via-rpc]]
+[[permissions]] · [[cards]]

--- a/corpus/members/_map.md
+++ b/corpus/members/_map.md
@@ -1,0 +1,5 @@
+# members
+
+The account behind everything — ownership, plans, roles.
+
+- [[members]] — the account behind everything; ownership stamped from whoever's asking ⚠️

--- a/corpus/members/members.md
+++ b/corpus/members/members.md
@@ -1,0 +1,103 @@
+---
+id: members
+domain: members
+status: current
+hazard: true
+related: [permissions, scheduling]
+updated: 2026-07-23
+---
+
+# Members
+
+Who a person _is_ to the app — the account behind every deck, card, and review,
+and the thing that says which of it all belongs to them.
+
+Sign in for the first time and, without anyone asking, a **member** appears —
+one row that stands for you across the whole app.
+
+From then on, almost everything you make carries a quiet stamp of your name.
+
+1. **You make a thing** — a deck, a card, a review.
+2. **It gets stamped** — _"this belongs to you"_ — the instant it's saved.
+
+That stamp is what keeps your stuff yours and everyone else's out of reach. You
+never write it; the app writes it for you, from whoever you're signed in as.
+
+> [!HAZARD] **The ownership stamp is copied from _whoever is asking_ — and a trusted backend job asks as nobody.**
+> Stamping "this belongs to you" from the signed-in person is exactly what makes
+> it effortless — you never have to set it. The flip side: a privileged backend
+> job runs with _no_ signed-in person, so the stamp comes back **empty**. On a
+> table that demands an owner, the write fails loudly. On one that _allows_ a
+> blank owner, it quietly saves a row that belongs to no one — invisible to its
+> real owner forever, and past the isolation wall that would have caught it.
+> [See how the stamp is filled ↓](#the-stamp-belongs-to-whoever-asked)
+
+## Born at sign-up
+
+A member isn't something you fill out a form for. The moment a new account is
+created, a member row is born alongside it, seeded with sensible defaults — a
+display name guessed from your login, a starting plan, an ordinary role.
+
+You can't sign in and _not_ have one. The account and the member are two halves
+of the same person, created together and deleted together.
+
+## The stamp belongs to whoever asked
+
+Nearly every row you own — decks, cards, reviews, media, feedback — carries an
+owner mark. You never set it by hand. When the row is saved, the app reads _who
+is making this request_ and writes that name onto the row.
+
+That's the whole trick behind isolation: since the owner mark can only ever be
+_your_ name, and you can only ever read rows marked with your name, you simply
+cannot see into anyone else's things.
+
+> [!WATCH]
+> The owner mark is taken from the request, not from anything the sender chose.
+> Hand the app a row that _claims_ a different owner and the claim is ignored —
+> the mark is overwritten with whoever you actually are. You can't gift a row to
+> someone else by lying about it.
+
+The catch lives at the edges. A few trusted backend jobs — billing, transcription
+— don't run _as_ a person; they run as the system, with special power that skips
+the isolation wall entirely. Ask for the owner there and you get nothing back.
+Where the row insists on an owner, the write is rejected. Where it doesn't, a row
+with a blank owner slips through and lands unreachable. Those jobs must set the
+owner themselves; they can't lean on the automatic stamp.
+
+## Plan and role: two different questions
+
+A member carries two separate dials, and they answer different questions.
+
+- **Plan** — _how much_ you can do. Free or paid, it sets the ceilings: how many
+  decks you can keep, how many cards fit in one. Reach a ceiling and the app
+  stops you, at the screen and again at the server.
+- **Role** — _what kind_ of thing you can do. Most people are ordinary members; a
+  few are moderators or admins who can reach past their own rows to run the
+  platform.
+
+The plan is never something you set for yourself. It moves only when billing says
+it moved — a successful payment lifts it, a lapsed one drops it back. The same
+lock keeps you from quietly promoting your own role. Both are off-limits to the
+one edit you _are_ allowed: changing your own display name, description, avatar.
+
+> [!RULE]
+> Your own edits can touch your profile, never your plan or your role. Those two
+> change only through billing and administration — paths that run with system
+> power, above the rule that pins everyone else to their own row.
+
+## What this isn't
+
+- **Not the permission rules.** _What_ a plan or role unlocks, and why the answer
+  always comes from the server, is [[permissions]]'s job — this is about what a
+  member _is_.
+- **Not billing.** How a payment turns into a plan change lives with the
+  subscription flow, not here.
+- **Not the public profile.** What _other_ people get to see of you — display
+  name, banner, description — is a narrow, deliberate slice, covered where reading
+  across the isolation wall is explained.
+- **Not the SQL.** The sign-up trigger, the stamping trigger, and the row-level
+  policies are code detail — the reference docs cover those.
+
+## Related
+
+[[permissions]] · [[scheduling]]

--- a/corpus/pacing/_map.md
+++ b/corpus/pacing/_map.md
@@ -1,0 +1,5 @@
+# pacing
+
+The per-deck dials that shape how hard a deck pushes you.
+
+- [[pacing]] — follow a preset or pin a dial; a pin is presence, not difference ⚠️

--- a/corpus/pacing/pacing.md
+++ b/corpus/pacing/pacing.md
@@ -1,0 +1,112 @@
+---
+id: pacing
+domain: pacing
+status: current
+hazard: true
+related: [scheduling]
+updated: 2026-07-23
+---
+
+# Pacing
+
+The per-deck dials that shape how hard a deck pushes you — how much you aim to
+remember, how gently new cards ramp up, how far out reviews may land.
+
+A deck studies at its own pace. Seven dials set that pace: your target
+retention, the little warm-up steps a new (or lapsed) card walks through, how
+many reviews and how many new cards a day, when a card counts as a "leech", and
+the furthest a review may ever be pushed.
+
+Setting all seven by hand on every deck would be tedious. So a deck usually
+**follows a preset** — a named bundle of all seven values you can point many
+decks at once.
+
+Where does a single dial's number actually come from? Walk down a ladder:
+
+1. **Did this deck pin that one dial itself?** Use the pin.
+2. **Otherwise, does the deck follow a preset?** Use the preset's value.
+3. **Otherwise**, fall back to the built-in default.
+
+The first rung that answers wins — dial by dial, not deck by deck. A deck can
+pin two dials and let a preset drive the other five.
+
+> [!HAZARD] **A pin that matches the preset is still a pin — and it quietly stops following the preset from then on.**
+> A dial is "pinned" purely because it's _present_ in the deck's override bag —
+> nothing compares its value to the preset. So dialing a control to the exact
+> number the preset already shows still pins it. It looks identical today, but
+> it has detached: edit that preset later and every following deck moves _except_
+> this one, which silently stays behind.
+> [See how a pin is tracked ↓](#a-pin-is-presence-not-difference)
+
+## Follow a preset, or pin a dial
+
+Left alone, every dial on a deck reads straight through its preset. Change one
+control and you **pin** just that dial — the deck now holds its own value there
+and ignores the preset for that one dial only. Every other dial keeps following.
+
+Pinning is per-dial and reversible. Un-pin a dial ("pull") and it drops back to
+whatever the preset says — the very next value, not the one it had when you
+pinned it.
+
+> [!NOTE]
+> For the daily caps and the maximum interval, `0` in the UI means "no limit".
+> A pin can hold that no-limit value on purpose — which is a different state from
+> having no pin at all. That's why the system tracks a pin by whether the dial is
+> _present_, not by whether it has a number: "pinned to unlimited" and "not
+> pinned" would otherwise look the same.
+
+## A pin is presence, not difference
+
+The deck keeps its pins as a small bag keyed by dial name. A dial is overridden
+when its key is _in the bag_, full stop — the value sitting there is never
+weighed against the preset.
+
+That's the trap in the hazard above. Editing a control always drops its key into
+the bag, even when you land on the preset's own number. Now the deck carries a
+pin that agrees with the preset by coincidence. The day someone edits the
+preset, the deck won't budge on that dial — the pin outranks it. Only pulling the
+dial removes the key and lets it follow again.
+
+## Pull one, push all
+
+Two directions move values between a deck and its preset, and they aren't
+symmetric:
+
+- **Pull** is deck-local and per-dial. Un-pinning a dial (or all of them at once)
+  changes only this deck.
+- **Push** is global and all-or-nothing. It writes _every_ current dial value
+  back into the preset — so every deck following that preset shifts with it. It's
+  confirmed, never per-dial, and it clears the deck's pins afterward (they'd
+  otherwise sit there agreeing with the preset — exactly the detached-pin trap).
+
+**Fork** is the escape hatch: it saves the deck's current dials as a brand-new
+preset and points the deck at it, pins cleared. Reach for it when you want your
+tweaks kept without disturbing the decks already on the old preset.
+
+> [!RULE]
+> There's one built-in **Default** preset shared across the whole app. You can
+> follow it and pin against it, but you can't rename, edit, delete, or push to it
+> — the only way to turn your tweaks into a preset off the Default is to fork.
+
+## When a change lands
+
+Pinning and pulling dials are staged in the deck's editor draft — nothing is
+written until you Save the deck. The preset actions are the exception: fork,
+push, rename, and delete hit the server the moment you confirm them, and they
+flush the deck's pacing side (its preset link and pin bag) along with the change
+so the two halves never disagree. The rest of your unsaved edits still wait for
+Save.
+
+## What this isn't
+
+- **Not the scheduler.** Pacing only supplies the dials; how a rating turns into
+  a due date is [[scheduling]]'s job.
+- **Not retroactive.** Changing a deck's pacing doesn't re-time the cards already
+  scheduled under the old values — it applies from the next review on. Why the
+  server never recomputes is [[scheduling]]'s hazard.
+- **Not the SQL.** The resolver, the sidecar table, and the override-bag shape
+  are code detail — the reference docs cover those.
+
+## Related
+
+[[scheduling]]

--- a/corpus/scheduling/_map.md
+++ b/corpus/scheduling/_map.md
@@ -1,0 +1,5 @@
+# scheduling
+
+The spaced-repetition engine — when each card comes back.
+
+- [[scheduling]] — FSRS decides when each card returns; the math runs on the client ⚠️

--- a/corpus/scheduling/scheduling.md
+++ b/corpus/scheduling/scheduling.md
@@ -1,0 +1,94 @@
+---
+id: scheduling
+domain: scheduling
+status: current
+hazard: true
+related: [pacing, study, cards]
+updated: 2026-07-23
+---
+
+# Scheduling
+
+How the app decides when each card comes back — the spaced-repetition engine at
+the heart of studying.
+
+Every card remembers two things:
+
+1. **How well you know it** — a couple of numbers the algorithm keeps.
+2. **When it's next due** — the date it should come back.
+
+When you rate a card — _Again, Hard, Good, Easy_ — the scheduling algorithm
+(FSRS) updates both: it nudges the "how well you know it" numbers and picks a new
+due date, pushed further out the better you did.
+
+Each deck tunes the algorithm with its own pacing — how much you want to
+remember, how gently new cards ramp up, how far out reviews may land. So the very
+same rating can schedule two decks differently.
+
+> [!HAZARD] **The schedule is computed on your device — the database only stores what your device tells it.**
+> The algorithm runs in the browser during a session; the server just records the
+> due date and stats the client already worked out. It never recomputes or checks
+> them. The upside is real — there's no second copy of the algorithm to keep in
+> sync. The trap: the stored schedule is only ever as correct as the client that
+> wrote it. An out-of-date app, a different algorithm version, or two devices
+> reviewing the same card can quietly write schedules under _different_ math — and
+> the database, not being the authority, can't tell. The client is the source of
+> scheduling truth; version it carefully.
+> [See what the server actually does ↓](#what-the-server-actually-does)
+
+## What a card remembers
+
+Behind each card sit a few numbers: roughly, how _durable_ the memory is (how
+long it'll survive before you'd likely forget) and how _hard_ the card is for
+you. From those, the algorithm derives the one thing you actually see — the next
+due date — plus a running tally of how many times you've reviewed it and how many
+times you've lapsed.
+
+> [!NOTE]
+> A brand-new card has no memory yet — it starts empty and picks up its numbers
+> the first time you rate it. Until then it's simply "new," and pacing treats new
+> and due cards under separate daily limits.
+
+## Rating moves the schedule
+
+_Again_ means you forgot — the card drops back to short, minutes-apart learning
+steps so you see it again this session. _Hard, Good, Easy_ all pass, each pushing
+the next due date further out than the last.
+
+How far "further out" actually lands depends on the deck's pacing — a deck that
+wants higher retention schedules tighter; one that allows longer intervals lets
+cards drift much further.
+
+> [!WATCH]
+> Changing a deck's pacing does **not** reschedule the cards already out there.
+> New pacing only affects each card the _next_ time it's rated. Lower your
+> retention expecting everything to come due sooner and nothing budges — the old
+> due dates stand until each card is reviewed again.
+
+## What the server actually does
+
+The server never schedules anything. Its whole job around reviews is two-fold:
+**store** the state the client computed, and **count** what's due.
+
+| Job                                            | Who does it                    |
+| ---------------------------------------------- | ------------------------------ |
+| Work out the new due date & memory numbers     | ⚠️ your device (the algorithm) |
+| Save that result + a log of the review         | the server (just records it)   |
+| Count how many cards are due, under daily caps | ✅ the server                  |
+
+The due-count you see on a deck is the server counting stored due dates and
+trimming them by the deck's daily limits (so many new, so many reviews). It reads
+the schedule; it never writes it.
+
+## What this isn't
+
+- **Not pacing.** The knobs themselves — retention, learning steps, daily caps —
+  and how they resolve are their own topic ([[pacing]]).
+- **Not the study session.** The queue, card flipping, and session flow are
+  separate from the scheduling math ([[study]]).
+- **Not the algorithm internals.** How FSRS turns a rating into numbers is library
+  detail — the reference docs and ts-fsrs cover that.
+
+## Related
+
+[[pacing]] · [[study]] · [[cards]]

--- a/corpus/study/_map.md
+++ b/corpus/study/_map.md
@@ -1,0 +1,5 @@
+# study
+
+The study session — running through due cards.
+
+- [[study]] — the session run over a merged pile; reviews save as you go ⚠️

--- a/corpus/study/study.md
+++ b/corpus/study/study.md
@@ -1,0 +1,117 @@
+---
+id: study
+domain: study
+status: current
+hazard: true
+related: [scheduling, media]
+updated: 2026-07-23
+---
+
+# Study session
+
+Sitting down with a deck and going through its due cards one at a time — flip,
+rate, next — until you're done. This is that experience: the run, not the math
+behind when a card comes back.
+
+You open a session over one deck, or several at once.
+
+Whatever you picked, the cards arrive as **one flat pile** — shuffled together,
+no seams between decks. You just work the pile.
+
+But each card quietly remembers which deck it came from. That memory is what
+lets one merged pile still treat every card by its own deck's rules.
+
+A session walks through four stages, in order:
+
+1. it **loads** the cards, then a cover card rises in;
+2. you **study** the pile;
+3. it shows a **summary** of how the run went.
+
+> [!HAZARD] **A card is marked reviewed the instant you rate it — locally, before the server confirms the save.**
+> Rating a card advances the pile and records the result on the spot; the actual
+> save to the server fires _after_, on its own. That ordering is what makes each
+> review land the moment you make it — but its flip side is a trap. If the save
+> fails, the card is already logged as done in the session's saved progress. The
+> error offers a **refresh** — and refreshing rebuilds that card as
+> already-reviewed, so it's never shown again and never retried. The review is
+> silently gone, and the card's schedule on the server stays stale.
+> [See how a review is saved ↓](#reviews-save-as-you-go)
+
+## One pile, whatever the decks
+
+The session core is **deck-blind**. It owns the pile, the flip, the four stages
+— and knows nothing about decks beyond the `deck_id` riding on each card.
+
+Everything deck-specific is looked up _through_ that id at the moment it's
+needed: which scheduler grades the card, which face it opens on, how far its next
+review lands. So a single merged pile can hold cards from five decks and still
+schedule each one by its own deck's pacing — the core never has to know it's
+juggling more than one.
+
+> [!NOTE]
+> Shuffle is all-or-nothing across the merge. If _any_ deck in the session wants
+> its cards shuffled, the whole combined pile shuffles — there's no shuffling one
+> deck's cards while keeping another's in order.
+
+## Four stages, one source of truth
+
+The session is always in exactly one stage — loading, cover, studying, or
+summary — and that single value drives everything the screen shows. There's no
+second flag saying "are we on the cover" or "which face is up" that could drift
+out of step; those are all read off the one stage.
+
+The run ends the moment it reaches summary. That happens two ways: you rate the
+last card, or you stop early. Either way, stopping mid-run still lands you on the
+summary of what you _did_ review — it isn't thrown away.
+
+## Reviews save as you go
+
+Rating a card doesn't wait for the end. Each review is sent to the server the
+instant you make it, one at a time, as you move through the pile.
+
+So the summary at the end isn't the save — by the time you get there, every
+review is already recorded. The end-of-session step only refreshes the deck
+counts so the dashboard reflects your work.
+
+> [!WATCH]
+> Because reviews are already on the server card-by-card, closing the tab
+> mid-run loses no _grades_ — everything you rated is saved. What's lost is only
+> the in-tab progress marker that lets a session resume (see below); the reviews
+> themselves survive.
+
+## Refreshing drops you back in
+
+A session keeps a running snapshot of itself — which cards are in the pile, which
+you've already rated, whether you finished — so a page refresh mid-run reopens
+the same session right where you left off.
+
+The snapshot locks the pile by card id. On resume, the cards you hadn't reached
+yet are re-fetched by those exact ids; the ones you'd already rated are rebuilt
+straight from the saved results and never shown again.
+
+Locking by id is deliberate. Without it, a resume would re-ask "what's due right
+now?" — and any card that came due _during_ your session would leak into a run
+that was supposed to be fixed the moment it started.
+
+> [!WATCH]
+> Resume is tab-scoped and refresh-scoped only. The snapshot lives in the tab's
+> own session storage, so it survives a refresh but not closing the tab — and it
+> never crosses to a second tab. Reopen in a fresh tab and you start a new
+> session, not the old one.
+
+## What this isn't
+
+- **Not the scheduling.** When a card is due, how far the next review lands, what
+  counts as a lapse — that's the FSRS math in [[scheduling]]. The session just
+  asks each card's deck to grade it and moves on.
+- **Not deck settings.** Pacing, starting side, shuffle, leech threshold are
+  configured on the deck; the session only _reads_ the resolved values.
+- **Not the card content.** Editing a card's text or image mid-run touches the
+  card, not the session — the session just patches its local copy so the change
+  shows without a reload.
+- **Not the wiring.** The controller, the engine's callbacks, the storage keys —
+  code detail the reference docs cover.
+
+## Related
+
+[[scheduling]] · [[media]]

--- a/corpus/theming/_map.md
+++ b/corpus/theming/_map.md
@@ -1,0 +1,5 @@
+# theming
+
+Where every color on the screen comes from.
+
+- [[theming]] — colors are roles, not shades; three switches reslot the whole screen ⚠️

--- a/corpus/theming/theming.md
+++ b/corpus/theming/theming.md
@@ -1,0 +1,116 @@
+---
+id: theming
+domain: theming
+status: current
+hazard: true
+related: []
+updated: 2026-07-23
+---
+
+# Theming
+
+Where every color on the screen comes from — and why nothing in the app ever
+names a specific shade.
+
+Nothing in the app says "be blue." It says _be the accent_, _be the surface_,
+_be the ink_ — a role, not a color.
+
+A role is a named slot. What actually fills it is decided by three switches, set
+high on the page and inherited all the way down to every element.
+
+Flip a switch and every role reslots at once — the whole screen re-themes, and
+not one component had to know a color's name to follow along.
+
+The three switches:
+
+1. **mode** — light or dark.
+2. **palette** — which accent color this member picked.
+3. **depth** — how raised a thing is: the flat page, a panel lifted off it, a
+   dialog floating above.
+
+> [!HAZARD] **The set of colors is closed — and a color that isn't in it resolves to nothing at all, with no error.**
+> The app deliberately wipes every stock color its styling toolkit ships with,
+> keeping only its own curated set. The upside is that every color on screen is
+> on-theme and dark-mode-correct by construction. The flip side: reach for a
+> color the set never registered — a leftover default class, a typo in a token
+> name — and it doesn't fall back to some near shade and it doesn't warn. The
+> style is simply inert: no color, no complaint, an element that renders bare.
+> [See what the reset does ↓](#colors-are-roles-not-shades)
+
+## Colors are roles, not shades
+
+Only a small, hand-picked set of shades exists at all. Everything else is a
+**role** — a named slot like _the surface_, _the accent_, _the ink_ — and every
+component fills its color by asking for a role, never by writing a shade.
+
+This is enforced at the root. The styling layer normally hands you hundreds of
+default colors; the app throws all of them out in one line and re-adds only the
+shades it curated. So the palette is a walled garden: inside it, everything is
+deliberate; step outside it and there's nothing there.
+
+> [!RULE]
+> Style by role, never by shade — ask for _the accent_, not _blue-500_. A
+> component that names a raw shade freezes one look into a slot the switches are
+> supposed to move, and re-themes wrong the moment a switch changes.
+
+## Three switches, set independently
+
+The switches are three separate dials, and they don't overlap. Each owns a
+different family of roles, so any combination composes cleanly with no "which
+one wins" rules:
+
+- **mode** shifts the _rendition_ of every role — the same slot, a light color
+  or a dark one. It's set once at the top of the page.
+- **palette** owns the **accent** roles only — the identity color and the few
+  slots that ride on it.
+- **depth** owns the **neutral chrome** roles — the surfaces, panels, and the
+  raised neutral elements resting on them. A thing's depth is how lifted it is,
+  and the neutral tones step to match.
+
+Because accent and neutral roles are disjoint, palette and depth never contend:
+a member's chosen accent and a panel's lift are answered by different slots.
+
+## The palette a member picks
+
+A member picks an accent, and that choice rides on the element as a single
+label — `blue`, `green`, `pink`. Everything beneath it inherits that accent, so
+one label re-colors a whole subtree.
+
+Some labels are **meanings, not colors**: a destructive control asks for
+_danger_, an informational one for _info_. Each meaning points at a real
+palette today, but the call site only ever says the meaning — so the color
+behind _danger_ can change without touching a single button.
+
+## Textured backgrounds
+
+Some surfaces carry a faint pattern — stripes, clouds, a dot grid — laid over
+their fill. This is the **bgx** layer, and its tint is just another themed role:
+_the accent's texture_ on an accent surface, _a neutral surface's texture_ on a
+plain one. Both follow the same switches, so a textured surface stays on-theme
+in every mode and palette without naming a color.
+
+The two go opposite ways on purpose. An accent surface is already colored, so
+its texture is a soft lighter **sheen**. A neutral surface is already pale, so
+its texture reads the other way — darker in light, lighter in dark — to stay
+visible.
+
+> [!NOTE]
+> The texture's strength is meant to live _in_ its role token, not in how each
+> use-site dials it. The direction is to bake the final blend into one opaque
+> color so a pattern's intensity is a property of the theme, not a knob every
+> caller reaches for — tune the token per surface, never the opacity at the
+> call.
+
+## What this isn't
+
+- **Not the shade list.** Which exact hues exist, and how the root reset and the
+  per-mode / per-depth selectors are wired, is styling detail — the reference
+  docs cover the mechanics.
+- **Not mode persistence.** How a member's light/dark choice is remembered and
+  applied to the page is app plumbing, not a theming truth.
+- **Not deck covers.** A cover happens to be where a member picks a palette, but
+  what a cover _is_ belongs to its own topic.
+
+## Related
+
+No sibling topics yet.


### PR DESCRIPTION
## Summary

Introduces `corpus/` — reader-first, plain-language docs of high-level **domain & system logic**, distinct from the implementation-altitude reference docs in `docs/`. Its purpose is to make the non-obvious obvious: surface the hazards and silent assumptions a reader would otherwise only find by getting burned.

- **Charter** (`corpus/CONTRIBUTING.md`) — defines the corpus shape (reader-first topics, callout palette, hazard model) and the **Archivist** persona that maintains it: do-nothing baseline, altitude gate, and active hazard-hunting.
- **12 topics** across authz, cards, decks, feedback, media (×2), members, pacing, scheduling, study, theming, architecture — each grounded in the real code.
- **12 audited system holes**, gathered into a generated `corpus/hazards.md` (ordered by blast radius). Each has been filed to the Task Board.
- **Per-commit instrumentation** — a tracked `post-commit` git hook (`.githooks/`) runs the Archivist agent (`.claude/agents/archivist.md`) headlessly over each commit's diff. Advisory; loop-guarded; writes isolated `[archivist]` corpus-only commits. Activate with `git config core.hooksPath .githooks`.