### PR TITLE
docs(groom): sharpen resolution rules — buildable depth, copy signoff, self-heal

### DIFF
--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -73,21 +73,23 @@ ordered lists and the churn shows up as noise in the page history.
 | ------------------------ | ---------- | ------------------------------------------------------------ |
 | `## Product description` | cut        | 1–3 lines, product terms                                     |
 | `## Repro`               | cut        | bugs only                                                    |
-| `## Acceptance criteria` | triage     | the only technical section — see below                       |
+| `## Acceptance criteria` | triage     | product-observable, one pass/fail each — see below           |
+| `## Tech details`        | groom      | terse companion criteria — the encoding the ACs can't carry  |
 | `## Open questions`      | cut/triage | unresolved forks; groom settles each into an AC + deletes it |
 | `## Blocked on`          | groom      | external facts only; omit if none                            |
 
-**There is no `## Decisions` section.** A resolved decision is an acceptance criterion.
+**There is no `## Decisions` section.** A resolved decision is an acceptance criterion — product-observable, with any technical encoding on a companion `## Tech details` line.
 
 A ticket carries only the sections that have content. Length tracks how much of the work is
 **decision** rather than typing — a mechanical change gets six lines, a cross-cutting refactor earns
 its ownership table and execution order.
 
-### `## Acceptance criteria` — the only technical section
+### `## Acceptance criteria` — product-observable, one per line
 
-Every resolved decision, chosen value, named mechanism, reuse pointer, and rejected path is an
-acceptance criterion. There is no "Decisions" or "Technical notes" section — worth recording means
-worth phrasing as pass-or-fail.
+Every AC is something you could watch pass or fail in the running product, in product terms — no
+filepaths, symbols, or SQL. This is the list the reviewer checks off and the implementer builds to,
+so keep it skimmable. The technical encoding each one rides on — the seam, mechanism, or reuse
+pointer — lives on a companion line in `## Tech details`, not here.
 
 Five gates on every AC:
 
@@ -102,8 +104,8 @@ Five gates on every AC:
 - **No smuggled design; no implementation.** A competence claim ("handles X correctly", "works
   across Y") isn't concrete unless X's behaviour is spelled out — undecided behaviour is an
   `## Open questions` fork, not an AC. And an AC pins the _design_ decision (placement, host, copy,
-  states, behaviour), never the _implementation_ (which composable, how it's wired) — that's a "built
-  from X" clause at most.
+  states, behaviour), never the _implementation_ (which composable, how it's wired) — that rides a
+  companion line in `## Tech details`.
 
 **Delete-test, per clause:** if removing it leaves no criterion ambiguous or unfailable, cut it.
 Rationale, plumbing traces, and restatements of another AC all fail it.
@@ -114,16 +116,23 @@ Rationale, plumbing traces, and restatements of another AC all fail it.
 > **Lean** (the AC alone): _A rated card advances instantly and is recorded `pending`, with no saving
 > state; it becomes durably reviewed only once its save confirms._
 
-**Still earns space** — won't be rediscovered: **prior art** (the primitive/rule already governing
-the surface, as a "built from X" clause), a bug's confirmed **root cause**, **negative facts**.
-Money / auth / boundary claims: `CONFIRMED (verified against <source>)`, else `ASSUMED`. A filepath
-only when it's the _answer_, never a line number.
-
-**Never earns space** — grep finds it in seconds: which files to edit, how the current code works,
-framework mechanics.
-
 Written concrete as decisions resolve (mostly groom). At cut time, only acceptance the user dictates,
 verbatim.
+
+### `## Tech details` — the companion encoding
+
+A terse companion to the ACs: one checkbox line per AC that needs the technical detail its product
+term can't carry — the seam, slot, composable, mechanism, reuse pointer, or the single file that _is_
+the answer. Same delete-test. This is where implementation encoding lives, so the ACs stay pure
+product language and skimmable. Omit the section when there's nothing technical to record.
+
+- **Prior art** as a "built from X" clause, a bug's confirmed **root cause**, **negative facts**
+  ("does not reuse Y").
+- Money / auth / boundary claims: `CONFIRMED (verified against <source>)`, else `ASSUMED`.
+- A filepath only when it's the _answer_ (a new file's home, a confirmed root-cause location), never
+  a line number.
+- **Never here** — grep finds it in seconds: exhaustive file lists, how the current code works,
+  framework mechanics.
 
 ### `## Open questions` — unresolved forks awaiting groom
 

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -89,7 +89,7 @@ Every resolved decision, chosen value, named mechanism, reuse pointer, and rejec
 acceptance criterion. There is no "Decisions" or "Technical notes" section — worth recording means
 worth phrasing as pass-or-fail.
 
-Four gates on every AC:
+Five gates on every AC:
 
 - **Independently failable.** "The menu shows the new option" can't fail separately from the feature
   existing — that's Product description as a checkbox. "Never-reviewed cards sort last" can. A
