### PR TITLE
TARO-233: Cap panel notices to one at a time

### DIFF
--- a/src/stores/notice-store.ts
+++ b/src/stores/notice-store.ts
@@ -47,6 +47,14 @@ export const useNoticeStore = defineStore('notice', () => {
 
   function addNotice(state: NoticeState, message: string, options?: NoticeOptions): void {
     const persist = options?.persist ?? Boolean(options?.actions?.length)
+    const variant = options?.variant ?? 'toast'
+
+    // Only one panel notice may be visible at a time; a newer one replaces
+    // any existing panel. Toasts are unaffected and may still stack.
+    if (variant === 'panel') {
+      const existing_panels = notices.value.filter((n) => n.variant === 'panel')
+      for (const panel of existing_panels) removeNotice(panel)
+    }
 
     notices.value.push({
       variant: 'toast',

--- a/tests/unit/stores/notice-store.test.js
+++ b/tests/unit/stores/notice-store.test.js
@@ -118,6 +118,32 @@ describe('useNoticeStore', () => {
     })
   })
 
+  describe('panel notices are capped to one at a time', () => {
+    test('adding a new panel notice replaces the existing one', () => {
+      const store = useNoticeStore()
+      store.info('first panel', { variant: 'panel' })
+      store.error('second panel', { variant: 'panel' })
+      expect(store.panel_notices).toHaveLength(1)
+      expect(store.panel_notices[0].message).toBe('second panel')
+    })
+
+    test('adding a panel notice does not touch existing toasts', () => {
+      const store = useNoticeStore()
+      store.info('toast msg')
+      store.error('panel msg', { variant: 'panel' })
+      expect(store.toast_notices).toHaveLength(1)
+      expect(store.toast_notices[0].message).toBe('toast msg')
+      expect(store.panel_notices).toHaveLength(1)
+    })
+
+    test('toasts still stack when multiple are added', () => {
+      const store = useNoticeStore()
+      store.info('toast one')
+      store.info('toast two')
+      expect(store.toast_notices).toHaveLength(2)
+    })
+  })
+
   describe('removeNotice', () => {
     test('removes the matching notice by id', () => {
       const store = useNoticeStore()


### PR DESCRIPTION
[TARO-233](https://app.notion.com/p/3a50953c224c80b19ff1c77f61cca3a1)

## Summary

Full-width panel notices could stack on top of each other. `addNotice` in `src/stores/notice-store.ts` now removes any existing panel notices before pushing a new one when the resolved `variant === 'panel'`, so the newest replaces the current one (old animates out, new animates in). Corner toasts are untouched and still stack.

## Changes

- Cap panel-variant notices to one visible at a time in `addNotice`
- Unit test coverage for the new replace-on-push behavior

## Test plan

- [ ] Trigger two panel notices in quick succession, confirm the first animates out as the second animates in
- [ ] Trigger multiple toast notices, confirm they still stack as before