### PR TITLE
Migrate ticket workflow from Notion to Jira

### DIFF
--- a/.claude/agents/archivist.md
+++ b/.claude/agents/archivist.md
@@ -58,10 +58,10 @@ git show <SHA>
 
 - **Never** `git add -A`, never stage or commit anything outside `corpus/`, never
   amend or rewrite existing commits, never push.
-- **New hazards: flag, don't file.** You have no reliable Notion access here. When
+- **New hazards: flag, don't file.** You have no reliable Jira access here. When
   you add a new hazard, record it in the commit body as a line beginning
   `NEW HAZARD:` (topic id + one-line summary) so a human files the backlog ticket.
-  Do not attempt to reach Notion or any MCP.
+  Do not attempt to reach Jira or any MCP.
 - **Match the exemplars' voice** (`corpus/authz/permissions.md`,
   `corpus/media/media.md`): open cold, one idea per beat, callouts that add (never
   restate), plain declarative present tense. When in doubt, change less.

--- a/.claude/agents/ticket-author.md
+++ b/.claude/agents/ticket-author.md
@@ -1,14 +1,14 @@
 ---
 name: ticket-author
-description: Writes tickets onto the TaroFlash Notion Task Board. Spawn when several tickets need cutting at once, or when a long investigation produced findings worth filing without spending the main session's context on Notion writes. Captures what was found; never specs, never grooms. A single ticket is usually cheaper to write inline via `.claude/rules/ticket-authoring.md`.
-tools: Read, Grep, Glob, Bash, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-create-pages, mcp__notion__notion-update-page
+description: Writes tickets into the TaroFlash Jira project (TARO). Spawn when several tickets need cutting at once, or when a long investigation produced findings worth filing without spending the main session's context on Jira writes. Captures what was found; never specs, never grooms. A single ticket is usually cheaper to write inline via `.claude/rules/ticket-authoring.md`.
+tools: Read, Grep, Glob, Bash, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue
 model: sonnet
 ---
 
-You are **the Ticket Author**. You turn findings into Task Board tickets and stop there.
+You are **the Ticket Author**. You turn findings into Jira tickets (project TARO) and stop there.
 
 **Read `.claude/rules/ticket-authoring.md` first, every run.** It is the source of truth for the
-board constants, field defaults, body templates, and authoring voice. What follows is only your
+Jira connection, field defaults, body templates, and authoring voice. What follows is only your
 operating loop.
 
 ## What you're invoked with
@@ -17,38 +17,42 @@ A description of one or more tickets to cut — often findings from an investiga
 context the caller gathered (root causes, file paths, the primitive that governs the surface).
 
 That context is the point. It was expensive to produce and is the thing most often lost. Get it into
-the body.
+the description.
 
 ## Loop
 
-1. **Read the rule.** Then check the board for near-duplicates before writing anything:
+1. **Read the rule.** Then check the project for near-duplicates before writing anything — a keyword
+   search on open issues (`cloudId: taroflash.atlassian.net`):
 
-   ```sql
-   SELECT "userDefined:ID" AS id, "Name", "Status", url
-   FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
-   WHERE "Status" NOT IN ('Done', 'Duplicate')
+   ```
+   searchJiraIssuesUsingJql — jql:
+   project = TARO AND statusCategory != Done AND summary ~ "<the ticket's key terms>"
    ```
 
-   A close match is reported back, not silently duplicated.
+   (`statusCategory != Done` excludes the closed lanes — Done, Duplicate, Won't Do.) A close match
+   is reported back, not silently duplicated.
 
 2. **Verify what you were handed, cheaply.** If the caller gave you a file path or root cause, spend
    one `Read`/`Grep` confirming it still holds. A wrong path in a ticket body sends `/triage` down a
    dead end. If you can't confirm it, label it `⚠️ Hunch-level — not code-confirmed` rather than
    dropping it — an unverified lead still beats nothing, but it must be marked.
 
-3. **Write each ticket** per the rule's template, fields, and voice. One ticket per idea; if the
-   input describes three things, cut three.
+3. **Write each ticket** per the rule's template, fields, and voice — `createJiraIssue`
+   (`projectKey: TARO`, `issueTypeName`, `summary`, markdown `description`, `additional_fields` for
+   `priority`), then transition it `To Do` → `Backlog`. One ticket per idea; if the input describes
+   three things, cut three.
 
-4. **Report** one line per ticket: `TARO-<ID> · <title> · <Priority> · <Type> → Backlog` + URL.
-   Then, separately, anything you could not verify and any near-duplicate you found.
+4. **Report** one line per ticket: `TARO-<n> · <title> · <Priority> · <Type> → Backlog` + URL
+   (`https://taroflash.atlassian.net/browse/TARO-<n>`). Then, separately, anything you could not
+   verify and any near-duplicate you found.
 
 ## Hard limits
 
-- **Only** the Task Board / Epic Board named in the rule. Never a backup or duplicate database.
+- **Only** project TARO. Never another project.
 - **Never** `Ready` / `Queued` / `In Progress` / `Done`. New tickets are `Backlog`.
-- **Never** set `Assignee` or `ID`.
+- **Never** set `Model`, or the issue key (Jira assigns it).
 - **Never** create an epic. If none fits, say so in your report and let the caller decide.
-- **Never** write code, edit files outside Notion, or touch tests.
+- **Never** write code, edit files outside Jira, or touch tests.
 - **Never** invent scope, acceptance criteria, or a taste decision. If the work needs a call on how
   something should look, feel, or read — record it as open.
 

--- a/.claude/context/app-map.md
+++ b/.claude/context/app-map.md
@@ -100,9 +100,9 @@ Use this first. Match words in the raw ticket to a starting path, then grep from
 
 ---
 
-## Epics (Notion Epic Board → code area)
+## Epics (TARO epics → code area)
 
-`/triage` sets the ticket's **Epic** relation. Active (In Dev / Ready / P0) first; map to code:
+`/triage` sets the ticket's **parent epic**. Active (In Dev / Ready / P0) first; map to code:
 
 | Epic                        | Status       | Code area                                              |
 | --------------------------- | ------------ | ------------------------------------------------------ |

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -1,49 +1,75 @@
 # Ticket Authoring
 
-How to cut a ticket on the Notion Task Board. Applies whenever the user says "cut a ticket", "file
+How to cut a ticket in Jira (project **TARO**). Applies whenever the user says "cut a ticket", "file
 that", "add that to the board", or when out-of-scope work is found mid-task.
 
 Cutting a ticket **captures**; it does not spec. `/triage` specs it later.
 
-## Board constants
+## Jira connection
 
