### PR TITLE
TARO-141: Snap spinbox steppers to the nearest multiple of step

### DIFF
--- a/src/components/ui-kit/spinbox/index.vue
+++ b/src/components/ui-kit/spinbox/index.vue
@@ -66,7 +66,7 @@ function decrement() {
     if (wrap && Number.isFinite(max)) value.value = max
     return
   }
-  value.value = clamp(value.value - step)
+  value.value = clamp((Math.ceil(value.value / step) - 1) * step)
 }
 
 function increment() {
@@ -76,7 +76,7 @@ function increment() {
     if (wrap && Number.isFinite(min)) value.value = min
     return
   }
-  value.value = clamp(value.value + step)
+  value.value = clamp((Math.floor(value.value / step) + 1) * step)
 }
 </script>
 

--- a/tests/integration/components/ui-kit/spinbox.test.js
+++ b/tests/integration/components/ui-kit/spinbox.test.js
@@ -182,6 +182,54 @@ describe('UiSpinbox', () => {
     expect(wrapper.emitted('update:value')).toEqual([[0]])
   })
 
+  // ── Snap to nearest multiple of step [obligation] ───────────────────────────
+  // TARO-141: the steppers snap to the nearest multiple of `step` in the
+  // pressed direction rather than offsetting from an off-grid value.
+
+  test('decrement snaps an off-grid value down to the nearest lower multiple of step [obligation]', async () => {
+    const wrapper = mountSpinbox({ value: 42, step: 5, min: 0, max: 100 })
+    await findDecrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[40]])
+  })
+
+  test('increment snaps an off-grid value up to the nearest higher multiple of step [obligation]', async () => {
+    const wrapper = mountSpinbox({ value: 42, step: 5, min: 0, max: 100 })
+    await findIncrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[45]])
+  })
+
+  test('decrement on an on-grid value moves by exactly one step [obligation]', async () => {
+    const wrapper = mountSpinbox({ value: 40, step: 5, min: 0, max: 100 })
+    await findDecrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[35]])
+  })
+
+  test('increment on an on-grid value moves by exactly one step [obligation]', async () => {
+    const wrapper = mountSpinbox({ value: 40, step: 5, min: 0, max: 100 })
+    await findIncrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[45]])
+  })
+
+  test('a value typed into the field stays off-grid until a stepper is pressed [obligation]', async () => {
+    const wrapper = mountSpinbox({ value: 5, step: 5, min: 0, max: 100 })
+    const input = findInput(wrapper)
+    input.element.value = '42'
+    await input.trigger('input')
+    expect(wrapper.emitted('update:value')).toEqual([[42]])
+  })
+
+  test('increment snaps an off-grid value up then clamps to max when the snapped multiple overshoots [obligation]', async () => {
+    const wrapper = mountSpinbox({ value: 41, step: 10, min: 0, max: 44 })
+    await findIncrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[44]])
+  })
+
+  test('decrement snaps an off-grid value down then clamps to min when the snapped multiple undershoots [obligation]', async () => {
+    const wrapper = mountSpinbox({ value: 5, step: 10, min: 3, max: 100 })
+    await findDecrement(wrapper).trigger('click')
+    expect(wrapper.emitted('update:value')).toEqual([[3]])
+  })
+
   // ── Wrap ───────────────────────────────────────────────────────────────────
 
   test('decrement at min wraps to max when wrap is enabled', async () => {


### PR DESCRIPTION
[TARO-141](https://app.notion.com/p/37d0953c224c8004b545febbe9cf15c0)

## Summary

The spinbox +/− steppers now snap to the nearest multiple of `step` in the pressed direction instead of adding/subtracting `step` from an off-grid value. A daily-limit spinbox (step 5) showing 42 now gives 40 on − and 45 on +, not 37 / 47.

## Changes

- Decrement → largest multiple of `step` strictly below the value: `(Math.ceil(value / step) - 1) * step`, clamped into `[min, max]`.
- Increment → smallest multiple of `step` strictly above the value: `(Math.floor(value / step) + 1) * step`, clamped into `[min, max]`.
- A value already on a multiple still moves by exactly one `step`; the out-of-range settle and the `wrap` branch are unchanged.
- No `snapToStep` prop added — snapping is the sole stepper behaviour, measured from `0`.

## Test plan

- [ ] Off-grid value snaps to the nearest lower/upper multiple on −/+
- [ ] On-grid value moves by exactly `step` in both directions
- [ ] Snap result clamps to `min`/`max` bounds
- [ ] Typed value stays off-grid until a stepper is pressed