### PR TITLE
docs: autonomous /work, self-heal, and the Groomed/Ready lane model

### DIFF
--- a/.claude/rules/self-heal.md
+++ b/.claude/rules/self-heal.md
@@ -1,0 +1,25 @@
+# Self-heal
+
+The interactive skills — `/triage`, `/groom`, `/work` — treat user pushback as a **defect in the
+skill or the rules it embodies**, not just in the artifact in front of them. The lesson is captured
+as a doc edit and shipped for review. _What_ each skill heals and _where_ the lesson routes is
+declared in that skill's `## Self-heal`; the mechanics below are shared.
+
+## One living PR
+
+All healing lands in a **single open PR**, on branch `self-heal` — one stream the user watches,
+whichever skill surfaced the lesson.
+
+- **Find or open.** Before starting, `gh pr list --head self-heal --state open`. If a PR is open,
+  **add to it** — check the branch out and commit onto it. Otherwise open it.
+- **One commit per lesson**, conventional — `docs(<skill-or-rule>): …` — so the PR reads as a clean
+  log of every healing change.
+- **Never merge it.** The user merges when satisfied; that closes the stream, and the next lesson
+  opens a fresh `self-heal` PR. Keep pushing to the open one as feedback continues until then.
+
+## Hygiene
+
+Never heal on the branch carrying the primary task — it pollutes that PR. Work the `self-heal` branch
+in its **own worktree** (`.claude/worktrees/self-heal`): cut it off clean `master` when the branch is
+new, or check the existing branch out into the worktree when a healing PR is already open. The user
+works the main checkout in parallel, so nothing there moves. Report the PR link; never merge.

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -14,16 +14,18 @@ out-of-scope work is found mid-task.
 - **MCP server**: `notion`. **Read** with `notion-query-data-sources` (SQL over the data source) +
   `notion-fetch` (page body — the query returns properties only). **Create** with
   `notion-create-pages`. **Update** with `notion-update-page`.
-- `Status`: `On Hold` · `Backlog` · `Needs More Info` · `Ready` · `Queued` · `In Progress` ·
+- `Status`: `On Hold` · `Backlog` · `Needs More Info` · `Groomed` · `Ready` · `In Progress` ·
   `Blocked` · `Review` · `Duplicate` · `Won't Do` · `Done`. Status is a plain property write — set
