### PR TITLE
TARO-265: Downgrade to free — lock & schedule deletion of over-limit decks (backend)

### DIFF
--- a/supabase/functions/stripe-webhook/index.test.ts
+++ b/supabase/functions/stripe-webhook/index.test.ts
@@ -1,0 +1,279 @@
+import { assertEquals, assertStringIncludes } from '@std/assert'
+import { handler, type Deps } from './index.ts'
+import { STRIPE_API_VERSION } from '../_shared/stripe.ts'
+
+type FakeOpts = {
+  // members.update(...).eq(...).select('id').maybeSingle() result
+  updatedMember?: { id: string } | null
+  // members.select(...).eq(...).maybeSingle() result (refundIfPendingDeletion)
+  deleteState?: {
+    id: string
+    delete_at: string | null
+    stripe_subscription_id: string | null
+  } | null
+  // plans.select('id').eq(...).single() result
+  planRow?: { id: string } | null
+  invoice?: any
+  rpcError?: { message: string } | null
+}
+
+const DEFAULT_MEMBER = { id: 'member_1' }
+const DEFAULT_PLAN = { id: 'paid' }
+const DEFAULT_INVOICE = {
+  id: 'in_1',
+  amount_paid: 1000,
+  currency: 'usd',
+  post_payment_credit_notes_amount: 0
+}
+
+function makeDeps(opts: FakeOpts = {}) {
+  const calls = {
+    membersUpdate: [] as any[],
+    rpc: [] as { fn: string; args: any }[],
+    subscriptionsCancel: [] as string[],
+    invoicesRetrieve: [] as string[],
+    creditNotesCreate: [] as any[]
+  }
+
+  const updatedMember = opts.updatedMember === undefined ? DEFAULT_MEMBER : opts.updatedMember
+  const planRow = opts.planRow === undefined ? DEFAULT_PLAN : opts.planRow
+
+  const supabase = {
+    from: (table: string) => {
+      if (table === 'plans') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: planRow,
+                  error: planRow ? null : { message: 'no matching plan' }
+                })
+            })
+          })
+        }
+      }
+      // members
+      return {
+        update: (vals: any) => {
+          calls.membersUpdate.push(vals)
+          return {
+            eq: () => ({
+              select: () => ({
+                maybeSingle: () => Promise.resolve({ data: updatedMember, error: null })
+              })
+            })
+          }
+        },
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: opts.deleteState === undefined ? null : opts.deleteState,
+                error: null
+              })
+          })
+        })
+      }
+    },
+    rpc: (fn: string, args: any) => {
+      calls.rpc.push({ fn, args })
+      return Promise.resolve({ error: opts.rpcError ?? null })
+    }
+  } as any
+
+  const stripe = {
+    webhooks: {
+      constructEventAsync: (body: string) => Promise.resolve(JSON.parse(body))
+    },
+    subscriptions: {
+      cancel: (id: string) => {
+        calls.subscriptionsCancel.push(id)
+        return Promise.resolve({ id, status: 'canceled' })
+      }
+    },
+    invoices: {
+      retrieve: (id: string) => {
+        calls.invoicesRetrieve.push(id)
+        return Promise.resolve(
+          opts.invoice === undefined ? { ...DEFAULT_INVOICE, id } : opts.invoice
+        )
+      }
+    },
+    creditNotes: {
+      create: (args: any) => {
+        calls.creditNotesCreate.push(args)
+        return Promise.resolve({ id: 'cn_1' })
+      }
+    }
+  } as any
+
+  const deps: Deps = {
+    stripe,
+    supabase,
+    cryptoProvider: {} as any,
+    webhookSecret: 'whsec_test'
+  }
+
+  return { deps, calls }
+}
+
+function subscriptionEvent(type: string, overrides: Record<string, unknown> = {}) {
+  return {
+    type,
+    api_version: STRIPE_API_VERSION,
+    data: {
+      object: {
+        customer: 'cus_1',
+        status: 'active',
+        id: 'sub_1',
+        items: { data: [{ price: { id: 'price_1' } }] },
+        ...overrides
+      }
+    }
+  }
+}
+
+function req(event: unknown, headers: Record<string, string> = { 'stripe-signature': 'sig_test' }) {
+  return new Request('http://localhost/stripe-webhook', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(event)
+  })
+}
+
+Deno.test('returns 405 for a non-POST request', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(new Request('http://localhost/stripe-webhook', { method: 'GET' }), deps)
+  assertEquals(res.status, 405)
+})
+
+Deno.test('returns 400 when the stripe-signature header is missing', async () => {
+  const { deps } = makeDeps()
+  const res = await handler(req(subscriptionEvent('customer.subscription.updated'), {}), deps)
+  assertEquals(res.status, 400)
+  assertEquals(await res.text(), 'Missing stripe-signature header')
+})
+
+Deno.test('returns 400 Invalid signature when constructEventAsync rejects', async () => {
+  const { deps } = makeDeps()
+  deps.stripe.webhooks.constructEventAsync = () => Promise.reject(new Error('bad signature'))
+  const res = await handler(req(subscriptionEvent('customer.subscription.updated')), deps)
+  assertEquals(res.status, 400)
+  assertStringIncludes(await res.text(), 'Invalid signature:')
+})
+
+Deno.test('customer.subscription.deleted (markFree) calls begin_downgrade_grace(member.id) [obligation]', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(req(subscriptionEvent('customer.subscription.deleted')), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.membersUpdate, [{ plan: 'free', stripe_subscription_id: null }])
+  assertEquals(calls.rpc, [{ fn: 'begin_downgrade_grace', args: { p_member_id: 'member_1' } }])
+})
+
+Deno.test('active syncSubscription (upgrade) calls clear_downgrade_grace(member.id) [obligation]', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(
+    req(subscriptionEvent('customer.subscription.updated', { status: 'active' })),
+    deps
+  )
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.membersUpdate, [{ plan: 'paid', stripe_subscription_id: 'sub_1' }])
+  assertEquals(calls.rpc, [{ fn: 'clear_downgrade_grace', args: { p_member_id: 'member_1' } }])
+})
+
+Deno.test('an inactive syncSubscription (not active/trialing) also calls begin_downgrade_grace', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(
+    req(subscriptionEvent('customer.subscription.updated', { status: 'canceled' })),
+    deps
+  )
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.membersUpdate, [{ plan: 'free', stripe_subscription_id: null }])
+  assertEquals(calls.rpc, [{ fn: 'begin_downgrade_grace', args: { p_member_id: 'member_1' } }])
+})
+
+Deno.test('no plan matching the price_id skips the members update and the downgrade-grace reconcile', async () => {
+  const { deps, calls } = makeDeps({ planRow: null })
+  const res = await handler(req(subscriptionEvent('customer.subscription.updated')), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.membersUpdate.length, 0)
+  assertEquals(calls.rpc.length, 0)
+})
+
+Deno.test('no matching member row skips the downgrade-grace reconcile', async () => {
+  const { deps, calls } = makeDeps({ updatedMember: null })
+  const res = await handler(req(subscriptionEvent('customer.subscription.deleted')), deps)
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.membersUpdate.length, 1)
+  assertEquals(calls.rpc.length, 0)
+})
+
+Deno.test('invoice.payment_succeeded refunds and re-cancels when the member is pending deletion', async () => {
+  const { deps, calls } = makeDeps({
+    deleteState: {
+      id: 'member_1',
+      delete_at: '2026-01-01T00:00:00Z',
+      stripe_subscription_id: 'sub_1'
+    }
+  })
+  const res = await handler(
+    req({
+      type: 'invoice.payment_succeeded',
+      api_version: STRIPE_API_VERSION,
+      data: { object: { customer: 'cus_1', id: 'in_1' } }
+    }),
+    deps
+  )
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.invoicesRetrieve, ['in_1'])
+  assertEquals(calls.creditNotesCreate.length, 1)
+  assertEquals(calls.subscriptionsCancel, ['sub_1'])
+})
+
+Deno.test('invoice.payment_succeeded is a no-op for a live (non-pending-deletion) account', async () => {
+  const { deps, calls } = makeDeps({ deleteState: null })
+  const res = await handler(
+    req({
+      type: 'invoice.payment_succeeded',
+      api_version: STRIPE_API_VERSION,
+      data: { object: { customer: 'cus_1', id: 'in_1' } }
+    }),
+    deps
+  )
+
+  assertEquals(res.status, 200)
+  assertEquals(calls.invoicesRetrieve.length, 0)
+  assertEquals(calls.subscriptionsCancel.length, 0)
+})
+
+Deno.test('an unhandled event type acks 200 with no side effects', async () => {
+  const { deps, calls } = makeDeps()
+  const res = await handler(
+    req({
+      type: 'checkout.session.completed',
+      api_version: STRIPE_API_VERSION,
+      data: { object: {} }
+    }),
+    deps
+  )
+
+  assertEquals(res.status, 200)
+  assertEquals(await res.json(), { received: true })
+  assertEquals(calls.rpc.length, 0)
+  assertEquals(calls.membersUpdate.length, 0)
+})
+
+Deno.test('returns 500 Handler error when the downstream RPC throws', async () => {
+  const { deps } = makeDeps({ rpcError: { message: 'rpc boom' } })
+  const res = await handler(req(subscriptionEvent('customer.subscription.deleted')), deps)
+
+  assertEquals(res.status, 500)
+  assertEquals(await res.text(), 'Handler error')
+})

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -9,27 +9,24 @@
 // proves it's really Stripe by signing the body with a shared secret
 // (STRIPE_WEBHOOK_SECRET); we verify that before trusting anything.
 
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { assertWebhookVersion, makeStripe, Stripe } from '../_shared/stripe.ts'
 import { refundInvoiceViaCreditNote } from '../_shared/prorated-refund.ts'
 
-const stripe = makeStripe()
+export type StripeLike = Pick<Stripe, 'webhooks' | 'subscriptions' | 'invoices' | 'creditNotes'>
 
-// Node's `crypto` isn't available in Deno, so signature verification gets
-// Deno's WebCrypto (SubtleCrypto) provider.
-const cryptoProvider = Stripe.createSubtleCryptoProvider()
+export type Deps = {
+  stripe: StripeLike
+  // Service role — bypasses RLS, which is essential here because the
+  // self-update policy deliberately blocks the client from touching
+  // `plan` / `stripe_*` / `downgrade_delete_at`. This is the ONLY writer for
+  // those columns in normal flow.
+  supabase: SupabaseClient
+  cryptoProvider: Stripe.CryptoProvider
+  webhookSecret: string
+}
 
