### PR TITLE
TARO-242: Add standard tap effect to spinbox steppers

### DIFF
--- a/src/components/ui-kit/spinbox/button.vue
+++ b/src/components/ui-kit/spinbox/button.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import UiIcon from '@/components/ui-kit/icon.vue'
-import { emitSfx } from '@/sfx/bus'
+import UiTappable from '@/components/ui-kit/tappable.vue'
 import { TYPE_SFX } from '@/sfx/config'
 
 type SpinboxButtonProps = {
@@ -13,21 +13,18 @@ const { icon, disabled = false } = defineProps<SpinboxButtonProps>()
 const emit = defineEmits<{
   (e: 'click'): void
 }>()
-
-function onClick() {
-  emitSfx('select')
-  emit('click')
-}
 </script>
 
 <template>
-  <button
+  <ui-tappable
+    as="button"
     type="button"
     :disabled="disabled"
-    class="inline-flex items-center justify-center aspect-square h-8 rounded-3 text-ink cursor-pointer transition-[background-color,color,transform] duration-100 hover:bg-accent hover:text-on-accent active:scale-95 disabled:opacity-[0.35] disabled:hover:bg-transparent disabled:hover:text-ink"
-    v-sfx="{ hover: TYPE_SFX }"
-    @click="onClick"
+    :sfx="{ hover: TYPE_SFX, press: 'select' }"
+    bgx_color="var(--color-accent-pattern)"
+    class="inline-flex items-center justify-center aspect-square h-8 rounded-3 text-ink cursor-pointer transition-[background-color,color] duration-100 hover:bg-accent hover:text-on-accent data-[tap-active=true]:bg-accent data-[tap-active=true]:text-on-accent disabled:opacity-[0.35] disabled:hover:bg-transparent disabled:hover:text-ink"
+    @tap="emit('click')"
   >
     <ui-icon :src="icon" class="size-4" />
-  </button>
+  </ui-tappable>
 </template>

--- a/tests/integration/components/ui-kit/spinbox.test.js
+++ b/tests/integration/components/ui-kit/spinbox.test.js
@@ -1,10 +1,19 @@
-import { describe, test, expect, vi } from 'vite-plus/test'
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount, mount } from '@vue/test-utils'
 
 // ── Hoisted mocks (sfx — break the sfx/config ↔ sfx/player circular init) ────
 
-vi.mock('@/sfx/bus', () => ({ emitSfx: vi.fn(), emitHoverSfx: vi.fn() }))
+const { coarseRef, fineRef, mockEmitSfx } = vi.hoisted(() => ({
+  coarseRef: { value: false },
+  fineRef: { value: true },
+  mockEmitSfx: vi.fn()
+}))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: vi.fn() }))
 vi.mock('@/sfx/config', () => ({ TYPE_SFX: [], HOVER_SFX_SET: new Set() }))
+vi.mock('@/composables/ui/media-query', () => ({
+  useMatchMedia: (query) => (query === 'fine' ? fineRef : coarseRef)
+}))
 
 // ── Component imports (after mocks) ───────────────────────────────────────────
 
@@ -349,23 +358,63 @@ describe('UiSpinbox', () => {
 
 // ── Button clickability (regression: captureMode removed) ─────────────────
 
+function mountSpinboxButton(props = {}) {
+  return mount(SpinboxButton, { props: { icon: 'chevron-up', ...props } })
+}
+
 describe('SpinboxButton', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+    coarseRef.value = false
+    fineRef.value = true
+  })
+
   test('clicking the button emits click on a fine-pointer device', async () => {
-    const wrapper = mount(SpinboxButton, { props: { icon: 'chevron-up' } })
+    const wrapper = mountSpinboxButton()
     await wrapper.find('button').trigger('click')
     expect(wrapper.emitted('click')).toHaveLength(1)
   })
 
-  test('clicking the button calls emitSfx with ui.select', async () => {
-    const { emitSfx } = await import('@/sfx/bus')
-    const wrapper = mount(SpinboxButton, { props: { icon: 'chevron-up' } })
-    await wrapper.find('button').trigger('click')
-    expect(emitSfx).toHaveBeenCalledWith('select')
-  })
-
   test('disabled button does not emit click', async () => {
-    const wrapper = mount(SpinboxButton, { props: { icon: 'chevron-up', disabled: true } })
+    const wrapper = mountSpinboxButton({ disabled: true })
     await wrapper.find('button').trigger('click')
     expect(wrapper.emitted('click')).toBeUndefined()
+  })
+
+  // ── Kit-standard tap feedback [obligation] ──────────────────────────────
+  // TARO-242: steppers route through the kit's staged-tap path instead of the
+  // old ad-hoc emitSfx('select') + active:scale-95. The sound itself stays
+  // 'select' — only the path it travels changed.
+
+  test('clicking the button plays the select press sfx through the staged-tap path', async () => {
+    const wrapper = mountSpinboxButton()
+    await wrapper.find('button').trigger('click')
+    expect(mockEmitSfx).toHaveBeenCalledWith('select', expect.any(Object))
+  })
+
+  test('plays the press sfx exactly once per click (no double sound)', async () => {
+    const wrapper = mountSpinboxButton()
+    await wrapper.find('button').trigger('click')
+    expect(mockEmitSfx).toHaveBeenCalledTimes(1)
+  })
+
+  test('disabled button plays no press sfx', async () => {
+    const wrapper = mountSpinboxButton({ disabled: true })
+    await wrapper.find('button').trigger('click')
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+  })
+
+  test('sets data-tap-active while a coarse-pointer tap is in flight', async () => {
+    coarseRef.value = true
+    const wrapper = mountSpinboxButton()
+    const p = wrapper.find('button').trigger('click')
+    await Promise.resolve()
+    expect(wrapper.find('button').attributes('data-tap-active')).toBe('true')
+    await p
+  })
+
+  test('data-tap-active is absent at rest', () => {
+    const wrapper = mountSpinboxButton()
+    expect(wrapper.find('button').attributes('data-tap-active')).toBeUndefined()
   })
 })


### PR DESCRIPTION
[TARO-242](https://app.notion.com/p/3a50953c224c8074984df3740986948c)

## Summary

The spinbox +/- steppers bypassed the button kit's tap system — a bare `<button>` with an inline `emitSfx('select')` call and a raw `active:scale-95`. They now use `ui-tappable`, so they get the same phase-correct press feedback as every other kit button.

## Changes

- `src/components/ui-kit/spinbox/button.vue`: swap the bare `<button>` for `<ui-tappable as="button">` with `:sfx="{ hover: TYPE_SFX, press: 'snappy_button_5' }"` — the kit-standard press key
- Remove the inline `emitSfx('select')` call and `onClick` wrapper; `@tap` emits `click` directly, so there's no double sound
- Drop the ad-hoc `active:scale-95`; `ui-tappable` provides the `data-tap-active` touch sweep instead