-  it directly, no transition step.
+  it directly, no transition step. `/groom` lands tickets in `Groomed`; the user promotes them to
+  `Ready`, the lane `/work` pulls from.
 - `Priority`: `⇞P0` · `↑P1` · `↓P2` · `⇟P3` (a ticket's urgency).
 - `Type`: `Bug` · `Task` · `Story` · `Spike`.
 - `Target`: `MVP` · `Fast-follow` · `Later` — which release the ticket ships in (orthogonal to
   Priority).
-- `Assignee`: `Me` · `Fable` · `Opus` · `Sonnet` — which agent model works the ticket in
-  `/work batch`. **`Me` means hands-off** — the user works it themselves; `/triage` and `/work`
-  leave it alone. `Status = On Hold` carries the same meaning.
+- `Assignee`: `Me` · `Fable` · `Opus` · `Sonnet` — which model works the ticket in `/work`.
+  Triage/groom set `Opus` or `Sonnet` when a ticket reaches `Groomed`; **`Fable` is the user's to
+  assign**, never an agent's pick. **`Me` means hands-off** — the user works it themselves;
+  `/triage` and `/work` leave it alone. `Status = On Hold` carries the same meaning.
 - `Epic`: relation to the Epic Board (single).
 - `ID` is a **read-only auto-increment** — never set it. Tickets are referred to as `#<n>`.
 
@@ -37,14 +39,14 @@ out-of-scope work is found mid-task.
 | Field      | Value when cutting                                                                                                         |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `Status`   | **`Backlog`**, always — a new ticket is un-triaged by definition                                                           |
-| `Assignee` | **empty** — only set when a ticket reaches `Queued`                                                                        |
+| `Assignee` | **empty** — triage/groom set it (`Opus`/`Sonnet`) at `Groomed`, never at cut                                               |
 | `Type`     | `Bug` broken · `Task` defined change · `Story` user-facing capability · `Spike` the deliverable is a decision, not shipped |
 | `Priority` | **empty** at cut time — a triage/groom decision. Set only when the user explicitly dictates one                            |
 | `Target`   | **empty** at cut time — a triage/groom decision, not a capture one                                                         |
 | `Epic`     | match the Epic Board; if nothing fits, propose a new epic rather than force-fit                                            |
 
-Never write `Ready` or `Queued` — those assert an agent can execute the ticket, which is never true
-at capture time. Never write `On Hold` or `Assignee = Me` on a fresh ticket — that's the user's own
+Never write `Groomed` or `Ready` — those assert the ticket is executable, which is never true at
+capture time. Never write `On Hold` or `Assignee = Me` on a fresh ticket — that's the user's own
 hands-off marker. Leave `Priority` and `Assignee` untouched unless the user explicitly asks for a
 value.
 
@@ -170,7 +172,7 @@ untouched` line is the "do not touch tests" rule in costume — delete it.
 - **Copy is the user's to sign off.** Any new or changed user-facing string carries its exact final
   wording in the AC, signed off by the user — never chosen for them, never deferred. Reused copy is
   stated as reused (same wording, its own key — keys aren't shared across features). A ticket with
-  undecided copy is not `Ready`.
+  undecided copy is not `Groomed`.
 
 ## Epics
 
@@ -237,7 +239,7 @@ read the `Blocked By` urls, then query the Task Board for those rows' `Status`. 
 when its `Status` is in the **`complete` group** — `Done`, `Won't Do`, or `Duplicate`.
 
 A split that emits siblings with no dependency and no `## Decisions so far` entry on the epic
-produces orphans: `/work batch` picks up step 3 of 5 with no way to know step 1 must land first.
+produces orphans: `/work` picks up step 3 of 5 with no way to know step 1 must land first.
 
 ## Batch work
 

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: groom
-description: Deep second pass over a single Notion Task Board ticket sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket and moves it to `Ready`/`Queued`. Owns splitting oversized tickets (wiring the `Blocked By` relation between the siblings), recording external blockers, and keeping the epic's decision log and fog current. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
+description: Deep second pass over a single Notion Task Board ticket sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket, assigns a model, and lands it in `Groomed` for the user to promote to `Ready`. Owns splitting oversized tickets (wiring the `Blocked By` relation between the siblings), recording external blockers, and keeping the epic's decision log and fog current. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
 allowed-tools: Read, Grep, Glob, Bash, Agent, WebFetch, WebSearch, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page, mcp__notion__notion-create-pages, mcp__notion__notion-search
 argument-hint: '[<ID>]'
 arguments:
@@ -16,11 +16,14 @@ because it carries unresolved design decisions. Groom **resolves them with the u
 what was decided and why, and lands the ticket executable.
 
 ```
-Needs More Info ──/groom──┬──► Ready / Queued     (decisions resolved)
+Needs More Info ──/groom──┬──► Groomed            (decisions resolved, model assigned)
                           ├──► split into N tickets
                           ├──► On Hold            (turned out to need product input, or premature)
                           └──► stays put          (blocked on an external fact)
 ```
+
+`Groomed` is the user's review gate: they promote it to `Ready` — the lane `/work` pulls from —
+themselves. Groom never writes `Ready`.
 
 One ticket at a time, conversationally. This is the opposite of `/triage`'s batching — depth is
 the whole point.
@@ -75,7 +78,7 @@ an invitation to redesign.
 
 For every new or changed user-facing string, **pause** and present **at least 3 reasonably-varied
 options per line**; only the user's chosen wording lands, verbatim, in the AC. Reused copy is stated
-as reused. Undecided copy keeps the ticket out of `Ready`.
+as reused. Undecided copy keeps the ticket out of `Groomed`.
 
 ## Board constants
 
@@ -83,8 +86,8 @@ as reused. Undecided copy keeps the ticket out of `Ready`.
 sources, every field and its option list, the body section list, brevity rules, and voice. Read it
 before writing anything to the board. This skill declares only its lanes and its own passes.
 
-- Lanes: pulls from `Needs More Info`; lands at `Ready` / `Queued`; may park at `On Hold`.
-  Never sets `In Progress` / `Review` / `Done` / `Blocked`.
+- Lanes: pulls from `Needs More Info`; lands at `Groomed`; may park at `On Hold`. Never sets `Ready`
+  / `In Progress` / `Review` / `Done` / `Blocked` — promoting `Groomed` → `Ready` is the user's gate.
 - **Retype to `Spike`** when grooming reveals the deliverable is a decision or recommendation rather
   than shipped behaviour — and drop the now-redundant `"Spike:"` title prefix.
 
@@ -224,23 +227,27 @@ the churn shows up as page-history noise.
 **Wire the ordering.** Where a split named siblings that must land in sequence, set **`Blocked By`**
 on each dependent sibling — never `Blocks`, which Notion fills reciprocally on its own (see
 [`ticket-authoring.md`](../../rules/ticket-authoring.md) § Dependencies). Siblings emitted with no
-dependency are orphans — `/work batch` will pick up step 3 of 5 with no way to know step 1 must land
+dependency are orphans — `/work` will pick up step 3 of 5 with no way to know step 1 must land
 first.
 
 **Update the epic** page: append the resolved ticket to `## Decisions so far` (gist + link, never a
 restatement), add any approved fog to `## Not yet specified`, delete the fog bullet that this
 session **graduated** into a ticket, and add any approved `## Out of scope` ruling.
 
-Then set `Status`:
+Then set `Status = Groomed` **and an `Assignee`** — the ticket is fully resolved and waiting for the
+user to promote it into `Ready`, the lane `/work` pulls from.
 
-- **`Queued`** — only when _zero_ decisions are unresolved. No human is in the loop.
-- **`Ready`** — executable. A ticket still carrying an unmade design or taste call does **not**
-  qualify, even labelled "decide during pairing" — that is what `Needs More Info` is for, and this
-  pass exists to settle it. The only thing that may ride into `Ready` is a decision genuinely blocked
-  on an external fact (§4), recorded under `## Blocked on`.
-- **Refuse to write `Queued` with `Assignee` empty or `Me`** (or any unresolved fork). `Queued` needs
-  an `Assignee` — Sonnet / Opus / Fable — because `/work batch` pins each subagent to it. **`Ready`
-  tickets carry no `Assignee`** — leave the field empty.
+- **`Assignee` is mandatory and is `Opus` or `Sonnet` only** — pick by fit: `Opus` for
+  architectural, cross-cutting, ambiguous, or security/backend-sensitive work; `Sonnet` for
+  well-scoped feature/bug work with a clear spec. **Never set `Fable`** — the user downgrades to
+  Fable himself when he wants it. Never leave `Assignee` empty or `Me`. `/work` pins each subagent to
+  this model.
+- A ticket still carrying an unmade design or taste call does **not** reach `Groomed`, even labelled
+  "decide during pairing" — that is what `Needs More Info` is for, and this pass exists to settle it.
+  The only thing that may ride into `Groomed` is a decision genuinely blocked on an external fact
+  (§4), recorded under `## Blocked on`; if the ticket cannot land without that fact, it stays in
+  `Needs More Info`.
+- **Never set `Ready`** — promoting `Groomed` → `Ready` is the user's own review gate, not groom's.
 
 Also sweep for **copy that the change makes false** — existing `src/locales/en-us.json` strings
 asserting the old behaviour ("this cannot be undone"). List them in the body as required edits.

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: '[<ID>]'
 arguments:
   - name: <ID>
     description: Numeric ticket ID to groom. Omit to take the top `Needs More Info` ticket by Priority → ID.
-lastUpdated: 2026-07-31T12:00:00Z
+lastUpdated: 2026-08-01T20:00:00Z
 ---
 
 ## What this skill does
@@ -274,14 +274,11 @@ it without guessing. Test it by asking:
 ## Self-heal
 
 The user will push back — correcting a miss, adding a granularity you skipped, rejecting a baked
-assumption. Treat that as a **defect in this skill**, not just in the ticket. Capture the lesson as a
-concrete edit to this skill (or [`ticket-authoring.md`](../../rules/ticket-authoring.md)) and ship it
-as its own branch + PR, separate from the ticket work.
-
-Before writing a single file: **check the working tree.** Branch off `master` only when it is clean;
-if the current branch isn't `master` or has uncommitted changes (the user works in parallel), make
-the edit in a git worktree so nothing in the active checkout is disturbed. Conventional-commit it
-(`docs(groom): …`), open the PR, report the link — never merge.
+assumption. Treat that as a **defect in this skill**, not just in the ticket. Route the lesson: a
+**process** miss (how this pass runs) → this skill; a **"what a ticket looks like"** miss → the
+single source, [`ticket-authoring.md`](../../rules/ticket-authoring.md). Ship it per
+[`self-heal.md`](../../rules/self-heal.md) — the shared living-PR mechanics — separate from the ticket
+work.
 
 ## Guardrails
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -60,14 +60,11 @@ Board data source, field option lists, body sections, and voice all live in
 ## Self-heal
 
 The user will push back — catching a miss, a wrong batch, a baked-in assumption. Treat that as a
-**defect in this skill**, not just in the batch. Capture the lesson as a concrete edit to this skill
-(or [`ticket-authoring.md`](../../rules/ticket-authoring.md)) and ship it as its own branch + PR,
-separate from the triage work.
-
-Before writing a single file: **check the working tree.** Branch off `master` only when it is clean;
-if the current branch isn't `master` or has uncommitted changes (the user works in parallel), make
-the edit in a git worktree so nothing in the active checkout is disturbed. Conventional-commit it
-(`docs(triage): …`), open the PR, report the link — never merge.
+**defect in this skill**, not just in the batch. Route the lesson: a **process** miss (how this pass
+runs) → this skill; a **"what a ticket looks like"** miss → the single source,
+[`ticket-authoring.md`](../../rules/ticket-authoring.md). Ship it per
+[`self-heal.md`](../../rules/self-heal.md) — the shared living-PR mechanics — separate from the triage
+work.
 
 ## Guardrails
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -21,11 +21,17 @@ Board data source, field option lists, body sections, and voice all live in
 1. **Fetch** the Backlog batch, ordered Priority → ID, capped at `--N` (default 10):
 
    ```sql
-   SELECT "userDefined:ID" AS id, "Name", "Type", "Priority", "Epic", url
+   SELECT "userDefined:ID" AS id, "Name", "Type", "Priority", "Target", "Epic", url
    FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
    WHERE "Status" = 'Backlog'
      AND ("Assignee" IS NULL OR "Assignee" <> 'Me')   -- Me = hands off
-   ORDER BY CASE "Priority"                            -- rank, NOT the raw glyph string
+   ORDER BY CASE "Target"                              -- release first: MVP is most important
+              WHEN 'MVP'         THEN 0
+              WHEN 'Fast-follow' THEN 1
+              WHEN 'Later'       THEN 2
+              ELSE 3                                   -- unset Target sorts last → propose one
+            END ASC,
+            CASE "Priority"                            -- then urgency — rank, NOT the raw glyph string
               WHEN '⇞P0' THEN 0
               WHEN '↑P1' THEN 1
               WHEN '↓P2' THEN 2
@@ -35,9 +41,11 @@ Board data source, field option lists, body sections, and voice all live in
             "userDefined:ID" ASC
    ```
 
-   **Never `ORDER BY "Priority"` directly.** The priority arrows sort by codepoint, not by urgency —
-   `↑`(P1, U+2191) `↓`(P2, U+2193) `⇞`(P0, U+21DE) `⇟`(P3, U+21DF) — so a raw string sort buries every
-   `P0` below `P1`/`P2`, and a null Priority leaps to the top. Rank with the `CASE` above.
+   **`Target` leads, then `Priority`** — an `MVP` ticket outranks a `Fast-follow` one whatever their
+   priorities, and inside a release urgency breaks the tie. **Never `ORDER BY` either field directly.**
+   The priority arrows sort by codepoint, not urgency — `↑`(P1, U+2191) `↓`(P2, U+2193) `⇞`(P0, U+21DE)
+   `⇟`(P3, U+21DF) — so a raw string sort buries every `P0` below `P1`/`P2`, and a null leaps to the
+   top; `Target`'s options aren't ordered alphabetically either. Rank both with the `CASE`s above.
 
 2. **Read** each ticket's page body via `notion-fetch` — the query returns properties only, and the
    user often writes real context into the raw ticket. Carry it through; don't re-derive from the name.
@@ -46,9 +54,10 @@ Board data source, field option lists, body sections, and voice all live in
    product intent, plain language, no fluff. Peek at code only if the raw ticket is too cryptic to
    clarify from its text. Don't spec it, don't add acceptance criteria — leave the design for `/groom`.
 
-4. **Fields.** Fill `Epic` and `Type` **only when unset**; `Priority` **only when missing** (the user
-   usually sets it at creation). Propose values — never apply unasked. If no epic fits, propose a new
-   one per [`ticket-authoring.md` § Epics](../../rules/ticket-authoring.md) rather than force-fitting.
+4. **Fields.** Fill `Epic` and `Type` **only when unset**; `Priority` and `Target` **only when
+   missing** (the user usually sets `Priority` at creation). Propose values — never apply unasked. If
+   no epic fits, propose a new one per [`ticket-authoring.md` § Epics](../../rules/ticket-authoring.md)
+   rather than force-fitting.
 
 5. **Checkpoint.** One summary for the whole batch. Per ticket, in product terms: new title, one-line
    intent, proposed fields. Stop for approval.
@@ -69,8 +78,8 @@ work.
 ## Guardrails
 
 - Only ever touch the Task Board named in the rule — never a backup or duplicate.
-- Every ticket ends in `Needs More Info`. Never route to `Ready`/`Queued`/`On Hold` or set
+- Every ticket ends in `Needs More Info`. Never route to `Groomed`/`Ready`/`On Hold` or set
   `In Progress`/`Review`/`Done`.
-- Propose `Epic`/`Type`/`Priority`, never apply unasked.
+- Propose `Epic`/`Type`/`Priority`/`Target`, never apply unasked.
 - Don't touch tests. Don't write code — this skill reads Notion (and lightly, code) and writes
   Notion. Self-healing _this skill_ is the sole exception; see § Self-heal.

--- a/.claude/skills/update-tests/SKILL.md
+++ b/.claude/skills/update-tests/SKILL.md
@@ -7,7 +7,7 @@ arguments:
     type: string
     description: Optional context to help understand the changes
 argument-hint: '[additional-context]'
-lastUpdated: 2026-07-15T00:00:00Z
+lastUpdated: 2026-08-01T20:00:00Z
 ---
 
 The main thread runs **only** the obligation-mining step below. The subagent has none of this conversation in its context, so the cross-cutting tests that depend on it must be discovered here and passed in explicitly. Everything mechanical (scoped per-file coverage of touched files, diff, type selection, writing, validation, re-measure, report) happens inside the subagent. The subagent measures coverage **only for touched files** and targets ~90% lines each — it does not run the full suite or baseline against master.
@@ -59,34 +59,35 @@ The subagent works from a cold diff and can mis-scope or over-claim. Cross-check
 
 1. **Scope completeness.** Run `git diff master...HEAD --name-only -- src/ supabase/` and `git status --short -- src/` yourself, and compare against the report's coverage table. A file the subagent claims "wasn't in the diff" but that actually appears here is a **missed obligation, not a scope decision** — this is the most common and most damaging failure. Every changed source file must be accounted for (covered, or an explicit justified deferral).
 2. **Obligations.** Every Step-A obligation must appear under "Obligations satisfied" with a ✅. Any ❌ or silent omission is a gap to close.
-3. **No collateral breakage.** The branch's own source changes can have broken existing test files the subagent never ran (it scopes to "touched files" and may not realise an untouched test exercises touched source). A composable that gained a new query dependency, for instance, throws `getActivePinia()` in every pre-existing test until its harness mocks the new hook; a barrel that now re-exports a heavier module makes every partial `vi.mock` of that barrel's transitive deps fail the ESM named-export check. On the backend, a renamed/reshaped `supabase/functions/_shared/*.ts` helper (or a `RETURNS TABLE`/view shape change) silently breaks every untouched edge function or pgTAP file that imports/depends on it — invisible until that gate's full run.
+3. **No collateral breakage.** The branch's own source changes can have broken existing test files the subagent never ran (it scopes to "touched files" and may not realise an untouched test exercises touched source). A composable that gained a new query dependency, for instance, throws `getActivePinia()` in every pre-existing test until its harness mocks the new hook; a barrel that now re-exports a heavier module makes every partial `vi.mock` of that barrel's transitive deps fail the ESM named-export check. On the backend, a renamed/reshaped `supabase/functions/_shared/*.ts` helper (or a `RETURNS TABLE`/view shape change) silently breaks every untouched edge function or pgTAP file that imports/depends on it — invisible here, caught by CI's full run on the PR.
 4. **Coverage floor.** Touched files should be ~90% lines; note any genuine deferrals.
 
-### Mandatory final gate — run each relevant full suite once, then scope
+### Final gate — run only the touched test files
 
-Before you commit, decide which gates apply from the touched-file scope you already gathered for item 1 above, and run **only** those — each **exactly once**:
+Before you commit, run **only the test files this run created or modified** — once each, never the
+full suite — to confirm they pass. Scope by the touched-file set you already gathered for item 1:
 
-| Touched scope                                         | Gate          | Command                                                                                                                           |
-| ----------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `src/` or `tests/**`                                  | Vitest (full) | `pnpm test:fast 2>&1 \| tee /tmp/update-tests-full-run.log \| tail -100`                                                          |
-| `supabase/migrations/**` (schema, RLS, RPC, triggers) | pgTAP (full)  | `supabase test db 2>&1 \| tee /tmp/update-tests-pgtap-run.log \| tail -100` (needs `supabase start`)                              |
-| `supabase/functions/**` (incl. `_shared/`)            | Deno (full)   | `cd supabase/functions && deno test --allow-net --allow-env --allow-read 2>&1 \| tee /tmp/update-tests-deno-run.log \| tail -100` |
+| Touched scope            | Command                                                                                                           |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `src/` or `tests/**`     | `vp test --no-coverage <changed test files…>`                                                                     |
+| `supabase/functions/**`  | `cd supabase/functions && deno test --allow-net --allow-env --allow-read <changed test files…>`                   |
+| `supabase/migrations/**` | `supabase test db` — pgTAP has no per-file scoping in the CLI, but it's DB-only and fast (needs `supabase start`) |
 
-Skip a gate whose scope wasn't touched entirely — a pure `supabase/` change never runs `pnpm test:fast`; a pure `src/` change never runs `supabase test db` or `deno test`. A change spanning both (e.g. a migration plus the FE query hook that consumes it) runs every applicable gate, each once.
+**The full suite is CI's job, not this skill's.** Collateral breakage in _untouched_ test files — a
+moved import, a widened barrel, a reshaped `_shared/*.ts` helper a sibling test depends on — is caught
+by CI on the PR, not here. Running the whole suite locally (especially under parallel `/work`
+subagents) would swamp the machine for a check CI already performs. Confirm only that the tests you
+touched are green, then commit; whoever owns the PR (the `/work` orchestrator, or you directly)
+watches CI to green.
 
-(Unit + Integration, no coverage, for the Vitest row — the fast full-suite runner. Never add `--coverage` to any of these; each gate only needs pass/fail, not instrumentation.)
+If a touched test is red:
 
-Capture each gate's full output to its own log file via `tee` in the same invocation. Tails may only show a coverage table or the last few tests, not the pass/fail summary — re-grep the saved log (e.g. `grep -E "Test Files|Tests |FAIL|failed" /tmp/update-tests-full-run.log`) instead of re-running the command. **Never re-invoke a gate just to see a different slice of output you didn't capture the first time** — that silently violates the once-per-invocation rule below.
-
-This is non-negotiable for whichever gates apply. The subagent only ever runs touched-file scope, so collateral breakage in **untouched** test files is invisible to it — and that is the single most common reason these PRs fail CI (it happens on nearly every move/barrel/mock-shape change, frontend or backend). The mirror-file check in item 3 is necessary but **not sufficient**: a file-move or barrel-widening refactor breaks tests that don't mirror any touched source at all (e.g. a sibling feature whose `vi.mock('@/some/barrel')` is now missing a newly-transitive export, or a sibling edge function importing a renamed `_shared/*.ts` export). Only a full run per gate catches those.
-
-**Each applicable gate runs at most once per skill invocation** — except pgTAP: `supabase test db` has no per-file scoping in the CLI (it runs the whole `supabase/tests/*.sql` suite as one transaction-wrapped batch), so if it's the failing gate, re-running it in full is the only option and is acceptable (it's DB-only, no browser, and fast). For Vitest and Deno, use the once-per-invocation full run only to identify which files are failing, then scope every subsequent run to those files (`vp test --no-coverage <path> ...` / `deno test --allow-net --allow-env --allow-read <file>`), never the full suite again. If you suspect the fixes had wider fallout, re-scope to the broader set of files plausibly affected (e.g. everything importing the changed barrel or shared helper), not to a second full-suite run.
-
-If a gate is red:
-
-- Fix the failures yourself when they're mechanical (repoint a moved import, add the missing export to a `vi.mock` factory or Deno fake-supabase, mock the barrel the source now imports instead of the old deep path). These are review fixes, not new authoring — keep them in the test commit.
-- Re-dispatch the subagent only if the failures reveal a genuine missing-coverage gap, not just a broken harness.
-- Verify fixes with the scoped run above (or, for pgTAP, a fresh full `supabase test db`), not a second full Vitest/Deno run. Do **not** commit until every file identified as failing is confirmed green.
+- Fix it when mechanical (repoint a moved import, add the missing export to a `vi.mock` factory or
+  Deno fake-supabase, mock the barrel the source now imports). These are review fixes, not new
+  authoring — keep them in the test commit.
+- Re-dispatch the subagent only if the failure reveals a genuine missing-coverage gap, not a broken
+  harness.
+- Do **not** commit until every touched test file is confirmed green.
 
 ### Decide
 

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -1,54 +1,43 @@
 ---
 name: work
