### PR TITLE
docs(tickets): slim ticket bodies, single-source the rules, return to Notion

### DIFF
--- a/.claude/agents/archivist.md
+++ b/.claude/agents/archivist.md
@@ -58,10 +58,10 @@ git show <SHA>
 
 - **Never** `git add -A`, never stage or commit anything outside `corpus/`, never
   amend or rewrite existing commits, never push.
-- **New hazards: flag, don't file.** You have no reliable Jira access here. When
+- **New hazards: flag, don't file.** You have no reliable Notion access here. When
   you add a new hazard, record it in the commit body as a line beginning
   `NEW HAZARD:` (topic id + one-line summary) so a human files the backlog ticket.
-  Do not attempt to reach Jira or any MCP.
+  Do not attempt to reach Notion or any MCP.
 - **Match the exemplars' voice** (`corpus/authz/permissions.md`,
   `corpus/media/media.md`): open cold, one idea per beat, callouts that add (never
   restate), plain declarative present tense. When in doubt, change less.

--- a/.claude/agents/ticket-author.md
+++ b/.claude/agents/ticket-author.md
@@ -8,16 +8,18 @@ model: sonnet
 You are **the Ticket Author**. You turn findings into Jira tickets (project TARO) and stop there.
 
 **Read `.claude/rules/ticket-authoring.md` first, every run.** It is the source of truth for the
-Jira connection, field defaults, body templates, and authoring voice. What follows is only your
-operating loop.
+Jira connection, field defaults, the body section list, brevity, and authoring voice. What follows
+is only your operating loop.
 
 ## What you're invoked with
 
 A description of one or more tickets to cut — often findings from an investigation, plus whatever
 context the caller gathered (root causes, file paths, the primitive that governs the surface).
 
-That context is the point. It was expensive to produce and is the thing most often lost. Get it into
-the description.
+Capture the part of that context a future agent **won't rediscover on its own** — the governing
+primitive, the confirmed root cause, what turned out not to need changing. Drop the rest: which
+files to edit and how the current code works are seconds of grep for whoever claims the ticket.
+Expensive-to-produce and worth-recording are not the same thing.
 
 ## Loop
 
@@ -37,7 +39,7 @@ the description.
    dead end. If you can't confirm it, label it `⚠️ Hunch-level — not code-confirmed` rather than
    dropping it — an unverified lead still beats nothing, but it must be marked.
 
-3. **Write each ticket** per the rule's template, fields, and voice — `createJiraIssue`
+3. **Write each ticket** per the rule's sections, fields, and voice — `createJiraIssue`
    (`projectKey: TARO`, `issueTypeName`, `summary`, markdown `description`, `additional_fields` for
    `priority`), then transition it `To Do` → `Backlog`. One ticket per idea; if the input describes
    three things, cut three.

--- a/.claude/agents/ticket-author.md
+++ b/.claude/agents/ticket-author.md
@@ -1,14 +1,14 @@
 ---
 name: ticket-author
-description: Writes tickets into the TaroFlash Jira project (TARO). Spawn when several tickets need cutting at once, or when a long investigation produced findings worth filing without spending the main session's context on Jira writes. Captures what was found; never specs, never grooms. A single ticket is usually cheaper to write inline via `.claude/rules/ticket-authoring.md`.
-tools: Read, Grep, Glob, Bash, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue
+description: Writes tickets onto the TaroFlash Notion Task Board. Spawn when several tickets need cutting at once, or when a long investigation produced findings worth filing without spending the main session's context on Notion writes. Captures what was found; never specs, never grooms. A single ticket is usually cheaper to write inline via `.claude/rules/ticket-authoring.md`.
+tools: Read, Grep, Glob, Bash, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-create-pages, mcp__notion__notion-update-page
 model: sonnet
 ---
 
-You are **the Ticket Author**. You turn findings into Jira tickets (project TARO) and stop there.
+You are **the Ticket Author**. You turn findings into Task Board tickets and stop there.
 
 **Read `.claude/rules/ticket-authoring.md` first, every run.** It is the source of truth for the
-Jira connection, field defaults, the body section list, brevity, and authoring voice. What follows
+board constants, field defaults, the body section list, brevity, and authoring voice. What follows
 is only your operating loop.
 
 ## What you're invoked with
@@ -23,38 +23,34 @@ Expensive-to-produce and worth-recording are not the same thing.
 
 ## Loop
 
-1. **Read the rule.** Then check the project for near-duplicates before writing anything — a keyword
-   search on open issues (`cloudId: taroflash.atlassian.net`):
+1. **Read the rule.** Then check the board for near-duplicates before writing anything:
 
-   ```
-   searchJiraIssuesUsingJql — jql:
-   project = TARO AND statusCategory != Done AND summary ~ "<the ticket's key terms>"
+   ```sql
+   SELECT "userDefined:ID" AS id, "Name", "Status", url
+   FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
+   WHERE "Status" NOT IN ('Done', 'Duplicate', 'Won''t Do')
    ```
 
-   (`statusCategory != Done` excludes the closed lanes — Done, Duplicate, Won't Do.) A close match
-   is reported back, not silently duplicated.
+   A close match is reported back, not silently duplicated.
 
 2. **Verify what you were handed, cheaply.** If the caller gave you a file path or root cause, spend
    one `Read`/`Grep` confirming it still holds. A wrong path in a ticket body sends `/triage` down a
    dead end. If you can't confirm it, label it `⚠️ Hunch-level — not code-confirmed` rather than
    dropping it — an unverified lead still beats nothing, but it must be marked.
 
-3. **Write each ticket** per the rule's sections, fields, and voice — `createJiraIssue`
-   (`projectKey: TARO`, `issueTypeName`, `summary`, markdown `description`, `additional_fields` for
-   `priority`), then transition it `To Do` → `Backlog`. One ticket per idea; if the input describes
-   three things, cut three.
+3. **Write each ticket** per the rule's sections, fields, and voice, with `Status = Backlog`. One
+   ticket per idea; if the input describes three things, cut three.
 
-4. **Report** one line per ticket: `TARO-<n> · <title> · <Priority> · <Type> → Backlog` + URL
-   (`https://taroflash.atlassian.net/browse/TARO-<n>`). Then, separately, anything you could not
-   verify and any near-duplicate you found.
+4. **Report** one line per ticket: `TARO-<ID> · <title> · <Priority> · <Type> → Backlog` + URL.
+   Then, separately, anything you could not verify and any near-duplicate you found.
 
 ## Hard limits
 
-- **Only** project TARO. Never another project.
+- **Only** the Task Board / Epic Board named in the rule. Never a backup or duplicate database.
 - **Never** `Ready` / `Queued` / `In Progress` / `Done`. New tickets are `Backlog`.
-- **Never** set `Model`, or the issue key (Jira assigns it).
+- **Never** set `Assignee` or `ID` (the board auto-increments it).
 - **Never** create an epic. If none fits, say so in your report and let the caller decide.
-- **Never** write code, edit files outside Jira, or touch tests.
+- **Never** write code, edit files outside Notion, or touch tests.
 - **Never** invent scope, acceptance criteria, or a taste decision. If the work needs a call on how
   something should look, feel, or read — record it as open.
 

--- a/.claude/context/app-map.md
+++ b/.claude/context/app-map.md
@@ -100,9 +100,9 @@ Use this first. Match words in the raw ticket to a starting path, then grep from
 
 ---
 
-## Epics (TARO epics → code area)
+## Epics (Notion Epic Board → code area)
 
-`/triage` sets the ticket's **parent epic**. Active (In Dev / Ready / P0) first; map to code:
+`/triage` sets the ticket's **Epic** relation. Active (In Dev / Ready / P0) first; map to code:
 
 | Epic                        | Status       | Code area                                              |
 | --------------------------- | ------------ | ------------------------------------------------------ |

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -1,76 +1,85 @@
 # Ticket Authoring
 
-**The single source of truth for what a TARO ticket looks like.** Board constants, body shape,
-brevity, and voice. `/triage` and `/groom` declare their own routing and lanes — never their own
-templates or voice rules. If a body rule isn't here, it doesn't exist.
+**The single source of truth for what a ticket looks like.** Board constants, body shape, brevity,
+and voice. `/triage` and `/groom` declare their own routing and lanes — never their own templates or
+voice rules. If a body rule isn't here, it doesn't exist.
 
 Applies whenever the user says "cut a ticket", "file that", "add that to the board", or when
 out-of-scope work is found mid-task.
 
-## Jira connection
+## Board constants
 