-// Service role bypasses RLS — essential here because the self-update policy
-// deliberately blocks the client from touching `plan` / `stripe_*` fields.
-// This function is the ONLY writer for those columns in normal flow.
-const supabase = createClient(
-  Deno.env.get('SUPABASE_URL')!,
-  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-)
-
-const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET')!
-
-Deno.serve(async (req) => {
+export async function handler(req: Request, deps: Deps): Promise<Response> {
   if (req.method !== 'POST') {
     return new Response('Method Not Allowed', { status: 405 })
   }
@@ -45,12 +42,12 @@ Deno.serve(async (req) => {
 
   let event: Stripe.Event
   try {
-    event = await stripe.webhooks.constructEventAsync(
+    event = await deps.stripe.webhooks.constructEventAsync(
       body,
       signature,
-      webhookSecret,
+      deps.webhookSecret,
       undefined,
-      cryptoProvider
+      deps.cryptoProvider
     )
   } catch (err) {
     console.error('Signature verification failed:', err)
@@ -68,7 +65,7 @@ Deno.serve(async (req) => {
       case 'customer.subscription.created':
       case 'customer.subscription.updated': {
         const subscription = event.data.object as Stripe.Subscription
-        await syncSubscription(subscription)
+        await syncSubscription(deps, subscription)
         break
       }
 
@@ -78,14 +75,14 @@ Deno.serve(async (req) => {
       // that account keeps renewing until the purge, and each renewal lands here.
       case 'invoice.payment_succeeded': {
         const invoice = event.data.object as Stripe.Invoice
-        await refundIfPendingDeletion(invoice.customer as string, invoice.id as string)
+        await refundIfPendingDeletion(deps, invoice.customer as string, invoice.id as string)
         break
       }
 
       // User (or Stripe) canceled outright. Demote to free, clear sub id.
       case 'customer.subscription.deleted': {
         const subscription = event.data.object as Stripe.Subscription
-        await markFree(subscription.customer as string)
+        await markFree(deps, subscription.customer as string)
         break
       }
 
@@ -104,11 +101,12 @@ Deno.serve(async (req) => {
   return new Response(JSON.stringify({ received: true }), {
     headers: { 'Content-Type': 'application/json' }
   })
-})
+}
 
 // Map Stripe's subscription state → our `members.plan` + stripe_subscription_id.
 // Works for both "created/updated" and the post-checkout retrieval path.
-async function syncSubscription(subscription: Stripe.Subscription) {
+async function syncSubscription(deps: Deps, subscription: Stripe.Subscription) {
+  const { supabase } = deps
   const customerId = subscription.customer as string
   const priceId = subscription.items.data[0]?.price?.id
   const active = subscription.status === 'active' || subscription.status === 'trialing'
@@ -150,16 +148,16 @@ async function syncSubscription(subscription: Stripe.Subscription) {
   // Reconcile the downgrade lock. Upgrading (active) clears any grace deadline,
   // unlocking every deck at once; a sync that lands the member on free stamps
   // the 15-day grace when they are over their deck_limit. Both are idempotent.
-  await reconcileDowngradeGrace(member.id, active)
+  await reconcileDowngradeGrace(deps, member.id, active)
 }
 
 // Stamp or clear the free-downgrade grace deadline on the member. Locking is
 // derived from rank + plan + this deadline, so this single write is the whole
 // lock/unlock — no per-deck state to touch. Both RPCs are service_role-only and
 // idempotent (begin keeps the original deadline, clear no-ops when already clear).
-async function reconcileDowngradeGrace(memberId: string, active: boolean) {
+async function reconcileDowngradeGrace(deps: Deps, memberId: string, active: boolean) {
   const rpc = active ? 'clear_downgrade_grace' : 'begin_downgrade_grace'
-  const { error } = await supabase.rpc(rpc, { p_member_id: memberId })
+  const { error } = await deps.supabase.rpc(rpc, { p_member_id: memberId })
 
   if (error) {
     console.error(`${rpc} failed for member ${memberId}`, error)
@@ -179,7 +177,8 @@ async function reconcileDowngradeGrace(memberId: string, active: boolean) {
 // gone; the payment hangs off invoice.payments, which needs expanding). Refunding
 // through a credit note against the invoice sidesteps that entirely — Stripe
 // resolves the payment itself — so there's no version-sensitive traversal here.
-async function refundIfPendingDeletion(customerId: string, invoiceId: string) {
+async function refundIfPendingDeletion(deps: Deps, customerId: string, invoiceId: string) {
+  const { supabase, stripe } = deps
   const { data: member, error } = await supabase
     .from('members')
     .select('id, delete_at, stripe_subscription_id')
@@ -207,13 +206,13 @@ async function refundIfPendingDeletion(customerId: string, invoiceId: string) {
   const refund = await refundInvoiceViaCreditNote(stripe, invoice)
   console.log(`Refund outcome for invoice ${invoiceId}:`, refund)
 
-  await reassertCancellation(member.stripe_subscription_id)
+  await reassertCancellation(stripe, member.stripe_subscription_id)
 }
 
 // The charge proves billing was still live, so the original cancel evidently
 // didn't take. Cancel plainly — no proration, since the whole invoice was just
 // refunded and prorating on top would credit the same period twice.
-async function reassertCancellation(subscriptionId: string | null) {
+async function reassertCancellation(stripe: StripeLike, subscriptionId: string | null) {
   if (!subscriptionId) return
 
   try {
@@ -225,7 +224,8 @@ async function reassertCancellation(subscriptionId: string | null) {
   }
 }
 
-async function markFree(customerId: string) {
+async function markFree(deps: Deps, customerId: string) {
+  const { supabase } = deps
   const { data: member, error } = await supabase
     .from('members')
     .update({ plan: 'free', stripe_subscription_id: null })
@@ -242,5 +242,22 @@ async function markFree(customerId: string) {
 
   // Lock over-limit decks and schedule their deletion. Idempotent: a re-fired
   // deletion event keeps the original 15-day deadline.
-  await reconcileDowngradeGrace(member.id, false)
+  await reconcileDowngradeGrace(deps, member.id, false)
+}
+
+if (import.meta.main) {
+  const stripe = makeStripe()
+
+  // Node's `crypto` isn't available in Deno, so signature verification gets
+  // Deno's WebCrypto (SubtleCrypto) provider.
+  const cryptoProvider = Stripe.createSubtleCryptoProvider()
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  )
+
+  const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET')!
+
+  Deno.serve((req) => handler(req, { stripe, supabase, cryptoProvider, webhookSecret }))
 }

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -130,16 +130,39 @@ async function syncSubscription(subscription: Stripe.Subscription) {
     return
   }
 
-  const { error } = await supabase
+  const { data: member, error } = await supabase
     .from('members')
     .update({
       plan: active ? plan.id : 'free',
       stripe_subscription_id: active ? subscription.id : null
     })
     .eq('stripe_customer_id', customerId)
+    .select('id')
+    .maybeSingle()
 
   if (error) {
     console.error('members update failed', error)
+    throw error
+  }
+
+  if (!member) return
+
+  // Reconcile the downgrade lock. Upgrading (active) clears any grace deadline,
+  // unlocking every deck at once; a sync that lands the member on free stamps
+  // the 15-day grace when they are over their deck_limit. Both are idempotent.
+  await reconcileDowngradeGrace(member.id, active)
+}
+
+// Stamp or clear the free-downgrade grace deadline on the member. Locking is
+// derived from rank + plan + this deadline, so this single write is the whole
+// lock/unlock — no per-deck state to touch. Both RPCs are service_role-only and
+// idempotent (begin keeps the original deadline, clear no-ops when already clear).
+async function reconcileDowngradeGrace(memberId: string, active: boolean) {
+  const rpc = active ? 'clear_downgrade_grace' : 'begin_downgrade_grace'
+  const { error } = await supabase.rpc(rpc, { p_member_id: memberId })
+
+  if (error) {
+    console.error(`${rpc} failed for member ${memberId}`, error)
     throw error
   }
 }
@@ -203,13 +226,21 @@ async function reassertCancellation(subscriptionId: string | null) {
 }
 
 async function markFree(customerId: string) {
-  const { error } = await supabase
+  const { data: member, error } = await supabase
     .from('members')
     .update({ plan: 'free', stripe_subscription_id: null })
     .eq('stripe_customer_id', customerId)
+    .select('id')
+    .maybeSingle()
 
   if (error) {
     console.error('members downgrade failed', error)
     throw error
   }
+
+  if (!member) return
+
+  // Lock over-limit decks and schedule their deletion. Idempotent: a re-fired
+  // deletion event keeps the original 15-day deadline.
+  await reconcileDowngradeGrace(member.id, false)
 }

--- a/supabase/migrations/20260801230558_downgrade-lock-decks.sql
+++ b/supabase/migrations/20260801230558_downgrade-lock-decks.sql
@@ -1,0 +1,449 @@
+drop policy "members can update their own non-privileged fields" on "public"."members";
+
+alter table "public"."members" add column "downgrade_delete_at" timestamp with time zone;
+
+-- ADD ATTRIBUTE rather than the drop/recreate `supabase db diff` emitted: the
+-- type is the return type of get_member_decks and save_deck, so a plain DROP
+-- fails on the dependency. CASCADE recompiles those dependents in place.
+alter type "public"."member_deck" add attribute "is_locked" boolean cascade;
+alter type "public"."member_deck" add attribute "locked_delete_at" timestamp with time zone cascade;
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.begin_downgrade_grace(p_member_id uuid)
+ RETURNS timestamp with time zone
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  -- The grace window lives here, in the only writer of downgrade_delete_at.
+  v_grace    interval := interval '15 days';
+  v_deadline timestamptz;
+  v_limit    int;
+  v_count    int;
+BEGIN
+  SELECT m.downgrade_delete_at, p.deck_limit
+    INTO v_deadline, v_limit
+  FROM public.members m
+  JOIN public.plans p ON p.id = m.plan
+  WHERE m.id = p_member_id
+  FOR UPDATE OF m;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No member %', p_member_id USING errcode = 'no_data_found';
+  END IF;
+
+  IF v_deadline IS NOT NULL THEN
+    RETURN v_deadline;
+  END IF;
+
+  -- NULL deck_limit = unlimited plan: nothing is ever over the line.
+  IF v_limit IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.decks
+  WHERE member_id = p_member_id;
+
+  IF v_count <= v_limit THEN
+    RETURN NULL;
+  END IF;
+
+  v_deadline := now() + v_grace;
+
+  UPDATE public.members
+  SET downgrade_delete_at = v_deadline
+  WHERE id = p_member_id;
+
+  RETURN v_deadline;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.clear_downgrade_grace(p_member_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  UPDATE public.members
+  SET downgrade_delete_at = NULL
+  WHERE id = p_member_id
+    AND downgrade_delete_at IS NOT NULL;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.deck_lock_deadline(p_deck_id bigint)
+ RETURNS timestamp with time zone
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT m.downgrade_delete_at
+  FROM public.decks d
+  JOIN public.members m ON m.id = d.member_id
+  JOIN public.plans p ON p.id = m.plan
+  WHERE d.id = p_deck_id
+    AND m.plan = 'free'
+    AND m.downgrade_delete_at IS NOT NULL
+    AND p.deck_limit IS NOT NULL
+    AND (
+      SELECT count(*)
+      FROM public.decks d2
+      WHERE d2.member_id = d.member_id
+        AND d2.rank < d.rank
+    ) >= p.deck_limit;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.purge_downgraded_decks()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  DELETE FROM public.decks d
+  USING public.members m, public.plans p
+  WHERE d.member_id = m.id
+    AND p.id = m.plan
+    AND m.plan = 'free'
+    AND m.downgrade_delete_at IS NOT NULL
+    AND m.downgrade_delete_at <= now()
+    AND p.deck_limit IS NOT NULL
+    AND (
+      SELECT count(*)
+      FROM public.decks d2
+      WHERE d2.member_id = d.member_id
+        AND d2.rank < d.rank
+    ) >= p.deck_limit;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_member_decks(p_today_start timestamp with time zone)
+ RETURNS SETOF public.member_deck
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT
+    d.id,
+    d.created_at,
+    d.updated_at,
+    d.description,
+    d.is_public,
+    d.title,
+    d.member_id,
+    m.display_name AS member_display_name,
+    d.tags,
+    d.has_image,
+    d.study_config,
+    d.cover_config,
+    d.card_attributes,
+
+    (
+      SELECT count(*)::int
+      FROM public.cards c
+      WHERE c.deck_id = d.id
+    ) AS card_count,
+
+    stats.reviewed_today_count,
+    stats.new_reviewed_today_count,
+
+    -- new_take + review_take, matching get_study_session_cards exactly.
+    -- COALESCE(cap - used, INT_MAX) treats a NULL cap as unbounded. A locked
+    -- deck reports 0 so it drops out of the review inbox and "study all due" —
+    -- study is barred there too (get_study_session_cards returns nothing).
+    CASE WHEN lock.deadline IS NOT NULL THEN 0 ELSE
+      GREATEST(
+        0,
+        LEAST(stats.new_available, stats.remaining_new, stats.remaining_total)
+      )
+      + GREATEST(
+        0,
+        LEAST(
+          stats.review_available,
+          stats.remaining_total
+            - GREATEST(0, LEAST(stats.new_available, stats.remaining_new, stats.remaining_total))
+        )
+      )
+    END AS due_count,
+
+    d.rank,
+
+    dp.review_pacing_preset_id,
+
+    -- All seven resolved pacing fields come from the shared resolver — the
+    -- override -> preset -> system ladder lives only in resolve_deck_pacing now.
+    rp.desired_retention,
+    rp.learning_steps,
+    rp.relearning_steps,
+    rp.max_reviews_per_day,
+    rp.max_new_per_day,
+    rp.leech_threshold,
+    rp.max_interval,
+
+    dp.overrides AS pacing_overrides,
+
+    -- Locked flag + deletion date the dashboard renders. Both fall out of the
+    -- one deck_lock_deadline read: non-NULL deadline ⇒ locked.
+    (lock.deadline IS NOT NULL) AS is_locked,
+    lock.deadline AS locked_delete_at
+
+  FROM public.decks d
+  LEFT JOIN LATERAL public.member_public_profile(d.member_id) m ON true
+  LEFT JOIN public.deck_review_pacing dp ON dp.deck_id = d.id
+  CROSS JOIN LATERAL public.resolve_deck_pacing(d.id) AS rp
+  CROSS JOIN LATERAL (SELECT public.deck_lock_deadline(d.id) AS deadline) AS lock
+  CROSS JOIN LATERAL (
+    SELECT
+      (
+        SELECT count(DISTINCT rl.card_id)::int
+        FROM public.review_logs rl
+        JOIN public.cards c ON c.id = rl.card_id
+        WHERE c.deck_id = d.id
+          AND rl.review >= p_today_start
+      ) AS reviewed_today_count,
+
+      (
+        SELECT count(DISTINCT rl.card_id)::int
+        FROM public.review_logs rl
+        JOIN public.cards c ON c.id = rl.card_id
+        WHERE c.deck_id = d.id
+          AND rl.state = 0
+          AND rl.review >= p_today_start
+      ) AS new_reviewed_today_count,
+
+      -- Cards with no reviews row at all = brand-new.
+      (
+        SELECT count(*)::int
+        FROM public.cards c
+        LEFT JOIN public.reviews r ON r.card_id = c.id
+        WHERE c.deck_id = d.id
+          AND r.id IS NULL
+      ) AS new_available,
+
+      -- Cards with a reviews row whose due date has passed.
+      (
+        SELECT count(*)::int
+        FROM public.cards c
+        JOIN public.reviews r ON r.card_id = c.id
+        WHERE c.deck_id = d.id
+          AND r.due <= now()
+      ) AS review_available,
+
+      GREATEST(
+        0,
+        COALESCE(
+          rp.max_reviews_per_day - (
+            SELECT count(DISTINCT rl.card_id)::int
+            FROM public.review_logs rl
+            JOIN public.cards c ON c.id = rl.card_id
+            WHERE c.deck_id = d.id
+              AND rl.review >= p_today_start
+          ),
+          2147483647
+        )
+      ) AS remaining_total,
+
+      GREATEST(
+        0,
+        COALESCE(
+          rp.max_new_per_day - (
+            SELECT count(DISTINCT rl.card_id)::int
+            FROM public.review_logs rl
+            JOIN public.cards c ON c.id = rl.card_id
+            WHERE c.deck_id = d.id
+              AND rl.state = 0
+              AND rl.review >= p_today_start
+          ),
+          2147483647
+        )
+      ) AS remaining_new
+  ) AS stats;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_session_decks_and_cards(p_deck_ids bigint[], p_today_start timestamp with time zone)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT jsonb_build_object(
+    'decks', COALESCE(decks.arr, '[]'::jsonb),
+    'cards', COALESCE(cards.arr, '[]'::jsonb)
+  )
+  FROM
+    -- One slim resolved record per requested deck, in requested order. Pacing
+    -- comes straight from resolve_deck_pacing so the ladder lives in one place.
+    (
+      SELECT jsonb_agg(deck_json ORDER BY d.ord) AS arr
+      FROM unnest(p_deck_ids) WITH ORDINALITY AS d(deck_id, ord)
+      CROSS JOIN LATERAL public.resolve_deck_pacing(d.deck_id) AS rp
+      CROSS JOIN LATERAL (
+        SELECT jsonb_build_object(
+          'id', dk.id,
+          'title', dk.title,
+          'starting_side', COALESCE(dk.study_config->>'starting_side', 'front'),
+          'shuffle', COALESCE((dk.study_config->>'shuffle')::boolean, false),
+          'cover_config', dk.cover_config,
+          'card_attributes', dk.card_attributes,
+          'desired_retention', rp.desired_retention,
+          'learning_steps', rp.learning_steps,
+          'relearning_steps', rp.relearning_steps,
+          'leech_threshold', rp.leech_threshold,
+          'max_interval', rp.max_interval
+        ) AS deck_json
+        FROM public.decks dk
+        WHERE dk.id = d.deck_id
+          -- A locked deck contributes nothing to a session: no deck record and
+          -- (via get_study_session_cards below) no cards.
+          AND public.deck_lock_deadline(dk.id) IS NULL
+      ) AS deck_row
+    ) AS decks,
+
+    -- Merged study queue. Reuse get_study_session_cards per deck (it owns the
+    -- caps + partition + interleave logic) via a lateral join over the deck ids.
+    -- card_ord is captured over the raw function output — row_number() with an
+    -- empty window numbers rows in the order the function emitted them, before
+    -- the reviews join can perturb it — so the final ORDER BY reproduces the
+    -- selection's order within each deck, decks stitched together by d.ord.
+    (
+      SELECT jsonb_agg(q.card_json ORDER BY d.ord, q.card_ord) AS arr
+      FROM unnest(p_deck_ids) WITH ORDINALITY AS d(deck_id, ord)
+      CROSS JOIN LATERAL (
+        SELECT
+          to_jsonb(sc.card) || jsonb_build_object(
+            'review',
+            CASE WHEN r.id IS NULL THEN NULL ELSE to_jsonb(r) END
+          ) AS card_json,
+          sc.card_ord
+        FROM (
+          SELECT g AS card, row_number() OVER () AS card_ord
+          FROM public.get_study_session_cards(d.deck_id, p_today_start) AS g
+        ) sc
+        LEFT JOIN public.reviews r ON r.card_id = (sc.card).id
+      ) AS q
+    ) AS cards;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_study_session_cards(p_deck_id bigint, p_today_start timestamp with time zone)
+ RETURNS SETOF public.cards_with_images
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE
+  v_max_total       int;
+  v_max_new         int;
+  v_used_total      int;
+  v_used_new        int;
+  v_remaining_total int;
+  v_remaining_new   int;
+  v_new_available   int;
+  v_new_take        int;
+  v_review_take     int;
+BEGIN
+  -- A locked deck yields no study cards at all — study is barred while the
+  -- downgrade grace runs, even though the deck stays fully readable/editable.
+  IF public.deck_lock_deadline(p_deck_id) IS NOT NULL THEN
+    RETURN;
+  END IF;
+
+  -- Read the resolved daily caps (NULL = unlimited) via the shared resolver.
+  SELECT rp.max_reviews_per_day, rp.max_new_per_day
+  INTO v_max_total, v_max_new
+  FROM public.resolve_deck_pacing(p_deck_id) rp;
+
+  -- Today's usage: distinct cards reviewed since the member's local midnight.
+  SELECT
+    count(DISTINCT rl.card_id)::int,
+    count(DISTINCT rl.card_id) FILTER (WHERE rl.state = 0)::int
+  INTO v_used_total, v_used_new
+  FROM public.review_logs rl
+  JOIN public.cards c ON c.id = rl.card_id
+  WHERE c.deck_id = p_deck_id
+    AND rl.review >= p_today_start;
+
+  -- Remaining budget. NULL cap → sentinel large int meaning unlimited.
+  v_remaining_total := GREATEST(0, COALESCE(v_max_total - v_used_total, 2147483647));
+  v_remaining_new   := GREATEST(0, COALESCE(v_max_new   - v_used_new,   2147483647));
+
+  -- How many new cards exist in this deck (no review row yet).
+  SELECT count(*)::int
+  INTO v_new_available
+  FROM public.cards c
+  LEFT JOIN public.reviews r ON r.card_id = c.id
+  WHERE c.deck_id = p_deck_id
+    AND r.id IS NULL;
+
+  -- New cards drawn first for budget purposes; review cards fill the rest.
+  -- (This only decides *how many* of each — final ordering interleaves them.)
+  v_new_take    := LEAST(v_new_available, v_remaining_new, v_remaining_total);
+  v_review_take := GREATEST(0, v_remaining_total - v_new_take);
+
+  RETURN QUERY
+  WITH new_queue AS (
+    -- row_number() OVER (ORDER BY c.rank) numbers each row 1..v_new_take in
+    -- rank order, without collapsing rows the way an aggregate would.
+    SELECT c.id, 1 AS bucket, row_number() OVER (ORDER BY c.rank) AS rn
+    FROM public.cards c
+    LEFT JOIN public.reviews r ON r.card_id = c.id
+    WHERE c.deck_id = p_deck_id
+      AND r.id IS NULL
+    ORDER BY c.rank
+    LIMIT v_new_take
+  ),
+  review_queue AS (
+    -- Most-overdue-first: order by due ASC (oldest due date = most overdue),
+    -- not rank. rank only breaks ties between cards due at the same instant.
+    SELECT c.id, 2 AS bucket, row_number() OVER (ORDER BY r.due ASC, c.rank) AS rn
+    FROM public.cards c
+    JOIN public.reviews r ON r.card_id = c.id
+    WHERE c.deck_id = p_deck_id
+      AND r.due <= now()
+    ORDER BY r.due ASC, c.rank
+    LIMIT v_review_take
+  ),
+  queue AS (
+    -- Proportional interleave: each bucket's row gets a key in (0, 1] based
+    -- on its position within that bucket alone (e.g. new card 2 of 5 → 0.3).
+    -- Sorting all rows by that shared key spreads new cards evenly through
+    -- the review cards instead of grouping all of one bucket before the other.
+    SELECT id, bucket, (rn - 0.5) / NULLIF(v_new_take, 0) AS interleave_key
+    FROM new_queue
+    UNION ALL
+    SELECT id, bucket, (rn - 0.5) / NULLIF(v_review_take, 0) AS interleave_key
+    FROM review_queue
+  )
+  SELECT cwi.*
+  FROM public.cards_with_images cwi
+  JOIN queue q ON q.id = cwi.id
+  ORDER BY q.interleave_key, q.bucket;
+END;
+$function$
+;
+
+  create policy "members can update their own non-privileged fields"
+  on "public"."members"
+  as permissive
+  for update
+  to authenticated
+using ((( SELECT public.active_member_id() AS active_member_id) = id))
+with check (((( SELECT public.active_member_id() AS active_member_id) = id) AND (role = ( SELECT members_1.role
+   FROM public.members members_1
+  WHERE (members_1.id = auth.uid()))) AND (plan = ( SELECT members_1.plan
+   FROM public.members members_1
+  WHERE (members_1.id = auth.uid()))) AND (NOT (stripe_customer_id IS DISTINCT FROM ( SELECT members_1.stripe_customer_id
+   FROM public.members members_1
+  WHERE (members_1.id = auth.uid())))) AND (NOT (stripe_subscription_id IS DISTINCT FROM ( SELECT members_1.stripe_subscription_id
+   FROM public.members members_1
+  WHERE (members_1.id = auth.uid())))) AND (NOT (delete_at IS DISTINCT FROM ( SELECT members_1.delete_at
+   FROM public.members members_1
+  WHERE (members_1.id = auth.uid())))) AND (NOT (downgrade_delete_at IS DISTINCT FROM ( SELECT members_1.downgrade_delete_at
+   FROM public.members members_1
+  WHERE (members_1.id = auth.uid()))))));
+
+
+

--- a/supabase/migrations/20260801230820_downgrade-lock-grants-and-cron.sql
+++ b/supabase/migrations/20260801230820_downgrade-lock-grants-and-cron.sql
@@ -1,0 +1,77 @@
+-- =============================================================================
+-- Downgrade-lock: function grant lockdown + daily deck purge cron
+-- =============================================================================
+--
+-- Hand-written because none of this is visible to `supabase db diff`: it emits
+-- ZERO function grants, and cron scheduling is DML in the cron schema. The
+-- function bodies live in the declarative schema and arrive via the generated
+-- migration alongside this one; this file only fixes their ACLs and schedules
+-- the sweep.
+--
+-- Reuses the `supabase_url` / `service_role_key` Vault secrets already
+-- provisioned for invoke_cleanup_media / invoke_purge_accounts — though this
+-- sweep needs neither, since it runs entirely in SQL (see below).
+
+-- -----------------------------------------------------------------------------
+-- 1. Lock down the new functions
+--
+--    A freshly-created function is EXECUTE-able by PUBLIC, and Supabase's
+--    default privileges hand anon/authenticated/service_role EXECUTE on public
+--    functions too. Left as-is:
+--
+--    * purge_downgraded_decks() is SECURITY DEFINER — any holder of the public
+--      anon key could POST /rest/v1/rpc/purge_downgraded_decks and delete decks
+--      as the owner, straight past RLS. It must reach NO client. The cron job
+--      runs as `postgres`, which OWNS it and keeps EXECUTE regardless.
+--
+--    * begin_/clear_downgrade_grace() are the only writers of
+--      downgrade_delete_at and belong to the stripe-webhook (service role)
+--      alone; a member calling them directly could try to unlock their own
+--      decks. RLS's frozen-column check already blocks the write, but keeping
+--      them off the authenticated RPC surface is the real boundary.
+REVOKE ALL ON FUNCTION public.purge_downgraded_decks() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.purge_downgraded_decks() FROM anon;
+REVOKE ALL ON FUNCTION public.purge_downgraded_decks() FROM authenticated;
+REVOKE ALL ON FUNCTION public.purge_downgraded_decks() FROM service_role;
+
+REVOKE ALL ON FUNCTION public.begin_downgrade_grace(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.begin_downgrade_grace(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.begin_downgrade_grace(uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.begin_downgrade_grace(uuid) TO service_role;
+
+REVOKE ALL ON FUNCTION public.clear_downgrade_grace(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.clear_downgrade_grace(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.clear_downgrade_grace(uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.clear_downgrade_grace(uuid) TO service_role;
+
+-- deck_lock_deadline() is SECURITY INVOKER and only ever reads the caller's own
+-- rows through RLS, so a broad grant leaks nothing — but state it explicitly so
+-- the intent is on record rather than inherited from defaults.
+GRANT EXECUTE ON FUNCTION public.deck_lock_deadline(bigint) TO anon;
+GRANT EXECUTE ON FUNCTION public.deck_lock_deadline(bigint) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.deck_lock_deadline(bigint) TO service_role;
+
+-- -----------------------------------------------------------------------------
+-- 2. Schedule the daily deck purge
+--
+--    Pure SQL, so unlike purge-accounts there is no edge function to invoke —
+--    cron runs purge_downgraded_decks() directly. Media reclaim rides the
+--    existing deck-delete soft-delete triggers + the hourly cleanup-media reaper.
+--
+--    Daily rather than hourly: the deadline is 15 days out, so purging within a
+--    day of it is well inside the window. 04:00 UTC, off-peak and clear of the
+--    03:30 account purge.
+--
+--    unschedule-if-exists guard so re-running this migration is not an error.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'purge-downgraded-decks-daily') THEN
+    PERFORM cron.unschedule('purge-downgraded-decks-daily');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'purge-downgraded-decks-daily',
+  '0 4 * * *',
+  $$SELECT public.purge_downgraded_decks();$$
+);

--- a/supabase/schemas/20_members.sql
+++ b/supabase/schemas/20_members.sql
@@ -27,7 +27,20 @@ CREATE TABLE public.members (
     -- default of `now() + interval '30 days'` would mark every new signup as
     -- pending deletion. The grace window lives in begin_account_deletion()
     -- below, which is the only thing that ever stamps this column.
-    delete_at timestamp with time zone
+    delete_at timestamp with time zone,
+    -- Account-level grace deadline for a free downgrade with too many decks.
+    -- NULL = no pending downgrade sweep. Non-NULL = the member downgraded to
+    -- free while over their plan's deck_limit, and this is when the purge cron
+    -- may hard-delete every deck ranked beyond the limit.
+    --
+    -- Locked-ness is NOT stored per deck: a deck is locked precisely while this
+    -- is set, the member is on `free`, and the deck sits beyond deck_limit by
+    -- rank. Reordering therefore changes which decks are locked with no extra
+    -- write — the rank IS the lock state. See deck_lock_deadline().
+    --
+    -- Same NO-DEFAULT reasoning as delete_at: begin_downgrade_grace() is the
+    -- only writer, so a fresh signup never gets stamped.
+    downgrade_delete_at timestamp with time zone
 );
 
 
@@ -341,6 +354,112 @@ ALTER FUNCTION public.invoke_purge_accounts() OWNER TO postgres;
 REVOKE ALL ON FUNCTION public.invoke_purge_accounts() FROM PUBLIC;
 
 
+-- --- downgrade grace lifecycle --------------------------------------------
+-- The free-downgrade analog of the account-deletion pair above. Same shape:
+-- one writer stamps the grace deadline, one writer clears it, both single
+-- transactions, both service_role-only so a member can't self-serve either
+-- direction (which would let them dodge the deck sweep while unsubscribed).
+--
+-- Unlike the account pair there is no per-row "unpublish" bookkeeping: locking
+-- derives from rank + plan + this column (see deck_lock_deadline), so stamping
+-- the deadline IS the lock and clearing it IS the unlock — nothing to record.
+
+-- Called by the stripe-webhook markFree() path after it flips the member to
+-- `free`. Idempotent: a re-fired webhook returns the original deadline rather
+-- than sliding the window the member was promised. Stamps nothing when the
+-- member is at or under their plan's deck_limit — there is no over-limit deck to
+-- schedule, so a 10-deck downgrade gets no deadline and nothing locks.
+--
+-- SECURITY INVOKER (the plpgsql default), matching begin_account_deletion: only
+-- service_role holds EXECUTE and it bypasses RLS, so an accidental grant to
+-- `authenticated` still can't stamp a row past the members self-update freeze.
+CREATE FUNCTION public.begin_downgrade_grace(p_member_id uuid) RETURNS timestamp with time zone
+    LANGUAGE plpgsql
+    SET search_path TO 'public'
+    AS $$
+DECLARE
+  -- The grace window lives here, in the only writer of downgrade_delete_at.
+  v_grace    interval := interval '15 days';
+  v_deadline timestamptz;
+  v_limit    int;
+  v_count    int;
+BEGIN
+  SELECT m.downgrade_delete_at, p.deck_limit
+    INTO v_deadline, v_limit
+  FROM public.members m
+  JOIN public.plans p ON p.id = m.plan
+  WHERE m.id = p_member_id
+  FOR UPDATE OF m;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No member %', p_member_id USING errcode = 'no_data_found';
+  END IF;
+
+  IF v_deadline IS NOT NULL THEN
+    RETURN v_deadline;
+  END IF;
+
+  -- NULL deck_limit = unlimited plan: nothing is ever over the line.
+  IF v_limit IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.decks
+  WHERE member_id = p_member_id;
+
+  IF v_count <= v_limit THEN
+    RETURN NULL;
+  END IF;
+
+  v_deadline := now() + v_grace;
+
+  UPDATE public.members
+  SET downgrade_delete_at = v_deadline
+  WHERE id = p_member_id;
+
+  RETURN v_deadline;
+END;
+$$;
+
+
+ALTER FUNCTION public.begin_downgrade_grace(uuid) OWNER TO postgres;
+
+
+-- Keep off PostgREST's authenticated RPC surface: a member clearing this
+-- themselves would unlock every deck while still unsubscribed and dodge the
+-- sweep. Only the webhook (service role) calls it.
+REVOKE ALL ON FUNCTION public.begin_downgrade_grace(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.begin_downgrade_grace(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.begin_downgrade_grace(uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.begin_downgrade_grace(uuid) TO service_role;
+
+
+-- Called by the stripe-webhook upgrade path (syncSubscription, active). Clears
+-- the deadline, which unlocks every deck at once because locking is derived.
+-- Idempotent: clearing an already-clear member is a no-op.
+CREATE FUNCTION public.clear_downgrade_grace(p_member_id uuid) RETURNS void
+    LANGUAGE plpgsql
+    SET search_path TO 'public'
+    AS $$
+BEGIN
+  UPDATE public.members
+  SET downgrade_delete_at = NULL
+  WHERE id = p_member_id
+    AND downgrade_delete_at IS NOT NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.clear_downgrade_grace(uuid) OWNER TO postgres;
+
+
+REVOKE ALL ON FUNCTION public.clear_downgrade_grace(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.clear_downgrade_grace(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.clear_downgrade_grace(uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.clear_downgrade_grace(uuid) TO service_role;
+
+
 ALTER TABLE public.members ENABLE ROW LEVEL SECURITY;
 
 
@@ -368,6 +487,10 @@ CREATE POLICY "admins can update any member" ON public.members FOR UPDATE TO aut
 -- the deck re-publishing and the plan/subscription reality of a restore). Both
 -- directions go through the definer functions below instead.
 --
+-- `downgrade_delete_at` is frozen for the same reason: a member clearing it
+-- would unlock every deck while still on free and slip past the deletion sweep;
+-- only the stripe-webhook (service role) may write it.
+--
 -- USING is on active_member_id(), so a pending member's profile edits match zero
 -- rows — suspension covers writes to their own row too. The frozen-field
 -- subqueries stay on auth.uid() because they only re-read the current row, and
@@ -381,6 +504,8 @@ CREATE POLICY "members can update their own non-privileged fields" ON public.mem
   WHERE (members_1.id = auth.uid())))) AND (NOT (stripe_subscription_id IS DISTINCT FROM ( SELECT members_1.stripe_subscription_id
    FROM public.members members_1
   WHERE (members_1.id = auth.uid())))) AND (NOT (delete_at IS DISTINCT FROM ( SELECT members_1.delete_at
+   FROM public.members members_1
+  WHERE (members_1.id = auth.uid())))) AND (NOT (downgrade_delete_at IS DISTINCT FROM ( SELECT members_1.downgrade_delete_at
    FROM public.members members_1
   WHERE (members_1.id = auth.uid()))))));
 

--- a/supabase/schemas/30_decks/00_types.sql
+++ b/supabase/schemas/30_decks/00_types.sql
@@ -34,7 +34,12 @@ CREATE TYPE public.member_deck AS (
     max_new_per_day               integer,
     leech_threshold               integer,
     max_interval                  integer,
-    pacing_overrides              jsonb
+    pacing_overrides              jsonb,
+    -- Downgrade-lock state, derived per read (see deck_lock_deadline). A locked
+    -- deck stays fully readable/editable but is barred from study, and its
+    -- due_count is forced to 0 so it drops out of every "due" surface.
+    is_locked                     boolean,
+    locked_delete_at              timestamp with time zone
 );
 
 

--- a/supabase/schemas/30_decks/deck_lock_deadline.sql
+++ b/supabase/schemas/30_decks/deck_lock_deadline.sql
@@ -1,0 +1,45 @@
+-- Hand-organized declarative schema (by domain). Edit freely — this file is the
+-- canonical definition. Run `supabase db diff -f <name>` after editing to
+-- produce the migration.
+SET check_function_bodies = false;
+
+-- The single source of truth for "is this deck locked, and until when?".
+--
+-- Returns the owner's downgrade grace deadline when the deck is locked, else
+-- NULL. A deck is locked precisely when its owner is on `free`, carries a
+-- downgrade_delete_at, and sits beyond the plan's deck_limit by rank — i.e. at
+-- least deck_limit of the owner's decks rank ahead of it. Nothing is stored per
+-- deck: reorder a deck above the line and this flips to NULL on the next read,
+-- with no lock-state write anywhere.
+--
+-- SECURITY INVOKER (the default): it reads `members`/`plans` under the caller's
+-- RLS. A member reading their own dashboard sees their own member row, so their
+-- own decks resolve correctly; a foreign caller can't read the owner's member
+-- row, so the join yields nothing and the deck reads as unlocked — locked-ness
+-- is a private, owner-only concern, never leaked across the RLS boundary.
+CREATE FUNCTION public.deck_lock_deadline(p_deck_id bigint) RETURNS timestamp with time zone
+    LANGUAGE sql STABLE
+    AS $$
+  SELECT m.downgrade_delete_at
+  FROM public.decks d
+  JOIN public.members m ON m.id = d.member_id
+  JOIN public.plans p ON p.id = m.plan
+  WHERE d.id = p_deck_id
+    AND m.plan = 'free'
+    AND m.downgrade_delete_at IS NOT NULL
+    AND p.deck_limit IS NOT NULL
+    AND (
+      SELECT count(*)
+      FROM public.decks d2
+      WHERE d2.member_id = d.member_id
+        AND d2.rank < d.rank
+    ) >= p.deck_limit;
+$$;
+
+
+ALTER FUNCTION public.deck_lock_deadline(bigint) OWNER TO postgres;
+
+
+GRANT ALL ON FUNCTION public.deck_lock_deadline(bigint) TO anon;
+GRANT ALL ON FUNCTION public.deck_lock_deadline(bigint) TO authenticated;
+GRANT ALL ON FUNCTION public.deck_lock_deadline(bigint) TO service_role;

--- a/supabase/schemas/30_decks/get_member_decks.sql
+++ b/supabase/schemas/30_decks/get_member_decks.sql
@@ -31,19 +31,23 @@ CREATE FUNCTION public.get_member_decks(p_today_start timestamp with time zone) 
     stats.new_reviewed_today_count,
 
     -- new_take + review_take, matching get_study_session_cards exactly.
-    -- COALESCE(cap - used, INT_MAX) treats a NULL cap as unbounded.
-    GREATEST(
-      0,
-      LEAST(stats.new_available, stats.remaining_new, stats.remaining_total)
-    )
-    + GREATEST(
-      0,
-      LEAST(
-        stats.review_available,
-        stats.remaining_total
-          - GREATEST(0, LEAST(stats.new_available, stats.remaining_new, stats.remaining_total))
+    -- COALESCE(cap - used, INT_MAX) treats a NULL cap as unbounded. A locked
+    -- deck reports 0 so it drops out of the review inbox and "study all due" —
+    -- study is barred there too (get_study_session_cards returns nothing).
+    CASE WHEN lock.deadline IS NOT NULL THEN 0 ELSE
+      GREATEST(
+        0,
+        LEAST(stats.new_available, stats.remaining_new, stats.remaining_total)
       )
-    ) AS due_count,
+      + GREATEST(
+        0,
+        LEAST(
+          stats.review_available,
+          stats.remaining_total
+            - GREATEST(0, LEAST(stats.new_available, stats.remaining_new, stats.remaining_total))
+        )
+      )
+    END AS due_count,
 
     d.rank,
 
@@ -59,12 +63,18 @@ CREATE FUNCTION public.get_member_decks(p_today_start timestamp with time zone) 
     rp.leech_threshold,
     rp.max_interval,
 
-    dp.overrides AS pacing_overrides
+    dp.overrides AS pacing_overrides,
+
+    -- Locked flag + deletion date the dashboard renders. Both fall out of the
+    -- one deck_lock_deadline read: non-NULL deadline ⇒ locked.
+    (lock.deadline IS NOT NULL) AS is_locked,
+    lock.deadline AS locked_delete_at
 
   FROM public.decks d
   LEFT JOIN LATERAL public.member_public_profile(d.member_id) m ON true
   LEFT JOIN public.deck_review_pacing dp ON dp.deck_id = d.id
   CROSS JOIN LATERAL public.resolve_deck_pacing(d.id) AS rp
+  CROSS JOIN LATERAL (SELECT public.deck_lock_deadline(d.id) AS deadline) AS lock
   CROSS JOIN LATERAL (
     SELECT
       (

--- a/supabase/schemas/30_decks/purge_downgraded_decks.sql
+++ b/supabase/schemas/30_decks/purge_downgraded_decks.sql
@@ -1,0 +1,52 @@
+-- Hand-organized declarative schema (by domain). Edit freely — this file is the
+-- canonical definition. Run `supabase db diff -f <name>` after editing to
+-- produce the migration.
+SET check_function_bodies = false;
+
+-- Daily sweep: hard-delete every deck still locked for a member whose downgrade
+-- grace has run out. The free-downgrade analog of purge-accounts, but pure SQL —
+-- there is no auth user or Stripe subscription to unwind, only decks — so it runs
+-- straight from pg_cron with no edge function. See the cron migration.
+--
+-- Deliberately dull, matching purge-accounts: it only ever touches decks whose
+-- owner is on `free`, carries a downgrade_delete_at already in the past, and that
+-- rank beyond the plan's deck_limit — exactly the decks deck_lock_deadline() calls
+-- locked. A member who resubscribed (deadline cleared) or reordered a deck above
+-- the line is untouched.
+--
+-- Media reclaim is free: DELETE FROM decks fires trg_deck_delete_soft_delete_media
+-- (and, via the cards cascade, trg_card_delete_soft_delete_media), which tombstone
+-- the storage rows for the hourly cleanup-media reaper. No bespoke media handling
+-- here.
+--
+-- SECURITY DEFINER so the cron owner (postgres) runs it regardless of RLS; the
+-- EXECUTE lockdown in the cron migration is the whole security boundary, since
+-- db diff emits no grants and this must never sit on the anon RPC surface.
+CREATE FUNCTION public.purge_downgraded_decks() RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+BEGIN
+  DELETE FROM public.decks d
+  USING public.members m, public.plans p
+  WHERE d.member_id = m.id
+    AND p.id = m.plan
+    AND m.plan = 'free'
+    AND m.downgrade_delete_at IS NOT NULL
+    AND m.downgrade_delete_at <= now()
+    AND p.deck_limit IS NOT NULL
+    AND (
+      SELECT count(*)
+      FROM public.decks d2
+      WHERE d2.member_id = d.member_id
+        AND d2.rank < d.rank
+    ) >= p.deck_limit;
+END;
+$$;
+
+
+ALTER FUNCTION public.purge_downgraded_decks() OWNER TO postgres;
+
+
+-- Lockdown lives in the cron migration (db diff emits no grants). Never anon.
+REVOKE ALL ON FUNCTION public.purge_downgraded_decks() FROM PUBLIC;

--- a/supabase/schemas/60_reviews/get_session_decks_and_cards.sql
+++ b/supabase/schemas/60_reviews/get_session_decks_and_cards.sql
@@ -48,6 +48,9 @@ CREATE FUNCTION public.get_session_decks_and_cards(p_deck_ids bigint[], p_today_
         ) AS deck_json
         FROM public.decks dk
         WHERE dk.id = d.deck_id
+          -- A locked deck contributes nothing to a session: no deck record and
+          -- (via get_study_session_cards below) no cards.
+          AND public.deck_lock_deadline(dk.id) IS NULL
       ) AS deck_row
     ) AS decks,
 

--- a/supabase/schemas/60_reviews/get_study_session_cards.sql
+++ b/supabase/schemas/60_reviews/get_study_session_cards.sql
@@ -17,6 +17,12 @@ DECLARE
   v_new_take        int;
   v_review_take     int;
 BEGIN
+  -- A locked deck yields no study cards at all — study is barred while the
+  -- downgrade grace runs, even though the deck stays fully readable/editable.
+  IF public.deck_lock_deadline(p_deck_id) IS NOT NULL THEN
+    RETURN;
+  END IF;
+
   -- Read the resolved daily caps (NULL = unlimited) via the shared resolver.
   SELECT rp.max_reviews_per_day, rp.max_new_per_day
   INTO v_max_total, v_max_new

--- a/supabase/tests/00009_decks_with_stats.sql
+++ b/supabase/tests/00009_decks_with_stats.sql
@@ -35,7 +35,7 @@ SELECT bag_eq(
       ('review_pacing_preset_id'), ('desired_retention'), ('learning_steps'), ('relearning_steps'),
       ('max_reviews_per_day'), ('max_new_per_day'),
       ('leech_threshold'), ('max_interval'),
-      ('pacing_overrides') $$,
+      ('pacing_overrides'), ('is_locked'), ('locked_delete_at') $$,
   'get_member_decks (via public.member_deck) exposes the columns the FE consumes [obligation]'
 );
 

--- a/supabase/tests/00035_downgrade_grace_lifecycle.sql
+++ b/supabase/tests/00035_downgrade_grace_lifecycle.sql
@@ -1,0 +1,179 @@
+-- =============================================================================
+-- begin_downgrade_grace() / clear_downgrade_grace() lifecycle
+--
+-- The free-downgrade analog of begin_account_deletion()/restore_account():
+--   * begin_downgrade_grace() stamps a ~15-day deadline only when the member
+--     is over their plan's deck_limit; idempotent (a re-fired webhook can't
+--     slide the window).
+--   * A member at-or-under the limit gets no deadline at all.
+--   * clear_downgrade_grace() clears the deadline, which unlocks every deck
+--     at once (locking is derived, nothing per-deck to unwind).
+--   * The members self-update policy freezes downgrade_delete_at: a member
+--     can neither set it nor clear it via a direct UPDATE.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(10);
+
+-- ── Setup (as postgres superuser) ─────────────────────────────────────────────
+
+SELECT tests.create_user('e0000000-0000-0000-0000-00000000a001'::uuid, 'grace_alice');
+SELECT tests.create_user('e0000000-0000-0000-0000-00000000b001'::uuid, 'grace_bob');
+
+-- Alice: 11 decks, one over the free deck_limit of 10. Explicit ids bypass
+-- enforce_member_deck_limit (it only checks inserts with no id assigned).
+-- member_id is NOT settable directly — set_member_id_on_deck always overwrites
+-- it from auth.uid(), so the insert must run as Alice herself.
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000a001'::uuid);
+SET LOCAL role = 'authenticated';
+
+INSERT INTO public.decks (id, title, is_public) VALUES
+  (9000, 'Alice deck 1',  false),
+  (9001, 'Alice deck 2',  false),
+  (9002, 'Alice deck 3',  false),
+  (9003, 'Alice deck 4',  false),
+  (9004, 'Alice deck 5',  false),
+  (9005, 'Alice deck 6',  false),
+  (9006, 'Alice deck 7',  false),
+  (9007, 'Alice deck 8',  false),
+  (9008, 'Alice deck 9',  false),
+  (9009, 'Alice deck 10', false),
+  (9010, 'Alice deck 11', false);
+
+SET LOCAL role = 'postgres';
+
+-- Bob: exactly at the free deck_limit of 10 — never over it.
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000b001'::uuid);
+SET LOCAL role = 'authenticated';
+
+INSERT INTO public.decks (id, title, is_public) VALUES
+  (9100, 'Bob deck 1',  false),
+  (9101, 'Bob deck 2',  false),
+  (9102, 'Bob deck 3',  false),
+  (9103, 'Bob deck 4',  false),
+  (9104, 'Bob deck 5',  false),
+  (9105, 'Bob deck 6',  false),
+  (9106, 'Bob deck 7',  false),
+  (9107, 'Bob deck 8',  false),
+  (9108, 'Bob deck 9',  false),
+  (9109, 'Bob deck 10', false);
+
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims(NULL);
+
+
+-- ── begin_downgrade_grace: over the limit locks [obligation] ─────────────────
+
+-- Test 1: an over-limit free member gets a deadline ~15 days out.
+SELECT ok(
+  (SELECT public.begin_downgrade_grace('e0000000-0000-0000-0000-00000000a001'::uuid))
+    - now() BETWEEN interval '14 days 23 hours' AND interval '15 days 1 hour',
+  'begin_downgrade_grace() stamps a deadline ~15 days out for an over-limit free member [obligation]'
+);
+
+-- Test 2: the deadline is actually persisted on the member row.
+SELECT isnt(
+  (SELECT downgrade_delete_at FROM public.members WHERE id = 'e0000000-0000-0000-0000-00000000a001'),
+  NULL::timestamptz,
+  'begin_downgrade_grace() persists the deadline on members.downgrade_delete_at'
+);
+
+
+-- ── begin_downgrade_grace: at-or-under the limit does not lock [obligation] ──
+
+-- Test 3: a member with exactly deck_limit decks gets no deadline.
+SELECT is(
+  (SELECT public.begin_downgrade_grace('e0000000-0000-0000-0000-00000000b001'::uuid)),
+  NULL::timestamptz,
+  'begin_downgrade_grace() returns NULL for a member at (not over) the deck_limit [obligation]'
+);
+
+-- Test 4: nothing was stamped for Bob.
+SELECT is(
+  (SELECT downgrade_delete_at FROM public.members WHERE id = 'e0000000-0000-0000-0000-00000000b001'),
+  NULL::timestamptz,
+  'begin_downgrade_grace() stamps nothing for a member at the deck_limit [obligation]'
+);
+
+
+-- ── begin_downgrade_grace: idempotent [obligation] ────────────────────────────
+
+-- Test 5: a second call returns the already-stored deadline, not a new one.
+SELECT is(
+  (SELECT public.begin_downgrade_grace('e0000000-0000-0000-0000-00000000a001'::uuid)),
+  (SELECT downgrade_delete_at FROM public.members WHERE id = 'e0000000-0000-0000-0000-00000000a001'),
+  'begin_downgrade_grace() is idempotent — a second call does not slide the deadline [obligation]'
+);
+
+
+-- ── clear_downgrade_grace: resubscribe unlocks [obligation] ──────────────────
+
+SELECT public.clear_downgrade_grace('e0000000-0000-0000-0000-00000000a001'::uuid);
+
+-- Test 6: the deadline is cleared.
+SELECT is(
+  (SELECT downgrade_delete_at FROM public.members WHERE id = 'e0000000-0000-0000-0000-00000000a001'),
+  NULL::timestamptz,
+  'clear_downgrade_grace() clears downgrade_delete_at [obligation]'
+);
+
+-- Test 7: every one of the member's decks reads as unlocked afterwards.
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.decks
+    WHERE member_id = 'e0000000-0000-0000-0000-00000000a001'
+      AND public.deck_lock_deadline(id) IS NOT NULL
+  ),
+  0,
+  'clear_downgrade_grace() unlocks every one of the member''s decks [obligation]'
+);
+
+
+-- ── Security: members self-update policy freezes downgrade_delete_at [obligation] ──
+
+-- Re-stamp a known deadline directly (bypassing RLS, as postgres) so the
+-- freeze tests below have a concrete value to try to tamper with.
+UPDATE public.members
+SET downgrade_delete_at = now() + interval '15 days'
+WHERE id = 'e0000000-0000-0000-0000-00000000a001';
+
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000a001'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 8: Alice cannot set/extend her own downgrade_delete_at.
+SELECT throws_ok(
+  $$
+    UPDATE public.members
+    SET downgrade_delete_at = now() + interval '99 days'
+    WHERE id = 'e0000000-0000-0000-0000-00000000a001'
+  $$,
+  NULL,
+  NULL,
+  'Alice cannot set/extend her own downgrade_delete_at via a direct update [obligation]'
+);
+
+-- Test 9: Alice cannot clear her own downgrade_delete_at (self-unlock).
+SELECT throws_ok(
+  $$
+    UPDATE public.members
+    SET downgrade_delete_at = NULL
+    WHERE id = 'e0000000-0000-0000-0000-00000000a001'
+  $$,
+  NULL,
+  NULL,
+  'Alice cannot clear her own downgrade_delete_at via a direct update [obligation]'
+);
+
+SET LOCAL role = 'postgres';
+
+-- Test 10: the frozen column is genuinely untouched by either failed write.
+SELECT ok(
+  (SELECT downgrade_delete_at FROM public.members WHERE id = 'e0000000-0000-0000-0000-00000000a001')
+    BETWEEN now() + interval '14 days 23 hours' AND now() + interval '15 days 1 hour',
+  'downgrade_delete_at is unchanged after both rejected self-writes'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/00036_deck_lock_deadline.sql
+++ b/supabase/tests/00036_deck_lock_deadline.sql
@@ -1,0 +1,197 @@
+-- =============================================================================
+-- deck_lock_deadline(): rank-derived lock boundary, live reorder, and the
+-- get_member_decks() dashboard projection built on top of it.
+--
+-- Covers [obligation]:
+--   1. For an over-limit free member with a deadline, the top deck_limit
+--      decks by rank are unlocked and every deck beyond is locked.
+--   2. Reorder is live: moving a locked deck above the limit line unlocks it
+--      and locks the displaced deck, with no write to the lock state itself
+--      (only decks.rank changes — downgrade_delete_at is untouched).
+--   3. A deck unlocked this way keeps its FSRS review data intact — unlock
+--      is purely derived, it never touches reviews.
+--   4. get_member_decks() reports is_locked / locked_delete_at / due_count
+--      correctly for both a locked and an unlocked deck.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(12);
+
+-- ── Setup (as postgres superuser) ─────────────────────────────────────────────
+
+SELECT tests.create_user('e0000000-0000-0000-0000-00000000c001'::uuid, 'lock_erin');
+
+-- 12 decks, inserted in id order so rank ascends 600 < 601 < ... < 611
+-- (set_deck_rank assigns +1000 per insert when rank is omitted).
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000c001'::uuid);
+SET LOCAL role = 'authenticated';
+
+INSERT INTO public.decks (id, title, is_public) VALUES
+  (600, 'Erin deck 600', false),
+  (601, 'Erin deck 601', false),
+  (602, 'Erin deck 602', false),
+  (603, 'Erin deck 603', false),
+  (604, 'Erin deck 604', false),
+  (605, 'Erin deck 605', false),
+  (606, 'Erin deck 606', false),
+  (607, 'Erin deck 607', false),
+  (608, 'Erin deck 608', false),
+  (609, 'Erin deck 609', false),
+  (610, 'Erin deck 610', false),
+  (611, 'Erin deck 611', false);
+
+-- Cards + a review on deck 611, which starts out beyond the limit (locked).
+-- Used later to prove unlocking a deck via reorder never touches review data.
+INSERT INTO public.cards (id, deck_id, front_text, back_text, rank) VALUES
+  (6110, 611, 'D611 Q1', 'A1', 1000),
+  (6111, 611, 'D611 Q2', 'A2', 2000);
+
+INSERT INTO public.reviews (id, card_id, due, stability, difficulty)
+VALUES (6110, 6110, now() - interval '1 day', 5.5, 6.6);
+
+SET LOCAL role = 'postgres';
+
+-- Stamp the grace deadline (12 decks > the free deck_limit of 10).
+SELECT public.begin_downgrade_grace('e0000000-0000-0000-0000-00000000c001'::uuid);
+
+
+-- ── Rank boundary [obligation] ────────────────────────────────────────────────
+
+-- Test 1: the top 10 decks by rank (600-609) are all unlocked.
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.decks
+    WHERE id BETWEEN 600 AND 609
+      AND public.deck_lock_deadline(id) IS NULL
+  ),
+  10,
+  'the top deck_limit decks by rank are unlocked (deck_lock_deadline IS NULL) [obligation]'
+);
+
+-- Test 2: every deck beyond the limit (610, 611) is locked.
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.decks
+    WHERE id IN (610, 611)
+      AND public.deck_lock_deadline(id) IS NOT NULL
+  ),
+  2,
+  'every deck ranked beyond deck_limit is locked (deck_lock_deadline IS NOT NULL) [obligation]'
+);
+
+
+-- ── Reorder is live [obligation] ──────────────────────────────────────────────
+
+-- Capture the deadline before the reorder, to prove afterwards that moving a
+-- deck never touches it.
+CREATE TEMP TABLE _deadline_before AS
+SELECT downgrade_delete_at FROM public.members WHERE id = 'e0000000-0000-0000-0000-00000000c001';
+
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000c001'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Move locked deck 611 to the very front — well inside the top 10.
+SELECT public.move_deck(611, 600, 'before');
+
+SET LOCAL role = 'postgres';
+
+-- Test 3: deck 611 is unlocked now that its rank sits inside the limit.
+SELECT is(
+  (SELECT public.deck_lock_deadline(611)),
+  NULL::timestamptz,
+  'reordering a locked deck above the limit line unlocks it [obligation]'
+);
+
+-- Test 4: deck 609, displaced from position 10 to position 11, is now locked.
+SELECT isnt(
+  (SELECT public.deck_lock_deadline(609)),
+  NULL::timestamptz,
+  'the deck displaced past the limit line by the reorder becomes locked [obligation]'
+);
+
+-- Test 5: the reorder wrote only decks.rank — the member's grace deadline
+-- itself was never touched.
+SELECT is(
+  (SELECT downgrade_delete_at FROM public.members WHERE id = 'e0000000-0000-0000-0000-00000000c001'),
+  (SELECT downgrade_delete_at FROM _deadline_before),
+  'reordering a deck does not write to the member''s downgrade_delete_at [obligation]'
+);
+
+
+-- ── Unlock preserves review data [obligation] ─────────────────────────────────
+
+-- Test 6: the review row on deck 611's card still exists after the unlock.
+SELECT is(
+  (SELECT count(*)::int FROM public.reviews WHERE card_id = 6110),
+  1,
+  'the review row for a card on the now-unlocked deck still exists [obligation]'
+);
+
+-- Test 7: its FSRS fields are untouched — unlocking never writes to reviews.
+SELECT is(
+  (SELECT stability FROM public.reviews WHERE card_id = 6110),
+  5.5::real,
+  'the review''s FSRS fields are unchanged by the unlock [obligation]'
+);
+
+
+-- ── get_member_decks() reporting [obligation] ─────────────────────────────────
+
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000c001'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- Test 8: the now-unlocked deck 611 reports is_locked = false.
+SELECT is(
+  (
+    SELECT is_locked FROM public.get_member_decks(date_trunc('day', now()))
+    WHERE id = 611
+  ),
+  false,
+  'get_member_decks() reports is_locked = false for the unlocked deck [obligation]'
+);
+
+-- Test 9: ... and locked_delete_at NULL to match.
+SELECT is(
+  (
+    SELECT locked_delete_at FROM public.get_member_decks(date_trunc('day', now()))
+    WHERE id = 611
+  ),
+  NULL::timestamptz,
+  'get_member_decks() reports locked_delete_at = NULL for the unlocked deck [obligation]'
+);
+
+-- Test 10: the now-locked deck 609 reports is_locked = true.
+SELECT is(
+  (
+    SELECT is_locked FROM public.get_member_decks(date_trunc('day', now()))
+    WHERE id = 609
+  ),
+  true,
+  'get_member_decks() reports is_locked = true for the locked deck [obligation]'
+);
+
+-- Test 11: ... with locked_delete_at set to the member's grace deadline.
+SELECT is(
+  (
+    SELECT locked_delete_at FROM public.get_member_decks(date_trunc('day', now()))
+    WHERE id = 609
+  ),
+  (SELECT downgrade_delete_at FROM public.members WHERE id = 'e0000000-0000-0000-0000-00000000c001'),
+  'get_member_decks() sets locked_delete_at to the member''s grace deadline [obligation]'
+);
+
+-- Test 12: ... and its due_count is forced to 0.
+SELECT is(
+  (
+    SELECT due_count FROM public.get_member_decks(date_trunc('day', now()))
+    WHERE id = 609
+  ),
+  0,
+  'get_member_decks() forces due_count to 0 for a locked deck [obligation]'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/00037_study_session_locked_deck.sql
+++ b/supabase/tests/00037_study_session_locked_deck.sql
@@ -1,0 +1,121 @@
+-- =============================================================================
+-- Study is barred on a locked deck: get_study_session_cards() and
+-- get_session_decks_and_cards() both exclude it entirely.
+--
+-- Covers [obligation]:
+--   1. get_study_session_cards() returns zero rows for a locked deck.
+--   2. get_session_decks_and_cards() omits a locked deck entirely — no entry
+--      in 'decks', no cards — even when its id is passed alongside an
+--      unlocked deck.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(5);
+
+-- ── Setup (as postgres superuser) ─────────────────────────────────────────────
+
+SELECT tests.create_user('e0000000-0000-0000-0000-00000000d001'::uuid, 'study_frank');
+
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000d001'::uuid);
+SET LOCAL role = 'authenticated';
+
+-- 11 decks: 700-709 unlocked (top 10 by rank), 710 locked (11th).
+INSERT INTO public.decks (id, title, is_public) VALUES
+  (700, 'Frank deck 700', false),
+  (701, 'Frank deck 701', false),
+  (702, 'Frank deck 702', false),
+  (703, 'Frank deck 703', false),
+  (704, 'Frank deck 704', false),
+  (705, 'Frank deck 705', false),
+  (706, 'Frank deck 706', false),
+  (707, 'Frank deck 707', false),
+  (708, 'Frank deck 708', false),
+  (709, 'Frank deck 709', false),
+  (710, 'Frank deck 710', false);
+
+-- New (unreviewed) cards on both the soon-to-be-unlocked deck (700) and the
+-- soon-to-be-locked deck (710) — proves the empty result on 710 is the lock,
+-- not just an empty deck.
+INSERT INTO public.cards (id, deck_id, front_text, back_text, rank) VALUES
+  (7000, 700, 'D700 Q1', 'A1', 1000),
+  (7100, 710, 'D710 Q1', 'A1', 1000);
+
+SET LOCAL role = 'postgres';
+
+-- Stamp the grace deadline (11 decks > the free deck_limit of 10).
+SELECT public.begin_downgrade_grace('e0000000-0000-0000-0000-00000000d001'::uuid);
+
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000d001'::uuid);
+SET LOCAL role = 'authenticated';
+
+
+-- ── get_study_session_cards [obligation] ──────────────────────────────────────
+
+-- Test 1: the locked deck yields no study cards, despite having one available.
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.get_study_session_cards(710, date_trunc('day', now()))
+  ),
+  0,
+  'get_study_session_cards() returns zero rows for a locked deck [obligation]'
+);
+
+
+-- ── get_session_decks_and_cards [obligation] ──────────────────────────────────
+
+-- Test 2: the locked deck has no entry in 'decks' ...
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM jsonb_array_elements(
+      (public.get_session_decks_and_cards(ARRAY[700, 710], date_trunc('day', now())))->'decks'
+    ) AS d
+    WHERE (d->>'id')::int = 710
+  ),
+  0,
+  'get_session_decks_and_cards() omits a locked deck from ''decks'' [obligation]'
+);
+
+-- Test 3: ... nor any cards.
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM jsonb_array_elements(
+      (public.get_session_decks_and_cards(ARRAY[700, 710], date_trunc('day', now())))->'cards'
+    ) AS c
+    WHERE (c->>'deck_id')::int = 710
+  ),
+  0,
+  'get_session_decks_and_cards() omits a locked deck''s cards [obligation]'
+);
+
+-- Test 4: the unlocked deck passed alongside it is unaffected.
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM jsonb_array_elements(
+      (public.get_session_decks_and_cards(ARRAY[700, 710], date_trunc('day', now())))->'decks'
+    ) AS d
+    WHERE (d->>'id')::int = 700
+  ),
+  1,
+  'get_session_decks_and_cards() still includes the unlocked deck alongside the locked one'
+);
+
+-- Test 5: ... and its cards still come through.
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM jsonb_array_elements(
+      (public.get_session_decks_and_cards(ARRAY[700, 710], date_trunc('day', now())))->'cards'
+    ) AS c
+    WHERE (c->>'deck_id')::int = 700
+  ),
+  1,
+  'get_session_decks_and_cards() still includes the unlocked deck''s cards'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/00038_purge_downgraded_decks.sql
+++ b/supabase/tests/00038_purge_downgraded_decks.sql
@@ -1,0 +1,155 @@
+-- =============================================================================
+-- purge_downgraded_decks(): the daily sweep.
+--
+-- Deletes only decks ranked beyond deck_limit for a free member whose
+-- downgrade_delete_at is in the past. Mirrors deck_lock_deadline()'s own
+-- rank math, so whatever reads as locked at sweep time is what gets deleted.
+--
+-- Covers [obligation]:
+--   1. A member past their deadline loses every deck beyond deck_limit; the
+--      top deck_limit survive.
+--   2. A member still within the deadline loses nothing.
+--   3. A member who resubscribed (deadline cleared) loses nothing.
+--   4. A member who reordered a deck above the line before the sweep keeps it.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(10);
+
+-- ── Setup (as postgres superuser) ─────────────────────────────────────────────
+
+SELECT tests.create_user('e0000000-0000-0000-0000-00000000f001'::uuid, 'purge_gary');
+SELECT tests.create_user('e0000000-0000-0000-0000-00000000f002'::uuid, 'purge_helen');
+SELECT tests.create_user('e0000000-0000-0000-0000-00000000f003'::uuid, 'purge_ivan');
+SELECT tests.create_user('e0000000-0000-0000-0000-00000000f004'::uuid, 'purge_julia');
+
+-- Gary: 12 decks, deadline already past — the sweep should fire.
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000f001'::uuid);
+SET LOCAL role = 'authenticated';
+INSERT INTO public.decks (id, title, is_public) VALUES
+  (900, 'Gary 900', false), (901, 'Gary 901', false), (902, 'Gary 902', false),
+  (903, 'Gary 903', false), (904, 'Gary 904', false), (905, 'Gary 905', false),
+  (906, 'Gary 906', false), (907, 'Gary 907', false), (908, 'Gary 908', false),
+  (909, 'Gary 909', false), (910, 'Gary 910', false), (911, 'Gary 911', false);
+SET LOCAL role = 'postgres';
+UPDATE public.members SET downgrade_delete_at = now() - interval '1 hour'
+WHERE id = 'e0000000-0000-0000-0000-00000000f001';
+
+-- Helen: 12 decks, deadline still 10 days out — the sweep should skip her.
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000f002'::uuid);
+SET LOCAL role = 'authenticated';
+INSERT INTO public.decks (id, title, is_public) VALUES
+  (920, 'Helen 920', false), (921, 'Helen 921', false), (922, 'Helen 922', false),
+  (923, 'Helen 923', false), (924, 'Helen 924', false), (925, 'Helen 925', false),
+  (926, 'Helen 926', false), (927, 'Helen 927', false), (928, 'Helen 928', false),
+  (929, 'Helen 929', false), (930, 'Helen 930', false), (931, 'Helen 931', false);
+SET LOCAL role = 'postgres';
+UPDATE public.members SET downgrade_delete_at = now() + interval '10 days'
+WHERE id = 'e0000000-0000-0000-0000-00000000f002';
+
+-- Ivan: 12 decks, deadline was set then cleared (resubscribed).
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000f003'::uuid);
+SET LOCAL role = 'authenticated';
+INSERT INTO public.decks (id, title, is_public) VALUES
+  (940, 'Ivan 940', false), (941, 'Ivan 941', false), (942, 'Ivan 942', false),
+  (943, 'Ivan 943', false), (944, 'Ivan 944', false), (945, 'Ivan 945', false),
+  (946, 'Ivan 946', false), (947, 'Ivan 947', false), (948, 'Ivan 948', false),
+  (949, 'Ivan 949', false), (950, 'Ivan 950', false), (951, 'Ivan 951', false);
+SET LOCAL role = 'postgres';
+UPDATE public.members SET downgrade_delete_at = now() - interval '1 hour'
+WHERE id = 'e0000000-0000-0000-0000-00000000f003';
+SELECT public.clear_downgrade_grace('e0000000-0000-0000-0000-00000000f003'::uuid);
+
+-- Julia: 12 decks, deadline past, but she reorders her locked deck (951)
+-- above the limit line before the sweep runs.
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000f004'::uuid);
+SET LOCAL role = 'authenticated';
+INSERT INTO public.decks (id, title, is_public) VALUES
+  (960, 'Julia 960', false), (961, 'Julia 961', false), (962, 'Julia 962', false),
+  (963, 'Julia 963', false), (964, 'Julia 964', false), (965, 'Julia 965', false),
+  (966, 'Julia 966', false), (967, 'Julia 967', false), (968, 'Julia 968', false),
+  (969, 'Julia 969', false), (970, 'Julia 970', false), (971, 'Julia 971', false);
+SET LOCAL role = 'postgres';
+UPDATE public.members SET downgrade_delete_at = now() - interval '1 hour'
+WHERE id = 'e0000000-0000-0000-0000-00000000f004';
+
+SELECT tests.set_claims('e0000000-0000-0000-0000-00000000f004'::uuid);
+SET LOCAL role = 'authenticated';
+SELECT public.move_deck(971, 960, 'before');
+SET LOCAL role = 'postgres';
+SELECT tests.set_claims(NULL);
+
+
+-- ── Run the sweep ──────────────────────────────────────────────────────────────
+
+SELECT public.purge_downgraded_decks();
+
+
+-- ── Gary: past deadline, over the limit — top deck_limit survive [obligation] ──
+
+SELECT is(
+  (SELECT count(*)::int FROM public.decks WHERE member_id = 'e0000000-0000-0000-0000-00000000f001'),
+  10,
+  'purge_downgraded_decks() leaves only the top deck_limit decks for a member past their deadline [obligation]'
+);
+
+SELECT ok(
+  NOT EXISTS (SELECT 1 FROM public.decks WHERE id = 910),
+  'purge_downgraded_decks() deletes a deck ranked beyond the limit [obligation]'
+);
+
+SELECT ok(
+  NOT EXISTS (SELECT 1 FROM public.decks WHERE id = 911),
+  'purge_downgraded_decks() deletes every deck ranked beyond the limit, not just the first [obligation]'
+);
+
+SELECT ok(
+  EXISTS (SELECT 1 FROM public.decks WHERE id = 900),
+  'purge_downgraded_decks() leaves a top-ranked deck untouched'
+);
+
+
+-- ── Helen: still within the deadline — loses nothing [obligation] ────────────
+
+SELECT is(
+  (SELECT count(*)::int FROM public.decks WHERE member_id = 'e0000000-0000-0000-0000-00000000f002'),
+  12,
+  'purge_downgraded_decks() touches nothing for a member still within their deadline [obligation]'
+);
+
+
+-- ── Ivan: resubscribed (deadline cleared) — loses nothing [obligation] ───────
+
+SELECT is(
+  (SELECT count(*)::int FROM public.decks WHERE member_id = 'e0000000-0000-0000-0000-00000000f003'),
+  12,
+  'purge_downgraded_decks() touches nothing for a member whose deadline was cleared [obligation]'
+);
+
+
+-- ── Julia: reordered a deck above the line — that deck survives [obligation] ──
+
+SELECT ok(
+  EXISTS (SELECT 1 FROM public.decks WHERE id = 971),
+  'purge_downgraded_decks() spares a deck reordered above the limit line before the sweep [obligation]'
+);
+
+SELECT is(
+  (SELECT count(*)::int FROM public.decks WHERE member_id = 'e0000000-0000-0000-0000-00000000f004'),
+  10,
+  'purge_downgraded_decks() still purges down to deck_limit for Julia, dynamically recomputed after her reorder'
+);
+
+SELECT ok(
+  NOT EXISTS (SELECT 1 FROM public.decks WHERE id = 969),
+  'purge_downgraded_decks() deletes the deck displaced past the line by Julia''s reorder'
+);
+
+SELECT ok(
+  NOT EXISTS (SELECT 1 FROM public.decks WHERE id = 970),
+  'purge_downgraded_decks() deletes every deck displaced past the line by Julia''s reorder'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/00039_downgrade_lock_grants.sql
+++ b/supabase/tests/00039_downgrade_lock_grants.sql
@@ -1,0 +1,99 @@
+-- =============================================================================
+-- Downgrade-lock function grants — the SECURITY DEFINER/INVOKER lockdown from
+-- 20260801230820_downgrade-lock-grants-and-cron.sql.
+--
+-- `supabase db diff` emits zero function grants, so this is the only thing
+-- that catches a freshly-created function landing back on PUBLIC's default
+-- EXECUTE the next time the schema is regenerated.
+--
+-- Covers [obligation]: purge_downgraded_decks(), begin_downgrade_grace(),
+-- and clear_downgrade_grace() are not executable by anon or authenticated.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(12);
+
+-- ── purge_downgraded_decks(): reaches NO client, not even service_role ───────
+-- (the cron job runs as postgres, which owns it and keeps EXECUTE regardless)
+
+SELECT is(
+  has_function_privilege('anon', 'public.purge_downgraded_decks()', 'EXECUTE'),
+  false,
+  'anon cannot execute purge_downgraded_decks() [obligation]'
+);
+
+SELECT is(
+  has_function_privilege('authenticated', 'public.purge_downgraded_decks()', 'EXECUTE'),
+  false,
+  'authenticated cannot execute purge_downgraded_decks() [obligation]'
+);
+
+SELECT is(
+  has_function_privilege('service_role', 'public.purge_downgraded_decks()', 'EXECUTE'),
+  false,
+  'service_role cannot execute purge_downgraded_decks() — only the owner (postgres) can'
+);
+
+SELECT is(
+  has_function_privilege('postgres', 'public.purge_downgraded_decks()', 'EXECUTE'),
+  true,
+  'postgres (owner, the role pg_cron runs as) retains EXECUTE on purge_downgraded_decks()'
+);
+
+
+-- ── begin_downgrade_grace(uuid): service_role (the webhook) + postgres only ──
+
+SELECT is(
+  has_function_privilege('anon', 'public.begin_downgrade_grace(uuid)', 'EXECUTE'),
+  false,
+  'anon cannot execute begin_downgrade_grace() [obligation]'
+);
+
+SELECT is(
+  has_function_privilege('authenticated', 'public.begin_downgrade_grace(uuid)', 'EXECUTE'),
+  false,
+  'authenticated cannot execute begin_downgrade_grace() [obligation]'
+);
+
+SELECT is(
+  has_function_privilege('service_role', 'public.begin_downgrade_grace(uuid)', 'EXECUTE'),
+  true,
+  'service_role (the stripe-webhook) can execute begin_downgrade_grace() [obligation]'
+);
+
+SELECT is(
+  has_function_privilege('postgres', 'public.begin_downgrade_grace(uuid)', 'EXECUTE'),
+  true,
+  'postgres (owner) retains EXECUTE on begin_downgrade_grace()'
+);
+
+
+-- ── clear_downgrade_grace(uuid): service_role (the webhook) + postgres only ──
+
+SELECT is(
+  has_function_privilege('anon', 'public.clear_downgrade_grace(uuid)', 'EXECUTE'),
+  false,
+  'anon cannot execute clear_downgrade_grace() [obligation]'
+);
+
+SELECT is(
+  has_function_privilege('authenticated', 'public.clear_downgrade_grace(uuid)', 'EXECUTE'),
+  false,
+  'authenticated cannot execute clear_downgrade_grace() [obligation]'
+);
+
+SELECT is(
+  has_function_privilege('service_role', 'public.clear_downgrade_grace(uuid)', 'EXECUTE'),
+  true,
+  'service_role (the stripe-webhook) can execute clear_downgrade_grace() [obligation]'
+);
+
+SELECT is(
+  has_function_privilege('postgres', 'public.clear_downgrade_grace(uuid)', 'EXECUTE'),
+  true,
+  'postgres (owner) retains EXECUTE on clear_downgrade_grace()'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
[TARO-265](https://app.notion.com/3ac0953c224c8133ba49cfaf904d5602)

## Summary

Server side of the free-downgrade flow. When a member downgrades to free with more decks than the plan's `deck_limit`, an account-level 15-day grace deadline (`members.downgrade_delete_at`) is stamped and every deck ranked beyond the limit locks. Locked-ness is **fully derived** from rank + plan + deadline via `deck_lock_deadline()` — no per-deck column — so a `move_deck` reorder across the line re-locks live with no extra write. Locked decks return no study cards and report `due_count = 0` (dropping out of every due surface) while staying fully readable and editable. A daily `pg_cron` sweep hard-deletes still-locked decks past the deadline; resubscribing clears the deadline and unlocks everything. Dashboard UI is a separate ticket.

## Changes

- **State** — `members.downgrade_delete_at` (nullable, no default); the member self-update policy freezes the column. `begin_downgrade_grace` / `clear_downgrade_grace` are service_role-only.
- **Derived lock** — `deck_lock_deadline()` computes locked-ness from rank vs `plans.deck_limit` while the deadline is set and `plan = 'free'` (limit is never hardcoded).
- **Reads** — `get_member_decks` annotates `is_locked` + deletion date and forces `due_count = 0` for locked decks; `get_study_session_cards` and `get_session_decks_and_cards` return nothing for a locked deck. Card reads/writes and `move_cards_to_deck` stay ungated so members can migrate cards out.
- **Webhook** — `stripe-webhook` stamps grace on `markFree` and clears it on the upgrade path (refactored behind a DI seam for testability).
- **Sweep** — daily `pg_cron` `purge_downgraded_decks` (SECURITY DEFINER, grants locked down); media reclaim rides the existing deck-delete soft-delete trigger + `cleanup-media` reaper. Mirrors the account-deletion grace/reaper pattern.

## Test plan

- [ ] Downgrade with >10 decks → top 10 usable, rest locked with a 15-day deadline; ≤10 decks → nothing locked
- [ ] Locked deck → 0 due, excluded from study-all-due, not reviewable; still openable/editable, cards movable
- [ ] Reorder a deck across rank 10 → lock state flips live
- [ ] Resubscribe before deadline → deadline cleared, all decks unlocked, FSRS state intact
- [ ] Sweep at deadline → still-locked decks deleted, images reclaimed; re-reconcile is idempotent