-description: Execute groomed Notion Task Board tickets. Two modes. `/work pair [ID]` works one Ready ticket interactively in this session — backend teaching on, you approve every change; tests stay untouched per the CLAUDE.md golden rule — then opens a PR. `/work batch [--count N] [--p0…]` pulls up to N Queued tickets routed to a model (Fable/Opus/Sonnet) and works them in parallel — one worktree-isolated subagent per ticket, each pinned to that ticket's model, each writing its own tests and cleaning up its worktree when done. Subagents report back to this session (the orchestrator), which organizes the branches into non-conflicting, CI-passing PRs. Both claim the ticket to In Progress first, open a PR (Review), then iterate on your review feedback via a main-workspace subagent that checks out the PR branch — never merge. The golden "no tests" rule is suspended only in batch mode; pair mode leaves tests alone. Trigger on `/work`, "work the board", "work a ticket".
+description: Execute groomed Notion Task Board tickets autonomously. `/work [<ID> …]` claims each ticket to In Progress, then fans out one worktree-isolated subagent per ticket — each pinned to that ticket's `Assignee` model (Fable/Opus/Sonnet), each implementing to the acceptance criteria, running `update-tests` for its change, and cleaning up its worktree when done. With no IDs it pulls the top unblocked `Ready` tickets by priority (`--count N`, default 1). This session is the orchestrator, on its own worktree; it organizes the subagents' branches into non-conflicting PRs, watches CI to green, then stays live for your review feedback — dispatching main-workspace fix subagents per PR. It never merges and never sets Done. Trigger on `/work`, "work the board", "work a ticket".
 allowed-tools: Read, Edit, Write, Grep, Glob, Bash, Agent, Skill, EnterWorktree, ExitWorktree, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page