-- **Task Board**: `collection://3630953c-224c-8065-8864-000bb9fe7bad`
-- **Epic Board**: `collection://2510953c-224c-80b7-9bb0-000b5384a47d`
-- `Priority`: `⇞P0` · `↑P1` · `↓P2` · `⇟P3` — `Type`: `Bug` · `Task` · `Story` · `Spike`
-- `Target`: `MVP` · `Fast-follow` · `Later` — which release the ticket ships in (orthogonal to Priority)
-- `ID` is read-only auto-increment. Never set it.
-- **The board is the source of truth for these lists, not this file.** `notion-fetch` on the
-  data-source URL returns the live options; check when a value seems not to fit, and fix this file.
+- **Project**: `TARO` (TaroFlash) — team-managed, on Atlassian Cloud.
+- **MCP server**: `atlassian` (official remote). Every tool takes a `cloudId` — use the site URL
+  **`taroflash.atlassian.net`** (UUID `44337aa0-a241-46a1-bc42-e7b4aa1d560b` also works).
+- **Create** with `createJiraIssue` (`projectKey: TARO`, `issueTypeName`, `summary`, markdown
+  `description`, `additional_fields` for priority / parent / custom fields). **Read/search** with
+  `searchJiraIssuesUsingJql` + `getJiraIssue`. **Update** with `editJiraIssue`. **Move status** with
+  `getTransitionsForJiraIssue` → `transitionJiraIssue`.
+- The key `TARO-<n>` is Jira's own auto-assigned sequence — never set it. URL:
+  `https://taroflash.atlassian.net/browse/TARO-<n>`.
 
-## Fields
+## Fields & vocab
 
-| Field      | Value when cutting                                                                                                                   |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `Status`   | **`Backlog`**, always — a new ticket is un-triaged by definition                                                                     |
-| `Assignee` | **empty** — only set when a ticket reaches `Queued`                                                                                  |
-| `Type`     | `Bug` broken · `Task` defined change · `Story` user-facing capability · `Spike` the deliverable is a decision, not shipped behaviour |
-| `Priority` | `⇞P0` data loss/security/broken core flow · `↑P1` real pain · `↓P2`/`⇟P3` rest                                                       |
-| `Target`   | **empty** at cut time — a triage/groom decision, not a capture one                                                                   |
-| `Epic`     | match the Epic Board; if nothing fits, propose a new epic rather than force-fit                                                      |
+- **Type** (`issueTypeName`): `Bug` · `Task` · `Story` · `Spike` (epics are type `Epic`).
+- **Priority**: `Highest` · `High` · `Medium` · `Low` (a ticket's urgency; Jira defaults new issues
+  to `Medium`).
+- **Status**: `Backlog` · `Needs More Info` · `Ready` · `Queued` · `In Progress` · `In Review` ·
+  `Blocked` · `On Hold` · `Done` · `Duplicate` · `Won't Do`. New issues are born in `To Do` and must
+  be **transitioned** to the target status.
+- **Target** (`customfield_10042`): `MVP` · `Fast Follow` · `Later` — which release the ticket ships
+  in (orthogonal to Priority).
+- **Model** (`customfield_10043`): `Sonnet` · `Opus` · `Fable` — which agent model works the ticket
+  in `/work batch`. This is the routing field (it replaced the old board's Assignee); it is **not**
+  Jira's native Assignee (a person), which stays unused.
+- **Parent**: the epic a ticket belongs to (`additional_fields.parent` = epic key, e.g. `TARO-7`).
+- `On Hold` means **hands-off** — the user works it themselves. `/triage` and `/work` leave it alone.
+
+> **The project is the source of truth for these option lists, not this file.**
+> `getJiraProjectIssueTypesMetadata` / `getJiraIssueTypeMetaWithFields` return the live issue types,
+> statuses, and custom-field ids; check when a value seems not to fit, and fix this file.
+
+## Fields when cutting
+
+| Field                    | Value when cutting                                                                                                         |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `Status`                 | **`Backlog`**, always — a new ticket is un-triaged by definition. Create in `To Do`, then transition to `Backlog`.         |
+| `Model`                  | **empty** — only set when a ticket reaches `Queued`                                                                        |
+| `Type` (`issueTypeName`) | `Bug` broken · `Task` defined change · `Story` user-facing capability · `Spike` the deliverable is a decision, not shipped |
+| `Priority`               | `Highest` data loss/security/broken core flow · `High` real pain · `Medium`/`Low` rest                                     |
+| `Target`                 | **empty** at cut time — a triage/groom decision, not a capture one                                                         |
+| `Parent` (epic)          | match an existing epic; if nothing fits, propose a new epic rather than force-fit                                          |
 
 Never write `Ready` or `Queued` — those assert an agent can execute the ticket, which is never true
-at capture time.
+at capture time. Never write `On Hold` on a fresh ticket — that's the user's own hands-off marker.
 
 ## Priority vs Target — two axes, don't collapse them
 
 `Priority` answers **in what order** (urgency/sequencing). `Target` answers **which release**
-(scope). They are orthogonal — a pre-launch `MVP` ticket still ranges `P0`→`P3`, so all four
+(scope). They are orthogonal — a pre-launch `MVP` ticket still ranges `Highest`→`Low`, so all four
 priority tiers stay meaningful inside the launch set instead of two being spent marking the cut-line.
 
 - `MVP` — ships before launch.
-- `Fast-follow` — committed to the first post-launch cycle. Has a home; gets swept.
+- `Fast Follow` — committed to the first post-launch cycle. Has a home; gets swept.
 - `Later` — genuinely deferred, allowed to be quiet.
 
-A ticket stays in its epic regardless of `Target` — the epic is the resurfacing anchor, not a
-graveyard. `Fast-follow` items surface in the **Fast-follow** board view (all epics, sorted by
-priority) for the post-launch sweep. Leave `Target` empty at capture; `/triage` and `/groom` set it.
+A ticket stays under its epic regardless of `Target` — the epic is the resurfacing anchor, not a
+graveyard. `Fast Follow` items surface via a Jira board/filter view (`Target = "Fast Follow"`, all
+epics, sorted by priority) for the post-launch sweep. Leave `Target` empty at capture; `/triage` and
+`/groom` set it.
 
 ## Body
+
+Pass the body as the issue **`description`** with `contentFormat: markdown` — Markdown headings,
+lists, and checkboxes render natively in Jira; no ADF needed.
 
 **Bug**
 
@@ -81,9 +107,9 @@ priority) for the post-launch sweep. Leave `Target` empty at capture; `/triage` 
 
 ## New epics
 
-Propose first, never create silently. Icon is a Notion built-in via its hosted SVG —
-`https://www.notion.so/icons/<name>_<color>.svg` (`gray|brown|orange|yellow|green|blue|purple|pink|red`).
-Not an emoji. The bare `icons/<name>_<color>` path is accepted by the API but **renders blank**.
+Propose first, never create silently. Create with `createJiraIssue` (`issueTypeName: "Epic"`,
+`summary` = the epic name); optionally set an issue colour via `additional_fields.customfield_10017`.
+Give a one-line scope, not a full spec — an epic is a resurfacing anchor.
 
 ## Batch work
 

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: groom
-description: Deep second pass over a single Notion Task Board ticket sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket and moves it to `Ready`/`Queued`. Owns splitting oversized tickets and recording external blockers. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
-allowed-tools: Read, Grep, Glob, Bash, Agent, WebFetch, WebSearch, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page, mcp__notion__notion-create-pages, mcp__notion__notion-search
+description: Deep second pass over a single Jira ticket (project TARO) sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket and moves it to `Ready`/`Queued`. Owns splitting oversized tickets and recording external blockers. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebFetch, WebSearch, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue
 argument-hint: '[<ID>]'
 arguments:
   - name: <ID>
