### PR TITLE
docs(ticket-authoring): fold decisions into concrete acceptance criteria

### DIFF
--- a/.claude/agents/ticket-author.md
+++ b/.claude/agents/ticket-author.md
@@ -52,7 +52,7 @@ Expensive-to-produce and worth-recording are not the same thing.
 - **Never** create an epic. If none fits, say so in your report and let the caller decide.
 - **Never** write code, edit files outside Notion, or touch tests.
 - **Never** invent scope, acceptance criteria, or a taste decision. If the work needs a call on how
-  something should look, feel, or read — record it as open.
+  something should look, feel, or read — record it under `## Open questions`, never as an AC.
 
 Your baseline output is faithful capture. When the input is too thin to make a ticket anyone could
 act on, say so instead of padding it.

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -69,59 +69,62 @@ ordered lists and the churn shows up as noise in the page history.
 
 **One section list. Each stage fills more of it — no stage invents sections.**
 
-| Section                  | Owner  | Notes                                            |
-| ------------------------ | ------ | ------------------------------------------------ |
-| `## Product description` | cut    | 1–3 lines, product terms                         |
-| `## Repro`               | cut    | bugs only                                        |
-| `## Acceptance criteria` | triage | **never at cut time** — see below                |
-| `## Decisions`           | triage | seeds prior art + rejected paths; groom resolves |
-| `## Blocked on`          | groom  | external facts only; omit if none                |
+| Section                  | Owner      | Notes                                                        |
+| ------------------------ | ---------- | ------------------------------------------------------------ |
+| `## Product description` | cut        | 1–3 lines, product terms                                     |
+| `## Repro`               | cut        | bugs only                                                    |
+| `## Acceptance criteria` | triage     | the only technical section — see below                       |
+| `## Open questions`      | cut/triage | unresolved forks; groom settles each into an AC + deletes it |
+| `## Blocked on`          | groom      | external facts only; omit if none                            |
+
+**There is no `## Decisions` section.** A resolved decision is an acceptance criterion.
 
 A ticket carries only the sections that have content. Length tracks how much of the work is
 **decision** rather than typing — a mechanical change gets six lines, a cross-cutting refactor earns
 its ownership table and execution order.
 
-### `## Acceptance criteria` — only what can fail independently
+### `## Acceptance criteria` — the only technical section
 
-An AC earns its place when it can fail on its own. "The menu shows the new option" cannot fail
-separately from the feature existing — that's the Product description restated as a checkbox. "Never
-reviewed cards sort last" and "survives infinite-scroll pagination" can fail on their own; those are
-the ACs.
+Every resolved decision, chosen value, named mechanism, reuse pointer, and rejected path is an
+acceptance criterion. There is no "Decisions" or "Technical notes" section — worth recording means
+worth phrasing as pass-or-fail.
 
-No `or`, `either`, `e.g.`, or parenthetical alternatives — a hedge in an AC is an unresolved
-decision, and it routes to `Needs More Info`.
+Four gates on every AC:
 
-**Not written at cut time.** Writing them before investigation invites inventing scope nobody agreed
-to. Exception: acceptance the user dictates, recorded verbatim.
+- **Independently failable.** "The menu shows the new option" can't fail separately from the feature
+  existing — that's Product description as a checkbox. "Never-reviewed cards sort last" can. A
+  rejected path counts too, as a negative: "no cross-session outbox is added".
+- **Concrete.** Values, mechanisms, exact copy — _in_ the criterion. Not "retries the save";
+  "retries 3× at 0.5s / 1s / 2s, then marks it failed".
+- **One sentence.** A second sentence means it's two ACs, or padding.
+- **No `or` / `either` / `e.g.` / parenthetical alternatives** — a hedge is an unresolved decision;
+  route it to `Needs More Info`.
 
-### `## Decisions` — the only technical section
+**Delete-test, per clause:** if removing it leaves no criterion ambiguous or unfailable, cut it.
+Rationale, plumbing traces, and restatements of another AC all fail it.
 
