### PR TITLE
Drive stripe listen with the durable Doppler key

### DIFF
--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -15,5 +15,7 @@ procs:
     shell: 'vp dev --host'
   # Forwards Stripe webhook events to the local stripe-webhook function.
   # Requires STRIPE_WEBHOOK_SECRET cached by scripts/bootstrap-env.sh.
+  # --api-key uses the durable Doppler key (present via `doppler run`) so listen
+  # never falls back to the CLI's `stripe login` key, which expires every ~90d.
   stripe:
-    shell: 'stripe listen --forward-to http://localhost:54321/functions/v1/stripe-webhook'
+    shell: 'stripe listen --api-key "$STRIPE_SECRET_KEY" --forward-to http://localhost:54321/functions/v1/stripe-webhook'

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -14,7 +14,8 @@ touch "$ENV_FILE"
 # Signing secret is stable per Stripe CLI login, so fetch once and reuse.
 if ! grep -q '^STRIPE_WEBHOOK_SECRET=' "$ENV_FILE"; then
   echo "Fetching Stripe webhook secret..."
-  secret=$(stripe listen --print-secret)
+  # --api-key: use the durable Doppler key, not the CLI's expiring login key.
+  secret=$(stripe listen --api-key "$(doppler secrets get STRIPE_SECRET_KEY --plain)" --print-secret)
   echo "STRIPE_WEBHOOK_SECRET=$secret" >> "$ENV_FILE"
   echo "Cached STRIPE_WEBHOOK_SECRET → $ENV_FILE"
 fi


### PR DESCRIPTION
## Summary

Local Stripe webhook forwarding broke with `api_key_expired` (401): the `stripe` mprocs pane and `bootstrap-env.sh` ran `stripe listen` with no `--api-key`, so they used the CLI's `stripe login` device key — which expires every ~90 days.

Both now pass `--api-key` sourced from the durable `STRIPE_SECRET_KEY` (already injected by `doppler run` for mprocs; fetched via `doppler secrets get` in bootstrap), so local Stripe keeps working without periodic `stripe login`. Verified the key authenticates `stripe listen` and its webhook secret matches the cached `STRIPE_WEBHOOK_SECRET`.