-    description: Numeric ticket ID to groom. Omit to take the top `Needs More Info` ticket by Priority → ID.
-lastUpdated: 2026-07-30T00:00:00Z
+    description: Jira ticket number to groom (the `<n>` in `TARO-<n>`). Omit to take the top `Needs More Info` ticket by Priority → creation order.
+lastUpdated: 2026-07-31T00:00:00Z
 ---
 
 ## What this skill does
@@ -25,7 +25,7 @@ Needs More Info ──/groom──┬──► Ready / Queued     (decisions res
 One ticket at a time, conversationally. This is the opposite of `/triage`'s batching — depth is
 the whole point.
 
-Do **not** touch tests. Do **not** write code. This skill reads code and writes Notion.
+Do **not** touch tests. Do **not** write code. This skill reads code and writes Jira.
 
 ## The core rule
 
@@ -44,15 +44,16 @@ recorded under `## Blocked on`, never left as an unmarked menu.
 
 ## Board constants
 
-- **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`
-- **Epic Board** data source: `collection://2510953c-224c-80b7-9bb0-000b5384a47d`
-- `Type`: `Bug` · `Task` · `Story` · `Spike`. **`Spike` when the deliverable is a decision or
-  recommendation rather than shipped behaviour** — retype a ticket if grooming reveals that's what it
-  really is, and drop any now-redundant `"Spike:"` title prefix.
-- The board is the source of truth for every option list, not this file — `notion-fetch` on the
-  data-source URL returns the live values. Check when something seems not to fit.
+- **Project**: `TARO` (TaroFlash) — team-managed, on Atlassian Cloud. MCP server `atlassian`; every
+  tool takes a `cloudId` — use the site URL **`taroflash.atlassian.net`**.
+- `Type` (`issueTypeName`): `Bug` · `Task` · `Story` · `Spike`. **`Spike` when the deliverable is a
+  decision or recommendation rather than shipped behaviour** — retype a ticket if grooming reveals
+  that's what it really is, and drop any now-redundant `"Spike:"` title prefix.
+- The project is the source of truth for every option list, not this file —
+  `getJiraProjectIssueTypesMetadata` / `getJiraIssueTypeMetaWithFields` return the live issue types,
+  statuses, and custom-field ids. Check when something seems not to fit.
 - Lanes: pulls from `Needs More Info`; lands at `Ready` / `Queued`; may park at `On Hold`.
-  Never sets `In Progress` / `Review` / `Done` / `Blocked`.
+  Never sets `In Progress` / `In Review` / `Done` / `Blocked`.
 
 ## Reporting voice
 
@@ -78,15 +79,14 @@ Either way, no walls of text:
 
 ### 1. SELECT
 
-```sql
-SELECT "userDefined:ID" AS id, "Name", "Priority", "Type", "Epic", "Assignee", url
-FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
-WHERE "Status" = 'Needs More Info'
-ORDER BY "Priority" ASC, "userDefined:ID" ASC
+```jql
+project = TARO AND status = "Needs More Info" ORDER BY priority DESC, created ASC
 ```
 
-Take the given `<ID>`, else the top row. Fetch its full page — `/triage` already wrote a body with
-the open forks recorded; build on it, don't restart. Echo which ticket you're grooming in one line.
+(`priority DESC` = Highest first; `created ASC` breaks ties oldest-first.) Take the given `<ID>`
+(`TARO-<ID>`), else the top row. Fetch its full issue with `getJiraIssue` (summary + `description`
+markdown) — `/triage` already wrote a body with the open forks recorded; build on it, don't restart.
+Echo which ticket you're grooming in one line.
 
 Leave `Status` alone. Grooming doesn't claim.
 
@@ -150,7 +150,8 @@ Only answerable once the design has resolved:
 
 ### 5. WRITE
 
-Rewrite the ticket body. Sections, in order:
+Rewrite the ticket **`description`** (markdown) via `editJiraIssue` `fields.description` — a single
+full-rewrite is fine. Any splits become new tickets via `createJiraIssue`. Sections, in order:
 
 ```
 ## Product description        <what the user experiences and why — product terms>
@@ -169,23 +170,19 @@ Rewrite the ticket body. Sections, in order:
 - **What was rejected and why** — this is what stops a future session re-proposing it.
 - **`CONFIRMED` / `ASSUMED`**, with the source for anything confirmed.
 
-Two formatting notes, learned the hard way:
+Prefer **bullets over numbered lists** for implementation steps — a stable style choice, not a
+tooling workaround.
 
-- Use **bullets, not numbered lists**, for implementation steps — Notion renumbers ordered lists,
-  which silently breaks any cross-reference and any later `update_content` anchored on them.
-- Prefer `replace_content` for a full rewrite over a chain of `update_content` edits. Batched
-  search-and-replace against a page you just restructured fails quietly.
-
-Then set `Status`:
+Then set `Status` via `getTransitionsForJiraIssue` → `transitionJiraIssue`:
 
 - **`Queued`** — only when _zero_ decisions are unresolved. No human is in the loop.
 - **`Ready`** — executable. A ticket still carrying an unmade design or taste call does **not**
   qualify, even labelled "decide during pairing" — that is what `Needs More Info` is for, and this
   pass exists to settle it. The only thing that may ride into `Ready` is a decision genuinely blocked
   on an external fact (§4), recorded under `## Blocked on`.
-- **Refuse to write `Queued` with `Assignee` = `Me` or empty**, or with any unresolved fork.
-  `Queued` needs a model (`/work batch` pins each subagent to it). **`Ready` tickets stay
-  unassigned** — leave the field empty.
+- **Refuse to write `Queued` with `Model` empty** (or any unresolved fork). `Queued` needs a `Model`
+  — Sonnet / Opus / Fable — because `/work batch` pins each subagent to it. **`Ready` tickets carry
+  no `Model`** — leave the field empty.
 
 Also sweep for **copy that the change makes false** — existing `src/locales/en-us.json` strings
 asserting the old behaviour ("this cannot be undone"). List them in the body as required edits.
@@ -208,9 +205,9 @@ it without guessing. Test it by asking:
 
 ## Guardrails
 
-- Only ever touch the Task Board / Epic Board data sources above — never a backup or duplicate.
+- Only ever touch project `TARO` — never a backup or duplicate.
 - Never write code, never touch tests, never open a PR. This pass ends at a ticket.
-- Never set `In Progress` / `Review` / `Done`.
+- Never set `In Progress` / `In Review` / `Done`.
 - Never resolve a decision the user should make — product calls, pricing, policy, and anything
   affecting users' money or data go to them as questions.
 - Never mark a fact `CONFIRMED` without having actually read the source.

--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -9,15 +9,15 @@ arguments:
   - name: --ticket <ID>
     description: Prefix the PR title with the ticket key `TARO-<ID>` (e.g. `TARO-207: …`). Omit for no prefix.
   - name: --ticket-url <URL>
-    description: Notion ticket URL. When given alongside `--ticket`, the PR body opens with a `[TARO-<ID>](<URL>)` link line. Omit to render just `TARO-<ID>` text (or nothing if `--ticket` is also absent).
-lastUpdated: 2026-07-20T00:00:00Z
+    description: Jira issue URL. When given alongside `--ticket`, the PR body opens with a `[TARO-<ID>](<URL>)` link line. Omit to render just `TARO-<ID>` text (or nothing if `--ticket` is also absent).
+lastUpdated: 2026-07-31T00:00:00Z
 ---
 
 ## Args
 
 - **`--no-watch`** (optional) — skip the post-create CI watch + coverage check (Step 10). Default behaviour blocks on CI after opening the PR until checks settle, then inspects coverage and writes more tests if it regressed.
-- **`--ticket <ID>`** (optional) — the Notion Task Board ticket ID this PR resolves. When given, the PR **title** is prefixed with `TARO-<ID>: ` and the PR **body** opens with a ticket-link line (Step 8). This affects the PR title and body only — commit subjects stay clean (ticket refs still belong in a commit-body `Refs:` trailer, per Notes). Omit to open a PR with no ticket prefix or link.
-- **`--ticket-url <URL>`** (optional) — the Notion page URL for the ticket. When given with `--ticket`, the body's top line renders as a markdown link `[TARO-<ID>](<URL>)`. Without it, the top line falls back to plain `TARO-<ID>` text. Ignored when `--ticket` is absent.
+- **`--ticket <ID>`** (optional) — the Jira issue number (the `<ID>` in `TARO-<ID>`) this PR resolves. When given, the PR **title** is prefixed with `TARO-<ID>: ` and the PR **body** opens with a ticket-link line (Step 8). This affects the PR title and body only — commit subjects stay clean (ticket refs still belong in a commit-body `Refs:` trailer, per Notes). Omit to open a PR with no ticket prefix or link.
+- **`--ticket-url <URL>`** (optional) — the Jira issue URL (`https://taroflash.atlassian.net/browse/TARO-<ID>`). When given with `--ticket`, the body's top line renders as a markdown link `[TARO-<ID>](<URL>)`. Without it, the top line falls back to plain `TARO-<ID>` text. Ignored when `--ticket` is absent.
 
 ## Fully autonomous — no approval gates
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: triage
-description: First pass over raw Notion Task Board tickets. Investigates where each ticket lives in the code, fills in every field (Priority/Type/Epic/Assignee), writes a body from the per-Type template, and routes each ticket to its next lane — `Ready`/`Queued` when it is executable as-is, or `Needs More Info` when it carries unresolved design decisions for `/groom` to settle. Batched and checkpointed; reports in product terms only. May propose creating epics, merging tickets, or parking them. Trigger on `/triage`, "triage the backlog", "triage tickets".
-allowed-tools: Read, Grep, Glob, Bash, Agent, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page, mcp__notion__notion-create-pages, mcp__notion__notion-search
+description: First pass over raw Jira (project TARO) tickets. Investigates where each ticket lives in the code, fills in every field (Priority/Type/Epic/Model), writes a body from the per-Type template, and routes each ticket to its next lane — `Ready`/`Queued` when it is executable as-is, or `Needs More Info` when it carries unresolved design decisions for `/groom` to settle. Batched and checkpointed; reports in product terms only. May propose creating epics, merging tickets, or parking them. Trigger on `/triage`, "triage the backlog", "triage tickets".
+allowed-tools: Read, Grep, Glob, Bash, Agent, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue, mcp__atlassian__getJiraProjectIssueTypesMetadata, mcp__atlassian__getJiraIssueTypeMetaWithFields
 argument-hint: '[--p0|--p1|--p2|--p3] [--count N] [<ID> <ID> …]'
 arguments:
   - name: --p0|--p1|--p2|--p3
     description: Only triage Backlog tickets of this priority.
   - name: --count N
-    description: Cap the batch at N tickets (default 10). Ordered Priority → ID.
+    description: Cap the batch at N tickets (default 10). Ordered Priority → created.
   - name: <ID>
-    description: One or more numeric ticket IDs to triage specifically (overrides filters).
-lastUpdated: 2026-07-29T00:00:00Z
+    description: One or more Jira ticket keys (`TARO-<n>`, or the bare number) to triage specifically (overrides filters).
+lastUpdated: 2026-07-31T00:00:00Z
 ---
 
 ## What this skill does
@@ -25,32 +25,40 @@ Backlog ──/triage──┬──► Ready / Queued        (executable as-is)
 ```
 
 Output per ticket: a descriptive **title**, a **body** from the per-Type template, all four
-**fields** (Priority/Type/Epic/Assignee), and a **lane** with the routing reason stated.
+**fields** (Priority/Type/Epic/Model), and a **lane** with the routing reason stated.
 
 Batched and checkpointed: ~2 interruptions for the whole batch, not one per ticket.
 
-Do **not** touch tests. Do **not** write code. This skill reads code and writes Notion.
+Do **not** touch tests. Do **not** write code. This skill reads code and writes Jira.
 
 ## Board constants
 
-- **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`
-- **Epic Board** data source: `collection://2510953c-224c-80b7-9bb0-000b5384a47d`
+- **Project**: `TARO` (TaroFlash) — team-managed, on Atlassian Cloud.
+- **MCP server**: `atlassian`. Every tool takes a `cloudId` — use the site URL
+  **`taroflash.atlassian.net`**.
 - **Fields & vocab:**
-  - `Status`: `On Hold` · `Backlog` · `Needs More Info` · `Ready` · `Queued` · `In Progress` · `Blocked` · `Review` · `Duplicate` · `Won't Do` · `Done`
-  - `Priority`: `⇞P0` · `↑P1` · `↓P2` · `⇟P3`
-  - `Type`: `Bug` · `Task` · `Story` · `Spike`
-  - `Assignee`: `Me` · `Fable` · `Opus` · `Sonnet`
+  - `Status`: `On Hold` · `Backlog` · `Needs More Info` · `Ready` · `Queued` · `In Progress` · `Blocked` · `In Review` · `Duplicate` · `Won't Do` · `Done`
+  - `Priority`: `Highest` · `High` · `Medium` · `Low`
+  - `Type` (`issueTypeName`): `Bug` · `Task` · `Story` · `Spike`
+  - `Model` (`customfield_10043`): `Sonnet` · `Opus` · `Fable`
+  - `Target` (`customfield_10042`): `MVP` · `Fast Follow` · `Later`
 
-> **The board is the source of truth for these lists, not this file.** A hardcoded vocabulary here
+> **The project is the source of truth for these lists, not this file.** A hardcoded vocabulary here
 > once went stale and `Spike` was invisible for months — tickets encoded it in their titles instead.
-> `notion-fetch` on the data-source URL returns the live option lists; check them when a value seems
-> not to fit, and fix this file rather than working around it.
+> `getJiraProjectIssueTypesMetadata` / `getJiraIssueTypeMetaWithFields` return the live issue types,
+> statuses, and custom-field ids; check them when a value seems not to fit, and fix this file rather
+> than working around it.
 
-- `Epic`: relation to Epic Board (single). `ID`: read-only auto-increment.
+- `Epic`: a ticket's epic is its **parent** (`additional_fields.parent` = epic key; epics are
+  `issuetype = Epic`). The key `TARO-<n>` is Jira's own auto-assigned sequence — never set it.
+  URL: `https://taroflash.atlassian.net/browse/TARO-<n>`.
+- **Status is a transition, not a field write.** Move status with `getTransitionsForJiraIssue` →
+  `transitionJiraIssue`; never try to set `Status` via `editJiraIssue`.
 
 Two parked lanes, distinguished by what is missing:
 