-There is no "Technical notes" section. Investigation findings are not recorded; **decisions are.**
-The claiming agent does its own exploration.
+> **Bloated** (a "Decisions" bullet restating an AC): _Optimistic advance stays; only the commit is
+> gated — the card flies away instantly, tracked by a per-card pending/saved/failed status. Rejected:
+> blocking the UI._
+> **Lean** (the AC alone): _A rated card advances instantly and is recorded `pending`, with no saving
+> state; it becomes durably reviewed only once its save confirms._
 
-The test for every line:
+**Still earns space** — won't be rediscovered: **prior art** (the primitive/rule already governing
+the surface, as a "built from X" clause), a bug's confirmed **root cause**, **negative facts**.
+Money / auth / boundary claims: `CONFIRMED (verified against <source>)`, else `ASSUMED`. A filepath
+only when it's the _answer_, never a line number.
 
-> **Will the claiming agent rediscover this on its own?**
+**Never earns space** — grep finds it in seconds: which files to edit, how the current code works,
+framework mechanics.
 
-| Cut — rediscovered in seconds     | Keep — won't be found, or found too late                       |
-| --------------------------------- | -------------------------------------------------------------- |
-| Which files to edit, line numbers | **Prior art** — the primitive/util/rule already governing this |
-| How the current code works        | The path deliberately **rejected**, and why                    |
-| The plumbing trace                | **Negative facts** — "no join change", "single UI surface"     |
-| Framework/API mechanics           | Confirmed root cause of a bug                                  |
+Written concrete as decisions resolve (mostly groom). At cut time, only acceptance the user dictates,
+verbatim.
 
-Prior art is the highest-value line in any ticket. An agent finds the file it needs in seconds; it
-never finds "`ui-tappable` already encodes press styling" unless pointed, because you can't grep for
-a thing you don't know exists. Negative facts are second — they delete exploration that would
-otherwise happen.
+### `## Open questions` — unresolved forks awaiting groom
 
-Name a filepath when it's the _answer_ (the primitive to use, the seam to extend), not when it's
-merely _where the work happens_. Never cite line numbers — they go stale and grep is faster.
-
-Groom-resolved decisions carry: **what** was decided · **why**, in a line · **what was rejected and
-why** (this is what stops a future session re-proposing it) · `CONFIRMED (verified against
-
-<source>)` or `ASSUMED`. Anything touching money, auth, or a system boundary must be `CONFIRMED`.
+The forks a ticket hands to `/groom` — a taste call left open at cut, a design fork triage won't
+settle — one line each, phrased as the question. Groom settles each into a concrete AC and **deletes
+the section**; it never reaches a takeable ticket.
 
 ### Never restate a rule that auto-loads
 
@@ -134,7 +137,7 @@ trigger it.
 ## Voice
 
 - **Product description is product terms** — screens, flows, what the user experiences. No
-  filepaths, symbols, function names, or SQL. Those live in `## Decisions`.
+  filepaths, symbols, function names, or SQL. Those live in the acceptance criteria.
 - **Point, don't narrate.** `Reuse: UiDropdownButton, UiRadio; mirror grid-item.vue` — not a
   parenthetical explaining what each one is for. The implementer opens the file.
 - **Say it once.** If Product description already carries a fact, no other section repeats it.

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -164,10 +164,12 @@ Rewrite the ticket's **page body** via `notion-update-page` — prefer `replace_
 rewrite over a chain of `update_content` edits. Any splits become new tickets via
 `notion-create-pages`.
 
-Sections and their shape live in [`ticket-authoring.md`](../../rules/ticket-authoring.md); groom
-owns `## Decisions` and `## Blocked on`, and may revise `## Acceptance criteria`. It writes no
-`Files` or `Implementation steps` section — the claiming agent explores for itself, and a decision
-that only makes sense as an ordered plan belongs in `## Decisions` as the decision it is.
+Sections and their shape live in [`ticket-authoring.md`](../../rules/ticket-authoring.md). Groom
+turns each resolved decision into a **concrete acceptance criterion** — specific values, named
+mechanisms, exact copy in the criterion itself — and **deletes `## Open questions`** as it goes.
+**There is no `## Decisions` section**; a decision that only reads as an ordered plan still lands as
+ACs, not a plan. Groom also owns `## Blocked on`, and writes no `Files` or `Implementation steps`
+section — the claiming agent explores for itself.
 
 **The resolution is the deliverable, not the investigation.** Grooming reads far more than it
 records: most of what you learned settling a decision is rediscoverable in seconds and does not