-argument-hint: 'pair [<ID>] | batch [--count N] [--p0|--p1|--p2|--p3]'
+argument-hint: '[<ID> <ID> …] [--count N]'
 arguments:
-  - name: pair
-    description: Interactive mode — work one Ready ticket with you in this session. Explores the code, then pauses for a bird's-eye plan review before implementing. Optional ID; else top by priority (oldest first).
-  - name: batch
-    description: Autonomous mode — work Queued tickets routed to a model, sequentially, each ending in a PR.
-  - name: --count N
-    description: batch only — how many tickets to work in parallel this run, one worktree-isolated subagent each (default 1).
-  - name: --p0|--p1|--p2|--p3
-    description: batch only — restrict to this priority.
   - name: <ID>
-    description: pair only — the specific ticket to work.
+    description: One or more numeric ticket IDs to work. Each gets its own subagent. Omit to auto-pull the top unblocked `Ready` tickets by priority.
+  - name: --count N
+    description: When no IDs are given, how many `Ready` tickets to pull and work in parallel (default 1). Ignored when IDs are named.
 lastUpdated: 2026-08-01T20:00:00Z
 ---
 
 ## What this skill does
 
-Pulls a groomed ticket off the board, does the work, and lands it at an **open PR** for your
-review. It never merges and never marks a ticket `Done` — you close the loop.
+Pulls groomed, user-promoted tickets off the board, works them **autonomously in parallel**, and
+lands each at an **open PR** for your review. It never merges and never marks a ticket `Done` — you
+close the loop.
 
-Two modes, chosen by the first arg. They differ deliberately:
+**One mode, always orchestrated.** This session is the **orchestrator**: it claims the tickets, fans
+out one worktree-isolated subagent per ticket, then organizes the branches they hand back into clean,
+CI-green PRs. The orchestrator never edits ticket code itself — subagents do. After the PRs open it
+stays live for your review feedback (§ Review & feedback loop).
 