-- **`On Hold`** — parked for the user's own reasons. Triage never routes here unasked.
+- **`On Hold`** — parked for the user's own reasons; this is the user's own hands-off marker. Triage
+  never routes here unasked.
 - **`Needs More Info`** — the _what_ is clear, the _how_ is not. Unresolved technical decisions.
   `/groom` picks these up.
 
@@ -74,30 +82,31 @@ every investigation.
 
 ### 1. FETCH
 
-```sql
-SELECT "userDefined:ID" AS id, "Name", "Type", "Priority", "Epic", "Assignee", url
-FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
-WHERE "Status" = 'Backlog'
-  AND ("Assignee" IS NULL OR "Assignee" <> 'Me')   -- Me on Backlog = hands off
-ORDER BY "Priority" ASC, "userDefined:ID" ASC
+```jql
+project = TARO AND type != Epic AND status = "Backlog"
+ORDER BY priority DESC, created ASC
 ```
 
-`Assignee = Me` on a Backlog ticket is the user's "don't triage this" signal. Apply args:
-`--pN` adds `AND "Priority" = '<glyph>'`; explicit `<ID>`s replace the WHERE with
-`"userDefined:ID" IN (…)` (overriding both filters, since naming a ticket is deliberate — but
-warn if it isn't in Backlog or is assigned `Me`). `--count N` caps the batch (default 10); if it
-would exceed the cap, take the top N and say how many were left.
+`type != Epic` excludes epics; `priority DESC` sorts `Highest` first; `created ASC` is the stable
+secondary. Apply args: `--pN` adds `AND priority = Highest|High|Medium|Low`; explicit `<ID>`s
+replace the status/priority filters with `AND key IN (TARO-…, …)` (overriding both, since naming a
+ticket is deliberate — but warn if it isn't in `Backlog`). `--count N` caps the batch (default 10);
+if it would exceed the cap, take the top N and say how many were left.
+
+(`searchJiraIssuesUsingJql` returns ≤100 issues/page — paginate via `nextPageToken` only if a batch
+ever runs that large; default batches are far smaller.)
 
 ### 2. SELECT
 
-Echo the batch as a compact numbered list (ID · Priority · raw name). If args fully determined it,
+Echo the batch as a compact numbered list (key · Priority · raw name). If args fully determined it,
 proceed. If ambiguous or oversized, ask before spending investigation time.
 
 ### 3. READ existing descriptions
 
-Fetch each ticket's **page body** via `notion-fetch` — §1 pulls properties only. The user often
-writes real context into a raw ticket. Read every in-scope body and carry it through. If a
-description already dictates the approach, honour it rather than re-deriving from the name.
+Fetch each ticket's **description** via `getJiraIssue` (request the `description` field — it comes
+back as markdown). The user often writes real context into a raw ticket. Read every in-scope
+description and carry it through. If a description already dictates the approach, honour it rather
+than re-deriving from the name.
 
 ### 4. INVESTIGATE
 
@@ -121,10 +130,10 @@ One interruption for the whole batch. Per ticket, **in product terms**, ≤2 lin
 - what it turned out to be (and anything surprising),
 - proposed lane + **which routing trigger fired**, in a short phrase.
 
-> `#141` the number steppers in review-pacing settings — styling only, kit already handles it
+> `TARO-141` the number steppers in review-pacing settings — styling only, kit already handles it
 > → Ready
 >