@@ -209,12 +211,12 @@ on the epic. No prose.
 A groomed ticket is done when a fresh session with **no memory of this conversation** could execute
 it without guessing. Test it by asking:
 
-- Does any acceptance criterion contain "or", "either", or a parenthetical alternative?
-- Would an implementer hit a fork the body doesn't settle?
-- Is any load-bearing fact `ASSUMED` that should be `CONFIRMED`?
-- Does the body say why the rejected alternatives were rejected — or will someone re-propose them?
-- Is the prior art named, so the implementer uses the existing primitive rather than reinventing it?
-- Is anything in the body something the claiming agent would rediscover in seconds? Cut it.
+- Is every AC concrete — specific values, mechanisms, copy in the criterion, not "retries the save"?
+- Does any AC contain "or", "either", a parenthetical alternative, or a second sentence?
+- Does any clause survive the delete-test — rationale, plumbing, or a restatement of another AC? Cut it.
+- Is `## Open questions` gone, and every fork it held now a concrete AC?
+- Is a rejected path recorded as a negative AC, so no one re-proposes it?
+- Is the prior art an AC clause ("built from X"), and is any money/auth/boundary fact `CONFIRMED`?
 - If this was a split: can `/work` tell which sibling must land first without reading all of them?
 
 ## Guardrails

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -233,18 +233,18 @@ not treat the marking as a reason to leave it in `Ready`.
 
 Section list, brevity, and voice all live in
 [`ticket-authoring.md`](../../rules/ticket-authoring.md). Triage owns two of its sections —
-`## Acceptance criteria` and `## Decisions` — and adds neither a template nor a rule of its own.
+`## Acceptance criteria` and `## Open questions` — and adds neither a template nor a rule of its own.
 
 Three things this skill is on the hook for:
 
-- **Prior art in `## Decisions`.** The most common implementation failure isn't a wrong decision, it's
-  an agent reinventing what the codebase already encodes — a stepper hand-rolling press styling when
-  `ui-tappable` defines it, a CSS hack where a prop exists. Investigation always answers _what
-  already governs this surface?_, and the answer is written down. It converts "the agent should have
-  known" into "the ticket said so."
+- **Prior art as an acceptance criterion.** The most common implementation failure isn't a wrong
+  decision, it's an agent reinventing what the codebase already encodes — a stepper hand-rolling
+  press styling when `ui-tappable` defines it, a CSS hack where a prop exists. Answer _what already
+  governs this surface?_ and write it as a concrete AC clause ("built from `ui-tappable`"). It
+  converts "the agent should have known" into "the ticket said so."
 - **Open forks, for a `Needs More Info` ticket.** It still gets a body — `/groom` builds on it rather
-  than starting over — with the unresolved forks listed explicitly under `## Decisions` so `/groom`
-  knows what it is there to settle.
+  than starting over — with the unresolved forks listed under `## Open questions` so `/groom` knows
+  what it is there to settle.
 - **`Type = Spike` carries its own meaning**, so the title must not be prefixed `"Spike: …"` — that
   prefix only existed because the Type was unavailable. Strip it when retyping an old ticket. A
   Spike's acceptance criteria describe what the written recommendation must cover, not a behaviour


### PR DESCRIPTION
## Summary

Retires the `## Decisions` section from the ticket-body doctrine. A resolved decision now lands as a concrete, independently-failable **acceptance criterion** — specific values, mechanisms, and copy live in the criterion itself, not in a parallel section that restates them.

- **`ticket-authoring.md`** — ACs are "the only technical section"; prior art, rejected paths, and negative facts all become AC clauses. Brevity is enforced mechanically: one sentence per AC, a per-clause delete-test, and an inline bloated→lean example.
- **`## Open questions`** — new transient section for the cut/triage→groom handoff; groom settles each fork into an AC and deletes it, so it never reaches a takeable ticket.
- **`groom` / `triage` / `ticket-author`** — updated to own/produce ACs + `## Open questions` instead of `## Decisions`.

The epic's separate `## Decisions so far` index is unchanged.