@@ -99,6 +99,11 @@ Four gates on every AC:
 - **One sentence.** A second sentence means it's two ACs, or padding.
 - **No `or` / `either` / `e.g.` / parenthetical alternatives** — a hedge is an unresolved decision;
   route it to `Needs More Info`.
+- **No smuggled design; no implementation.** A competence claim ("handles X correctly", "works
+  across Y") isn't concrete unless X's behaviour is spelled out — undecided behaviour is an
+  `## Open questions` fork, not an AC. And an AC pins the _design_ decision (placement, host, copy,
+  states, behaviour), never the _implementation_ (which composable, how it's wired) — that's a "built
+  from X" clause at most.
 
 **Delete-test, per clause:** if removing it leaves no criterion ambiguous or unfailable, cut it.
 Rationale, plumbing traces, and restatements of another AC all fail it.
@@ -134,6 +139,9 @@ tokens", "declarative schema then `db diff`", or "do not touch tests" into a bod
 Name a rule file **only** when the ticket departs from it, or when the ticket's area wouldn't
 trigger it.
 
+A restated rule is still noise when it wears a section heading: an `## Out of scope: tests stay
+untouched` line is the "do not touch tests" rule in costume — delete it.
+
 ## Voice
 
 - **Product description is product terms** — screens, flows, what the user experiences. No
@@ -149,6 +157,10 @@ trigger it.
   copy says, how a layout should look — record as open. `/groom` settles them with the user.
 - New user-facing text → note that locale keys are needed (`src/locales/en-us.json`), see
   [`i18n`](./i18n.md).
+- **Copy is the user's to sign off.** Any new or changed user-facing string carries its exact final
+  wording in the AC, signed off by the user — never chosen for them, never deferred. Reused copy is
+  stated as reused (same wording, its own key — keys aren't shared across features). A ticket with
+  undecided copy is not `Ready`.
 
 ## Epics
 

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -42,6 +42,33 @@ should look. Those are resolved _with the user, here_, not deferred into impleme
 The sole exception is a decision blocked on an **external fact** nobody in the session has (§4) —
 recorded under `## Blocked on`, never left as an unmarked menu.
 
+### Resolve to buildable, not to gist
+
+A decision is resolved only when an implementer can build it **without one design or taste choice of
+their own**. Every answer spawns finer ones — a "header toggle" needs a _side_; a "floating bar"
+needs a _host_ (which primitive, which slot). After each answer ask **"what would someone still have
+to invent to build exactly this?"** and resolve that too, recursively.
+
+Pin every **design** dimension of a UI element (UX decisions, not implementation): **placement**
+(side, order) · **host** (component / primitive / slot) · **trigger** (how invoked; what it swaps or
+coexists with) · **label + icon** (signed-off copy) · **states** (default, disabled, empty, count).
+
+Two traps this closes:
+
+- **"Mirror/match X" is itself a gist.** Walk each mirrored element and confirm it fits the new
+  context — parity that reads wrong (a "Move Deck" button on a cross-deck surface) is not resolved.
+- **Survey the seam.** Before placing new content at an existing seam (slot, store, registry, layout
+  region), inspect how its sibling content is _owned_, not just whether the seam is empty. "Is the
+  slot empty?" is the wrong question; "how is its neighbour owned?" is the right one.
+
+Gist is the first question, never the last.
+
+### Copy is signed off, not settled silently
+
+For every new or changed user-facing string, **pause** and present **at least 3 reasonably-varied
+options per line**; only the user's chosen wording lands, verbatim, in the AC. Reused copy is stated
+as reused. Undecided copy keeps the ticket out of `Ready`.
+
 ## Board constants
 
 **[`ticket-authoring.md`](../../rules/ticket-authoring.md) is the single source** for the board data
@@ -218,11 +245,30 @@ it without guessing. Test it by asking:
 - Is a rejected path recorded as a negative AC, so no one re-proposes it?
 - Is the prior art an AC clause ("built from X"), and is any money/auth/boundary fact `CONFIRMED`?
 - If this was a split: can `/work` tell which sibling must land first without reading all of them?
+- For every UI element: are placement, host/slot, trigger, label/icon, and states decided — or would
+  an implementer still choose?
+- Is every new or changed string the user-signed-off exact wording (≥3 options offered), and is
+  reused copy marked as reused?
+- Does any AC smuggle undecided design behind a competence claim, or grow into implementation mechanics?
+- Was each seam this ticket touches surveyed for how its existing content is owned?
+
+## Self-heal
+
+The user will push back — correcting a miss, adding a granularity you skipped, rejecting a baked
+assumption. Treat that as a **defect in this skill**, not just in the ticket. Capture the lesson as a
+concrete edit to this skill (or [`ticket-authoring.md`](../../rules/ticket-authoring.md)) and ship it
+as its own branch + PR, separate from the ticket work.
+
+Before writing a single file: **check the working tree.** Branch off `master` only when it is clean;
+if the current branch isn't `master` or has uncommitted changes (the user works in parallel), make
+the edit in a git worktree so nothing in the active checkout is disturbed. Conventional-commit it
+(`docs(groom): …`), open the PR, report the link — never merge.
 
 ## Guardrails
 
 - Only ever touch the Task Board and Epic Board named in the rule — never a backup or duplicate.
-- Never write code, never touch tests, never open a PR. This pass ends at a ticket.
+- Never write code, never touch tests, and never open a PR **for the ticket** — this pass ends at a
+  ticket. (Self-healing _this skill_ is the sole exception; see § Self-heal.)
 - Never set `In Progress` / `Review` / `Done`.
 - Never resolve a decision the user should make — product calls, pricing, policy, and anything
   affecting users' money or data go to them as questions.

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -192,11 +192,12 @@ rewrite over a chain of `update_content` edits. Any splits become new tickets vi
 `notion-create-pages`.
 
 Sections and their shape live in [`ticket-authoring.md`](../../rules/ticket-authoring.md). Groom
-turns each resolved decision into a **concrete acceptance criterion** — specific values, named
-mechanisms, exact copy in the criterion itself — and **deletes `## Open questions`** as it goes.
-**There is no `## Decisions` section**; a decision that only reads as an ordered plan still lands as
-ACs, not a plan. Groom also owns `## Blocked on`, and writes no `Files` or `Implementation steps`
-section — the claiming agent explores for itself.
+turns each resolved decision into a **product-observable acceptance criterion**, plus a terse
+companion line in `## Tech details` for the seam / mechanism / reuse pointer it rides on — so the ACs
+stay pure product language — and **deletes `## Open questions`** as it goes. **There is no
+`## Decisions` section**; a decision that only reads as an ordered plan still lands as ACs, not a
+plan. Groom also owns `## Blocked on`, and writes no `Files` / `Implementation steps` narration —
+`## Tech details` is terse pointers, not a file-by-file plan.
 
 **The resolution is the deliverable, not the investigation.** Grooming reads far more than it
 records: most of what you learned settling a decision is rediscoverable in seconds and does not
@@ -243,14 +244,15 @@ it without guessing. Test it by asking:
 - Does any clause survive the delete-test — rationale, plumbing, or a restatement of another AC? Cut it.
 - Is `## Open questions` gone, and every fork it held now a concrete AC?
 - Is a rejected path recorded as a negative AC, so no one re-proposes it?
-- Is the prior art an AC clause ("built from X"), and is any money/auth/boundary fact `CONFIRMED`?
+- Is the prior art a `## Tech details` clause ("built from X"), and is any money/auth/boundary fact `CONFIRMED`?
 - If this was a split: can `/work` tell which sibling must land first without reading all of them?
 - For every UI element: are placement, host/slot, trigger, label/icon, and states decided — or would
   an implementer still choose?
 - Is every new or changed string the user-signed-off exact wording (≥3 options offered), and is
   reused copy marked as reused?
-- Does any AC smuggle undecided design behind a competence claim, or grow into implementation mechanics?
+- Does any AC smuggle undecided design behind a competence claim, or grow into implementation mechanics (which belong on `## Tech details` lines)?
 - Was each seam this ticket touches surveyed for how its existing content is owned?
+- Do the ACs read as pure product language, with the technical encoding on companion `## Tech details` lines?
 
 ## Self-heal
 


### PR DESCRIPTION
## Summary

Tightens `/groom` and `ticket-authoring.md` after a re-groom session surfaced three ways decisions were resolved to *gist* and stopped.

**`ticket-authoring.md`**
- **Never-restate:** an `## Out of scope: tests stay untouched` heading is the "do not touch tests" golden rule in costume — delete it.
- **New AC gate — no smuggled design, no implementation:** a competence claim ("handles X correctly") isn't concrete unless the behaviour is spelled out; an AC pins the *design* decision, never the *implementation* mechanics.
- **Voice — copy signoff:** any new/changed user-facing string carries its signed-off exact wording in the AC; reuse the copy, not the key.

**`groom/SKILL.md`**
- **Resolve to buildable, not to gist:** recurse on every answer until an implementer has no design/taste choice left; pin placement · host · trigger · label+icon · states. Closes two traps — *"mirror X" is itself a gist* (walk each element for context-fit) and *survey the seam* (inspect how a slot's neighbour is owned, not just whether it's empty).
- **Copy is signed off, not settled silently:** pause and present ≥3 varied options per line.
- **Self-heal:** user pushback is a defect in the skill — capture it as its own branch + PR (worktree off `master` when the tree isn't clean). The "no PR" guardrail is scoped so self-heal is the carve-out.
- Matching quality-bar checks.

---

## Follow-up: product-language ACs + `## Tech details`

Second commit reshapes the AC body format:
- **Acceptance criteria** become entirely product-observable — a skimmable checklist for review, no filepaths/symbols/SQL.
- New **`## Tech details`** section carries the terse companion encoding (seam / slot / composable / mechanism / reuse pointer / answer-filepath) that each product AC rides on.
- Reconciles gate 5 (implementation now has a home instead of being banished), the `## Decisions`/earns-space guidance, and the groom WRITE step + quality bar.