-> `#264` deleting your account — needs decisions on the grace period and what a deleted user sees
+> `TARO-264` deleting your account — needs decisions on the grace period and what a deleted user sees
 > → Needs More Info (new stored state + billing)
 
 Separate the clean tickets from the ones needing a decision. **Stop for confirmation or redirect**
@@ -138,17 +147,16 @@ review. Per ticket:
 
 - **Title** — descriptive rewrite.
 - **Summary** — one line of product intent.
-- **Fields** — `Priority`, `Type`, `Epic`, and `Assignee` **only when the lane is `Queued`**
-  (see § Assignee). Tickets now arrive with only name +
-  description, so **propose all four**; never apply them unasked.
+- **Fields** — `Priority`, `Type`, `Epic` (parent), and `Model` **only when the lane is `Queued`**
+  (see § Model). Tickets now arrive with only name + description, so **propose all four**; never
+  apply them unasked.
 - **Lane** — with the trigger that decided it.
 - **Proposals** — CREATE a new ticket, MERGE into another (name the survivor), or CREATE a new
   epic. Never silently.
 
-**New epics.** If no existing epic fits, propose one rather than forcing a bad match. Set its icon
-to a Notion built-in via external URL — `https://www.notion.so/icons/<name>_<color>.svg` (colors:
-`gray|brown|orange|yellow|green|blue|purple|pink|red`). Not an emoji. The bare `icons/<name>_<color>`
-path is accepted by the API but renders blank — always use the full `.svg` URL.
+**New epics.** If no existing epic fits, propose one rather than forcing a bad match. Create it with
+`createJiraIssue` (`issueTypeName: "Epic"`, `summary` = the epic name, a one-line scope in the
+description) — an epic is a resurfacing anchor, not a full spec.
 
 **Consolidate for the `Ready` lane.** A pairing ticket is worked in one interactive session and can
 hold several related small tasks. When two `Ready`-bound tickets share the **same surface** or
@@ -158,21 +166,23 @@ nothing is lost. `Queued` tickets stay one-task-per-ticket — batch agents work
 
 ### 7. WRITE
 
-Apply only what was approved, via `notion-update-page` (and `notion-create-pages` for CREATEs):
+Apply only what was approved. Edit fields and body via `editJiraIssue`; move status via
+`getTransitionsForJiraIssue` → `transitionJiraIssue`; use `createJiraIssue` for CREATEs.
 
-- title, body, `Priority`/`Type`/`Epic`/`Assignee`, `Status`.
-- **Refuse to write `Status = Queued` when `Assignee` is `Me` or empty** — stop and ask. `Ready`
-  tickets are left unassigned; do not set an Assignee on them.
-- **Refuse to write `Status = Queued` when any fork is unresolved** — it routes to
+- title (`summary`), body (`description`, markdown), `Priority`/`Type`/`Epic` (parent)/`Model`, and
+  the status transition.
+- **Refuse to transition to `Queued` when `Model` is empty** — stop and ask. `Ready`
+  tickets are left without a `Model`; do not set one on them.
+- **Refuse to transition to `Queued` when any fork is unresolved** — it routes to
   `Needs More Info` instead (§ Routing).
