### PR TITLE
Self-heal: /work review-loop mechanics

### DIFF
--- a/.claude/docs/code-style-comments.md
+++ b/.claude/docs/code-style-comments.md
@@ -1,0 +1,22 @@
+# Comments
+
+Comment the non-obvious _why_, never the _what_. Most code needs none — a clear name beats a comment.
+
+- **One line, maybe two.** A comment that needs a paragraph means the code is too clever (simplify it) or the rationale belongs in the commit message, not the source.
+- **No narration.** Don't restate the next line (`// loop over items`) or label a section (`// setup`) — blank-line phases already segment a body ([`code-style-phases`](./code-style-phases.md)).
+- **None in `<template>` markup** — see [`vue-templates`](../rules/vue-templates.md). Improve `data-testid` / slot / component names instead.
+- **JSDoc on exported composable fns** stays tight — lead with behaviour, skip restating types ([`composables`](../rules/composables.md)).
+
+Bad — three lines narrating one branch:
+
+```ts
+// A cached image (flipping the preview away and back) is already complete;
+// decode() can reject on the reinserted element, so skip it and reveal
+// straight away rather than waiting on a decode that never settles.
+```
+
+Good:
+
+```ts
+// Cached image can reject decode() on reinsert — skip decode when already loaded.
+```

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -6,9 +6,10 @@ paths:
 
 # Code Style
 
-Four rules; each is a quick read. Apply every edit.
+Five rules; each is a quick read. Apply every edit.
 
 - [`code-style-phases`](../docs/code-style-phases.md) — blank lines mark phases inside a function body
 - [`code-style-nesting`](../docs/code-style-nesting.md) — at most one level of `if` / `for` / `try`; invert + return early
 - [`code-style-responsibility`](../docs/code-style-responsibility.md) — orchestrator OR worker, never both
 - [`code-style-variants`](../docs/code-style-variants.md) — no unused size/variant maps
+- [`code-style-comments`](../docs/code-style-comments.md) — comment the non-obvious _why_; terse, none in templates

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -223,7 +223,9 @@ Propose first, never create silently. Give a one-line scope, not a full spec. Se
 Notion built-in via its hosted SVG — `https://www.notion.so/icons/<name>_<color>.svg` (colours:
 `gray|brown|orange|yellow|green|blue|purple|pink|red`). Not an emoji. The bare
 `icons/<name>_<color>` path is accepted by the API but **renders blank** — always the full `.svg`
-URL.
+URL. **Validate the name resolves first** — `curl -s -o /dev/null -w '%{http_code}'
+https://www.notion.so/icons/<name>_<color>.svg` must be `200`; an unknown name is accepted silently
+and renders blank (`gear_gray` ✓, `settings_gray` ✗).
 
 ## Dependencies
 

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -13,7 +13,9 @@ out-of-scope work is found mid-task.
 - **Epic Board** data source: `collection://2510953c-224c-80b7-9bb0-000b5384a47d`
 - **MCP server**: `notion`. **Read** with `notion-query-data-sources` (SQL over the data source) +
   `notion-fetch` (page body — the query returns properties only). **Create** with
-  `notion-create-pages`. **Update** with `notion-update-page`.
+  `notion-create-pages`, always passing the board's default page template
+  (`template_id: 3af0953c224c800d984cf0b443d67d20`) so the ticket inherits its default icon and
+  field defaults. **Update** with `notion-update-page`.
 - `Status`: `On Hold` · `Backlog` · `Needs More Info` · `Groomed` · `Ready` · `In Progress` ·
   `Blocked` · `Review` · `Duplicate` · `Won't Do` · `Done`. Status is a plain property write — set
   it directly, no transition step. `/groom` lands tickets in `Groomed`; the user promotes them to

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -109,7 +109,10 @@ Dispatch all subagents in a single message (multiple `Agent` calls) so they run 
 - Prompt carries the ticket's title + body + acceptance criteria and instructs the subagent to:
   **rename** the worktree's existing branch to a conventional name (`git branch -m <fix/…|feat/…>`) —
   **not** `git checkout -b`, which orphans the auto-created `worktree-agent-<id>` branch as junk —
