### PR TITLE
TARO-235: Detect deleted account, notify and redirect to welcome

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,16 @@ watch(
 )
 
 watch(
+  () => member.profile_missing,
+  (missing) => {
+    if (!missing) return
+
+    session.forceLogout('account-deleted')
+  },
+  { immediate: true }
+)
+
+watch(
   () => member.preferences,
   (prefs) => {
     const resolved = withMemberPreferencesDefaults(prefs)

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -44,6 +44,8 @@
   "session.expired-error-action": "Got It",
   "member.load-error": "Couldn't load your account",
   "member.load-error-sub": "Something went wrong loading your profile.",
+  "member.account-deleted": "This account no longer exists",
+  "member.account-deleted-sub": "Your account was deleted, so we've signed you out.",
   "login-dialog.forgot-password-link": "Forgot password?",
   "forgot-password-modal.heading": "Reset Password",
   "forgot-password-modal.instructions": "Enter your email and we'll send you a link to reset your password.",

--- a/src/stores/member.ts
+++ b/src/stores/member.ts
@@ -10,6 +10,7 @@ export const useMemberStore = defineStore('member', () => {
   const query = useCurrentMemberQuery()
   const member = query.data
   const error = query.error
+  const status = query.status
 
   // `id` is sourced from the session (set synchronously once auth restores),
   // not the member-profile query. Downstream api calls that scope queries by
@@ -33,8 +34,18 @@ export const useMemberStore = defineStore('member', () => {
 
   const has_member = computed(() => Boolean(id.value))
 
+  // The account was deleted server-side while the JWT is still valid: auth
+  // says we're logged in, but the profile fetch succeeded with zero rows
+  // (`fetchMemberById` resolves PGRST116 to null rather than throwing, so
+  // `error` stays empty). Only trustworthy once the query has settled —
+  // `data` is null while pending too.
+  const profile_missing = computed(
+    () => session.authenticated && status.value === 'success' && member.value == null
+  )
+
   return {
     has_member,
+    profile_missing,
     display_name,
     description,
     email,

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -33,6 +33,17 @@ import { useNoticeStore } from '@/stores/notice-store'
 import { useTaroPhoneStore } from '@/stores/taro-phone'
 import { closeAll as closeAllModals } from '@/composables/modal'
 
+/** Why a session was torn down without the member asking to log out. */
+export type ForceLogoutReason = 'expired' | 'account-deleted'
+
+const FORCE_LOGOUT_COPY: Record<ForceLogoutReason, { message: string; sub_message?: string }> = {
+  expired: { message: 'session.expired-error' },
+  'account-deleted': {
+    message: 'member.account-deleted',
+    sub_message: 'member.account-deleted-sub'
+  }
+}
+
 export const useSessionStore = defineStore('sessionStore', () => {
   const router = useRouter()
   const { t } = useI18n()
@@ -115,13 +126,17 @@ export const useSessionStore = defineStore('sessionStore', () => {
   }
 
   // Same end state as logout(), but skipped when already logged out (avoids
-  // reacting to its own signOut() call below) and shows a "session expired"
-  // notice instead of silently redirecting.
-  async function forceLogout(): Promise<void> {
+  // reacting to its own signOut() call below) and explains why the session
+  // ended instead of silently redirecting. `reason` only picks the copy —
+  // every reason gets the same teardown + redirect.
+  async function forceLogout(reason: ForceLogoutReason = 'expired'): Promise<void> {
     if (!authenticated.value) return
 
+    const copy = FORCE_LOGOUT_COPY[reason]
+
     reset()
-    notice.warn(t('session.expired-error'), {
+    notice.warn(t(copy.message), {
+      subMessage: copy.sub_message ? t(copy.sub_message) : undefined,
       variant: 'panel',
       persist: true,
       closable: false,
@@ -229,6 +244,7 @@ export const useSessionStore = defineStore('sessionStore', () => {
     checkPasswordRecovery,
     restoreSession,
     logout,
+    forceLogout,
     handleAuthError,
     signupEmail,
     signInOAuth,

--- a/tests/integration/app.test.js
+++ b/tests/integration/app.test.js
@@ -16,6 +16,7 @@ const {
   mockLoad,
   mockStartLoading,
   mockStopLoading,
+  mockForceLogout,
   mockSetup,
   mockInstallAudioLifecycle,
   mockInstallSafeAreaPadding,
@@ -24,6 +25,7 @@ const {
   mockLoad: vi.fn(),
   mockStartLoading: vi.fn(),
   mockStopLoading: vi.fn(),
+  mockForceLogout: vi.fn(),
   mockSetup: vi.fn(() => Promise.resolve()),
   mockInstallAudioLifecycle: vi.fn(() => vi.fn()),
   mockInstallSafeAreaPadding: vi.fn(),
@@ -35,10 +37,14 @@ vi.mock('@/stores/theme', () => ({
 }))
 
 vi.mock('@/stores/session', () => ({
-  useSessionStore: () => ({ startLoading: mockStartLoading, stopLoading: mockStopLoading })
+  useSessionStore: () => ({
+    startLoading: mockStartLoading,
+    stopLoading: mockStopLoading,
+    forceLogout: mockForceLogout
+  })
 }))
 
-const mockMember = reactive({ preferences: {}, error: null })
+const mockMember = reactive({ preferences: {}, error: null, profile_missing: false })
 
 vi.mock('@/stores/member', () => ({
   useMemberStore: () => mockMember
@@ -73,6 +79,8 @@ function mountApp() {
 
 beforeEach(() => {
   mockMember.error = null
+  mockMember.profile_missing = false
+  mockForceLogout.mockReset()
   mockInstallSafeAreaPadding.mockReset().mockReturnValue(mockTeardownSafeAreaPadding)
   mockTeardownSafeAreaPadding.mockReset()
 })
@@ -123,6 +131,36 @@ describe('App', () => {
       const notice = useNoticeStore()
 
       expect(notice.error).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('member.profile_missing watcher', () => {
+    test('tears down the session with the account-deleted reason when the profile goes missing', async () => {
+      const wrapper = mountApp()
+
+      mockMember.profile_missing = true
+      await flushPromises()
+
+      expect(mockForceLogout).toHaveBeenCalledWith('account-deleted')
+      wrapper.unmount()
+    })
+
+    test('tears down immediately when the profile is already known missing at mount', () => {
+      mockMember.profile_missing = true
+
+      const wrapper = mountApp()
+
+      expect(mockForceLogout).toHaveBeenCalledWith('account-deleted')
+      wrapper.unmount()
+    })
+
+    test('does NOT tear down while profile_missing is false', async () => {
+      const wrapper = mountApp()
+
+      await flushPromises()
+
+      expect(mockForceLogout).not.toHaveBeenCalled()
+      wrapper.unmount()
     })
   })
 })

--- a/tests/unit/stores/member.test.js
+++ b/tests/unit/stores/member.test.js
@@ -1,17 +1,20 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
 import { setActivePinia, createPinia } from 'pinia'
 
-const { memberRef, sessionUser } = vi.hoisted(() => ({
+const { memberRef, sessionUser, sessionAuthenticated } = vi.hoisted(() => ({
   memberRef: { value: null },
-  sessionUser: { value: null }
+  sessionUser: { value: null },
+  sessionAuthenticated: { value: false }
 }))
 
 vi.mock('@/api/members', async () => {
   const { ref } = await vi.importActual('vue')
   const errorRef = ref(null)
+  const statusRef = ref('pending')
   return {
-    useCurrentMemberQuery: () => ({ data: memberRef, error: errorRef }),
-    __mockMemberError: errorRef
+    useCurrentMemberQuery: () => ({ data: memberRef, error: errorRef, status: statusRef }),
+    __mockMemberError: errorRef,
+    __mockMemberStatus: statusRef
   }
 })
 
@@ -19,19 +22,27 @@ vi.mock('@/stores/session', () => ({
   useSessionStore: () => ({
     get user() {
       return sessionUser.value
+    },
+    get authenticated() {
+      return sessionAuthenticated.value
     }
   })
 }))
 
 import { useMemberStore } from '@/stores/member'
-import { __mockMemberError as memberErrorRef } from '@/api/members'
+import {
+  __mockMemberError as memberErrorRef,
+  __mockMemberStatus as memberStatusRef
+} from '@/api/members'
 
 describe('useMemberStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     memberRef.value = null
     sessionUser.value = null
+    sessionAuthenticated.value = false
     memberErrorRef.value = null
+    memberStatusRef.value = 'pending'
   })
 
   test('all fields are undefined and has_member is false when nothing is loaded', () => {
@@ -187,6 +198,65 @@ describe('useMemberStore', () => {
 
       expect(store.deck_limit).toBeNull()
       expect(store.cards_per_deck_limit).toBeNull()
+    })
+  })
+
+  // ── profile_missing — deleted account with a still-valid JWT ───────────────
+
+  describe('profile_missing', () => {
+    test('is false while the profile query is still pending', () => {
+      sessionAuthenticated.value = true
+      sessionUser.value = { id: 'user-1' }
+      memberStatusRef.value = 'pending'
+      memberRef.value = null
+
+      const store = useMemberStore()
+
+      expect(store.profile_missing).toBe(false)
+    })
+
+    test('is true once the query settles successfully with no row', () => {
+      sessionAuthenticated.value = true
+      sessionUser.value = { id: 'user-1' }
+      memberStatusRef.value = 'success'
+      memberRef.value = null
+
+      const store = useMemberStore()
+
+      expect(store.profile_missing).toBe(true)
+    })
+
+    test('is false when the settled query returned a member row', () => {
+      sessionAuthenticated.value = true
+      sessionUser.value = { id: 'user-1' }
+      memberStatusRef.value = 'success'
+      memberRef.value = { id: 'user-1' }
+
+      const store = useMemberStore()
+
+      expect(store.profile_missing).toBe(false)
+    })
+
+    test('is false when the query errored — that is a load failure, not a deletion', () => {
+      sessionAuthenticated.value = true
+      sessionUser.value = { id: 'user-1' }
+      memberStatusRef.value = 'error'
+      memberRef.value = null
+      memberErrorRef.value = new Error('fetch failed')
+
+      const store = useMemberStore()
+
+      expect(store.profile_missing).toBe(false)
+    })
+
+    test('is false when logged out, even with a settled empty query', () => {
+      sessionAuthenticated.value = false
+      memberStatusRef.value = 'success'
+      memberRef.value = null
+
+      const store = useMemberStore()
+
+      expect(store.profile_missing).toBe(false)
     })
   })
 

--- a/tests/unit/stores/session.test.js
+++ b/tests/unit/stores/session.test.js
@@ -497,6 +497,59 @@ describe('useSessionStore', () => {
     })
   })
 
+  describe('forceLogout reason copy', () => {
+    async function authenticatedStore() {
+      mockGetSession.mockResolvedValueOnce({ user: { id: 'u1', aud: 'authenticated' } })
+      mockLogout.mockResolvedValueOnce(undefined)
+      const store = useSessionStore()
+      await store.restoreSession()
+      return store
+    }
+
+    test('defaults to the session-expired copy with no sub-message', async () => {
+      const store = await authenticatedStore()
+
+      await store.forceLogout()
+
+      expect(mockNotice.warn).toHaveBeenCalledWith(
+        'session.expired-error',
+        expect.objectContaining({ subMessage: undefined, variant: 'panel' })
+      )
+    })
+
+    test('uses the account-deleted copy when that reason is given', async () => {
+      const store = await authenticatedStore()
+
+      await store.forceLogout('account-deleted')
+
+      expect(mockNotice.warn).toHaveBeenCalledWith(
+        'member.account-deleted',
+        expect.objectContaining({
+          subMessage: 'member.account-deleted-sub',
+          variant: 'panel',
+          persist: true,
+          closable: false
+        })
+      )
+    })
+
+    test('account-deleted runs the same teardown and welcome redirect as any forced logout', async () => {
+      const store = await authenticatedStore()
+
+      await store.forceLogout('account-deleted')
+
+      expect(store.user).toBeUndefined()
+      expect(mockCloseAllModals).toHaveBeenCalled()
+      expect(mockTaroPhoneReset).toHaveBeenCalled()
+      expect(mockLogout).toHaveBeenCalledOnce()
+
+      const [, options] = mockNotice.warn.mock.calls[0]
+      options.onDismiss()
+
+      expect(mockPush).toHaveBeenCalledWith({ name: 'welcome' })
+    })
+  })
+
   describe('forceLogout guard [obligation]', () => {
     test('is a no-op when already logged out, preventing its own supaLogout from re-triggering it [obligation]', async () => {
       // Store is never authenticated in this test (no restoreSession call).


### PR DESCRIPTION
[TARO-235](https://app.notion.com/p/3a50953c224c8020b8e7ecfa63deb7f9)

## Summary

If an account is deleted on the backend while the JWT is still valid, refreshing used to land the user on a blank dashboard. The app now detects the missing profile, shows a notice, and redirects to welcome.

## Changes

- `src/stores/member.ts`: new `profile_missing` computed — true only when authenticated, the member query has settled `success`, and data is null. Pending/error/logged-out all read false, so a transient load failure can't be mistaken for a deletion.
- `src/stores/session.ts`: `forceLogout(reason)` with a copy map for `expired` | `account-deleted`. Teardown + welcome redirect are identical; the reason only selects the notice copy.
- `src/App.vue`: watches `profile_missing` and calls `forceLogout('account-deleted')`.
- New i18n keys `member.account-deleted` / `member.account-deleted-sub`.

## Test plan

- [ ] Unit: `profile_missing` false while pending/errored/logged out, true only on settled-success-null.
- [ ] Unit: `forceLogout` tears down session and redirects for both reasons, with distinct copy.
- [ ] Integration: App reacts to `profile_missing` by forcing logout once.
- [ ] Manual: delete the account server-side with a live session, refresh — notice shows, lands on welcome.