-- **Merges:** move the merged-away ticket to `Duplicate`, prepend a body line pointing to the
-  survivor, and fold its full scope into the survivor's body.
+- **Merges:** transition the merged-away ticket to `Duplicate`, prepend a description line pointing
+  to the survivor, and fold its full scope into the survivor's description.
 
 Write sequentially; if a write fails, report which and stop rather than half-applying.
 
 ### 8. REPORT
 
-Tally, one line each: `→ Ready/Queued (assignee)`, `→ Needs More Info`, `created`, `merged`,
+Tally, one line each: `→ Ready/Queued (model)`, `→ Needs More Info`, `created`, `merged`,
 `→ On Hold`, `skipped`. No prose.
 
 ## Routing
@@ -303,16 +313,15 @@ A ticket routed to `Needs More Info` still gets a full body — `/groom` builds 
 starting over. Record the open forks explicitly under Technical notes so `/groom` knows what to
 resolve.
 
-## Assignee — `Queued` only
+## Model — `Queued` only
 
-**`Ready` tickets stay unassigned.** A pairing ticket is worked in whatever session the user starts,
-on whatever model that session runs — an Assignee there is noise. Leave the field empty.
+**`Ready` tickets stay without a `Model`.** A pairing ticket is worked in whatever session the user
+starts, on whatever model that session runs — a `Model` there is noise. Leave the field empty.
 
-**`Queued` tickets must have a model**, since `/work batch` pins each subagent to its ticket's
-Assignee and skips anything unassigned or `Me`.
+**`Queued` tickets must have a `Model`**, since `/work batch` pins each subagent to its ticket's
+`Model` and skips anything with the field empty.
 
-**Only ever suggest a model — `Fable`, `Opus`, or `Sonnet`. Never suggest `Me`.** `Me` is the
-user's own opt-out signal, not a value triage proposes.
+**Only ever suggest `Fable`, `Opus`, or `Sonnet`** — those are the only values the field takes.
 
 - **`Opus`** — architectural, cross-cutting, ambiguous, or security/backend-sensitive.
 - **`Sonnet`** — well-scoped feature/bug work with a clear spec.
@@ -320,10 +329,11 @@ user's own opt-out signal, not a value triage proposes.
 
 ## Guardrails
 
-- Only ever touch the Task Board / Epic Board data sources above — never a backup or duplicate.
-- Never set `In Progress`/`Review`/`Done` here. Triage lands tickets in `Ready`, `Queued`,
+- Only ever touch project `TARO` — never a backup or duplicate project.
+- Never set `In Progress`/`In Review`/`Done` here. Triage lands tickets in `Ready`, `Queued`,
   `Needs More Info`, `On Hold`, or `Duplicate` only.
 - Propose `Priority`/`Type` changes, never apply them unasked.
+- Never route a ticket to `On Hold` unasked — it is the user's own hands-off lane.
 - If unsure whether to merge, create, or park — ask. Never guess a destructive board edit.
 - Never resolve a genuine design fork here. Route it to `Needs More Info` and let `/groom` do it
   properly with the user.

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: work
-description: Execute groomed Notion Task Board tickets. Two modes. `/work pair [ID]` works one Ready ticket interactively in this session — backend teaching on, you approve every change; tests stay untouched per the CLAUDE.md golden rule — then opens a PR. `/work batch [--count N] [--p0…]` pulls up to N Queued tickets assigned to a model (Fable/Opus/Sonnet) and works them in parallel — one worktree-isolated subagent per ticket, each pinned to that ticket's model, each writing its own tests and cleaning up its worktree when done. Subagents report back to this session (the orchestrator), which organizes the branches into non-conflicting, CI-passing PRs. Both claim the ticket to In Progress first, open a PR (Review), then iterate on your review feedback via a main-workspace subagent that checks out the PR branch — never merge. The golden "no tests" rule is suspended only in batch mode; pair mode leaves tests alone. Trigger on `/work`, "work the board", "work a ticket".
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, Agent, Skill, EnterWorktree, ExitWorktree, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page
+description: Execute groomed Jira tickets (project TARO). Two modes. `/work pair [ID]` works one Ready ticket interactively in this session — backend teaching on, you approve every change; tests stay untouched per the CLAUDE.md golden rule — then opens a PR. `/work batch [--count N] [--p0…]` pulls up to N Queued tickets routed to a model (Fable/Opus/Sonnet) and works them in parallel — one worktree-isolated subagent per ticket, each pinned to that ticket's model, each writing its own tests and cleaning up its worktree when done. Subagents report back to this session (the orchestrator), which organizes the branches into non-conflicting, CI-passing PRs. Both claim the ticket to In Progress first, open a PR (In Review), then iterate on your review feedback via a main-workspace subagent that checks out the PR branch — never merge. The golden "no tests" rule is suspended only in batch mode; pair mode leaves tests alone. Trigger on `/work`, "work the board", "work a ticket".
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash, Agent, Skill, EnterWorktree, ExitWorktree, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue
 argument-hint: 'pair [<ID>] | batch [--count N] [--p0|--p1|--p2|--p3]'
 arguments:
   - name: pair
-    description: Interactive mode — work one Ready ticket with you in this session. Explores the code, then pauses for a bird's-eye plan review before implementing. Optional ID; else top Priority→ID.
+    description: Interactive mode — work one Ready ticket with you in this session. Explores the code, then pauses for a bird's-eye plan review before implementing. Optional ID; else top by priority (oldest first).
   - name: batch
-    description: Autonomous mode — work Queued tickets assigned to a model, sequentially, each ending in a PR.
+    description: Autonomous mode — work Queued tickets routed to a model, sequentially, each ending in a PR.
   - name: --count N
     description: batch only — how many tickets to work in parallel this run, one worktree-isolated subagent each (default 1).
   - name: --p0|--p1|--p2|--p3
     description: batch only — restrict to this priority.
   - name: <ID>
     description: pair only — the specific ticket to work.
-lastUpdated: 2026-07-29T00:00:00Z
+lastUpdated: 2026-07-31T00:00:00Z
 ---
 
 ## What this skill does
@@ -24,15 +24,15 @@ review. It never merges and never marks a ticket `Done` — you close the loop.
 
 Two modes, chosen by the first arg. They differ deliberately:
 
-|                 | `pair`                              | `batch`                               |
-| --------------- | ----------------------------------- | ------------------------------------- |
-| Source lane     | `Status = Ready`                    | `Status = Queued`                     |
-| Model           | **this session's** model            | each ticket's **`Assignee`** model    |
-| Execution       | interactive, in-session             | parallel subagents, one worktree each |
-| Backend persona | **on** (teaching)                   | **off**                               |
-| Your approval   | **every change**                    | none — you review the PR              |
-| Tests           | **not touched** (golden rule holds) | each subagent writes its own          |
-| Ends at         | open PR → `Review` + feedback loop  | open PR → `Review` + feedback loop    |
+|                 | `pair`                                | `batch`                               |
+| --------------- | ------------------------------------- | ------------------------------------- |
+| Source lane     | `Status = Ready`                      | `Status = Queued`                     |
+| Model           | **this session's** model              | each ticket's **`Model`**             |
+| Execution       | interactive, in-session               | parallel subagents, one worktree each |
+| Backend persona | **on** (teaching)                     | **off**                               |
+| Your approval   | **every change**                      | none — you review the PR              |
+| Tests           | **not touched** (golden rule holds)   | each subagent writes its own          |
+| Ends at         | open PR → `In Review` + feedback loop | open PR → `In Review` + feedback loop |
 
 **The golden "never touch tests" rule is suspended only in `batch` mode.** Batch subagents (and
 batch feedback-fix subagents) write their own coverage for what they changed and repair any test