-|                 | `pair`                              | `batch`                               |
-| --------------- | ----------------------------------- | ------------------------------------- |
-| Source lane     | `Status = Ready`                    | `Status = Queued`                     |
-| Model           | **this session's** model            | each ticket's **`Assignee`**          |
-| Execution       | interactive, in-session             | parallel subagents, one worktree each |
-| Backend persona | **on** (teaching)                   | **off**                               |
-| Your approval   | **every change**                    | none — you review the PR              |
-| Tests           | **not touched** (golden rule holds) | each subagent writes its own          |
-| Ends at         | open PR → `Review` + feedback loop  | open PR → `Review` + feedback loop    |
-
-**The golden "never touch tests" rule is suspended only in `batch` mode.** Batch subagents (and
-batch feedback-fix subagents) write their own coverage for what they changed and repair any test
-their change broke, inline — they do **not** invoke the `update-tests` skill. **`pair` mode does not
-touch tests at all** — the CLAUDE.md golden rule holds in full: no checking, running, writing, or
-updating tests, even when a change clearly should have them. At most note in one line that tests may
-need attention, then leave them; the user will invoke test work explicitly (e.g. `/update-tests`).
+- **Source lane** — `Ready` (you promote `Groomed` → `Ready` yourself; that promotion is the human
+  gate this skill trusts).
+- **Model** — each ticket's `Assignee` (`Fable` / `Opus` / `Sonnet`), one subagent pinned to it.
+- **Tests** — the golden "no tests" rule is **suspended here**: each subagent runs the `update-tests`
+  skill to cover its own change. The orchestrator never authors ticket code or tests.
+- **No backend teaching persona** — `/work` is autonomous, no one is in the loop to teach. Supabase
+  teaching happens when you work those tickets by hand, not here.
 
 ## Board constants
 
 - **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`. Full board
   constants live in [`ticket-authoring.md`](../../rules/ticket-authoring.md).
-- `Status` lanes this skill uses: pulls from `Ready`/`Queued`; claims to `In Progress`; lands at
-  `Review`; parks stuck work at `Blocked`. Never sets `Done`/`Duplicate`.
-- `Assignee`: `Fable` · `Opus` · `Sonnet` — which agent model works the ticket in batch.
-  **`Assignee = Me` and `Status = On Hold` are both hands-off** (user-owned) and never batch-eligible.
+- `Status` lanes this skill uses: pulls from `Ready`; claims to `In Progress`; lands at `Review`;
+  parks stuck work at `Blocked`. Never sets `Done` / `Duplicate` / `Groomed`.
+- `Assignee`: `Fable` · `Opus` · `Sonnet` — the model each subagent is pinned to. **`Assignee = Me`
+  and `Status = On Hold` are both hands-off** (user-owned) and never eligible.
 - Status and field writes are plain `notion-update-page` property writes — no transition step.
 
 ## Blockers — a ticket is not takeable just because it's in the lane
@@ -72,196 +61,137 @@ takeable.
 
 Because this skill never sets `Done` — the user merges and closes — a blocker only clears when the
 user does. That's intended: it's the same gate as the merge. If a run finds every candidate blocked,
-say so and stop rather than reaching further down the queue for something unrelated.
+say so and stop rather than reaching further down the queue for something unrelated. Two siblings of
+one split are never both takeable — the `Blocked By` relation means one waits; `/work` runs
+**independent** tickets, and a chain is worked a link at a time.
 
-## Claim protocol (both modes, per ticket)
+## Procedure
 
-Before touching any code, **claim atomically**: write `Status = In Progress` via
-`notion-update-page`. Re-query the source lane first — if the ticket is no longer there
-(someone/another run grabbed it), skip it. This is what stops two runs
-colliding on the same ticket.
+### 0. ORCHESTRATOR WORKTREE — always
 
----
+Before anything else, move into your **own** worktree (`EnterWorktree`, e.g. `work-orchestrator`) and
+run the entire skill from there — claims, conflict checks, PR orchestration, teardown, the feedback
+loop, and any self-heal. This keeps the shared/main checkout free for the user to work in during the
+run. **Any side request the user makes mid-run that is outside ticket scope** (a tweak to this skill,
+tooling, docs) is also done on the orchestrator worktree — branch and commit freely there; it's
+yours. The only work that leaves it is a **feedback-loop fix**, which lands on the main checkout so
+the user's dev server sees it (§ Review & feedback loop).
 
-## Mode: `pair [ID]`
+### 1. SELECT
 
-Interactive, in **this** session, using **whatever model the session is running** (ignore the
-ticket's `Assignee`).
+```sql
+SELECT "userDefined:ID" AS id, "Name", "Priority", "Assignee", "Blocked By", url
+FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
+WHERE "Status" = 'Ready' AND "Assignee" IN ('Sonnet', 'Opus', 'Fable')
+ORDER BY "Priority" ASC, "userDefined:ID" ASC
+```
 
-1. **SELECT** — query the Task Board `WHERE "Status" = 'Ready' ORDER BY "Priority" ASC,
-"userDefined:ID" ASC`, selecting `"Blocked By"` alongside the usual properties (or take the given
-   `<ID>`). Auto-picking takes the **first unblocked** row. Fetch its page body via `notion-fetch`.
-   Echo what you're about to work.
+When **IDs are named**, replace the `Status` filter with `"userDefined:ID" IN (…)` and work exactly
+those (warn, don't silently skip, if one isn't in `Ready` or is `Assignee = Me`). With **no IDs**,
+take the top `--count` (default 1) rows. **Drop every blocked row** (§ Blockers) before taking the
+top N — highest priority first, lowest ID as the stable tie-break. `On Hold` and `Assignee = Me`
+tickets are excluded by the WHERE. Echo the plan (ID · priority · assignee) before starting, and name
+any ticket skipped for an open blocker so the queue's shape is visible.
 
-   **If the ticket is blocked** (§ Blockers): when the user named it explicitly, say which open
-   blocker stands in the way and ask before claiming — their call, they may know it's fine. When
-   auto-picking, skip it silently and take the next.
+### 2. CLAIM ALL
 
-2. **CLAIM** → `In Progress`.
-3. **BRANCH** — conventional branch off `master` matching the ticket (`fix/…`, `feat/…`).
-4. **EXPLORE & ALIGN — before any code.** Read the relevant code to ground the ticket in reality
-   (no edits yet). Then **stop and present a bird's-eye plan for approval** — this checkpoint is
-   mandatory; do **not** start implementing until the user has responded. Keep it high-level and
-   concise (the user wants the shape, not a wall of text):
-   - **The plan in brief** — the handful of steps/changes you intend to make, at altitude. Name the
-     key files/components involved, not line-by-line edits.
-   - **Assumptions & open decisions** — call out every design or feature detail you'd otherwise
-     just assume: UX/interaction choices, edge-case handling, scope boundaries, naming, which
-     variant/pattern to follow. Surface them **explicitly as questions**, don't bake them in
-     silently. This is where the user talks through decisions before they're made.
-   - **Pushback surface** — flag anything in the groomer's spec that looks like a hole, is
-     ambiguous, seems unnecessary, or that you'd propose doing differently. Make it easy for the
-     user to cut or redirect scope here.
+For each selected ticket, re-check it's still `Ready` **and still unblocked**, then write
+`Status = In Progress` via `notion-update-page`. Drop any that another run already grabbed. Claim
+before dispatching so parallel runs don't collide.
 
-   Wait for the user to react — they may trim scope, correct an assumption, or reshape the
-   approach. Fold their answers in, then proceed. If they redirect materially, re-summarize the
-   adjusted plan before coding.
+### 3. FAN OUT — one subagent per ticket, in parallel
 
-5. **IMPLEMENT — together.** Work through the acceptance criteria (as adjusted in step 4) in small
-   steps. **Pause for approval on every change.** If the `Area` touches `supabase/**` (migrations,
-   RPCs, RLS, edge functions), the backend teaching persona is **on** — teach as you write per
-   CLAUDE.md. **Do not touch tests** — the golden rule holds in pair mode (see the callout above);
-   at most note in one line that tests may need attention, then leave them. Follow all
-   `.claude/rules/*`.
-6. **PR** — invoke the **`prepare-pr`** skill with `--ticket <ID> --ticket-url <url>` (the ticket's
-   ticket's `<ID>` and its Notion page URL) so the PR title is prefixed `TARO-<ID>:` and the body
-   opens with a `[TARO-<ID>](<url>)` link (commits,
-   conventional messages, lint+type gate, opens one PR, watches CI to green).
-7. **HANDOFF** — set the ticket to `Review` and append the PR URL into its body via
-   `notion-update-page` (append, don't clobber the body). Then enter the **Review & feedback loop** (below)
-   and wait for the user's feedback.
+Dispatch all subagents in a single message (multiple `Agent` calls) so they run concurrently. Each
+`Agent`:
 
-## Mode: `batch [--count N] [--p0…]`
+- `agentType: general-purpose`, `isolation: worktree` (its own worktree — they edit files in parallel
+  and must not collide), `model:` = the ticket's `Assignee` lowercased → `fable`/`opus`/`sonnet`.
+- Prompt carries the ticket's title + body + acceptance criteria and instructs the subagent to:
+  **rename** the worktree's existing branch to a conventional name (`git branch -m <fix/…|feat/…>`) —
+  **not** `git checkout -b`, which orphans the auto-created `worktree-agent-<id>` branch as junk —
+  implement to the acceptance criteria, and follow `.claude/rules/*`.
+- **Tests via `update-tests`, not the full suite.** After implementing, the subagent invokes the
+  **`update-tests`** skill to cover its own change, then runs **`vp check`** (format + lint +
+  type-check) green. It does **not** run the full `vp test` suite — parallel subagents each running
+  the whole suite would swamp the machine, and `update-tests` already runs the scoped tests for what
+  it touched. **CI is the gate**, watched by the orchestrator (step 4).
+- **Confine every action to its own worktree — never touch the shared checkout.** The prompt must
+  give the subagent its worktree's **absolute path** and tell it to: run `pwd` first and confirm it's
+  inside `.claude/worktrees/agent-<id>`; do **all** reads, writes, `cd`s, and git commands there; and
+  build **every file path from that worktree root** — never a bare `/…/TaroFlash/src/…` or any path
+  outside its worktree, which is the shared/main checkout a human may be editing live. If it ever
+  notices a change landed on the shared checkout, it must **stop and report it — never
+  `git checkout` / `git restore` / revert the file**, since a blind revert-to-HEAD can wipe the
+  human's uncommitted work.
+- It **reports back** to the orchestrator: branch name, a summary of what changed, the file paths it
+  touched, whether `update-tests` + `vp check` passed, and any unresolved failure or unmet acceptance
+  criterion.
+- **Clean up when done.** After it has pushed/handed back its branch and reported, the subagent
+  removes its own worktree (`git worktree remove`) so no orphaned worktrees pile up. Exception: a
+  **stuck/blocked** ticket leaves its worktree in place for human inspection (step 5).
 
-Autonomous. **Parallel** — up to `N` tickets are worked at once, each by its own subagent in its
-own git worktree. This session is the **orchestrator**: it claims the tickets, fans out the
-subagents, then organizes the branches they hand back into clean, passing PRs. The orchestrator
-never edits ticket code itself.
+### 4. ORCHESTRATE PRs
 
-0. **ORCHESTRATOR WORKTREE — always.** Before anything else, the orchestrator moves into its **own**
-   worktree (`EnterWorktree`, e.g. `batch-orchestrator`) and runs the entire batch from there —
-   claims, conflict checks, PR orchestration, teardown, and the feedback loop. This keeps the
-   shared/main checkout free for the user to work in during the run. **Any side request the user
-   makes mid-run that is outside the ticket scope** (e.g. a tweak to this skill, tooling, or docs) is
-   also done on the orchestrator worktree — create branches and commit freely there; it's yours. The
-   only work that leaves the orchestrator worktree is a **feedback-loop fix**, which must land on the
-   main checkout so the user's dev server sees it (see that section for the coordination it needs).
+Once subagents report, turn their branches into PRs. One PR per ticket:
 
-1. **SELECT** — `notion-query-data-sources`:
+a. **READINESS CHECK** — if a subagent reported it couldn't satisfy acceptance, or left `vp check`
+red it couldn't fix, don't open its PR; treat the ticket as stuck (step 5).
+b. **CONFLICT CHECK** — for each finished branch, verify it merges cleanly into current `master`
+(`git merge-tree` / dry-run merge). Then test-merge **every pair** of finished branches against
+each other to catch cross-PR conflicts (two subagents touching the same code).
+c. **RESOLVE** — a branch that's clean vs master and vs its peers gets a PR **based off `master`**.
+When two branches conflict but the overlap is mechanical, **stack** the dependent PR on the other
+(base its branch on the peer's branch) so it merges cleanly. If the two tickets carry a
+`Blocked By` relation, **that decides the stack direction** — the blocker is the base; never invert
+it, and never guess a direction when the relation already states it. When a conflict needs
+**genuine human judgment** (semantic overlap, incompatible approaches), do **not** guess: **raise
+it** in the final report and set that ticket to `Blocked`.
+d. **OPEN** — for each non-blocked ticket, invoke the **`prepare-pr`** skill with `--ticket <ID>
+   --ticket-url <url>` (the ticket's `<ID>` and its Notion page URL) → one PR titled `TARO-<ID>: …`
+whose body opens with a `[TARO-<ID>](<url>)` link. Pass the stack base when the PR is stacked.
+`prepare-pr` watches CI; **a PR isn't done until it's green.** If CI fails, route it through the
+**Review & feedback loop** (below) — a main-workspace fix subagent on the PR branch; if it still
+can't pass after real effort, treat the ticket as stuck.
+e. **HANDOFF** — for each opened, green PR: set the ticket to `Review`, append the PR URL into the
+ticket body via `notion-update-page` (append, don't clobber the body).
+f. **TEAR DOWN** — once a ticket is handed off (PR open + green, branch pushed to origin), **remove
+its worktree**: `git worktree remove <path>`. The branch lives on origin and its local ref
+survives worktree removal, so the human can `git checkout <branch>` in the **main** working copy to
+review it against their local dev server — which a worktree checkout can't feed. Then delete any
+leftover `worktree-agent-<id>` placeholder branch (`git branch -D`) if a subagent left one behind.
+Only tear down **successful** tickets here; blocked ones keep their worktree (step 5).
 
-   ```sql
-   SELECT "userDefined:ID" AS id, "Name", "Priority", "Assignee", "Blocked By", url
-   FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
-   WHERE "Status" = 'Queued' AND "Assignee" IN ('Sonnet', 'Opus', 'Fable')
-   ORDER BY "Priority" ASC, "userDefined:ID" ASC
-   ```
+### 5. STUCK / BLOCKED
 
-   `--pN` adds `AND priority = Highest|High|Medium|Low`; `--count N` sets **how many tickets to work
-   in parallel** (default 1). **Drop every blocked row** (§ Blockers) before taking the top `N`
-   (highest priority first, lowest ID as stable tie-break). `On Hold` and `Assignee = Me` tickets are
-   naturally excluded by the WHERE. Echo the plan (ID · priority · assignee) before starting, and
-   name any ticket skipped for an open blocker so the queue's shape is visible.
+A ticket is stuck when its subagent can't satisfy acceptance, its CI won't pass after real effort, or
+a conflict needs human resolution. Set it to `Blocked`, append a one-line reason + what's needed into
+the body, and leave its branch/worktree in place for the human. Never silently fail or leave a ticket
+stranded in `In Progress`.
 
-   Two siblings of one split are never both takeable — the `Blocked By` relation means one waits.
-   Batch is for **independent** tickets; a chain is worked a link at a time.
+### 6. REPORT
 
-2. **CLAIM ALL** — for each selected ticket, re-check it's still `Queued` **and still unblocked**,
-   then write `Status = In Progress`. Drop any that another run already grabbed. Claim before dispatching so parallel runs don't collide.
+Tally: worked → `Review` (with PR links, noting any stacked pairs), `Blocked` (with reasons + which
+need human conflict resolution), skipped. Then enter the **Review & feedback loop** below.
 
-3. **FAN OUT — one subagent per ticket, in parallel.** Dispatch all subagents in a single message
-   (multiple `Agent` calls) so they run concurrently. Each `Agent`:
-   - `agentType: general-purpose`, `isolation: worktree` (its own worktree — they edit files in
-     parallel and must not collide), `model:` = the ticket's `Assignee` lowercased →
-     `fable`/`opus`/`sonnet`.
-   - Prompt carries the ticket's title + body + acceptance criteria and instructs the subagent to:
-     **rename** the worktree's existing branch to a conventional name (`git branch -m <fix/…|feat/…>`)
-     — **not** `git checkout -b`, which orphans the auto-created `worktree-agent-<id>` branch as junk —
-     implement to the acceptance criteria, follow `.claude/rules/*`, **write its own tests** — new
-     coverage for what it added and fixes for any tests its change broke (it does **not** invoke
-     `update-tests`), and run the gate (`vp check` + `vp test`) green in its worktree.
-   - **Confine every action to its own worktree — never touch the shared checkout.** The prompt must
-     give the subagent its worktree's **absolute path** and tell it to: run `pwd` first and confirm
-     it is inside `.claude/worktrees/agent-<id>`; do **all** reads, writes, `cd`s, and git commands
-     there; and build **every file path from that worktree root** — never a bare `/…/TaroFlash/src/…`
-     or any path outside its worktree, which is the shared/main checkout a human may be editing live.
-     If it ever notices a change landed on the shared checkout, it must **stop and report it — never
-     `git checkout` / `git restore` / revert the file**, since a blind revert-to-HEAD can wipe the
-     human's uncommitted work.
-   - **Confine every action to its own worktree — never touch the shared checkout.** The prompt must
-     tell the subagent: run `pwd` first and confirm it's inside `.claude/worktrees/agent-<id>`; do
-     **all** reads, writes, `cd`s, and git commands there; and make **every edited path resolve under
-     that worktree root**. It must **never** edit a bare `/…/TaroFlash/src/…` (or any path outside its
-     worktree) — that is the shared/main checkout a human may be editing live. Pass the subagent its
-     worktree's absolute path and tell it to build file paths from that, not from the repo root. If it
-     ever notices a change landed on the shared checkout, it must **stop and report it — never
-     `git checkout`/`git restore`/revert the file**, since a blind revert-to-HEAD can wipe the human's
-     uncommitted work.
-   - **No backend teaching persona** in batch.
-   - It **reports back** to the orchestrator: branch name, a summary of what changed, the file
-     paths it touched, and gate status (pass/fail + any unresolved failure).
-   - **Clean up when done.** After it has pushed/handed back its branch and reported, the subagent
-     removes its own worktree (`git worktree remove`) so no orphaned worktrees pile up. Exception:
-     a **stuck/blocked** ticket leaves its worktree in place for human inspection (step 5).
-
-4. **ORCHESTRATE PRs** — once subagents report, turn their branches into PRs. One PR per ticket:
-   a. **GATE CHECK** — if a subagent reported a failing/unfinished gate, don't open its PR; treat
-   the ticket as stuck (step 5).
-   b. **CONFLICT CHECK** — for each finished branch, verify it merges cleanly into current
-   `master` (`git merge-tree` / dry-run merge). Then test-merge **every pair** of finished batch
-   branches against each other to catch cross-PR conflicts (two subagents touching the same code).
-   c. **RESOLVE** — a branch that's clean vs master and vs its peers gets a PR **based off
-   `master`**. When two branches conflict but the overlap is mechanical, **stack** the dependent
-   PR on the other (base its branch on the peer's branch) so it merges cleanly. If the two tickets
-   carry a `Blocked By` relation, **that decides the stack direction** — the blocker is the base;
-   never invert it, and never guess a direction when the relation already states it. When a conflict needs
-   **genuine human judgment** (semantic overlap, incompatible approaches), do **not** guess:
-   **raise it** in the final report and set that ticket to `Blocked`.
-   d. **OPEN** — for each non-blocked ticket, invoke the **`prepare-pr`** skill with `--ticket
-<ID> --ticket-url <url>` (the ticket's `<ID>` and its Notion page URL) → one PR titled
-   `TARO-<ID>: …` whose body opens
-   with a `[TARO-<ID>](<url>)` link. Pass the stack base when the PR is stacked. `prepare-pr` watches
-   CI; **a PR isn't done until it's green.** If CI fails, route it through the **Review & feedback
-   loop** (below) — a main-workspace fix subagent on the PR branch; if it still can't pass after real
-   effort, treat the ticket as stuck.
-   e. **HANDOFF** — for each opened, green PR: set the ticket to `Review`, append the PR URL into
-   the ticket body via `notion-update-page` (append, don't clobber the body).
-   f. **TEAR DOWN** — once a ticket is handed off (PR open + green, branch pushed to origin),
-   **remove its worktree**: `git worktree remove <path>`. The branch lives on origin and its local
-   ref survives worktree removal, so the human can `git checkout <branch>` in the **main** working
-   copy to review it against their local dev server — which a worktree checkout can't feed. Then
-   delete any leftover `worktree-agent-<id>` placeholder branch (`git branch -D`) if a subagent left
-   one behind. Only tear down **successful** tickets here; blocked ones keep their worktree (step 5).
-
-5. **STUCK / BLOCKED** — a ticket is stuck when its subagent can't satisfy acceptance, its gate or
-   CI won't pass after real effort, or a conflict needs human resolution. Set it to `Blocked`,
-   append a one-line reason + what's needed into the body, and leave its branch/worktree in
-   place for the human. Never silently fail or leave a ticket stranded in `In Progress`.
-
-6. **REPORT** — tally: worked → `Review` (with PR links, noting any stacked pairs), `Blocked`
-   (with reasons + which need human conflict resolution), skipped. Then enter the **Review &
-   feedback loop** below.
-
-## Review & feedback loop (both modes)
+## Review & feedback loop
 
 Opening the PRs is not the end of the run — it's the handoff into review. After PRs are open the run
 **stays live and waits for the user's feedback**. The user reviews the PRs themselves and will
 usually come back **one PR at a time**, leaving comments on that PR.
 
-Every follow-up change — whether it's user review feedback, a red CI run, or any other fix the PR
-needs — is handled the same way:
+Every follow-up change — user review feedback, a red CI run, or any other fix the PR needs — is
+handled the same way:
 
-1. **Dispatch a fix subagent on the MAIN workspace** (not a worktree). It **checks out the PR
-   branch** in the main checkout. The user keeps a dev server running against the main workspace and
-   verifies each fix **live**, so the fix must land on the branch they're looking at. Model: the
-   ticket's `Assignee` in batch, this session's model in pair. Work one PR at a time (the user goes
-   in order), so only one fix subagent touches the main checkout at once.
-2. **Fix — plus a test pass in batch only.** The subagent makes the code change. In **batch**, it
-   also does a fresh test pass alongside — new coverage for the new behaviour plus repairs to any
-   test the change breaks (golden "no tests" rule stays suspended for batch). In **pair**, it does
-   **not** touch tests — code change only, with at most a one-line note that tests may need
-   attention.
-3. **Gate, push, watch green.** Run `vp check` + `vp test`, push to the PR branch, and watch CI to
-   green (via `prepare-pr` or directly). A PR isn't done until it's green again.
+1. **Dispatch a fix subagent on the MAIN workspace** (not a worktree). It **checks out the PR branch**
+   in the main checkout. The user keeps a dev server running against the main workspace and verifies
+   each fix **live**, so the fix must land on the branch they're looking at. Model: the ticket's
+   `Assignee`. Work one PR at a time (the user goes in order), so only one fix subagent touches the
+   main checkout at once.
+2. **Fix — plus tests.** The subagent makes the code change and runs `update-tests` for it — new
+   coverage for the new behaviour plus repairs to any test the change breaks (golden "no tests" rule
+   stays suspended in `/work`).
+3. **Check, push, watch green.** Run `vp check`, push to the PR branch, and let CI run (via
+   `prepare-pr` or directly). A PR isn't done until CI is green again — no local full-suite run.
 4. **Answer the thread.** Reply to the feedback on the PR prefixed `🤖 Claude:` so the user can tell
    your replies from their own. Leave the ticket in `Review`.
 
@@ -270,9 +200,10 @@ user's call, exactly as at first handoff.
 
 ## Self-heal
 
-Review feedback is this skill's richest signal — the user reviews each PR and says, in effect, "we
-don't do it this way." Run every correction (PR-review comments, and live pushback in `pair`) through
-four gates; what survives is a **defect in the codebase's rules**, healed per
+The **orchestrator** performs self-heal (the per-ticket subagents are gone and their worktrees torn
+down by the time feedback lands). Review feedback is this skill's richest signal — the user reviews
+each PR and says, in effect, "we don't do it this way." Run every correction through four gates; what
+survives is a **defect in the codebase's rules**, healed per
 [`self-heal.md`](../../rules/self-heal.md) — the shared living-PR mechanics — separate from the ticket
 PR.
 
@@ -281,8 +212,8 @@ PR.
    Only a **correct-ticket / wrong-code** miss continues.
 2. **Generalizes.** Restate the correction as a standing rule: true on the _next_ ticket, or only
    this one? Instance-only ("the count should be 5") → fix the PR, no heal.
-3. **Code, or the pass.** About prep depth, claim, PR handoff, or review mechanics → heal **this
-   skill**. About the code itself → gate 4.
+3. **Code, or the pass.** About claim, PR handoff, or review mechanics → heal **this skill**. About
+   the code itself → gate 4.
 4. **Gap, not adherence.** Grep the corpus first — CLAUDE.md, `.claude/rules/*`, memory feedback:
    - **No rule** → write one, routed by scope: repo-wide → a CLAUDE.md guideline; a domain that has a
      rule file → extend it; a domain with none → a new path-triggered `.claude/rules/*.md`. Bias
@@ -290,42 +221,42 @@ PR.
      every existing one.
    - **Rule exists but vague or misplaced** → sharpen or relocate it. This is a heal.
    - **A clear rule already existed** → an _adherence_ miss, not a corpus gap; leave it — **unless**
-     the same clear rule is violated repeatedly (across PRs this batch, or across sessions), which
-     means it's weak, misplaced, or not loading, and that _is_ a heal (strengthen, relocate, or make
-     it path-load).
+     the same clear rule is violated repeatedly (across PRs this run, or across sessions), which means
+     it's weak, misplaced, or not loading, and that _is_ a heal (strengthen, relocate, or make it
+     path-load).
 
-Batch multiplies the signal: the **same correction on multiple PRs in one run** is a high-confidence
-gap — weight it up at gate 2. The healing PR is autonomous; the user's review of it confirms or kills
-the generalization, so there is no inline confirm mid-run.
+Working several tickets at once multiplies the signal: the **same correction on multiple PRs in one
+run** is a high-confidence gap — weight it up at gate 2. The healing PR is autonomous; the user's
+review of it confirms or kills the generalization, so there is no inline confirm mid-run.
 
 ## Guardrails
 
 - Only ever touch the Task Board named in the rule — never a backup/duplicate board.
-- **Never merge, never set `Done`.** Opening the PR is a handoff into `Review`, not the end — the
-  run stays live through the feedback loop until the user merges. Merging is always the user's call.
+- **Never merge, never set `Done`.** Opening the PR is a handoff into `Review`, not the end — the run
+  stays live through the feedback loop until the user merges. Merging is always the user's call.
 - Claim before coding; re-check the lane to avoid double-work.
-- **Never work a ticket with an open `Blocked By` row** (§ Blockers) — batch skips it silently, pair
-  asks first when the user named it explicitly. Lane membership alone doesn't make a ticket takeable.
-- Batch never runs the backend teaching persona and never works an `On Hold` or `Assignee = Me`
-  ticket (those are the user's hands-off, and aren't `Queued` anyway). These are mode contracts — don't cross them.
-- **Tests: batch only.** The golden "no tests" rule is suspended **only in batch** — batch
-  subagents write/repair their own tests inline (never via `update-tests`). **Pair never touches
-  tests** (golden rule holds); it only notes, in one line, that tests may need attention and leaves
-  them for the user to pick up explicitly.
+- **Never work a ticket with an open `Blocked By` row** (§ Blockers) — skip it silently when
+  auto-pulling; warn when the user named it explicitly. Lane membership alone doesn't make a ticket
+  takeable.
+- Never work an `On Hold` or `Assignee = Me` ticket (the user's hands-off, and not in `Ready`
+  anyway), and never run a backend teaching persona — `/work` is autonomous.
+- **Tests run via `update-tests`.** The golden "no tests" rule is suspended in `/work`: each subagent
+  (and each feedback-fix subagent) invokes `update-tests` for its change. No subagent runs the full
+  `vp test` suite — CI is the gate the orchestrator watches.
 - One PR per ticket (via `prepare-pr`). Don't batch multiple tickets into a single PR.
 - Self-heal ships to the shared `self-heal` PR (§ Self-heal), never merged and separate from ticket
   PRs — a rule fix rides its own stream, never a ticket branch.
-- In batch, the orchestrator runs from its **own worktree** (step 0) and never edits ticket code —
-  subagents do. Out-of-scope side requests during the run are done on that orchestrator worktree.
-  Initial ticket implementation happens in per-ticket **worktrees**, which the subagent **removes
-  when done** (except a stuck ticket, whose worktree is left for inspection). Post-open **fixes
-  happen on the main workspace** on the checked-out PR branch, one PR at a time, so the user's live
-  dev server reflects them.
+- The orchestrator runs from its **own worktree** (step 0) and never edits ticket code — subagents
+  do. Out-of-scope side requests during the run are done on that orchestrator worktree. Initial ticket
+  implementation happens in per-ticket **worktrees**, which the subagent **removes when done** (except
+  a stuck ticket, whose worktree is left for inspection). Post-open **fixes happen on the main
+  workspace** on the checked-out PR branch, one PR at a time, so the user's live dev server reflects
+  them.
 - **Subagents stay inside their own worktree.** Each works only under its `.claude/worktrees/agent-<id>`
   path — never edits the shared/main checkout, and never reverts a shared-checkout file (that can
   destroy the user's uncommitted work); it stops and reports instead.
-- Every batch PR must merge cleanly (vs `master` and vs the other batch PRs) and be CI-green before
+- Every PR must merge cleanly (vs `master` and vs the other in-flight PRs) and be CI-green before
   handoff. A conflict needing human judgment → raise it + `Blocked`; never guess a resolution.
-- Successful batch tickets leave **no worktree and no `worktree-agent-*` branch** behind — subagents
-  rename their worktree branch (never `checkout -b`), and the orchestrator removes each worktree after
+- Successful tickets leave **no worktree and no `worktree-agent-*` branch** behind — subagents rename
+  their worktree branch (never `checkout -b`), and the orchestrator removes each worktree after
   handoff. Only blocked tickets keep their worktree.

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -14,7 +14,7 @@ arguments:
     description: batch only — restrict to this priority.
   - name: <ID>
     description: pair only — the specific ticket to work.
-lastUpdated: 2026-07-31T12:00:00Z
+lastUpdated: 2026-08-01T20:00:00Z
 ---
 
 ## What this skill does
@@ -268,6 +268,36 @@ needs — is handled the same way:
 Repeat per PR until the user merges. **Never merge and never set `Done` yourself** — that stays the
 user's call, exactly as at first handoff.
 
+## Self-heal
+
+Review feedback is this skill's richest signal — the user reviews each PR and says, in effect, "we
+don't do it this way." Run every correction (PR-review comments, and live pushback in `pair`) through
+four gates; what survives is a **defect in the codebase's rules**, healed per
+[`self-heal.md`](../../rules/self-heal.md) — the shared living-PR mechanics — separate from the ticket
+PR.
+
+1. **Execution, not spec.** If the feedback shows the _ticket / AC_ was wrong or ambiguous, that's a
+   `/triage`–`/groom` miss, not this skill's — note "needs regroom", fix the PR, don't heal here.
+   Only a **correct-ticket / wrong-code** miss continues.
+2. **Generalizes.** Restate the correction as a standing rule: true on the _next_ ticket, or only
+   this one? Instance-only ("the count should be 5") → fix the PR, no heal.
+3. **Code, or the pass.** About prep depth, claim, PR handoff, or review mechanics → heal **this
+   skill**. About the code itself → gate 4.
+4. **Gap, not adherence.** Grep the corpus first — CLAUDE.md, `.claude/rules/*`, memory feedback:
+   - **No rule** → write one, routed by scope: repo-wide → a CLAUDE.md guideline; a domain that has a
+     rule file → extend it; a domain with none → a new path-triggered `.claude/rules/*.md`. Bias
+     toward extending the nearest file; create a new one only when the lesson would be off-topic in
+     every existing one.
+   - **Rule exists but vague or misplaced** → sharpen or relocate it. This is a heal.
+   - **A clear rule already existed** → an _adherence_ miss, not a corpus gap; leave it — **unless**
+     the same clear rule is violated repeatedly (across PRs this batch, or across sessions), which
+     means it's weak, misplaced, or not loading, and that _is_ a heal (strengthen, relocate, or make
+     it path-load).
+
+Batch multiplies the signal: the **same correction on multiple PRs in one run** is a high-confidence
+gap — weight it up at gate 2. The healing PR is autonomous; the user's review of it confirms or kills
+the generalization, so there is no inline confirm mid-run.
+
 ## Guardrails
 
 - Only ever touch the Task Board named in the rule — never a backup/duplicate board.
@@ -283,6 +313,8 @@ user's call, exactly as at first handoff.
   tests** (golden rule holds); it only notes, in one line, that tests may need attention and leaves
   them for the user to pick up explicitly.
 - One PR per ticket (via `prepare-pr`). Don't batch multiple tickets into a single PR.
+- Self-heal ships to the shared `self-heal` PR (§ Self-heal), never merged and separate from ticket
+  PRs — a rule fix rides its own stream, never a ticket branch.
 - In batch, the orchestrator runs from its **own worktree** (step 0) and never edits ticket code —
   subagents do. Out-of-scope side requests during the run are done on that orchestrator worktree.
   Initial ticket implementation happens in per-ticket **worktrees**, which the subagent **removes


### PR DESCRIPTION
## Summary

Reworks the ticket-workflow skills for autonomous execution. Docs-only (`.claude/`), no code changes.

- **`/work` is one autonomous mode.** Drops `pair`/`batch`; takes a list of ticket IDs (or auto-pulls the top unblocked `Ready` by priority). Always runs an orchestrator on its own worktree that fans out one worktree-isolated subagent per ticket. Subagents run the `update-tests` skill + `vp check` — never the full `vp test` suite — and **CI is the gate** the orchestrator watches. Backend teaching persona and the pair-mode no-tests carve-out are gone.
- **Lane model.** Renames `Ready`→`Groomed` and `Queued`→`Ready`. `/groom` lands tickets at `Groomed` with an assigned model (`Opus`/`Sonnet` only — never `Fable`, which stays the user's to assign); the user promotes `Groomed`→`Ready`, the lane `/work` pulls from.
- **Self-heal.** New `rules/self-heal.md` holds the shared living-PR mechanics — a single open `self-heal` PR that triage/groom/work all append to until merged. `/work` gains a four-gate detector (execution-vs-spec, generalizes, code-vs-pass, gap-vs-adherence) the orchestrator runs on review feedback.
- **Triage** orders by `Target` (MVP first) then `Priority`.
- **update-tests** final gate runs only the touched test files, not the full suite; collateral breakage is CI's job.

> **Board action needed:** rename the two Notion `Status` options — `Ready`→`Groomed`, `Queued`→`Ready` (keep `Groomed` ordered before `Ready`).