### PR TITLE
Fix cover image vanishing after a preview flip (mobile preview)

### DIFF
--- a/src/components/card/card-cover.vue
+++ b/src/components/card/card-cover.vue
@@ -12,7 +12,7 @@ const img_el = useTemplateRef<HTMLImageElement>('img')
 // image_path (public URL or staged objectURL) makes a custom image fill the
 // cover; palette/pattern/icon stay configured but never render behind it.
 const has_image = computed(() => !!cover?.image_path)
-const { decoded } = useImageReveal(() => cover?.image_path, img_el)
+const { decoded, onLoad } = useImageReveal(() => cover?.image_path, img_el)
 
 // While decoding, show the shared SKELETON_COVER so loading matches the app
 // skeleton; once decoded, drop chrome (null) for the full-bleed image.
@@ -42,6 +42,7 @@ const bindings = computed(() => {
       :src="cover!.image_path"
       class="card-cover__image absolute inset-0 h-full w-full object-cover"
       :class="decoded ? 'opacity-100' : 'opacity-0'"
+      @load="onLoad"
     />
 
     <div

--- a/src/composables/card/image-reveal.ts
+++ b/src/composables/card/image-reveal.ts
@@ -2,9 +2,12 @@ import { nextTick, ref, toValue, watch, type MaybeRefOrGetter, type ShallowRef }
 import { revealFaceImage } from '@/utils/animations/face-image'
 
 /**
- * Gate a face/cover image behind decode: `decoded` stays false (caller shows a
- * skeleton) until the `<img>` decodes, then fades in via revealFaceImage. Re-runs
- * on every `source` change, including the element being reinserted after a flip.
+ * Gate a face/cover image behind load: `decoded` stays false (caller shows a
+ * skeleton) until the `<img>` has loaded, then fades it in via revealFaceImage.
+ * Re-runs on every `source` change, including the element being reinserted after
+ * a flip. Bind the returned `onLoad` to the `<img>`'s `@load` — a reinserted
+ * element can reject `decode()` mid-flip and isn't `complete` on the first tick,
+ * so the load event is the reliable reveal signal; decode is only a fast path.
  *
  * @param source - getter for the image src; falsy clears `decoded`.
  * @param img - template ref to the `<img>` being revealed.
@@ -15,43 +18,41 @@ export function useImageReveal(
 ) {
   const decoded = ref(false)
 
-  async function decodeThenReveal() {
-    decoded.value = false
-    await nextTick()
-
+  async function reveal() {
     const el = img.value
-    if (!el) return
-
-    // A cached image (flip away + back) is already loaded, and decode() can
-    // reject on the reinserted element — skip decode when it's already loaded.
-    if (!isLoaded(el)) {
-      try {
-        await el.decode()
-      } catch {
-        // Bail only if genuinely not loaded (src changed mid-flight); a loaded
-        // image reveals anyway so the skeleton never sticks.
-        if (!isLoaded(el)) return
-      }
-    }
-
+    if (!el || decoded.value) return
     decoded.value = true
     await nextTick()
     if (img.value) revealFaceImage(img.value)
   }
 
+  async function decodeThenReveal() {
+    await nextTick()
+
+    const el = img.value
+    if (!el) return
+    if (isLoaded(el)) return reveal()
+
+    try {
+      await el.decode()
+      await reveal()
+    } catch {
+      // decode() can reject on an element reinserted mid-flip; reveal if it did
+      // load, else the <img>'s @load (onLoad) will — never leave it stuck.
+      if (isLoaded(el)) reveal()
+    }
+  }
+
   watch(
     () => toValue(source),
     (path) => {
-      if (!path) {
-        decoded.value = false
-        return
-      }
-      decodeThenReveal()
+      decoded.value = false
+      if (path) decodeThenReveal()
     },
     { immediate: true }
   )
 
-  return { decoded }
+  return { decoded, onLoad: reveal }
 }
 
 function isLoaded(el: HTMLImageElement) {


### PR DESCRIPTION
## Summary

Fixes the cover image disappearing after flipping the deck-settings design preview away from the cover and back — reproducible in Chrome's phone-layout (mobile) preview.

## Root cause

Flipping re-renders the preview card, reinserting the cover `<img>`. `useImageReveal` gated the reveal on `img.decode()`: on the reinserted element `decode()` can reject mid-flip, and the cached-blob image isn't `complete` on the first tick, so the code bailed and `decoded` never flipped back to true — the cover stayed blank. It's engine-independent (same Blink in the mobile preview); the phone-layout flip timing is just what exposes it.

## Fix

Drive the reveal off the `<img>`'s `load` event instead of solely `decode()`:

- `useImageReveal` now returns an `onLoad` handler bound to the image's `@load`, so the reveal fires whenever the image finishes loading — including a reinserted element.
- `decode()` stays as a fast path (clean first paint when it resolves) but is no longer the only signal, and a rejection never leaves the cover stuck.

## Test plan

- [ ] Deck with a cover image → deck settings (phone/mobile preview) → flip cover→front→back→cover → cover image reappears (previously blank).
- [ ] Desktop preview still reveals correctly on first open and on flip-back.
- [ ] First-time upload still shows the skeleton then fades the image in.