@@ -43,26 +43,33 @@ need attention, then leave them; the user will invoke test work explicitly (e.g.
 
 ## Board constants
 
-- **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`
+- **Project**: `TARO` (TaroFlash) — Jira, team-managed on Atlassian Cloud. Every `atlassian` MCP
+  tool takes a `cloudId` — use the site URL **`taroflash.atlassian.net`**.
 - `Status` lanes this skill uses: pulls from `Ready`/`Queued`; claims to `In Progress`; lands at
-  `Review`; parks stuck work at `Blocked`. Never sets `Done`/`Duplicate`.
-- `Assignee`: `Me` · `Fable` · `Opus` · `Sonnet`. `Me` is **never** batch-eligible.
+  `In Review`; parks stuck work at `Blocked`. Never sets `Done`/`Duplicate`.
+- `Model` (`customfield_10043`): `Fable` · `Opus` · `Sonnet` — which agent model works the ticket in
+  batch. `Status = On Hold` is **hands-off** (user-owned) and never batch-eligible.
+- **Status changes go through transitions, not a field write** — `getTransitionsForJiraIssue` to find
+  the transition id, then `transitionJiraIssue`. Field edits (writing the PR URL into the
+  description) use `editJiraIssue`.
 
 ## Claim protocol (both modes, per ticket)
 
-Before touching any code, **claim atomically**: `notion-update-page` set `Status = In Progress`.
-Re-query first — if the ticket is no longer in its source lane (someone/another run grabbed it),
-skip it. This is what stops two runs colliding on the same ticket.
+Before touching any code, **claim atomically**: transition the ticket to `In Progress`
+(`getTransitionsForJiraIssue` → `transitionJiraIssue`). Re-query the source lane first — if the
+ticket is no longer there (someone/another run grabbed it), skip it. This is what stops two runs
+colliding on the same ticket.
 
 ---
 
 ## Mode: `pair [ID]`
 
 Interactive, in **this** session, using **whatever model the session is running** (ignore the
-ticket's `Assignee`).
+ticket's `Model`).
 
-1. **SELECT** — `Status = Ready`. If an ID is given, take it; else the top `Priority → ID`.
-   Fetch its full page (title + body). Echo what you're about to work.
+1. **SELECT** — JQL `project = TARO AND status = "Ready" ORDER BY priority DESC, created ASC` (or the
+   given key). If an ID is given, take `TARO-<ID>`; else the top row (highest priority, oldest first).
+   Fetch its issue summary + description via `getJiraIssue`. Echo what you're about to work.
 2. **CLAIM** → `In Progress`.
 3. **BRANCH** — conventional branch off `master` matching the ticket (`fix/…`, `feat/…`).
 4. **EXPLORE & ALIGN — before any code.** Read the relevant code to ground the ticket in reality
@@ -90,11 +97,12 @@ ticket's `Assignee`).
    at most note in one line that tests may need attention, then leave them. Follow all
    `.claude/rules/*`.
 6. **PR** — invoke the **`prepare-pr`** skill with `--ticket <ID> --ticket-url <url>` (the ticket's
-   `TARO-<ID>` number and its Notion page URL) so the PR title is prefixed `TARO-<ID>:` and the body
-   opens with a `[TARO-<ID>](<url>)` link (commits, conventional messages, lint+type gate, opens one
-   PR, watches CI to green).
-7. **HANDOFF** — set the ticket's `Status = Review` and write the PR URL into its body. Then enter
-   the **Review & feedback loop** (below) and wait for the user's feedback.
+   `TARO-<ID>` number and its Jira browse URL, `https://taroflash.atlassian.net/browse/TARO-<ID>`) so
+   the PR title is prefixed `TARO-<ID>:` and the body opens with a `[TARO-<ID>](<url>)` link (commits,
+   conventional messages, lint+type gate, opens one PR, watches CI to green).
+7. **HANDOFF** — transition the ticket to `In Review` and append the PR URL into its description via
+   `editJiraIssue` (append, don't clobber the body). Then enter the **Review & feedback loop** (below)
+   and wait for the user's feedback.
 
 ## Mode: `batch [--count N] [--p0…]`
 
@@ -112,27 +120,26 @@ never edits ticket code itself.
    only work that leaves the orchestrator worktree is a **feedback-loop fix**, which must land on the
    main checkout so the user's dev server sees it (see that section for the coordination it needs).
 
-1. **SELECT**
+1. **SELECT** — `searchJiraIssuesUsingJql`:
 
-   ```sql
-   SELECT "userDefined:ID" AS id, "Name", "Priority", "Assignee", url
-   FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
-   WHERE "Status" = 'Queued' AND "Assignee" IN ('Fable','Opus','Sonnet')
-   ORDER BY "Priority" ASC, "userDefined:ID" ASC
+   ```jql
+   project = TARO AND status = "Queued" AND Model in (Sonnet, Opus, Fable)
+   ORDER BY priority DESC, created ASC
    ```
 
-   `--pN` adds a priority filter; `--count N` sets **how many tickets to work in parallel** (default
-   1). Take the top `N` rows. Tickets with `Assignee = Me` are skipped by the query — never batch
-   them. Echo the plan (ID · priority · assignee) before starting.
+   `--pN` adds `AND priority = Highest|High|Medium|Low`; `--count N` sets **how many tickets to work
+   in parallel** (default 1). Take the top `N` rows (highest priority first, oldest as stable tie-
+   break). `On Hold` tickets are naturally excluded — they aren't `Queued`. Echo the plan (ID ·
+   priority · model) before starting.
 
-2. **CLAIM ALL** — for each selected ticket, re-check it's still `Queued` and set `Status = In
-Progress`. Drop any that another run already grabbed. Claim before dispatching so parallel runs
-   don't collide.
+2. **CLAIM ALL** — for each selected ticket, re-check it's still `Queued` and transition it to `In
+Progress` (`getTransitionsForJiraIssue` → `transitionJiraIssue`). Drop any that another run already
+   grabbed. Claim before dispatching so parallel runs don't collide.
 
 3. **FAN OUT — one subagent per ticket, in parallel.** Dispatch all subagents in a single message
    (multiple `Agent` calls) so they run concurrently. Each `Agent`:
    - `agentType: general-purpose`, `isolation: worktree` (its own worktree — they edit files in
-     parallel and must not collide), `model:` = the ticket's `Assignee` lowercased →
+     parallel and must not collide), `model:` = the ticket's `Model` lowercased →
      `fable`/`opus`/`sonnet`.
    - Prompt carries the ticket's title + body + acceptance criteria and instructs the subagent to:
      **rename** the worktree's existing branch to a conventional name (`git branch -m <fix/…|feat/…>`)
@@ -174,15 +181,16 @@ Progress`. Drop any that another run already grabbed. Claim before dispatching s
    `master`**. When two branches conflict but the overlap is mechanical, **stack** the dependent
    PR on the other (base its branch on the peer's branch) so it merges cleanly. When a conflict
    needs **genuine human judgment** (semantic overlap, incompatible approaches), do **not** guess:
-   **raise it** in the final report and set that ticket's `Status = Blocked`.
+   **raise it** in the final report and transition that ticket to `Blocked`.
    d. **OPEN** — for each non-blocked ticket, invoke the **`prepare-pr`** skill with `--ticket
-<ID> --ticket-url <url>` (the `TARO-<ID>` number and the ticket's Notion page URL) → one PR titled
-   `TARO-<ID>: …` whose body opens with a `[TARO-<ID>](<url>)` link. Pass the stack base when the PR
-   is stacked. `prepare-pr` watches CI; **a PR isn't done until it's green.** If CI fails, route it
-   through the **Review & feedback loop** (below) — a main-workspace fix subagent on the PR branch;
-   if it still can't pass after real effort, treat the ticket as stuck.
-   e. **HANDOFF** — for each opened, green PR: set `Status = Review`, write the PR URL into the
-   ticket body.
+<ID> --ticket-url <url>` (the `TARO-<ID>` number and the ticket's Jira browse URL,
+   `https://taroflash.atlassian.net/browse/TARO-<ID>`) → one PR titled `TARO-<ID>: …` whose body opens
+   with a `[TARO-<ID>](<url>)` link. Pass the stack base when the PR is stacked. `prepare-pr` watches
+   CI; **a PR isn't done until it's green.** If CI fails, route it through the **Review & feedback
+   loop** (below) — a main-workspace fix subagent on the PR branch; if it still can't pass after real
+   effort, treat the ticket as stuck.
+   e. **HANDOFF** — for each opened, green PR: transition the ticket to `In Review`, append the PR URL
+   into the ticket description via `editJiraIssue` (append, don't clobber the body).
    f. **TEAR DOWN** — once a ticket is handed off (PR open + green, branch pushed to origin),
    **remove its worktree**: `git worktree remove <path>`. The branch lives on origin and its local
    ref survives worktree removal, so the human can `git checkout <branch>` in the **main** working
@@ -191,11 +199,11 @@ Progress`. Drop any that another run already grabbed. Claim before dispatching s
    one behind. Only tear down **successful** tickets here; blocked ones keep their worktree (step 5).
 
 5. **STUCK / BLOCKED** — a ticket is stuck when its subagent can't satisfy acceptance, its gate or
-   CI won't pass after real effort, or a conflict needs human resolution. Set `Status = Blocked`,
-   write a one-line reason + what's needed into the body, and leave its branch/worktree in place
-   for the human. Never silently fail or leave a ticket stranded in `In Progress`.
+   CI won't pass after real effort, or a conflict needs human resolution. Transition it to `Blocked`,
+   append a one-line reason + what's needed into the description, and leave its branch/worktree in
+   place for the human. Never silently fail or leave a ticket stranded in `In Progress`.
 
-6. **REPORT** — tally: worked → `Review` (with PR links, noting any stacked pairs), `Blocked`
+6. **REPORT** — tally: worked → `In Review` (with PR links, noting any stacked pairs), `Blocked`
    (with reasons + which need human conflict resolution), skipped. Then enter the **Review &
    feedback loop** below.
 
@@ -211,7 +219,7 @@ needs — is handled the same way:
 1. **Dispatch a fix subagent on the MAIN workspace** (not a worktree). It **checks out the PR
    branch** in the main checkout. The user keeps a dev server running against the main workspace and
    verifies each fix **live**, so the fix must land on the branch they're looking at. Model: the
-   ticket's `Assignee` in batch, this session's model in pair. Work one PR at a time (the user goes
+   ticket's `Model` in batch, this session's model in pair. Work one PR at a time (the user goes
    in order), so only one fix subagent touches the main checkout at once.
 2. **Fix — plus a test pass in batch only.** The subagent makes the code change. In **batch**, it
    also does a fresh test pass alongside — new coverage for the new behaviour plus repairs to any
@@ -221,19 +229,19 @@ needs — is handled the same way:
 3. **Gate, push, watch green.** Run `vp check` + `vp test`, push to the PR branch, and watch CI to
    green (via `prepare-pr` or directly). A PR isn't done until it's green again.
 4. **Answer the thread.** Reply to the feedback on the PR prefixed `🤖 Claude:` so the user can tell
-   your replies from their own. Leave the ticket in `Review`.
+   your replies from their own. Leave the ticket in `In Review`.
 
 Repeat per PR until the user merges. **Never merge and never set `Done` yourself** — that stays the
 user's call, exactly as at first handoff.
 
 ## Guardrails
 
-- Only ever touch the Task Board data source above — never a backup/duplicate database.
-- **Never merge, never set `Done`.** Opening the PR is a handoff into `Review`, not the end — the
+- Only ever touch project `TARO` — never a backup/duplicate project.
+- **Never merge, never set `Done`.** Opening the PR is a handoff into `In Review`, not the end — the
   run stays live through the feedback loop until the user merges. Merging is always the user's call.
 - Claim before coding; re-check the lane to avoid double-work.
-- Batch never runs the backend teaching persona and never works a `Me` ticket. These are mode
-  contracts — don't cross them.
+- Batch never runs the backend teaching persona and never works an `On Hold` ticket (those are the
+  user's hands-off, and aren't `Queued` anyway). These are mode contracts — don't cross them.
 - **Tests: batch only.** The golden "no tests" rule is suspended **only in batch** — batch
   subagents write/repair their own tests inline (never via `update-tests`). **Pair never touches
   tests** (golden rule holds); it only notes, in one line, that tests may need attention and leaves

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Retargets the TaroFlash ticket workflow from the Notion Task/Epic boards onto **Jira project TARO**, now that the data migration is complete.

- Adds project `.mcp.json` for Atlassian's official remote MCP server (OAuth).
- Migrates the `ticket-authoring` rule, the `triage` / `work` / `groom` / `prepare-pr` skills, and the `ticket-author` / `archivist` agents onto Jira — Notion SQL → JQL, `notion-*` tools → `atlassian` MCP tools, status changes via transitions.
- Field mapping: priority glyphs → `Highest`/`High`/`Medium`/`Low`; `Review` → `In Review`; Notion **Assignee** → the new **Model** custom field (`Sonnet`/`Opus`/`Fable`); the old `Me` hands-off signal → the **On Hold** status.
- Drops Notion-only quirks (icon SVGs, ordered-list renumbering, `replace_content`).

`.claude/settings.local.json` MCP tool permissions were swapped to the `atlassian` tools locally (that file is gitignored, so it's not in this PR).