-  implement to the acceptance criteria, and follow `.claude/rules/*`.
+  implement to the acceptance criteria, and follow `.claude/rules/*` — call out `code-style` and
+  `vue-templates` explicitly in the prompt: comments are terse one-liners for the non-obvious _why_,
+  never multi-line prose, and never inside `<template>` markup. Verbose subagent comments are a
+  recurring review complaint.
 - **Tests via `update-tests`, not the full suite.** After implementing, the subagent invokes the
   **`update-tests`** skill to cover its own change, then runs **`vp check`** (format + lint +
   type-check) green. It does **not** run the full `vp test` suite — parallel subagents each running

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -150,7 +150,7 @@ d. **OPEN** — for each non-blocked ticket, invoke the **`prepare-pr`** skill w
    --ticket-url <url>` (the ticket's `<ID>` and its Notion page URL) → one PR titled `TARO-<ID>: …`
 whose body opens with a `[TARO-<ID>](<url>)` link. Pass the stack base when the PR is stacked.
 `prepare-pr` watches CI; **a PR isn't done until it's green.** If CI fails, route it through the
-**Review & feedback loop** (below) — a main-workspace fix subagent on the PR branch; if it still
+**Review & feedback loop** (below) — an inline main-checkout fix on the PR branch; if it still
 can't pass after real effort, treat the ticket as stuck.
 e. **HANDOFF** — for each opened, green PR: set the ticket to `Review`, append the PR URL into the
 ticket body via `notion-update-page` (append, don't clobber the body).
@@ -182,18 +182,25 @@ usually come back **one PR at a time**, leaving comments on that PR.
 Every follow-up change — user review feedback, a red CI run, or any other fix the PR needs — is
 handled the same way:
 
-1. **Dispatch a fix subagent on the MAIN workspace** (not a worktree). It **checks out the PR branch**
-   in the main checkout. The user keeps a dev server running against the main workspace and verifies
-   each fix **live**, so the fix must land on the branch they're looking at. Model: the ticket's
-   `Assignee`. Work one PR at a time (the user goes in order), so only one fix subagent touches the
-   main checkout at once.
-2. **Fix — plus tests.** The subagent makes the code change and runs `update-tests` for it — new
-   coverage for the new behaviour plus repairs to any test the change breaks (golden "no tests" rule
-   stays suspended in `/work`).
+1. **Fix inline, in the orchestrator session — no subagent by default.** Once the PRs are open the
+   parallel build is over; dispatching a subagent per one-line review tweak is heavyweight and
+   serializes badly. The orchestrator edits the PR branch **directly in the main checkout** — the user
+   runs a dev server against it and verifies each fix **live**, so the fix must land on the branch
+   they're looking at. Check the PR branch out in the main checkout, edit, commit per logical fix. Work
+   **one PR at a time** (the user goes in order). Fall back to a fix subagent (still on the main
+   checkout, never a fresh worktree) only when an initial-build subagent is still live on that checkout
+   — editing the same tree concurrently would collide — or when the fix is large enough to warrant its
+   own agent.
+2. **Leave tests alone until the user asks.** Default to **not touching tests** during the feedback
+   loop — the golden "no tests" rule is back in force here; the user very commonly wants tests left
+   untouched while they reshape the code. Do **not** run `update-tests` per fix. When the user says
+   they're ready for tests, run **one** consolidated `update-tests` pass over everything the review
+   changed. (A user "put tests on hold" mid-review just confirms this default; honour it immediately.)
 3. **Check, push, watch green.** Run `vp check`, push to the PR branch, and let CI run (via
    `prepare-pr` or directly). A PR isn't done until CI is green again — no local full-suite run.
-4. **Answer the thread.** Reply to the feedback on the PR prefixed `🤖 Claude:` so the user can tell
-   your replies from their own. Leave the ticket in `Review`.
+4. **Answer the thread.** If the feedback came on the PR, reply prefixed `🤖 Claude:` so the user can
+   tell your replies from their own; feedback given in chat is answered in chat. Leave the ticket in
+   `Review`.
 
 Repeat per PR until the user merges. **Never merge and never set `Done` yourself** — that stays the
 user's call, exactly as at first handoff.
@@ -240,18 +247,20 @@ review of it confirms or kills the generalization, so there is no inline confirm
   takeable.
 - Never work an `On Hold` or `Assignee = Me` ticket (the user's hands-off, and not in `Ready`
   anyway), and never run a backend teaching persona — `/work` is autonomous.
-- **Tests run via `update-tests`.** The golden "no tests" rule is suspended in `/work`: each subagent
-  (and each feedback-fix subagent) invokes `update-tests` for its change. No subagent runs the full
-  `vp test` suite — CI is the gate the orchestrator watches.
+- **Tests: suspended only for the initial build.** Each initial-build subagent invokes `update-tests`
+  for its change (golden "no tests" rule suspended there); no subagent runs the full `vp test` suite —
+  CI is the gate the orchestrator watches. In the **Review & feedback loop the rule is back on**: don't
+  touch tests until the user asks, then one consolidated `update-tests` pass over all the review edits.
 - One PR per ticket (via `prepare-pr`). Don't batch multiple tickets into a single PR.
 - Self-heal ships to the shared `self-heal` PR (§ Self-heal), never merged and separate from ticket
   PRs — a rule fix rides its own stream, never a ticket branch.
-- The orchestrator runs from its **own worktree** (step 0) and never edits ticket code — subagents
-  do. Out-of-scope side requests during the run are done on that orchestrator worktree. Initial ticket
-  implementation happens in per-ticket **worktrees**, which the subagent **removes when done** (except
-  a stuck ticket, whose worktree is left for inspection). Post-open **fixes happen on the main
-  workspace** on the checked-out PR branch, one PR at a time, so the user's live dev server reflects
-  them.
+- The orchestrator runs from its **own worktree** (step 0). During the **initial build** it never
+  edits ticket code — subagents do, in per-ticket **worktrees**, which the subagent **removes when
+  done** (except a stuck ticket, whose worktree is left for inspection). Out-of-scope side requests
+  during the run are done on the orchestrator worktree. **Post-open review fixes are edited inline by
+  the orchestrator** on the checked-out PR branch in the **main checkout**, one PR at a time, so the
+  user's live dev server reflects them — a fix subagent is the fallback, not the default (§ Review &
+  feedback loop).
 - **Subagents stay inside their own worktree.** Each works only under its `.claude/worktrees/agent-<id>`
   path — never edits the shared/main checkout, and never reverts a shared-checkout file (that can
   destroy the user's uncommitted work); it stops and reports instead.


### PR DESCRIPTION
Living self-heal PR (never auto-merged — you merge when satisfied).

## Lesson

From the TARO-7 review pass: once `/work` PRs are open, review fixes should be done **inline in the orchestrator session**, not via a dispatched subagent per change; and tests should be **left untouched until explicitly asked**, not auto-run via `update-tests` on every fix.

## Change

`.claude/skills/work/SKILL.md` — Review & feedback loop + matching guardrails:
- Inline main-checkout fixes are the default; a fix subagent is the fallback (initial-build agent still on the checkout, or a large fix).
- Golden no-tests rule is back in force for the feedback loop — one consolidated `update-tests` pass when the user says they're ready.
- CI-failure path and the orchestrator/tests guardrails updated to match.