-- **Project**: `TARO` (TaroFlash) — team-managed, on Atlassian Cloud.
-- **MCP server**: `atlassian` (official remote). Every tool takes a `cloudId` — use the site URL
-  **`taroflash.atlassian.net`** (UUID `44337aa0-a241-46a1-bc42-e7b4aa1d560b` also works).
-- **Create** with `createJiraIssue` (`projectKey: TARO`, `issueTypeName`, `summary`, markdown
-  `description`, `additional_fields` for priority / parent / custom fields). **Read/search** with
-  `searchJiraIssuesUsingJql` + `getJiraIssue`. **Update** with `editJiraIssue`. **Move status** with
-  `getTransitionsForJiraIssue` → `transitionJiraIssue`. **Link** with `createIssueLink`.
-- The key `TARO-<n>` is Jira's own auto-assigned sequence — never set it. URL:
-  `https://taroflash.atlassian.net/browse/TARO-<n>`.
+- **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`
+- **Epic Board** data source: `collection://2510953c-224c-80b7-9bb0-000b5384a47d`
+- **MCP server**: `notion`. **Read** with `notion-query-data-sources` (SQL over the data source) +
+  `notion-fetch` (page body — the query returns properties only). **Create** with
+  `notion-create-pages`. **Update** with `notion-update-page`.
+- `Status`: `On Hold` · `Backlog` · `Needs More Info` · `Ready` · `Queued` · `In Progress` ·
+  `Blocked` · `Review` · `Duplicate` · `Won't Do` · `Done`. Status is a plain property write — set
+  it directly, no transition step.
+- `Priority`: `⇞P0` · `↑P1` · `↓P2` · `⇟P3` (a ticket's urgency).
+- `Type`: `Bug` · `Task` · `Story` · `Spike`.
+- `Target`: `MVP` · `Fast-follow` · `Later` — which release the ticket ships in (orthogonal to
+  Priority).
+- `Assignee`: `Me` · `Fable` · `Opus` · `Sonnet` — which agent model works the ticket in
+  `/work batch`. **`Me` means hands-off** — the user works it themselves; `/triage` and `/work`
+  leave it alone. `Status = On Hold` carries the same meaning.
+- `Epic`: relation to the Epic Board (single).
+- `ID` is a **read-only auto-increment** — never set it. Tickets are referred to as `#<n>`.
 
-## Fields & vocab
-
-- **Type** (`issueTypeName`): `Bug` · `Task` · `Story` · `Spike` (epics are type `Epic`).
-- **Priority**: `Highest` · `High` · `Medium` · `Low` (urgency; Jira defaults new issues to
-  `Medium`).
-- **Status**: `Backlog` · `Needs More Info` · `Ready` · `Queued` · `In Progress` · `In Review` ·
-  `Blocked` · `On Hold` · `Done` · `Duplicate` · `Won't Do`. New issues are born in `To Do` and must
-  be **transitioned** to the target status.
-- **Target** (`customfield_10042`): `MVP` · `Fast Follow` · `Later` — which release the ticket ships
-  in (orthogonal to Priority).
-- **Model** (`customfield_10043`): `Sonnet` · `Opus` · `Fable` — which agent model works the ticket
-  in `/work batch`. This is the routing field (it replaced the old board's Assignee); it is **not**
-  Jira's native Assignee (a person), which stays unused.
-- **Parent**: the epic a ticket belongs to (`additional_fields.parent` = epic key, e.g. `TARO-7`).
-- `On Hold` means **hands-off** — the user works it themselves. `/triage` and `/work` leave it alone.
-
-> **The project is the source of truth for these option lists, not this file.**
-> `getJiraProjectIssueTypesMetadata` / `getJiraIssueTypeMetaWithFields` return the live issue types,
-> statuses, and custom-field ids; check when a value seems not to fit, and fix this file.
+> **The board is the source of truth for these option lists, not this file.** A hardcoded vocabulary
+> here once went stale and `Spike` was invisible for months — tickets encoded it in their titles
+> instead. `notion-fetch` on the data-source URL returns the live options; check when a value seems
+> not to fit, and fix this file.
 
 ## Fields when cutting
 
-| Field                    | Value when cutting                                                                                                         |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `Status`                 | **`Backlog`**, always — a new ticket is un-triaged by definition. Create in `To Do`, then transition to `Backlog`.         |
-| `Model`                  | **empty** — only set when a ticket reaches `Queued`                                                                        |
-| `Type` (`issueTypeName`) | `Bug` broken · `Task` defined change · `Story` user-facing capability · `Spike` the deliverable is a decision, not shipped |
-| `Priority`               | `Highest` data loss/security/broken core flow · `High` real pain · `Medium`/`Low` rest                                     |
-| `Target`                 | **empty** at cut time — a triage/groom decision, not a capture one                                                         |
-| `Parent` (epic)          | match an existing epic; if nothing fits, propose a new epic rather than force-fit                                          |
+| Field      | Value when cutting                                                                                                         |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `Status`   | **`Backlog`**, always — a new ticket is un-triaged by definition                                                           |
+| `Assignee` | **empty** — only set when a ticket reaches `Queued`                                                                        |
+| `Type`     | `Bug` broken · `Task` defined change · `Story` user-facing capability · `Spike` the deliverable is a decision, not shipped |
+| `Priority` | `⇞P0` data loss/security/broken core flow · `↑P1` real pain · `↓P2`/`⇟P3` rest                                             |
+| `Target`   | **empty** at cut time — a triage/groom decision, not a capture one                                                         |
+| `Epic`     | match the Epic Board; if nothing fits, propose a new epic rather than force-fit                                            |
 
 Never write `Ready` or `Queued` — those assert an agent can execute the ticket, which is never true
-at capture time. Never write `On Hold` on a fresh ticket — that's the user's own hands-off marker.
+at capture time. Never write `On Hold` or `Assignee = Me` on a fresh ticket — that's the user's own
+hands-off marker.
+
+## Priority vs Target — two axes, don't collapse them
+
+`Priority` answers **in what order** (urgency/sequencing). `Target` answers **which release**
+(scope). They are orthogonal — a pre-launch `MVP` ticket still ranges `P0`→`P3`, so all four
+priority tiers stay meaningful inside the launch set instead of two being spent marking the cut-line.
+
+- `MVP` — ships before launch.
+- `Fast-follow` — committed to the first post-launch cycle. Has a home; gets swept.
+- `Later` — genuinely deferred, allowed to be quiet.
+
+A ticket stays in its epic regardless of `Target` — the epic is the resurfacing anchor, not a
+graveyard. `Fast-follow` items surface in the **Fast-follow** board view (all epics, sorted by
+priority) for the post-launch sweep. Leave `Target` empty at capture; `/triage` and `/groom` set it.
 
 ## Body
 
-Pass the body as the issue **`description`** with `contentFormat: markdown` — Markdown headings,
-lists, and checkboxes render natively in Jira; no ADF needed.
+The body is the Notion **page content**. Prefer `replace_content` for a full rewrite over a chain of
+`update_content` edits. Use **bullets, not numbered lists**, for anything ordered — Notion renumbers
+ordered lists and the churn shows up as noise in the page history.
 
 **One section list. Each stage fills more of it — no stage invents sections.**
 
 | Section                  | Owner  | Notes                                            |
 | ------------------------ | ------ | ------------------------------------------------ |
 | `## Product description` | cut    | 1–3 lines, product terms                         |
-| `## Repro`               | cut    | bugs only; numbered steps                        |
+| `## Repro`               | cut    | bugs only                                        |
 | `## Acceptance criteria` | triage | **never at cut time** — see below                |
 | `## Decisions`           | triage | seeds prior art + rejected paths; groom resolves |
 | `## Blocked on`          | groom  | external facts only; omit if none                |
 
 A ticket carries only the sections that have content. Length tracks how much of the work is
-**decision** rather than typing — a mechanical change gets six lines, a cross-cutting refactor
-earns its ownership table and execution order.
+**decision** rather than typing — a mechanical change gets six lines, a cross-cutting refactor earns
+its ownership table and execution order.
 
 ### `## Acceptance criteria` — only what can fail independently
 
@@ -140,7 +149,8 @@ trigger it.
 
 ## Epics
 
-An epic is the resurfacing anchor for an effort, and the only place effort-level state lives.
+An epic is the resurfacing anchor for an effort, and the only place effort-level state lives. These
+sections live in the epic's Notion **page body**.
 
 ```markdown
 <one-line scope>
@@ -149,7 +159,7 @@ An epic is the resurfacing anchor for an effort, and the only place effort-level
 
 <!-- one line per resolved ticket: gist + link. The index — detail lives in the ticket. -->
 
-- [<ticket summary>](url) — <one-line gist of what was decided>
+- [#<n> <ticket name>](url) — <one-line gist of what was decided>
 
 ## Not yet specified
 
@@ -175,29 +185,31 @@ it's still fog where you know — that's the half that tells the next session wh
 - Excludes what's already ticketed, already decided, or out of scope.
 
 **`## Out of scope`** — work consciously ruled past this epic's goal. Scope, not sharpness, lands it
-here. One line + why. If an existing ticket turns out to sit here, close it (`Won't Do`) and leave
+here. One line + why. If an existing ticket turns out to sit here, move it to `Won't Do` and leave
 the line.
 
 ### New epics
 
-Propose first, never create silently. Create with `createJiraIssue` (`issueTypeName: "Epic"`,
-`summary` = the epic name); optionally set an issue colour via `additional_fields.customfield_10017`.
-Give a one-line scope, not a full spec.
+Propose first, never create silently. Give a one-line scope, not a full spec. Set the icon to a
+Notion built-in via its hosted SVG — `https://www.notion.so/icons/<name>_<color>.svg` (colours:
+`gray|brown|orange|yellow|green|blue|purple|pink|red`). Not an emoji. The bare
+`icons/<name>_<color>` path is accepted by the API but **renders blank** — always the full `.svg`
+URL.
 
 ## Dependencies
 
 When a ticket must land before another can start — most often after `/groom` splits one ticket into
-several — wire it with Jira's native **`Blocks`** link, not a line in the body:
+several — record it on the **`Blocked by`** self-relation on the Task Board, not as a line in the
+body. A relation renders in Notion as a linked row, so what's actually takeable is visible without
+opening a ticket.
 
-```
-createIssueLink  type: "Blocks"  inwardIssue: <blocker>  outwardIssue: <blocked>
-```
+> ⚠️ **The `Blocked by` relation may not exist on the board yet.** Notion has no native issue-link
+> type, so this is a self-relation someone must add to the Task Board by hand. Check with
+> `notion-fetch` on the data-source URL before relying on it; if it's absent, say so and fall back to
+> a `Blocked by: #<n>, #<n>` line at the top of the body until it's created.
 
-(`inward` = blocker, `outward` = blocked; reads "blocked _is blocked by_ blocker".) Native links
-render in the Jira UI, so what's actually takeable is visible without opening a ticket.
-
-A split that emits siblings with no edges and no `## Decisions so far` entry on the epic produces
-orphans: `/work batch` picks up step 3 of 5 with no way to know step 1 must land first.
+A split that emits siblings with no dependency and no `## Decisions so far` entry on the epic
+produces orphans: `/work batch` picks up step 3 of 5 with no way to know step 1 must land first.
 
 ## Batch work
 

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -1,9 +1,11 @@
 # Ticket Authoring
 
-How to cut a ticket in Jira (project **TARO**). Applies whenever the user says "cut a ticket", "file
-that", "add that to the board", or when out-of-scope work is found mid-task.
+**The single source of truth for what a TARO ticket looks like.** Board constants, body shape,
+brevity, and voice. `/triage` and `/groom` declare their own routing and lanes — never their own
+templates or voice rules. If a body rule isn't here, it doesn't exist.
 
-Cutting a ticket **captures**; it does not spec. `/triage` specs it later.
+Applies whenever the user says "cut a ticket", "file that", "add that to the board", or when
+out-of-scope work is found mid-task.
 
 ## Jira connection
 
@@ -13,15 +15,15 @@ Cutting a ticket **captures**; it does not spec. `/triage` specs it later.
 - **Create** with `createJiraIssue` (`projectKey: TARO`, `issueTypeName`, `summary`, markdown
   `description`, `additional_fields` for priority / parent / custom fields). **Read/search** with
   `searchJiraIssuesUsingJql` + `getJiraIssue`. **Update** with `editJiraIssue`. **Move status** with
-  `getTransitionsForJiraIssue` → `transitionJiraIssue`.
+  `getTransitionsForJiraIssue` → `transitionJiraIssue`. **Link** with `createIssueLink`.
 - The key `TARO-<n>` is Jira's own auto-assigned sequence — never set it. URL:
   `https://taroflash.atlassian.net/browse/TARO-<n>`.
 
 ## Fields & vocab
 
 - **Type** (`issueTypeName`): `Bug` · `Task` · `Story` · `Spike` (epics are type `Epic`).
-- **Priority**: `Highest` · `High` · `Medium` · `Low` (a ticket's urgency; Jira defaults new issues
-  to `Medium`).
+- **Priority**: `Highest` · `High` · `Medium` · `Low` (urgency; Jira defaults new issues to
+  `Medium`).
 - **Status**: `Backlog` · `Needs More Info` · `Ready` · `Queued` · `In Progress` · `In Review` ·
   `Blocked` · `On Hold` · `Done` · `Duplicate` · `Won't Do`. New issues are born in `To Do` and must
   be **transitioned** to the target status.
@@ -51,65 +53,151 @@ Cutting a ticket **captures**; it does not spec. `/triage` specs it later.
 Never write `Ready` or `Queued` — those assert an agent can execute the ticket, which is never true
 at capture time. Never write `On Hold` on a fresh ticket — that's the user's own hands-off marker.
 
-## Priority vs Target — two axes, don't collapse them
-
-`Priority` answers **in what order** (urgency/sequencing). `Target` answers **which release**
-(scope). They are orthogonal — a pre-launch `MVP` ticket still ranges `Highest`→`Low`, so all four
-priority tiers stay meaningful inside the launch set instead of two being spent marking the cut-line.
-
-- `MVP` — ships before launch.
-- `Fast Follow` — committed to the first post-launch cycle. Has a home; gets swept.
-- `Later` — genuinely deferred, allowed to be quiet.
-
-A ticket stays under its epic regardless of `Target` — the epic is the resurfacing anchor, not a
-graveyard. `Fast Follow` items surface via a Jira board/filter view (`Target = "Fast Follow"`, all
-epics, sorted by priority) for the post-launch sweep. Leave `Target` empty at capture; `/triage` and
-`/groom` set it.
-
 ## Body
 
 Pass the body as the issue **`description`** with `contentFormat: markdown` — Markdown headings,
 lists, and checkboxes render natively in Jira; no ADF needed.
 
-**Bug**
+**One section list. Each stage fills more of it — no stage invents sections.**
 
-```
-## Product description
-<1–3 lines: what the user sees and why it's wrong, product terms>
-## Repro
-1. …
-## Expected / Actual
-- Expected: … / Actual: …
-## Technical notes
-- Area: <path(s)> — <root cause if known>
-- Prior art: <the primitive/utility/rule already governing this surface>
-- Found during: <what was being worked on>
-```
+| Section                  | Owner  | Notes                                            |
+| ------------------------ | ------ | ------------------------------------------------ |
+| `## Product description` | cut    | 1–3 lines, product terms                         |
+| `## Repro`               | cut    | bugs only; numbered steps                        |
+| `## Acceptance criteria` | triage | **never at cut time** — see below                |
+| `## Decisions`           | triage | seeds prior art + rejected paths; groom resolves |
+| `## Blocked on`          | groom  | external facts only; omit if none                |
 
-**Task / Story** — same, minus Repro and Expected/Actual.
+A ticket carries only the sections that have content. Length tracks how much of the work is
+**decision** rather than typing — a mechanical change gets six lines, a cross-cutting refactor
+earns its ownership table and execution order.
+
+### `## Acceptance criteria` — only what can fail independently
+
+An AC earns its place when it can fail on its own. "The menu shows the new option" cannot fail
+separately from the feature existing — that's the Product description restated as a checkbox. "Never
+reviewed cards sort last" and "survives infinite-scroll pagination" can fail on their own; those are
+the ACs.
+
+No `or`, `either`, `e.g.`, or parenthetical alternatives — a hedge in an AC is an unresolved
+decision, and it routes to `Needs More Info`.
+
+**Not written at cut time.** Writing them before investigation invites inventing scope nobody agreed
+to. Exception: acceptance the user dictates, recorded verbatim.
+
+### `## Decisions` — the only technical section
+
+There is no "Technical notes" section. Investigation findings are not recorded; **decisions are.**
+The claiming agent does its own exploration.
+
+The test for every line:
+
+> **Will the claiming agent rediscover this on its own?**
+
+| Cut — rediscovered in seconds     | Keep — won't be found, or found too late                       |
+| --------------------------------- | -------------------------------------------------------------- |
+| Which files to edit, line numbers | **Prior art** — the primitive/util/rule already governing this |
+| How the current code works        | The path deliberately **rejected**, and why                    |
+| The plumbing trace                | **Negative facts** — "no join change", "single UI surface"     |
+| Framework/API mechanics           | Confirmed root cause of a bug                                  |
+
+Prior art is the highest-value line in any ticket. An agent finds the file it needs in seconds; it
+never finds "`ui-tappable` already encodes press styling" unless pointed, because you can't grep for
+a thing you don't know exists. Negative facts are second — they delete exploration that would
+otherwise happen.
+
+Name a filepath when it's the _answer_ (the primitive to use, the seam to extend), not when it's
+merely _where the work happens_. Never cite line numbers — they go stale and grep is faster.
+
+Groom-resolved decisions carry: **what** was decided · **why**, in a line · **what was rejected and
+why** (this is what stops a future session re-proposing it) · `CONFIRMED (verified against
+
+<source>)` or `ASSUMED`. Anything touching money, auth, or a system boundary must be `CONFIRMED`.
+
+### Never restate a rule that auto-loads
+
+`.claude/rules/*` load by path; CLAUDE.md is always on. Writing "use `data-testid`", "theming
+tokens", "declarative schema then `db diff`", or "do not touch tests" into a body is pure noise.
+
+Name a rule file **only** when the ticket departs from it, or when the ticket's area wouldn't
+trigger it.
 
 ## Voice
 
-- **Product description is product terms** — screens, flows, what the user experiences. No filepaths
-  or symbols; those live in Technical notes.
+- **Product description is product terms** — screens, flows, what the user experiences. No
+  filepaths, symbols, function names, or SQL. Those live in `## Decisions`.
+- **Point, don't narrate.** `Reuse: UiDropdownButton, UiRadio; mirror grid-item.vue` — not a
+  parenthetical explaining what each one is for. The implementer opens the file.
+- **Say it once.** If Product description already carries a fact, no other section repeats it.
 - **Plain, not flowery.** Short microcopy stays plain — avoid AI-flavoured flourishes and bare
   keyword lists alike.
 - **Record only what you know.** A confirmed root cause is stated; a guess is labelled
-  `⚠️ Hunch-level — not code-confirmed`. `/triage` trusts what's written.
-- **No acceptance criteria** — writing them invites inventing scope nobody agreed to. Exception:
-  acceptance the user dictates, recorded verbatim.
-- **Never resolve a taste decision.** Which icon, what an animation feels like, what the copy says,
-  how a layout should look — record as open, never pick.
-- **Prior art is the highest-value line.** The primitive that already governs the surface is what
-  stops an implementer reinventing it.
+  `⚠️ Hunch-level — not code-confirmed`.
+- **Never resolve a taste decision at cut time.** Which icon, what an animation feels like, what the
+  copy says, how a layout should look — record as open. `/groom` settles them with the user.
 - New user-facing text → note that locale keys are needed (`src/locales/en-us.json`), see
   [`i18n`](./i18n.md).
 
-## New epics
+## Epics
+
+An epic is the resurfacing anchor for an effort, and the only place effort-level state lives.
+
+```markdown
+<one-line scope>
+
+## Decisions so far
+
+<!-- one line per resolved ticket: gist + link. The index — detail lives in the ticket. -->
+
+- [<ticket summary>](url) — <one-line gist of what was decided>
+
+## Not yet specified
+
+<!-- in-scope fog: questions you can tell are coming but can't phrase sharply yet -->
+
+## Out of scope
+
+<!-- ruled beyond this epic's goal; never graduates back -->
+```
+
+**`## Decisions so far`** is an index, never a store — gist and link, never restate. `/groom`
+appends a line when it lands a ticket that resolved something an adjacent ticket will need.
+
+**`## Not yet specified`** — one bullet per fog patch, deliberately **coarser than a ticket**.
+Question-shaped, not task-shaped ("moderation of board posts", not "add a hide button"). Say why
+it's still fog where you know — that's the half that tells the next session what would sharpen it.
+
+- **Ticket when** you can state the question precisely now — even if blocked, even if unanswerable.
+- **Fog when** you can't phrase it that sharply. Don't pre-slice fog into ticket-sized pieces; one
+  patch may graduate into three tickets, or none.
+- **Graduating a patch deletes its bullet.** It now lives in exactly one place — its ticket. Skip
+  this and the section becomes a stale second index that contradicts the board.
+- Excludes what's already ticketed, already decided, or out of scope.
+
+**`## Out of scope`** — work consciously ruled past this epic's goal. Scope, not sharpness, lands it
+here. One line + why. If an existing ticket turns out to sit here, close it (`Won't Do`) and leave
+the line.
+
+### New epics
 
 Propose first, never create silently. Create with `createJiraIssue` (`issueTypeName: "Epic"`,
 `summary` = the epic name); optionally set an issue colour via `additional_fields.customfield_10017`.
-Give a one-line scope, not a full spec — an epic is a resurfacing anchor.
+Give a one-line scope, not a full spec.
+
+## Dependencies
+
+When a ticket must land before another can start — most often after `/groom` splits one ticket into
+several — wire it with Jira's native **`Blocks`** link, not a line in the body:
+
+```
+createIssueLink  type: "Blocks"  inwardIssue: <blocker>  outwardIssue: <blocked>
+```
+
+(`inward` = blocker, `outward` = blocked; reads "blocked _is blocked by_ blocker".) Native links
+render in the Jira UI, so what's actually takeable is visible without opening a ticket.
+
+A split that emits siblings with no edges and no `## Decisions so far` entry on the epic produces
+orphans: `/work batch` picks up step 3 of 5 with no way to know step 1 must land first.
 
 ## Batch work
 

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -199,14 +199,17 @@ URL.
 ## Dependencies
 
 When a ticket must land before another can start — most often after `/groom` splits one ticket into
-several — record it on the **`Blocked by`** self-relation on the Task Board, not as a line in the
-body. A relation renders in Notion as a linked row, so what's actually takeable is visible without
-opening a ticket.
+several — record it on the Task Board's **`Blocked By`** self-relation, not as a line in the body. A
+relation renders in Notion as a linked row, so what's actually takeable is visible without opening a
+ticket.
 
-> ⚠️ **The `Blocked by` relation may not exist on the board yet.** Notion has no native issue-link
-> type, so this is a self-relation someone must add to the Task Board by hand. Check with
-> `notion-fetch` on the data-source URL before relying on it; if it's absent, say so and fall back to
-> a `Blocked by: #<n>, #<n>` line at the top of the body until it's created.
+`Blocked By` and **`Blocks`** are the two halves of one reciprocal pair: setting `Blocked By` on the
+dependent ticket fills `Blocks` on the blocker automatically. **Write only `Blocked By`** — setting
+both by hand duplicates the edge.
+
+Each column holds a **JSON array of page URLs**, not statuses, so judging takeability is two steps:
+read the `Blocked By` urls, then query the Task Board for those rows' `Status`. A blocker is cleared
+when its `Status` is in the **`complete` group** — `Done`, `Won't Do`, or `Duplicate`.
 
 A split that emits siblings with no dependency and no `## Decisions so far` entry on the epic
 produces orphans: `/work batch` picks up step 3 of 5 with no way to know step 1 must land first.

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: groom
-description: Deep second pass over a single Notion Task Board ticket sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket and moves it to `Ready`/`Queued`. Owns splitting oversized tickets (wiring the `Blocked by` relation between the siblings), recording external blockers, and keeping the epic's decision log and fog current. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
+description: Deep second pass over a single Notion Task Board ticket sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket and moves it to `Ready`/`Queued`. Owns splitting oversized tickets (wiring the `Blocked By` relation between the siblings), recording external blockers, and keeping the epic's decision log and fog current. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
 allowed-tools: Read, Grep, Glob, Bash, Agent, WebFetch, WebSearch, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page, mcp__notion__notion-create-pages, mcp__notion__notion-search
 argument-hint: '[<ID>]'
 arguments:
@@ -145,7 +145,7 @@ Only answerable once the design has resolved:
 
 - **Split** — if the resolved shape is clearly several tickets, propose the split with a one-line
   scope each. Groom owns this because size is only knowable after the design is settled. Say which
-  siblings must **land in order** — that ordering becomes a `Blocked by` relation in §5, not prose.
+  siblings must **land in order** — that ordering becomes a `Blocked By` relation in §5, not prose.
 - **External blockers** — facts only the user can supply (a dashboard setting, a vendor account
   detail, a product call). Record under `## Blocked on` with what it blocks. If the ticket cannot
   land without one, it stays in `Needs More Info` and the report says why.
@@ -174,11 +174,11 @@ records: most of what you learned settling a decision is rediscoverable in secon
 reach the body. Prefer **bullets over numbered lists** — Notion renumbers ordered lists and
 the churn shows up as page-history noise.
 
-**Wire the ordering.** Where a split named siblings that must land in sequence, set the `Blocked by`
-relation on each dependent sibling (see [`ticket-authoring.md`](../../rules/ticket-authoring.md) § Dependencies — check the property
-exists before relying on it, and fall back to a `Blocked by: #<n>` body line if it doesn't).
-Siblings emitted with no dependency are orphans — `/work batch` will pick up step 3 of 5 with no way
-to know step 1 must land first.
+**Wire the ordering.** Where a split named siblings that must land in sequence, set **`Blocked By`**
+on each dependent sibling — never `Blocks`, which Notion fills reciprocally on its own (see
+[`ticket-authoring.md`](../../rules/ticket-authoring.md) § Dependencies). Siblings emitted with no
+dependency are orphans — `/work batch` will pick up step 3 of 5 with no way to know step 1 must land
+first.
 
 **Update the epic** page: append the resolved ticket to `## Decisions so far` (gist + link, never a
 restatement), add any approved fog to `## Not yet specified`, delete the fog bullet that this

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: groom
-description: Deep second pass over a single Jira ticket (project TARO) sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket and moves it to `Ready`/`Queued`. Owns splitting oversized tickets (wiring `Blocks` links between the siblings), recording external blockers, and keeping the epic's decision log and fog current. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
-allowed-tools: Read, Grep, Glob, Bash, Agent, WebFetch, WebSearch, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue, mcp__atlassian__createIssueLink, mcp__atlassian__getIssueLinkTypes
+description: Deep second pass over a single Notion Task Board ticket sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket and moves it to `Ready`/`Queued`. Owns splitting oversized tickets (wiring the `Blocked by` relation between the siblings), recording external blockers, and keeping the epic's decision log and fog current. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebFetch, WebSearch, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page, mcp__notion__notion-create-pages, mcp__notion__notion-search
 argument-hint: '[<ID>]'
 arguments:
   - name: <ID>
-    description: Jira ticket number to groom (the `<n>` in `TARO-<n>`). Omit to take the top `Needs More Info` ticket by Priority → creation order.
+    description: Numeric ticket ID to groom. Omit to take the top `Needs More Info` ticket by Priority → ID.
 lastUpdated: 2026-07-31T12:00:00Z
 ---
 
@@ -25,7 +25,7 @@ Needs More Info ──/groom──┬──► Ready / Queued     (decisions res
 One ticket at a time, conversationally. This is the opposite of `/triage`'s batching — depth is
 the whole point.
 
-Do **not** touch tests. Do **not** write code. This skill reads code and writes Jira.
+Do **not** touch tests. Do **not** write code. This skill reads code and writes Notion.
 
 ## The core rule
 
@@ -44,12 +44,12 @@ recorded under `## Blocked on`, never left as an unmarked menu.
 
 ## Board constants
 
-**[`ticket-authoring.md`](../../rules/ticket-authoring.md) is the single source** for the Jira
-connection, every field and its option list, the body section list, brevity rules, and voice. Read
-it before writing anything to the board. This skill declares only its lanes and its own passes.
+**[`ticket-authoring.md`](../../rules/ticket-authoring.md) is the single source** for the board data
+sources, every field and its option list, the body section list, brevity rules, and voice. Read it
+before writing anything to the board. This skill declares only its lanes and its own passes.
 
 - Lanes: pulls from `Needs More Info`; lands at `Ready` / `Queued`; may park at `On Hold`.
-  Never sets `In Progress` / `In Review` / `Done` / `Blocked`.
+  Never sets `In Progress` / `Review` / `Done` / `Blocked`.
 - **Retype to `Spike`** when grooming reveals the deliverable is a decision or recommendation rather
   than shipped behaviour — and drop the now-redundant `"Spike:"` title prefix.
 
@@ -80,14 +80,16 @@ Either way, no walls of text:
 
 ### 1. SELECT
 
-```jql
-project = TARO AND status = "Needs More Info" ORDER BY priority DESC, created ASC
+```sql
+SELECT "userDefined:ID" AS id, "Name", "Type", "Priority", "Epic", "Assignee", url
+FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
+WHERE "Status" = 'Needs More Info'
+ORDER BY "Priority" ASC, "userDefined:ID" ASC
 ```
 
-(`priority DESC` = Highest first; `created ASC` breaks ties oldest-first.) Take the given `<ID>`
-(`TARO-<ID>`), else the top row. Fetch its full issue with `getJiraIssue` (summary + `description`
-markdown) — `/triage` already wrote a body with the open forks recorded; build on it, don't restart.
-Echo which ticket you're grooming in one line.
+Take the given `<ID>`, else the top row. Fetch its page body with `notion-fetch` — the query returns
+properties only, and `/triage` already wrote a body with the open forks recorded; build on it, don't
+restart. Echo which ticket you're grooming in one line.
 
 Leave `Status` alone. Grooming doesn't claim.
 
@@ -143,7 +145,7 @@ Only answerable once the design has resolved:
 
 - **Split** — if the resolved shape is clearly several tickets, propose the split with a one-line
   scope each. Groom owns this because size is only knowable after the design is settled. Say which
-  siblings must **land in order** — that ordering becomes `Blocks` links in §5, not prose.
+  siblings must **land in order** — that ordering becomes a `Blocked by` relation in §5, not prose.
 - **External blockers** — facts only the user can supply (a dashboard setting, a vendor account
   detail, a product call). Record under `## Blocked on` with what it blocks. If the ticket cannot
   land without one, it stays in `Needs More Info` and the report says why.
@@ -158,8 +160,9 @@ Only answerable once the design has resolved:
 
 ### 5. WRITE
 
-Rewrite the ticket **`description`** (markdown) via `editJiraIssue` `fields.description` — a single
-full-rewrite is fine. Any splits become new tickets via `createJiraIssue`.
+Rewrite the ticket's **page body** via `notion-update-page` — prefer `replace_content` for a full
+rewrite over a chain of `update_content` edits. Any splits become new tickets via
+`notion-create-pages`.
 
 Sections and their shape live in [`ticket-authoring.md`](../../rules/ticket-authoring.md); groom
 owns `## Decisions` and `## Blocked on`, and may revise `## Acceptance criteria`. It writes no
@@ -168,28 +171,29 @@ that only makes sense as an ordered plan belongs in `## Decisions` as the decisi
 
 **The resolution is the deliverable, not the investigation.** Grooming reads far more than it
 records: most of what you learned settling a decision is rediscoverable in seconds and does not
-reach the body. Prefer **bullets over numbered lists** — a stable style choice, not a tooling
-workaround.
+reach the body. Prefer **bullets over numbered lists** — Notion renumbers ordered lists and
+the churn shows up as page-history noise.
 
-**Wire the ordering.** Where a split named siblings that must land in sequence, add native `Blocks`
-links (`createIssueLink`, `inwardIssue` = blocker, `outwardIssue` = blocked). Siblings emitted with
-no edges are orphans — `/work batch` will pick up step 3 of 5 with no way to know step 1 must land
-first.
+**Wire the ordering.** Where a split named siblings that must land in sequence, set the `Blocked by`
+relation on each dependent sibling (see [`ticket-authoring.md`](../../rules/ticket-authoring.md) § Dependencies — check the property
+exists before relying on it, and fall back to a `Blocked by: #<n>` body line if it doesn't).
+Siblings emitted with no dependency are orphans — `/work batch` will pick up step 3 of 5 with no way
+to know step 1 must land first.
 
-**Update the epic** via `editJiraIssue`: append the resolved ticket to `## Decisions so far` (gist +
-link, never a restatement), add any approved fog to `## Not yet specified`, delete the fog bullet
-that this session **graduated** into a ticket, and add any approved `## Out of scope` ruling.
+**Update the epic** page: append the resolved ticket to `## Decisions so far` (gist + link, never a
+restatement), add any approved fog to `## Not yet specified`, delete the fog bullet that this
+session **graduated** into a ticket, and add any approved `## Out of scope` ruling.
 
-Then set `Status` via `getTransitionsForJiraIssue` → `transitionJiraIssue`:
+Then set `Status`:
 
 - **`Queued`** — only when _zero_ decisions are unresolved. No human is in the loop.
 - **`Ready`** — executable. A ticket still carrying an unmade design or taste call does **not**
   qualify, even labelled "decide during pairing" — that is what `Needs More Info` is for, and this
   pass exists to settle it. The only thing that may ride into `Ready` is a decision genuinely blocked
   on an external fact (§4), recorded under `## Blocked on`.
-- **Refuse to write `Queued` with `Model` empty** (or any unresolved fork). `Queued` needs a `Model`
-  — Sonnet / Opus / Fable — because `/work batch` pins each subagent to it. **`Ready` tickets carry
-  no `Model`** — leave the field empty.
+- **Refuse to write `Queued` with `Assignee` empty or `Me`** (or any unresolved fork). `Queued` needs
+  an `Assignee` — Sonnet / Opus / Fable — because `/work batch` pins each subagent to it. **`Ready`
+  tickets carry no `Assignee`** — leave the field empty.
 
 Also sweep for **copy that the change makes false** — existing `src/locales/en-us.json` strings
 asserting the old behaviour ("this cannot be undone"). List them in the body as required edits.
@@ -215,9 +219,9 @@ it without guessing. Test it by asking:
 
 ## Guardrails
 
-- Only ever touch project `TARO` — never a backup or duplicate.
+- Only ever touch the Task Board and Epic Board named in the rule — never a backup or duplicate.
 - Never write code, never touch tests, never open a PR. This pass ends at a ticket.
-- Never set `In Progress` / `In Review` / `Done`.
+- Never set `In Progress` / `Review` / `Done`.
 - Never resolve a decision the user should make — product calls, pricing, policy, and anything
   affecting users' money or data go to them as questions.
 - Never mark a fact `CONFIRMED` without having actually read the source.

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: groom
-description: Deep second pass over a single Jira ticket (project TARO) sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket and moves it to `Ready`/`Queued`. Owns splitting oversized tickets and recording external blockers. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
-allowed-tools: Read, Grep, Glob, Bash, Agent, WebFetch, WebSearch, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue
+description: Deep second pass over a single Jira ticket (project TARO) sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket and moves it to `Ready`/`Queued`. Owns splitting oversized tickets (wiring `Blocks` links between the siblings), recording external blockers, and keeping the epic's decision log and fog current. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
+allowed-tools: Read, Grep, Glob, Bash, Agent, WebFetch, WebSearch, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue, mcp__atlassian__createIssueLink, mcp__atlassian__getIssueLinkTypes
 argument-hint: '[<ID>]'
 arguments:
   - name: <ID>
     description: Jira ticket number to groom (the `<n>` in `TARO-<n>`). Omit to take the top `Needs More Info` ticket by Priority → creation order.
-lastUpdated: 2026-07-31T00:00:00Z
+lastUpdated: 2026-07-31T12:00:00Z
 ---
 
 ## What this skill does
@@ -44,18 +44,19 @@ recorded under `## Blocked on`, never left as an unmarked menu.
 
 ## Board constants
 
-- **Project**: `TARO` (TaroFlash) — team-managed, on Atlassian Cloud. MCP server `atlassian`; every
-  tool takes a `cloudId` — use the site URL **`taroflash.atlassian.net`**.
-- `Type` (`issueTypeName`): `Bug` · `Task` · `Story` · `Spike`. **`Spike` when the deliverable is a
-  decision or recommendation rather than shipped behaviour** — retype a ticket if grooming reveals
-  that's what it really is, and drop any now-redundant `"Spike:"` title prefix.
-- The project is the source of truth for every option list, not this file —
-  `getJiraProjectIssueTypesMetadata` / `getJiraIssueTypeMetaWithFields` return the live issue types,
-  statuses, and custom-field ids. Check when something seems not to fit.
+**[`ticket-authoring.md`](../../rules/ticket-authoring.md) is the single source** for the Jira
+connection, every field and its option list, the body section list, brevity rules, and voice. Read
+it before writing anything to the board. This skill declares only its lanes and its own passes.
+
 - Lanes: pulls from `Needs More Info`; lands at `Ready` / `Queued`; may park at `On Hold`.
   Never sets `In Progress` / `In Review` / `Done` / `Blocked`.
+- **Retype to `Spike`** when grooming reveals the deliverable is a decision or recommendation rather
+  than shipped behaviour — and drop the now-redundant `"Spike:"` title prefix.
 
 ## Reporting voice
+
+This governs the **chat**; ticket bodies follow
+[`ticket-authoring.md`](../../rules/ticket-authoring.md).
 
 **Open at altitude, in product terms; drop to detail on demand.** The first present — the
 checkpoint — is a bird's-eye view: what the ticket changes for the user and the decisions that need
@@ -141,37 +142,43 @@ break some of your assumptions — that is the skill working, not failing. Rules
 Only answerable once the design has resolved:
 
 - **Split** — if the resolved shape is clearly several tickets, propose the split with a one-line
-  scope each. Groom owns this because size is only knowable after the design is settled.
+  scope each. Groom owns this because size is only knowable after the design is settled. Say which
+  siblings must **land in order** — that ordering becomes `Blocks` links in §5, not prose.
 - **External blockers** — facts only the user can supply (a dashboard setting, a vendor account
   detail, a product call). Record under `## Blocked on` with what it blocks. If the ticket cannot
   land without one, it stays in `Needs More Info` and the report says why.
 - **Wrong lane** — if it turns out to need product input rather than technical decisions, or is
   premature, propose `On Hold`.
+- **Past the goal** — if resolving the design reveals this ticket (or a sibling) sits beyond its
+  epic's scope, propose `Won't Do` plus a line on the epic's `## Out of scope`. Don't resolve work
+  that shouldn't happen.
+- **Newly exposed fog** — a resolved decision routinely exposes adjacent questions. Sharp enough to
+  phrase → a new ticket. Not sharp enough → the epic's `## Not yet specified`. Never invented into
+  a ticket to look thorough.
 
 ### 5. WRITE
 
 Rewrite the ticket **`description`** (markdown) via `editJiraIssue` `fields.description` — a single
-full-rewrite is fine. Any splits become new tickets via `createJiraIssue`. Sections, in order:
+full-rewrite is fine. Any splits become new tickets via `createJiraIssue`.
 
-```
-## Product description        <what the user experiences and why — product terms>
-## Design decisions           <the point of this pass — see shape below>
-## Files                      <schema / edge functions / frontend, grouped>
-## Acceptance criteria        <observable, no "or", one per resolved behaviour>
-## Implementation steps       <ordered, each naming the decision section it implements>
-## Blocked on                 <external facts, omit if none>
-## Notes                      <branch, tests owed, overlaps, risks>
-```
+Sections and their shape live in [`ticket-authoring.md`](../../rules/ticket-authoring.md); groom
+owns `## Decisions` and `## Blocked on`, and may revise `## Acceptance criteria`. It writes no
+`Files` or `Implementation steps` section — the claiming agent explores for itself, and a decision
+that only makes sense as an ordered plan belongs in `## Decisions` as the decision it is.
 
-**Design decisions shape** — one subsection per decision:
+**The resolution is the deliverable, not the investigation.** Grooming reads far more than it
+records: most of what you learned settling a decision is rediscoverable in seconds and does not
+reach the body. Prefer **bullets over numbered lists** — a stable style choice, not a tooling
+workaround.
 
-- **What was decided**, concretely.
-- **Why**, in a line or two.
-- **What was rejected and why** — this is what stops a future session re-proposing it.
-- **`CONFIRMED` / `ASSUMED`**, with the source for anything confirmed.
+**Wire the ordering.** Where a split named siblings that must land in sequence, add native `Blocks`
+links (`createIssueLink`, `inwardIssue` = blocker, `outwardIssue` = blocked). Siblings emitted with
+no edges are orphans — `/work batch` will pick up step 3 of 5 with no way to know step 1 must land
+first.
 
-Prefer **bullets over numbered lists** for implementation steps — a stable style choice, not a
-tooling workaround.
+**Update the epic** via `editJiraIssue`: append the resolved ticket to `## Decisions so far` (gist +
+link, never a restatement), add any approved fog to `## Not yet specified`, delete the fog bullet
+that this session **graduated** into a ticket, and add any approved `## Out of scope` ruling.
 
 Then set `Status` via `getTransitionsForJiraIssue` → `transitionJiraIssue`:
 
@@ -190,7 +197,8 @@ Behaviour changes routinely leave lying microcopy behind.
 
 ### 6. REPORT
 
-Three lines maximum: ticket → lane, decisions resolved (count), anything blocked or split. No prose.
+Three lines maximum: ticket → lane, decisions resolved (count), anything blocked, split, or parked
+on the epic. No prose.
 
 ## Quality bar
 
@@ -202,6 +210,8 @@ it without guessing. Test it by asking:
 - Is any load-bearing fact `ASSUMED` that should be `CONFIRMED`?
 - Does the body say why the rejected alternatives were rejected — or will someone re-propose them?
 - Is the prior art named, so the implementer uses the existing primitive rather than reinventing it?
+- Is anything in the body something the claiming agent would rediscover in seconds? Cut it.
+- If this was a split: can `/work` tell which sibling must land first without reading all of them?
 
 ## Guardrails
 

--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -9,15 +9,15 @@ arguments:
   - name: --ticket <ID>
     description: Prefix the PR title with the ticket key `TARO-<ID>` (e.g. `TARO-207: …`). Omit for no prefix.
   - name: --ticket-url <URL>
-    description: Jira issue URL. When given alongside `--ticket`, the PR body opens with a `[TARO-<ID>](<URL>)` link line. Omit to render just `TARO-<ID>` text (or nothing if `--ticket` is also absent).
+    description: Notion ticket URL. When given alongside `--ticket`, the PR body opens with a `[TARO-<ID>](<URL>)` link line. Omit to render just `TARO-<ID>` text (or nothing if `--ticket` is also absent).
 lastUpdated: 2026-07-31T00:00:00Z
 ---
 
 ## Args
 
 - **`--no-watch`** (optional) — skip the post-create CI watch + coverage check (Step 10). Default behaviour blocks on CI after opening the PR until checks settle, then inspects coverage and writes more tests if it regressed.
-- **`--ticket <ID>`** (optional) — the Jira issue number (the `<ID>` in `TARO-<ID>`) this PR resolves. When given, the PR **title** is prefixed with `TARO-<ID>: ` and the PR **body** opens with a ticket-link line (Step 8). This affects the PR title and body only — commit subjects stay clean (ticket refs still belong in a commit-body `Refs:` trailer, per Notes). Omit to open a PR with no ticket prefix or link.
-- **`--ticket-url <URL>`** (optional) — the Jira issue URL (`https://taroflash.atlassian.net/browse/TARO-<ID>`). When given with `--ticket`, the body's top line renders as a markdown link `[TARO-<ID>](<URL>)`. Without it, the top line falls back to plain `TARO-<ID>` text. Ignored when `--ticket` is absent.
+- **`--ticket <ID>`** (optional) — the Notion Task Board ticket ID this PR resolves. When given, the PR **title** is prefixed with `TARO-<ID>: ` and the PR **body** opens with a ticket-link line (Step 8). This affects the PR title and body only — commit subjects stay clean (ticket refs still belong in a commit-body `Refs:` trailer, per Notes). Omit to open a PR with no ticket prefix or link.
+- **`--ticket-url <URL>`** (optional) — the Notion page URL for the ticket. When given with `--ticket`, the body's top line renders as a markdown link `[TARO-<ID>](<URL>)`. Without it, the top line falls back to plain `TARO-<ID>` text. Ignored when `--ticket` is absent.
 
 ## Fully autonomous — no approval gates
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: triage
-description: First pass over raw Jira (project TARO) tickets. Investigates where each ticket lives in the code, fills in every field (Priority/Type/Epic/Model), writes a slim body per `.claude/rules/ticket-authoring.md`, parks adjacent fog on the epic, and routes each ticket to its next lane — `Ready`/`Queued` when it is executable as-is, or `Needs More Info` when it carries unresolved design decisions for `/groom` to settle. Batched and checkpointed; reports in product terms only. May propose creating epics, merging tickets, or parking them. Trigger on `/triage`, "triage the backlog", "triage tickets".
-allowed-tools: Read, Grep, Glob, Bash, Agent, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue, mcp__atlassian__getJiraProjectIssueTypesMetadata, mcp__atlassian__getJiraIssueTypeMetaWithFields
+description: First pass over raw Notion Task Board tickets. Investigates where each ticket lives in the code, fills in every field (Priority/Type/Epic/Assignee), writes a slim body per `.claude/rules/ticket-authoring.md`, parks adjacent fog on the epic, and routes each ticket to its next lane — `Ready`/`Queued` when it is executable as-is, or `Needs More Info` when it carries unresolved design decisions for `/groom` to settle. Batched and checkpointed; reports in product terms only. May propose creating epics, merging tickets, or parking them. Trigger on `/triage`, "triage the backlog", "triage tickets".
+allowed-tools: Read, Grep, Glob, Bash, Agent, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page, mcp__notion__notion-create-pages, mcp__notion__notion-search
 argument-hint: '[--p0|--p1|--p2|--p3] [--count N] [<ID> <ID> …]'
 arguments:
   - name: --p0|--p1|--p2|--p3
     description: Only triage Backlog tickets of this priority.
   - name: --count N
-    description: Cap the batch at N tickets (default 10). Ordered Priority → created.
+    description: Cap the batch at N tickets (default 10). Ordered Priority → ID.
   - name: <ID>
-    description: One or more Jira ticket keys (`TARO-<n>`, or the bare number) to triage specifically (overrides filters).
+    description: One or more numeric ticket IDs to triage specifically (overrides filters).
 lastUpdated: 2026-07-31T12:00:00Z
 ---
 
@@ -26,23 +26,23 @@ Backlog ──/triage──┬──► Ready / Queued        (executable as-is)
 
 Output per ticket: a descriptive **title**, a **slim body** per
 [`ticket-authoring.md`](../../rules/ticket-authoring.md), all four **fields**
-(Priority/Type/Epic/Model), and a **lane** with the routing reason stated. Anything the
+(Priority/Type/Epic/Assignee), and a **lane** with the routing reason stated. Anything the
 investigation surfaced that isn't this ticket lands on its **epic**, not in a premature ticket.
 
 Batched and checkpointed: ~2 interruptions for the whole batch, not one per ticket.
 
-Do **not** touch tests. Do **not** write code. This skill reads code and writes Jira.
+Do **not** touch tests. Do **not** write code. This skill reads code and writes Notion.
 
 ## Board constants
 
-**[`ticket-authoring.md`](../../rules/ticket-authoring.md) is the single source** for the Jira
-connection, every field and its option list, the body section list, brevity rules, and voice. Read
-it before writing anything to the board. This skill declares only its routing and lanes.
+**[`ticket-authoring.md`](../../rules/ticket-authoring.md) is the single source** for the board data
+sources, every field and its option list, the body section list, brevity rules, and voice. Read it
+before writing anything to the board. This skill declares only its routing and lanes.
 
 Two parked lanes, distinguished by what is missing:
 
-- **`On Hold`** — parked for the user's own reasons; this is the user's own hands-off marker. Triage
-  never routes here unasked.
+- **`On Hold`** — parked for the user's own reasons; this is the user's own hands-off marker,
+  alongside `Assignee = Me`. Triage never routes here unasked.
 - **`Needs More Info`** — the _what_ is clear, the _how_ is not. Unresolved technical decisions.
   `/groom` picks these up.
 
@@ -68,31 +68,30 @@ every investigation.
 
 ### 1. FETCH
 
-```jql
-project = TARO AND type != Epic AND status = "Backlog"
-ORDER BY priority DESC, created ASC
+```sql
+SELECT "userDefined:ID" AS id, "Name", "Type", "Priority", "Epic", "Assignee", url
+FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
+WHERE "Status" = 'Backlog'
+  AND ("Assignee" IS NULL OR "Assignee" <> 'Me')   -- Me on Backlog = hands off
+ORDER BY "Priority" ASC, "userDefined:ID" ASC
 ```
 
-`type != Epic` excludes epics; `priority DESC` sorts `Highest` first; `created ASC` is the stable
-secondary. Apply args: `--pN` adds `AND priority = Highest|High|Medium|Low`; explicit `<ID>`s
-replace the status/priority filters with `AND key IN (TARO-…, …)` (overriding both, since naming a
-ticket is deliberate — but warn if it isn't in `Backlog`). `--count N` caps the batch (default 10);
-if it would exceed the cap, take the top N and say how many were left.
-
-(`searchJiraIssuesUsingJql` returns ≤100 issues/page — paginate via `nextPageToken` only if a batch
-ever runs that large; default batches are far smaller.)
+`Assignee = Me` on a Backlog ticket is the user's "don't triage this" signal. Apply args:
+`--pN` adds `AND "Priority" = '<glyph>'`; explicit `<ID>`s replace the WHERE with
+`"userDefined:ID" IN (…)` (overriding both filters, since naming a ticket is deliberate — but warn
+if it isn't in `Backlog` or is assigned `Me`). `--count N` caps the batch (default 10); if it would
+exceed the cap, take the top N and say how many were left.
 
 ### 2. SELECT
 
-Echo the batch as a compact numbered list (key · Priority · raw name). If args fully determined it,
+Echo the batch as a compact numbered list (ID · Priority · raw name). If args fully determined it,
 proceed. If ambiguous or oversized, ask before spending investigation time.
 
 ### 3. READ existing descriptions
 
-Fetch each ticket's **description** via `getJiraIssue` (request the `description` field — it comes
-back as markdown). The user often writes real context into a raw ticket. Read every in-scope
-description and carry it through. If a description already dictates the approach, honour it rather
-than re-deriving from the name.
+Fetch each ticket's **page body** via `notion-fetch` — §1 pulls properties only. The user often
+writes real context into a raw ticket. Read every in-scope body and carry it through. If a
+description already dictates the approach, honour it rather than re-deriving from the name.
 
 ### 4. INVESTIGATE
 
@@ -124,10 +123,10 @@ One interruption for the whole batch. Per ticket, **in product terms**, ≤2 lin
 - what it turned out to be (and anything surprising),
 - proposed lane + **which routing trigger fired**, in a short phrase.
 
-> `TARO-141` the number steppers in review-pacing settings — styling only, kit already handles it
+> `#141` the number steppers in review-pacing settings — styling only, kit already handles it
 > → Ready
 >
-> `TARO-264` deleting your account — needs decisions on the grace period and what a deleted user sees
+> `#264` deleting your account — needs decisions on the grace period and what a deleted user sees
 > → Needs More Info (new stored state + billing)
 
 Separate the clean tickets from the ones needing a decision. **Stop for confirmation or redirect**
@@ -141,9 +140,9 @@ review. Per ticket:
 
 - **Title** — descriptive rewrite.
 - **Summary** — one line of product intent.
-- **Fields** — `Priority`, `Type`, `Epic` (parent), and `Model` **only when the lane is `Queued`**
-  (see § Model). Tickets now arrive with only name + description, so **propose all four**; never
-  apply them unasked.
+- **Fields** — `Priority`, `Type`, `Epic`, and `Assignee` **only when the lane is `Queued`** (see
+  § Assignee). Tickets now arrive with only name + description, so **propose all four**; never apply
+  them unasked.
 - **Lane** — with the trigger that decided it.
 - **Proposals** — CREATE a new ticket, MERGE into another (name the survivor), or CREATE a new
   epic. Never silently.
@@ -162,20 +161,18 @@ nothing is lost. `Queued` tickets stay one-task-per-ticket — batch agents work
 
 ### 7. WRITE
 
-Apply only what was approved. Edit fields and body via `editJiraIssue`; move status via
-`getTransitionsForJiraIssue` → `transitionJiraIssue`; use `createJiraIssue` for CREATEs.
+Apply only what was approved, via `notion-update-page` (and `notion-create-pages` for CREATEs):
 
-- title (`summary`), body (`description`, markdown), `Priority`/`Type`/`Epic` (parent)/`Model`, and
-  the status transition.
-- **Refuse to transition to `Queued` when `Model` is empty** — stop and ask. `Ready`
-  tickets are left without a `Model`; do not set one on them.
-- **Refuse to transition to `Queued` when any fork is unresolved** — it routes to
+- title, body, `Priority`/`Type`/`Epic`/`Assignee`, `Status`.
+- **Refuse to write `Status = Queued` when `Assignee` is `Me` or empty** — stop and ask. `Ready`
+  tickets are left unassigned; do not set an Assignee on them.
+- **Refuse to write `Status = Queued` when any fork is unresolved** — it routes to
   `Needs More Info` instead (§ Routing).
-- **Merges:** transition the merged-away ticket to `Duplicate`, prepend a description line pointing
-  to the survivor, and fold its full scope into the survivor's description.
-- **Epic writes:** append approved fog bullets to the epic's `## Not yet specified` and approved
-  rulings to `## Out of scope` via `editJiraIssue`. A ticket ruled past the epic's goal is
-  transitioned to `Won't Do` and gets its `## Out of scope` line — never left open.
+- **Merges:** move the merged-away ticket to `Duplicate`, prepend a body line pointing to the
+  survivor, and fold its full scope into the survivor's body.
+- **Epic writes:** append approved fog bullets to the epic page's `## Not yet specified` and
+  approved rulings to `## Out of scope`. A ticket ruled past the epic's goal is moved to `Won't Do`
+  and gets its `## Out of scope` line — never left open.
 
 Write sequentially; if a write fails, report which and stop rather than half-applying.
 
@@ -253,13 +250,13 @@ Three things this skill is on the hook for:
   Spike's acceptance criteria describe what the written recommendation must cover, not a behaviour
   change.
 
-## Model — `Queued` only
+## Assignee — `Queued` only
 
-**`Ready` tickets stay without a `Model`.** A pairing ticket is worked in whatever session the user
-starts, on whatever model that session runs — a `Model` there is noise. Leave the field empty.
+**`Ready` tickets stay unassigned.** A pairing ticket is worked in whatever session the user starts,
+on whatever model that session runs — an `Assignee` there is noise. Leave the field empty.
 
-**`Queued` tickets must have a `Model`**, since `/work batch` pins each subagent to its ticket's
-`Model` and skips anything with the field empty.
+**`Queued` tickets must have an `Assignee`**, since `/work batch` pins each subagent to its ticket's
+`Assignee` and skips anything with the field empty.
 
 **Only ever suggest `Fable`, `Opus`, or `Sonnet`** — those are the only values the field takes.
 
@@ -269,8 +266,8 @@ starts, on whatever model that session runs — a `Model` there is noise. Leave 
 
 ## Guardrails
 
-- Only ever touch project `TARO` — never a backup or duplicate project.
-- Never set `In Progress`/`In Review`/`Done` here. Triage lands tickets in `Ready`, `Queued`,
+- Only ever touch the Task Board and Epic Board named in the rule — never a backup or duplicate.
+- Never set `In Progress`/`Review`/`Done` here. Triage lands tickets in `Ready`, `Queued`,
   `Needs More Info`, `On Hold`, or `Duplicate` only.
 - Propose `Priority`/`Type` changes, never apply them unasked.
 - Never route a ticket to `On Hold` unasked — it is the user's own hands-off lane.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage
-description: First pass over raw Jira (project TARO) tickets. Investigates where each ticket lives in the code, fills in every field (Priority/Type/Epic/Model), writes a body from the per-Type template, and routes each ticket to its next lane — `Ready`/`Queued` when it is executable as-is, or `Needs More Info` when it carries unresolved design decisions for `/groom` to settle. Batched and checkpointed; reports in product terms only. May propose creating epics, merging tickets, or parking them. Trigger on `/triage`, "triage the backlog", "triage tickets".
+description: First pass over raw Jira (project TARO) tickets. Investigates where each ticket lives in the code, fills in every field (Priority/Type/Epic/Model), writes a slim body per `.claude/rules/ticket-authoring.md`, parks adjacent fog on the epic, and routes each ticket to its next lane — `Ready`/`Queued` when it is executable as-is, or `Needs More Info` when it carries unresolved design decisions for `/groom` to settle. Batched and checkpointed; reports in product terms only. May propose creating epics, merging tickets, or parking them. Trigger on `/triage`, "triage the backlog", "triage tickets".
 allowed-tools: Read, Grep, Glob, Bash, Agent, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue, mcp__atlassian__getJiraProjectIssueTypesMetadata, mcp__atlassian__getJiraIssueTypeMetaWithFields
 argument-hint: '[--p0|--p1|--p2|--p3] [--count N] [<ID> <ID> …]'
 arguments:
@@ -10,7 +10,7 @@ arguments:
     description: Cap the batch at N tickets (default 10). Ordered Priority → created.
   - name: <ID>
     description: One or more Jira ticket keys (`TARO-<n>`, or the bare number) to triage specifically (overrides filters).
-lastUpdated: 2026-07-31T00:00:00Z
+lastUpdated: 2026-07-31T12:00:00Z
 ---
 
 ## What this skill does
@@ -24,8 +24,10 @@ Backlog ──/triage──┬──► Ready / Queued        (executable as-is)
                    └──► On Hold               (parked)
 ```
 
-Output per ticket: a descriptive **title**, a **body** from the per-Type template, all four
-**fields** (Priority/Type/Epic/Model), and a **lane** with the routing reason stated.
+Output per ticket: a descriptive **title**, a **slim body** per
+[`ticket-authoring.md`](../../rules/ticket-authoring.md), all four **fields**
+(Priority/Type/Epic/Model), and a **lane** with the routing reason stated. Anything the
+investigation surfaced that isn't this ticket lands on its **epic**, not in a premature ticket.
 
 Batched and checkpointed: ~2 interruptions for the whole batch, not one per ticket.
 
@@ -33,27 +35,9 @@ Do **not** touch tests. Do **not** write code. This skill reads code and writes 
 
 ## Board constants
 
-- **Project**: `TARO` (TaroFlash) — team-managed, on Atlassian Cloud.
-- **MCP server**: `atlassian`. Every tool takes a `cloudId` — use the site URL
-  **`taroflash.atlassian.net`**.
-- **Fields & vocab:**
-  - `Status`: `On Hold` · `Backlog` · `Needs More Info` · `Ready` · `Queued` · `In Progress` · `Blocked` · `In Review` · `Duplicate` · `Won't Do` · `Done`
-  - `Priority`: `Highest` · `High` · `Medium` · `Low`
-  - `Type` (`issueTypeName`): `Bug` · `Task` · `Story` · `Spike`
-  - `Model` (`customfield_10043`): `Sonnet` · `Opus` · `Fable`
-  - `Target` (`customfield_10042`): `MVP` · `Fast Follow` · `Later`
-
-> **The project is the source of truth for these lists, not this file.** A hardcoded vocabulary here
-> once went stale and `Spike` was invisible for months — tickets encoded it in their titles instead.
-> `getJiraProjectIssueTypesMetadata` / `getJiraIssueTypeMetaWithFields` return the live issue types,
-> statuses, and custom-field ids; check them when a value seems not to fit, and fix this file rather
-> than working around it.
-
-- `Epic`: a ticket's epic is its **parent** (`additional_fields.parent` = epic key; epics are
-  `issuetype = Epic`). The key `TARO-<n>` is Jira's own auto-assigned sequence — never set it.
-  URL: `https://taroflash.atlassian.net/browse/TARO-<n>`.
-- **Status is a transition, not a field write.** Move status with `getTransitionsForJiraIssue` →
-  `transitionJiraIssue`; never try to set `Status` via `editJiraIssue`.
+**[`ticket-authoring.md`](../../rules/ticket-authoring.md) is the single source** for the Jira
+connection, every field and its option list, the body section list, brevity rules, and voice. Read
+it before writing anything to the board. This skill declares only its routing and lanes.
 
 Two parked lanes, distinguished by what is missing:
 
@@ -64,12 +48,14 @@ Two parked lanes, distinguished by what is missing:
 
 ## Reporting voice
 
+This governs the **chat**; ticket bodies follow
+[`ticket-authoring.md`](../../rules/ticket-authoring.md).
+
 **Product terms only. Concise. No walls of text.**
 
 Describe where a thing sits in the **UI** and what the user experiences — "the number steppers in
 deck review-pacing settings", "the popup after Google sign-up". Never surface filepaths,
-component/composable names, function names, or symbols in a report to the user. Those belong in
-the ticket **body** (agent-facing), never in the chat.
+component/composable names, function names, or symbols in a report to the user.
 
 One line per ticket at checkpoints. If something genuinely needs depth, it goes in the body.
 
@@ -116,12 +102,20 @@ cluster.
 
 Gather per ticket:
 
-- **What / where** — the surface, the files, the root cause for bugs.
+- **What / where** — the surface, the root cause for bugs.
 - **Prior art** — _what already exists here that encodes the answer?_ The ui-kit primitive,
-  directive, utility, or rule file that governs this surface. See § Prior art below — this is the
-  single highest-value output of investigation.
-- **Constraints** — `.claude/rules/*` that govern the area, i18n key paths.
+  directive, utility, or rule file that governs this surface. **The single highest-value output of
+  investigation** — an agent finds the file it needs in seconds, but never finds the primitive it
+  should have used unless pointed.
+- **Negative facts** — what turns out _not_ to need changing. These delete exploration the claiming
+  agent would otherwise do; they are worth as much as the positive ones.
 - **Forks** — any point where two viable approaches exist. These drive routing (§ Routing).
+- **Adjacent fog** — unclear work the investigation tripped over that isn't this ticket. Do not cut
+  a premature ticket for it; it goes to the epic (§ 7).
+
+Investigate deep, record shallow. Most of what you learn is **not** written down — the claiming
+agent re-explores. Only what survives the rediscovery test in
+[`ticket-authoring.md`](../../rules/ticket-authoring.md) reaches a body.
 
 ### 5. CHECKPOINT ▸ findings + routing
 
@@ -153,10 +147,12 @@ review. Per ticket:
 - **Lane** — with the trigger that decided it.
 - **Proposals** — CREATE a new ticket, MERGE into another (name the survivor), or CREATE a new
   epic. Never silently.
+- **Epic writes** — adjacent fog to add under the epic's `## Not yet specified`, or work ruled past
+  the epic's goal to add under `## Out of scope`. One line each; propose, never apply unasked.
 
-**New epics.** If no existing epic fits, propose one rather than forcing a bad match. Create it with
-`createJiraIssue` (`issueTypeName: "Epic"`, `summary` = the epic name, a one-line scope in the
-description) — an epic is a resurfacing anchor, not a full spec.
+**New epics.** If no existing epic fits, propose one rather than forcing a bad match — an epic is a
+resurfacing anchor, not a full spec. Shape per
+[`ticket-authoring.md` § Epics](../../rules/ticket-authoring.md).
 
 **Consolidate for the `Ready` lane.** A pairing ticket is worked in one interactive session and can
 hold several related small tasks. When two `Ready`-bound tickets share the **same surface** or
@@ -177,6 +173,9 @@ Apply only what was approved. Edit fields and body via `editJiraIssue`; move sta
   `Needs More Info` instead (§ Routing).
 - **Merges:** transition the merged-away ticket to `Duplicate`, prepend a description line pointing
   to the survivor, and fold its full scope into the survivor's description.
+- **Epic writes:** append approved fog bullets to the epic's `## Not yet specified` and approved
+  rulings to `## Out of scope` via `editJiraIssue`. A ticket ruled past the epic's goal is
+  transitioned to `Won't Do` and gets its `## Out of scope` line — never left open.
 
 Write sequentially; if a write fails, report which and stop rather than half-applying.
 
@@ -233,85 +232,26 @@ Naming an unmade decision documents it; it does not make it. A ticket saying "ex
 or "pair to land the approach" routes to `Needs More Info`, however well-specified the rest is. Do
 not treat the marking as a reason to leave it in `Ready`.
 
-## Prior art
+## Bodies
 
-The most common implementation failure is not a wrong decision — it is an agent reinventing
-something the codebase already encodes. A stepper that hand-rolls press styling when `ui-tappable`
-already defines it; a CSS hack where a component prop exists.
+Section list, brevity, and voice all live in
+[`ticket-authoring.md`](../../rules/ticket-authoring.md). Triage owns two of its sections —
+`## Acceptance criteria` and `## Decisions` — and adds neither a template nor a rule of its own.
 
-So investigation always answers: **what already governs this surface?** Record it in the body:
+Three things this skill is on the hook for:
 
-```
-**Prior art:** this surface uses `ui-tappable` — press/tap styling is already encoded there, use
-it rather than hand-rolling. Backgrounds follow the `bgx` accent utilities (`.claude/rules/theming.md`).
-```
-
-This catches governing primitives, not every detail — but it converts "the agent should have known"
-into "the ticket said so."
-
-## Body templates
-
-Every body carries **Product description** (what the user experiences and why — no filepaths) and
-**Technical notes** (agent-facing: paths, root cause, approach, prior art, constraints, rules,
-i18n key paths).
-
-**Bug**
-
-```
-## Product description
-<1–3 lines: what the user sees and why it's wrong, product terms>
-## Repro
-1. …
-## Expected / Actual
-- Expected: …
-- Actual: …
-## Acceptance
-<observable condition proving it's fixed — no "or">
-## Technical notes
-- Area: <path(s)> — <root cause if known>
-- Approach: <where the fix lives / how>
-- Prior art: <the primitive/utility/rule that already governs this surface>
-- Constraints & rules: <.claude/rules/*, i18n key path, gotchas>
-```
-
-**Task / Story**
-
-```
-## Product description
-<what & why for the user, product terms>
-## Acceptance criteria
-- [ ] …
-## Technical notes
-- Area: <path(s)>
-- Approach: <how / where>
-- Prior art: <the primitive/utility/rule that already governs this surface>
-- Constraints & out of scope: <…, rules, i18n key path>
-```
-
-**Spike** — use when the deliverable is a **decision or recommendation, not shipped behaviour**.
-The acceptance criteria describe what the written output must cover, not a behaviour change.
-
-```
-## Product description
-<the question to answer and why it's open, product terms>
-## Acceptance criteria (spike deliverable)
-- [ ] A written recommendation covering: <the specific questions>
-- [ ] Follow-up implementation tickets proposed with rough scope
-## Technical notes
-- Current behaviour: <what happens today — the baseline the decision moves from>
-- Area: <path(s)>
-- Constraints: <…, rules>
-```
-
-`Type = Spike` carries the meaning, so the **title must not be prefixed `"Spike: …"`** — that
-prefix only ever existed because the Type was unavailable. Strip it when retyping an old ticket.
-
-Keep bodies tight — enough to act on, no padding. Any new user-facing copy the ticket implies gets
-its locale key path noted (`src/locales/en-us.json`).
-
-A ticket routed to `Needs More Info` still gets a full body — `/groom` builds on it rather than
-starting over. Record the open forks explicitly under Technical notes so `/groom` knows what to
-resolve.
+- **Prior art in `## Decisions`.** The most common implementation failure isn't a wrong decision, it's
+  an agent reinventing what the codebase already encodes — a stepper hand-rolling press styling when
+  `ui-tappable` defines it, a CSS hack where a prop exists. Investigation always answers _what
+  already governs this surface?_, and the answer is written down. It converts "the agent should have
+  known" into "the ticket said so."
+- **Open forks, for a `Needs More Info` ticket.** It still gets a body — `/groom` builds on it rather
+  than starting over — with the unresolved forks listed explicitly under `## Decisions` so `/groom`
+  knows what it is there to settle.
+- **`Type = Spike` carries its own meaning**, so the title must not be prefixed `"Spike: …"` — that
+  prefix only existed because the Type was unavailable. Strip it when retyping an old ticket. A
+  Spike's acceptance criteria describe what the written recommendation must cover, not a behaviour
+  change.
 
 ## Model — `Queued` only
 

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -14,7 +14,7 @@ arguments:
     description: batch only — restrict to this priority.
   - name: <ID>
     description: pair only — the specific ticket to work.
-lastUpdated: 2026-07-31T00:00:00Z
+lastUpdated: 2026-07-31T12:00:00Z
 ---
 
 ## What this skill does
@@ -53,6 +53,21 @@ need attention, then leave them; the user will invoke test work explicitly (e.g.
   the transition id, then `transitionJiraIssue`. Field edits (writing the PR URL into the
   description) use `editJiraIssue`.
 
+## Blockers — a ticket is not takeable just because it's in the lane
+
+`/groom` wires ordering between split siblings as native **`Blocks`** links (see
+[`ticket-authoring.md`](../../rules/ticket-authoring.md)). A ticket with an **open blocker** is not
+work — its foundation hasn't landed, and working it produces a PR against code that's about to
+change.
+
+**Request `issuelinks` in the SELECT query** (`fields: [..., "issuelinks"]`) and read it per
+candidate. A ticket is **blocked** when any `is blocked by` link points at an issue whose
+`statusCategory` is not `Done`. Blocked tickets are not takeable.
+
+Because this skill never sets `Done` — the user merges and closes — a blocker only clears when the
+user does. That's intended: it's the same gate as the merge. If a run finds every candidate blocked,
+say so and stop rather than reaching further down the queue for something unrelated.
+
 ## Claim protocol (both modes, per ticket)
 
 Before touching any code, **claim atomically**: transition the ticket to `In Progress`
@@ -68,8 +83,14 @@ Interactive, in **this** session, using **whatever model the session is running*
 ticket's `Model`).
 
 1. **SELECT** — JQL `project = TARO AND status = "Ready" ORDER BY priority DESC, created ASC` (or the
-   given key). If an ID is given, take `TARO-<ID>`; else the top row (highest priority, oldest first).
-   Fetch its issue summary + description via `getJiraIssue`. Echo what you're about to work.
+   given key), requesting `issuelinks`. If an ID is given, take `TARO-<ID>`; else the **first
+   unblocked** row (highest priority, oldest first). Fetch its issue summary + description via
+   `getJiraIssue`. Echo what you're about to work.
+
+   **If the ticket is blocked** (§ Blockers): when the user named it explicitly, say which open
+   blocker stands in the way and ask before claiming — their call, they may know it's fine. When
+   auto-picking, skip it silently and take the next.
+
 2. **CLAIM** → `In Progress`.
 3. **BRANCH** — conventional branch off `master` matching the ticket (`fix/…`, `feat/…`).
 4. **EXPLORE & ALIGN — before any code.** Read the relevant code to ground the ticket in reality
@@ -128,13 +149,17 @@ never edits ticket code itself.
    ```
 
    `--pN` adds `AND priority = Highest|High|Medium|Low`; `--count N` sets **how many tickets to work
-   in parallel** (default 1). Take the top `N` rows (highest priority first, oldest as stable tie-
-   break). `On Hold` tickets are naturally excluded — they aren't `Queued`. Echo the plan (ID ·
-   priority · model) before starting.
+   in parallel** (default 1). Request `issuelinks` and **drop every blocked row** (§ Blockers) before
+   taking the top `N` (highest priority first, oldest as stable tie-break). `On Hold` tickets are
+   naturally excluded — they aren't `Queued`. Echo the plan (ID · priority · model) before starting,
+   and name any ticket skipped for an open blocker so the queue's shape is visible.
 
-2. **CLAIM ALL** — for each selected ticket, re-check it's still `Queued` and transition it to `In
-Progress` (`getTransitionsForJiraIssue` → `transitionJiraIssue`). Drop any that another run already
-   grabbed. Claim before dispatching so parallel runs don't collide.
+   Two siblings of one split are never both takeable — the `Blocks` edge means one waits. Batch is
+   for **independent** tickets; a chain is worked a link at a time.
+
+2. **CLAIM ALL** — for each selected ticket, re-check it's still `Queued` **and still unblocked**,
+   then transition it to `In Progress` (`getTransitionsForJiraIssue` → `transitionJiraIssue`). Drop
+   any that another run already grabbed. Claim before dispatching so parallel runs don't collide.
 
 3. **FAN OUT — one subagent per ticket, in parallel.** Dispatch all subagents in a single message
    (multiple `Agent` calls) so they run concurrently. Each `Agent`:
@@ -179,8 +204,10 @@ Progress` (`getTransitionsForJiraIssue` → `transitionJiraIssue`). Drop any tha
    branches against each other to catch cross-PR conflicts (two subagents touching the same code).
    c. **RESOLVE** — a branch that's clean vs master and vs its peers gets a PR **based off
    `master`**. When two branches conflict but the overlap is mechanical, **stack** the dependent
-   PR on the other (base its branch on the peer's branch) so it merges cleanly. When a conflict
-   needs **genuine human judgment** (semantic overlap, incompatible approaches), do **not** guess:
+   PR on the other (base its branch on the peer's branch) so it merges cleanly. If the two tickets
+   carry a `Blocks` link, **that edge decides the stack direction** — the blocker is the base; never
+   invert it, and never guess a direction when an edge already states it. When a conflict needs
+   **genuine human judgment** (semantic overlap, incompatible approaches), do **not** guess:
    **raise it** in the final report and transition that ticket to `Blocked`.
    d. **OPEN** — for each non-blocked ticket, invoke the **`prepare-pr`** skill with `--ticket
 <ID> --ticket-url <url>` (the `TARO-<ID>` number and the ticket's Jira browse URL,
@@ -240,6 +267,8 @@ user's call, exactly as at first handoff.
 - **Never merge, never set `Done`.** Opening the PR is a handoff into `In Review`, not the end — the
   run stays live through the feedback loop until the user merges. Merging is always the user's call.
 - Claim before coding; re-check the lane to avoid double-work.
+- **Never work a ticket with an open `Blocks` blocker** (§ Blockers) — batch skips it silently, pair
+  asks first when the user named it explicitly. Lane membership alone doesn't make a ticket takeable.
 - Batch never runs the backend teaching persona and never works an `On Hold` ticket (those are the
   user's hands-off, and aren't `Queued` anyway). These are mode contracts — don't cross them.
 - **Tests: batch only.** The golden "no tests" rule is suspended **only in batch** — batch

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -53,18 +53,22 @@ need attention, then leave them; the user will invoke test work explicitly (e.g.
 
 ## Blockers — a ticket is not takeable just because it's in the lane
 
-`/groom` wires ordering between split siblings on the **`Blocked by`** self-relation (see
-[`ticket-authoring.md`](../../rules/ticket-authoring.md) § Dependencies). A ticket with an **open
-blocker** is not work — its foundation hasn't landed, and working it produces a PR against code
-that's about to change.
+`/groom` wires ordering between split siblings on the Task Board's **`Blocked By`** self-relation
+(see [`ticket-authoring.md`](../../rules/ticket-authoring.md) § Dependencies). A ticket with an
+**open blocker** is not work — its foundation hasn't landed, and working it produces a PR against
+code that's about to change.
 
-**Select `"Blocked by"` in the query** and resolve each related row's `Status`. A ticket is
-**blocked** when any `Blocked by` row is not `Done` / `Won't Do` / `Duplicate`. Blocked tickets are
-not takeable.
+`Blocked By` holds a **JSON array of page URLs**, not statuses, so the takeability check is two
+steps:
 
-> ⚠️ The `Blocked by` relation may not exist on the board yet — Notion has no native blocking, so it
-> is a self-relation someone must add by hand. If the property is absent, fall back to reading a
-> `Blocked by: #<n>` line at the top of the body, and say once that the relation isn't set up.
+1. Select `"Blocked By"` alongside the usual properties. Rows with an empty array are unblocked —
+   done, no second query needed.
+2. For the rest, collect the union of their `Blocked By` urls and resolve them in **one** follow-up
+   query (`WHERE url IN (…)`), then read each blocker's `Status`.
+
+A blocker is cleared when its `Status` is in the **`complete` group** — `Done`, `Won't Do`, or
+`Duplicate`. Any blocker outside that group makes the ticket **blocked**, and blocked tickets are not
+takeable.
 
 Because this skill never sets `Done` — the user merges and closes — a blocker only clears when the
 user does. That's intended: it's the same gate as the merge. If a run finds every candidate blocked,
@@ -85,7 +89,7 @@ Interactive, in **this** session, using **whatever model the session is running*
 ticket's `Assignee`).
 
 1. **SELECT** — query the Task Board `WHERE "Status" = 'Ready' ORDER BY "Priority" ASC,
-   "userDefined:ID" ASC`, selecting `"Blocked by"` alongside the usual properties (or take the given
+   "userDefined:ID" ASC`, selecting `"Blocked By"` alongside the usual properties (or take the given
    `<ID>`). Auto-picking takes the **first unblocked** row. Fetch its page body via `notion-fetch`.
    Echo what you're about to work.
 
@@ -146,7 +150,7 @@ never edits ticket code itself.
 1. **SELECT** — `notion-query-data-sources`:
 
    ```sql
-   SELECT "userDefined:ID" AS id, "Name", "Priority", "Assignee", "Blocked by", url
+   SELECT "userDefined:ID" AS id, "Name", "Priority", "Assignee", "Blocked By", url
    FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
    WHERE "Status" = 'Queued' AND "Assignee" IN ('Sonnet', 'Opus', 'Fable')
    ORDER BY "Priority" ASC, "userDefined:ID" ASC
@@ -158,7 +162,7 @@ never edits ticket code itself.
    naturally excluded by the WHERE. Echo the plan (ID · priority · assignee) before starting, and
    name any ticket skipped for an open blocker so the queue's shape is visible.
 
-   Two siblings of one split are never both takeable — the `Blocked by` relation means one waits.
+   Two siblings of one split are never both takeable — the `Blocked By` relation means one waits.
    Batch is for **independent** tickets; a chain is worked a link at a time.
 
 2. **CLAIM ALL** — for each selected ticket, re-check it's still `Queued` **and still unblocked**,
@@ -208,7 +212,7 @@ never edits ticket code itself.
    c. **RESOLVE** — a branch that's clean vs master and vs its peers gets a PR **based off
    `master`**. When two branches conflict but the overlap is mechanical, **stack** the dependent
    PR on the other (base its branch on the peer's branch) so it merges cleanly. If the two tickets
-   carry a `Blocked by` relation, **that decides the stack direction** — the blocker is the base;
+   carry a `Blocked By` relation, **that decides the stack direction** — the blocker is the base;
    never invert it, and never guess a direction when the relation already states it. When a conflict needs
    **genuine human judgment** (semantic overlap, incompatible approaches), do **not** guess:
    **raise it** in the final report and set that ticket to `Blocked`.
@@ -270,7 +274,7 @@ user's call, exactly as at first handoff.
 - **Never merge, never set `Done`.** Opening the PR is a handoff into `Review`, not the end — the
   run stays live through the feedback loop until the user merges. Merging is always the user's call.
 - Claim before coding; re-check the lane to avoid double-work.
-- **Never work a ticket with an open `Blocked by` row** (§ Blockers) — batch skips it silently, pair
+- **Never work a ticket with an open `Blocked By` row** (§ Blockers) — batch skips it silently, pair
   asks first when the user named it explicitly. Lane membership alone doesn't make a ticket takeable.
 - Batch never runs the backend teaching persona and never works an `On Hold` or `Assignee = Me`
   ticket (those are the user's hands-off, and aren't `Queued` anyway). These are mode contracts — don't cross them.

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: work
-description: Execute groomed Jira tickets (project TARO). Two modes. `/work pair [ID]` works one Ready ticket interactively in this session — backend teaching on, you approve every change; tests stay untouched per the CLAUDE.md golden rule — then opens a PR. `/work batch [--count N] [--p0…]` pulls up to N Queued tickets routed to a model (Fable/Opus/Sonnet) and works them in parallel — one worktree-isolated subagent per ticket, each pinned to that ticket's model, each writing its own tests and cleaning up its worktree when done. Subagents report back to this session (the orchestrator), which organizes the branches into non-conflicting, CI-passing PRs. Both claim the ticket to In Progress first, open a PR (In Review), then iterate on your review feedback via a main-workspace subagent that checks out the PR branch — never merge. The golden "no tests" rule is suspended only in batch mode; pair mode leaves tests alone. Trigger on `/work`, "work the board", "work a ticket".
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash, Agent, Skill, EnterWorktree, ExitWorktree, mcp__atlassian__searchJiraIssuesUsingJql, mcp__atlassian__getJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getTransitionsForJiraIssue, mcp__atlassian__transitionJiraIssue
+description: Execute groomed Notion Task Board tickets. Two modes. `/work pair [ID]` works one Ready ticket interactively in this session — backend teaching on, you approve every change; tests stay untouched per the CLAUDE.md golden rule — then opens a PR. `/work batch [--count N] [--p0…]` pulls up to N Queued tickets routed to a model (Fable/Opus/Sonnet) and works them in parallel — one worktree-isolated subagent per ticket, each pinned to that ticket's model, each writing its own tests and cleaning up its worktree when done. Subagents report back to this session (the orchestrator), which organizes the branches into non-conflicting, CI-passing PRs. Both claim the ticket to In Progress first, open a PR (Review), then iterate on your review feedback via a main-workspace subagent that checks out the PR branch — never merge. The golden "no tests" rule is suspended only in batch mode; pair mode leaves tests alone. Trigger on `/work`, "work the board", "work a ticket".
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash, Agent, Skill, EnterWorktree, ExitWorktree, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page
 argument-hint: 'pair [<ID>] | batch [--count N] [--p0|--p1|--p2|--p3]'
 arguments:
   - name: pair
@@ -27,12 +27,12 @@ Two modes, chosen by the first arg. They differ deliberately:
 |                 | `pair`                                | `batch`                               |
 | --------------- | ------------------------------------- | ------------------------------------- |
 | Source lane     | `Status = Ready`                      | `Status = Queued`                     |
-| Model           | **this session's** model              | each ticket's **`Model`**             |
+| Model           | **this session's** model              | each ticket's **`Assignee`**          |
 | Execution       | interactive, in-session               | parallel subagents, one worktree each |
 | Backend persona | **on** (teaching)                     | **off**                               |
 | Your approval   | **every change**                      | none — you review the PR              |
 | Tests           | **not touched** (golden rule holds)   | each subagent writes its own          |
-| Ends at         | open PR → `In Review` + feedback loop | open PR → `In Review` + feedback loop |
+| Ends at         | open PR → `Review` + feedback loop    | open PR → `Review` + feedback loop    |
 
 **The golden "never touch tests" rule is suspended only in `batch` mode.** Batch subagents (and
 batch feedback-fix subagents) write their own coverage for what they changed and repair any test
@@ -43,26 +43,28 @@ need attention, then leave them; the user will invoke test work explicitly (e.g.
 
 ## Board constants
 
-- **Project**: `TARO` (TaroFlash) — Jira, team-managed on Atlassian Cloud. Every `atlassian` MCP
-  tool takes a `cloudId` — use the site URL **`taroflash.atlassian.net`**.
+- **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`. Full board
+  constants live in [`ticket-authoring.md`](../../rules/ticket-authoring.md).
 - `Status` lanes this skill uses: pulls from `Ready`/`Queued`; claims to `In Progress`; lands at
-  `In Review`; parks stuck work at `Blocked`. Never sets `Done`/`Duplicate`.
-- `Model` (`customfield_10043`): `Fable` · `Opus` · `Sonnet` — which agent model works the ticket in
-  batch. `Status = On Hold` is **hands-off** (user-owned) and never batch-eligible.
-- **Status changes go through transitions, not a field write** — `getTransitionsForJiraIssue` to find
-  the transition id, then `transitionJiraIssue`. Field edits (writing the PR URL into the
-  description) use `editJiraIssue`.
+  `Review`; parks stuck work at `Blocked`. Never sets `Done`/`Duplicate`.
+- `Assignee`: `Fable` · `Opus` · `Sonnet` — which agent model works the ticket in batch.
+  **`Assignee = Me` and `Status = On Hold` are both hands-off** (user-owned) and never batch-eligible.
+- Status and field writes are plain `notion-update-page` property writes — no transition step.
 
 ## Blockers — a ticket is not takeable just because it's in the lane
 
-`/groom` wires ordering between split siblings as native **`Blocks`** links (see
-[`ticket-authoring.md`](../../rules/ticket-authoring.md)). A ticket with an **open blocker** is not
-work — its foundation hasn't landed, and working it produces a PR against code that's about to
-change.
+`/groom` wires ordering between split siblings on the **`Blocked by`** self-relation (see
+[`ticket-authoring.md`](../../rules/ticket-authoring.md) § Dependencies). A ticket with an **open
+blocker** is not work — its foundation hasn't landed, and working it produces a PR against code
+that's about to change.
 
-**Request `issuelinks` in the SELECT query** (`fields: [..., "issuelinks"]`) and read it per
-candidate. A ticket is **blocked** when any `is blocked by` link points at an issue whose
-`statusCategory` is not `Done`. Blocked tickets are not takeable.
+**Select `"Blocked by"` in the query** and resolve each related row's `Status`. A ticket is
+**blocked** when any `Blocked by` row is not `Done` / `Won't Do` / `Duplicate`. Blocked tickets are
+not takeable.
+
+> ⚠️ The `Blocked by` relation may not exist on the board yet — Notion has no native blocking, so it
+> is a self-relation someone must add by hand. If the property is absent, fall back to reading a
+> `Blocked by: #<n>` line at the top of the body, and say once that the relation isn't set up.
 
 Because this skill never sets `Done` — the user merges and closes — a blocker only clears when the
 user does. That's intended: it's the same gate as the merge. If a run finds every candidate blocked,
@@ -70,9 +72,9 @@ say so and stop rather than reaching further down the queue for something unrela
 
 ## Claim protocol (both modes, per ticket)
 
-Before touching any code, **claim atomically**: transition the ticket to `In Progress`
-(`getTransitionsForJiraIssue` → `transitionJiraIssue`). Re-query the source lane first — if the
-ticket is no longer there (someone/another run grabbed it), skip it. This is what stops two runs
+Before touching any code, **claim atomically**: write `Status = In Progress` via
+`notion-update-page`. Re-query the source lane first — if the ticket is no longer there
+(someone/another run grabbed it), skip it. This is what stops two runs
 colliding on the same ticket.
 
 ---
@@ -80,12 +82,12 @@ colliding on the same ticket.
 ## Mode: `pair [ID]`
 
 Interactive, in **this** session, using **whatever model the session is running** (ignore the
-ticket's `Model`).
+ticket's `Assignee`).
 
-1. **SELECT** — JQL `project = TARO AND status = "Ready" ORDER BY priority DESC, created ASC` (or the
-   given key), requesting `issuelinks`. If an ID is given, take `TARO-<ID>`; else the **first
-   unblocked** row (highest priority, oldest first). Fetch its issue summary + description via
-   `getJiraIssue`. Echo what you're about to work.
+1. **SELECT** — query the Task Board `WHERE "Status" = 'Ready' ORDER BY "Priority" ASC,
+   "userDefined:ID" ASC`, selecting `"Blocked by"` alongside the usual properties (or take the given
+   `<ID>`). Auto-picking takes the **first unblocked** row. Fetch its page body via `notion-fetch`.
+   Echo what you're about to work.
 
    **If the ticket is blocked** (§ Blockers): when the user named it explicitly, say which open
    blocker stands in the way and ask before claiming — their call, they may know it's fine. When
@@ -118,11 +120,11 @@ ticket's `Model`).
    at most note in one line that tests may need attention, then leave them. Follow all
    `.claude/rules/*`.
 6. **PR** — invoke the **`prepare-pr`** skill with `--ticket <ID> --ticket-url <url>` (the ticket's
-   `TARO-<ID>` number and its Jira browse URL, `https://taroflash.atlassian.net/browse/TARO-<ID>`) so
-   the PR title is prefixed `TARO-<ID>:` and the body opens with a `[TARO-<ID>](<url>)` link (commits,
+   ticket's `<ID>` and its Notion page URL) so the PR title is prefixed `TARO-<ID>:` and the body
+   opens with a `[TARO-<ID>](<url>)` link (commits,
    conventional messages, lint+type gate, opens one PR, watches CI to green).
-7. **HANDOFF** — transition the ticket to `In Review` and append the PR URL into its description via
-   `editJiraIssue` (append, don't clobber the body). Then enter the **Review & feedback loop** (below)
+7. **HANDOFF** — set the ticket to `Review` and append the PR URL into its body via
+   `notion-update-page` (append, don't clobber the body). Then enter the **Review & feedback loop** (below)
    and wait for the user's feedback.
 
 ## Mode: `batch [--count N] [--p0…]`
@@ -141,30 +143,31 @@ never edits ticket code itself.
    only work that leaves the orchestrator worktree is a **feedback-loop fix**, which must land on the
    main checkout so the user's dev server sees it (see that section for the coordination it needs).
 
-1. **SELECT** — `searchJiraIssuesUsingJql`:
+1. **SELECT** — `notion-query-data-sources`:
 
-   ```jql
-   project = TARO AND status = "Queued" AND Model in (Sonnet, Opus, Fable)
-   ORDER BY priority DESC, created ASC
+   ```sql
+   SELECT "userDefined:ID" AS id, "Name", "Priority", "Assignee", "Blocked by", url
+   FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
+   WHERE "Status" = 'Queued' AND "Assignee" IN ('Sonnet', 'Opus', 'Fable')
+   ORDER BY "Priority" ASC, "userDefined:ID" ASC
    ```
 
    `--pN` adds `AND priority = Highest|High|Medium|Low`; `--count N` sets **how many tickets to work
-   in parallel** (default 1). Request `issuelinks` and **drop every blocked row** (§ Blockers) before
-   taking the top `N` (highest priority first, oldest as stable tie-break). `On Hold` tickets are
-   naturally excluded — they aren't `Queued`. Echo the plan (ID · priority · model) before starting,
-   and name any ticket skipped for an open blocker so the queue's shape is visible.
+   in parallel** (default 1). **Drop every blocked row** (§ Blockers) before taking the top `N`
+   (highest priority first, lowest ID as stable tie-break). `On Hold` and `Assignee = Me` tickets are
+   naturally excluded by the WHERE. Echo the plan (ID · priority · assignee) before starting, and
+   name any ticket skipped for an open blocker so the queue's shape is visible.
 
-   Two siblings of one split are never both takeable — the `Blocks` edge means one waits. Batch is
-   for **independent** tickets; a chain is worked a link at a time.
+   Two siblings of one split are never both takeable — the `Blocked by` relation means one waits.
+   Batch is for **independent** tickets; a chain is worked a link at a time.
 
 2. **CLAIM ALL** — for each selected ticket, re-check it's still `Queued` **and still unblocked**,
-   then transition it to `In Progress` (`getTransitionsForJiraIssue` → `transitionJiraIssue`). Drop
-   any that another run already grabbed. Claim before dispatching so parallel runs don't collide.
+   then write `Status = In Progress`. Drop any that another run already grabbed. Claim before dispatching so parallel runs don't collide.
 
 3. **FAN OUT — one subagent per ticket, in parallel.** Dispatch all subagents in a single message
    (multiple `Agent` calls) so they run concurrently. Each `Agent`:
    - `agentType: general-purpose`, `isolation: worktree` (its own worktree — they edit files in
-     parallel and must not collide), `model:` = the ticket's `Model` lowercased →
+     parallel and must not collide), `model:` = the ticket's `Assignee` lowercased →
      `fable`/`opus`/`sonnet`.
    - Prompt carries the ticket's title + body + acceptance criteria and instructs the subagent to:
      **rename** the worktree's existing branch to a conventional name (`git branch -m <fix/…|feat/…>`)
@@ -205,19 +208,19 @@ never edits ticket code itself.
    c. **RESOLVE** — a branch that's clean vs master and vs its peers gets a PR **based off
    `master`**. When two branches conflict but the overlap is mechanical, **stack** the dependent
    PR on the other (base its branch on the peer's branch) so it merges cleanly. If the two tickets
-   carry a `Blocks` link, **that edge decides the stack direction** — the blocker is the base; never
-   invert it, and never guess a direction when an edge already states it. When a conflict needs
+   carry a `Blocked by` relation, **that decides the stack direction** — the blocker is the base;
+   never invert it, and never guess a direction when the relation already states it. When a conflict needs
    **genuine human judgment** (semantic overlap, incompatible approaches), do **not** guess:
-   **raise it** in the final report and transition that ticket to `Blocked`.
+   **raise it** in the final report and set that ticket to `Blocked`.
    d. **OPEN** — for each non-blocked ticket, invoke the **`prepare-pr`** skill with `--ticket
-<ID> --ticket-url <url>` (the `TARO-<ID>` number and the ticket's Jira browse URL,
-   `https://taroflash.atlassian.net/browse/TARO-<ID>`) → one PR titled `TARO-<ID>: …` whose body opens
+<ID> --ticket-url <url>` (the ticket's `<ID>` and its Notion page URL) → one PR titled
+   `TARO-<ID>: …` whose body opens
    with a `[TARO-<ID>](<url>)` link. Pass the stack base when the PR is stacked. `prepare-pr` watches
    CI; **a PR isn't done until it's green.** If CI fails, route it through the **Review & feedback
    loop** (below) — a main-workspace fix subagent on the PR branch; if it still can't pass after real
    effort, treat the ticket as stuck.
-   e. **HANDOFF** — for each opened, green PR: transition the ticket to `In Review`, append the PR URL
-   into the ticket description via `editJiraIssue` (append, don't clobber the body).
+   e. **HANDOFF** — for each opened, green PR: set the ticket to `Review`, append the PR URL into
+   the ticket body via `notion-update-page` (append, don't clobber the body).
    f. **TEAR DOWN** — once a ticket is handed off (PR open + green, branch pushed to origin),
    **remove its worktree**: `git worktree remove <path>`. The branch lives on origin and its local
    ref survives worktree removal, so the human can `git checkout <branch>` in the **main** working
@@ -226,11 +229,11 @@ never edits ticket code itself.
    one behind. Only tear down **successful** tickets here; blocked ones keep their worktree (step 5).
 
 5. **STUCK / BLOCKED** — a ticket is stuck when its subagent can't satisfy acceptance, its gate or
-   CI won't pass after real effort, or a conflict needs human resolution. Transition it to `Blocked`,
-   append a one-line reason + what's needed into the description, and leave its branch/worktree in
+   CI won't pass after real effort, or a conflict needs human resolution. Set it to `Blocked`,
+   append a one-line reason + what's needed into the body, and leave its branch/worktree in
    place for the human. Never silently fail or leave a ticket stranded in `In Progress`.
 
-6. **REPORT** — tally: worked → `In Review` (with PR links, noting any stacked pairs), `Blocked`
+6. **REPORT** — tally: worked → `Review` (with PR links, noting any stacked pairs), `Blocked`
    (with reasons + which need human conflict resolution), skipped. Then enter the **Review &
    feedback loop** below.
 
@@ -246,7 +249,7 @@ needs — is handled the same way:
 1. **Dispatch a fix subagent on the MAIN workspace** (not a worktree). It **checks out the PR
    branch** in the main checkout. The user keeps a dev server running against the main workspace and
    verifies each fix **live**, so the fix must land on the branch they're looking at. Model: the
-   ticket's `Model` in batch, this session's model in pair. Work one PR at a time (the user goes
+   ticket's `Assignee` in batch, this session's model in pair. Work one PR at a time (the user goes
    in order), so only one fix subagent touches the main checkout at once.
 2. **Fix — plus a test pass in batch only.** The subagent makes the code change. In **batch**, it
    also does a fresh test pass alongside — new coverage for the new behaviour plus repairs to any
@@ -256,21 +259,21 @@ needs — is handled the same way:
 3. **Gate, push, watch green.** Run `vp check` + `vp test`, push to the PR branch, and watch CI to
    green (via `prepare-pr` or directly). A PR isn't done until it's green again.
 4. **Answer the thread.** Reply to the feedback on the PR prefixed `🤖 Claude:` so the user can tell
-   your replies from their own. Leave the ticket in `In Review`.
+   your replies from their own. Leave the ticket in `Review`.
 
 Repeat per PR until the user merges. **Never merge and never set `Done` yourself** — that stays the
 user's call, exactly as at first handoff.
 
 ## Guardrails
 
-- Only ever touch project `TARO` — never a backup/duplicate project.
-- **Never merge, never set `Done`.** Opening the PR is a handoff into `In Review`, not the end — the
+- Only ever touch the Task Board named in the rule — never a backup/duplicate board.
+- **Never merge, never set `Done`.** Opening the PR is a handoff into `Review`, not the end — the
   run stays live through the feedback loop until the user merges. Merging is always the user's call.
 - Claim before coding; re-check the lane to avoid double-work.
-- **Never work a ticket with an open `Blocks` blocker** (§ Blockers) — batch skips it silently, pair
+- **Never work a ticket with an open `Blocked by` row** (§ Blockers) — batch skips it silently, pair
   asks first when the user named it explicitly. Lane membership alone doesn't make a ticket takeable.
-- Batch never runs the backend teaching persona and never works an `On Hold` ticket (those are the
-  user's hands-off, and aren't `Queued` anyway). These are mode contracts — don't cross them.
+- Batch never runs the backend teaching persona and never works an `On Hold` or `Assignee = Me`
+  ticket (those are the user's hands-off, and aren't `Queued` anyway). These are mode contracts — don't cross them.
 - **Tests: batch only.** The golden "no tests" rule is suspended **only in batch** — batch
   subagents write/repair their own tests inline (never via `update-tests`). **Pair never touches
   tests** (golden rule holds); it only notes, in one line, that tests may need attention and leaves


### PR DESCRIPTION
## Summary

Slims ticket bodies, makes `ticket-authoring.md` the single source for what a ticket looks like, and
moves the whole ticket workflow back off Jira onto the Notion Task Board.

**Body shape.** `Technical notes` is gone, replaced by `## Decisions` gated on one test — _will the
claiming agent rediscover this on its own?_ Prior art, deliberately rejected paths, negative facts
and confirmed root causes stay; file lists, plumbing traces and line numbers go. Acceptance criteria
only earn a line when they can fail independently, and bodies never restate rules that already
auto-load (`data-testid`, theming, "don't touch tests").

**One source.** `/triage` and `/groom` no longer declare their own templates, board constants, or
body voice — they keep only their routing and lanes. Fixes a live contradiction where
`ticket-authoring.md` banned acceptance criteria outright while `/triage` mandated them.

**Effort-level state on the epic.** New `## Decisions so far` (index of what's been settled),
`## Not yet specified` (fog you can't phrase as a ticket yet, deleted on graduation), and
`## Out of scope`. `/triage` parks adjacent fog there instead of cutting premature tickets; `/groom`
keeps them current.

**Split ordering.** `/groom` wires the Task Board's `Blocked By` self-relation between siblings, and
`/work` treats a ticket with an unresolved blocker as not takeable — batch drops it before selection,
pair asks when you named it explicitly, and the relation decides stack direction on conflicting
branches.

**Back to Notion.** SQL over the Task/Epic Board data sources, `notion-*` tools, `⇞P0`–`⇟P3`,
`Assignee` (including the `Me` hands-off signal) in place of `Model`, `Review` in place of
`In Review`, plain property writes in place of status transitions. Verified against the live board
schema.
