### PR TITLE
docs(task-board): extract board schema; migrate Target to quarter scheme

### DIFF
--- a/.claude/agents/ticket-author.md
+++ b/.claude/agents/ticket-author.md
@@ -7,9 +7,10 @@ model: sonnet
 
 You are **the Ticket Author**. You turn findings into Task Board tickets and stop there.
 
-**Read `.claude/rules/ticket-authoring.md` first, every run.** It is the source of truth for the
-board constants, field defaults, the body section list, brevity, and authoring voice. What follows
-is only your operating loop.
+**Read `.claude/rules/ticket-authoring.md` and `.claude/rules/task-board-schema.md` first, every
+run.** `task-board-schema.md` is the source of truth for the board data sources, fields, and option
+lists; `ticket-authoring.md` for field defaults, the body section list, brevity, and authoring voice.
+What follows is only your operating loop.
 
 ## What you're invoked with
 

--- a/.claude/rules/task-board-schema.md
+++ b/.claude/rules/task-board-schema.md
@@ -1,0 +1,101 @@
+# Task Board Schema
+
+**The single source of truth for the board's shape** — data sources, the MCP server, and every field
+with its option list. Skills and the authoring rule reference this file instead of re-listing
+constants; change a field here once and every consumer follows.
+
+- This file owns the **schema** (what fields exist, their options, their semantics).
+- [`ticket-authoring.md`](./ticket-authoring.md) owns **authoring** (body sections, brevity, voice,
+  which fields a stage fills).
+
+> **The live board is the ultimate source of truth, not this file.** Option lists drift — a hardcoded
+> vocabulary here once went stale and `Spike` was invisible for months. `notion-fetch` on a data-source
+> URL returns the live options; check when a value seems not to fit, and fix this file. This is doubly
+> true for **`Target`**, whose quarter options roll forward over time (see below).
+
+## Data sources
+
+- **MCP server**: `notion`.
+- **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`
+- **Epic Board** data source: `collection://2510953c-224c-80b7-9bb0-000b5384a47d`
+- **Default page template** (pass on every `notion-create-pages` so the ticket inherits its default
+  icon + field defaults): `template_id: 3af0953c224c800d984cf0b443d67d20`
+
+**Read** with `notion-query-data-sources` (SQL over the data source) + `notion-fetch` (page body — the
+query returns properties only). **Create** with `notion-create-pages`. **Update** with
+`notion-update-page`. Status and all field writes are plain property writes — no transition step.
+Add/remove/rename a field's **options** with `notion-update-data-source`
+(`ALTER COLUMN "<field>" SET SELECT(...)`); dropping an option nulls any page still on it, so migrate
+first and verify with a row-level `WHERE id IN (…)` query — Notion's aggregate `COUNT/GROUP BY` reads
+lag row writes.
+
+## Fields
+
+### `Status` — a `status`-type field (grouped)
+
+`On Hold` · `Backlog` · `Needs More Info` · `Groomed` · `Ready` · `In Progress` · `Blocked` ·
+`Review` · `Duplicate` · `Won't Do` · `Done`. A plain property write — set it directly.
+
+- **`complete` group** = `Done` · `Won't Do` · `Duplicate`. A `Blocked By` blocker is cleared only
+  when its status is in this group.
+- **`On Hold` = hands-off** (user-owned), same as `Assignee = Me`.
+- Lane ownership by stage: `/triage` → `Needs More Info`; `/groom` → `Groomed`; the user promotes
+  `Groomed` → `Ready`; `/work` claims `Ready` → `In Progress` → `Review`. New tickets are `Backlog`.
+
+### `Priority` — `select` (a ticket's urgency)
+
+`⇞P0` · `↑P1` · `↓P2` · `⇟P3`. **The glyphs sort by codepoint, not urgency** —
+`↑`(P1, U+2191) `↓`(P2, U+2193) `⇞`(P0, U+21DE) `⇟`(P3, U+21DF) — so a raw `ORDER BY "Priority"`
+buries every P0 below P1/P2 and a null leaps to the top. Always rank with a `CASE`:
+
+```sql
+CASE "Priority" WHEN '⇞P0' THEN 0 WHEN '↑P1' THEN 1 WHEN '↓P2' THEN 2 WHEN '⇟P3' THEN 3 ELSE 4 END
+```
+
+### `Type` — `select`
+
+`Bug` (broken) · `Task` (defined change) · `Story` (user-facing capability) · `Spike` (the deliverable
+is a decision, not shipped code).
+
+### `Target` — `select` (which release/quarter it ships in)
+
+`MVP` · `Q3 '26` · `Q4 '26` · `Q1 '27` · `side`.
+
+- **`MVP`** — launch scope: everything gating the first ship. Occupies the current quarter alongside a
+  few pulled-in tickets; kept as its own value rather than folded into the current quarter.
+- **`Q3 '26` / `Q4 '26` / `Q1 '27`** — **rolling quarter buckets**. `Q3 '26` is the current quarter.
+  As the horizon advances, **add the next quarter's option** (`Q2 '27`, …) and retire quarters once
+  empty — the option set here is a snapshot, the live board is authoritative.
+- **`side`** — side / experimental work, orthogonal to the roadmap.
+
+`Target`'s options are **not** alphabetical and won't sort by urgency; rank with a `CASE` that lists
+`MVP` first, then quarters chronologically, unset last:
+
+```sql
+CASE "Target" WHEN 'MVP' THEN 0 WHEN 'Q3 ''26' THEN 1 WHEN 'Q4 ''26' THEN 2 WHEN 'Q1 ''27' THEN 3 ELSE 9 END
+```
+
+Priority and Target are **orthogonal axes** — Priority answers _in what order_, Target answers _which
+quarter_. Every quarter spans P0→P3. How `/backlog` fills Target (theme-grouped, priority-driven
+overflow) lives in [`ticket-authoring.md` § Priority vs Target](./ticket-authoring.md) and the
+[`backlog`](../skills/backlog/SKILL.md) skill.
+
+### `Assignee` — `select` (which model works the ticket in `/work`)
+
+`Me` · `Fable` · `Opus` · `Sonnet`.
+
+- **`Me` = hands-off** — the user works it themselves; `/triage`, `/backlog`, and `/work` leave it
+  alone (same meaning as `Status = On Hold`).
+- **`Fable` is the user's to assign**, never an agent's pick. `/groom` sets `Opus` or `Sonnet` when a
+  ticket reaches `Groomed`.
+
+### Relations & system fields
+
+- **`Epic`** — relation to the Epic Board, **single** (limit 1).
+- **`Blocked By`** / **`Blocks`** — a self-relation **reciprocal pair**: setting `Blocked By` on the
+  dependent ticket fills `Blocks` on the blocker automatically. **Write only `Blocked By`.** Each holds
+  a JSON array of page URLs, not statuses — judge takeability by reading the blockers' `Status` (see
+  `complete` group above). Usage doctrine: [`ticket-authoring.md` § Dependencies](./ticket-authoring.md).
+- **`Finished Date`** — `date`, set when work completes.
+- **`ID`** — read-only `auto_increment`. **Never set it.** Tickets are referred to as `#<n>` /
+  `TARO-<n>`.

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -1,40 +1,18 @@
 # Ticket Authoring
 
-**The single source of truth for what a ticket looks like.** Board constants, body shape, brevity,
-and voice. `/triage` and `/groom` declare their own routing and lanes — never their own templates or
-voice rules. If a body rule isn't here, it doesn't exist.
+**The single source of truth for what a ticket looks like.** Body shape, brevity, voice, and which
+stage fills each field. `/triage` and `/groom` declare their own routing and lanes — never their own
+templates or voice rules. If a body rule isn't here, it doesn't exist.
 
 Applies whenever the user says "cut a ticket", "file that", "add that to the board", or when
 out-of-scope work is found mid-task.
 
 ## Board constants
 
-- **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`
-- **Epic Board** data source: `collection://2510953c-224c-80b7-9bb0-000b5384a47d`
-- **MCP server**: `notion`. **Read** with `notion-query-data-sources` (SQL over the data source) +
-  `notion-fetch` (page body — the query returns properties only). **Create** with
-  `notion-create-pages`, always passing the board's default page template
-  (`template_id: 3af0953c224c800d984cf0b443d67d20`) so the ticket inherits its default icon and
-  field defaults. **Update** with `notion-update-page`.
-- `Status`: `On Hold` · `Backlog` · `Needs More Info` · `Groomed` · `Ready` · `In Progress` ·
-  `Blocked` · `Review` · `Duplicate` · `Won't Do` · `Done`. Status is a plain property write — set
-  it directly, no transition step. `/groom` lands tickets in `Groomed`; the user promotes them to
-  `Ready`, the lane `/work` pulls from.
-- `Priority`: `⇞P0` · `↑P1` · `↓P2` · `⇟P3` (a ticket's urgency).
-- `Type`: `Bug` · `Task` · `Story` · `Spike`.
-- `Target`: `MVP` · `Fast-follow` · `Later` — which release the ticket ships in (orthogonal to
-  Priority).
-- `Assignee`: `Me` · `Fable` · `Opus` · `Sonnet` — which model works the ticket in `/work`.
-  Triage/groom set `Opus` or `Sonnet` when a ticket reaches `Groomed`; **`Fable` is the user's to
-  assign**, never an agent's pick. **`Me` means hands-off** — the user works it themselves;
-  `/triage` and `/work` leave it alone. `Status = On Hold` carries the same meaning.
-- `Epic`: relation to the Epic Board (single).
-- `ID` is a **read-only auto-increment** — never set it. Tickets are referred to as `#<n>`.
-
-> **The board is the source of truth for these option lists, not this file.** A hardcoded vocabulary
-> here once went stale and `Spike` was invisible for months — tickets encoded it in their titles
-> instead. `notion-fetch` on the data-source URL returns the live options; check when a value seems
-> not to fit, and fix this file.
+The board **schema** — data sources, the MCP server + default template, and every field with its
+option list and semantics — lives in [`task-board-schema.md`](./task-board-schema.md). Read it for any
+data-source URL, field name, or option value. This file owns only how those fields are **filled** when
+authoring: what a cut sets, what each stage owns, and the two-axis Priority/Target doctrine below.
 
 ## Fields when cutting
 
@@ -56,22 +34,25 @@ value.
 the portfolio pass's to set — it sees the whole Backlog at once and distributes them comparatively.
 Capture leaves them empty (bar an obvious `Type`/`Epic` or a user-dictated value); `/backlog` fills
 them; `/triage` and `/groom` fill only stragglers a sweep hasn't reached yet. Priority especially is
-never a per-ticket call — it's a forced distribution across the board, which only `/backlog` can see.
+never a per-ticket call — it's a comparative call across the whole board, which only `/backlog` can see.
 
 ## Priority vs Target — two axes, don't collapse them
 
-`Priority` answers **in what order** (urgency/sequencing). `Target` answers **which release**
-(scope). They are orthogonal — a pre-launch `MVP` ticket still ranges `P0`→`P3`, so all four
-priority tiers stay meaningful inside the launch set instead of two being spent marking the cut-line.
+`Priority` answers **in what order** (urgency). `Target` answers **which quarter** it ships in. They
+are orthogonal — every quarter spans `P0`→`P3`, so a quarter never collapses into a single priority
+tier.
 
-- `MVP` — ships before launch.
-- `Fast-follow` — committed to the first post-launch cycle. Has a home; gets swept.
-- `Later` — genuinely deferred, allowed to be quiet.
+- `MVP` — launch scope: everything gating first ship. The current quarter's committed set, kept as its
+  own value.
+- `Q3 '26` / `Q4 '26` / `Q1 '27` — rolling quarter buckets (the live set lives in
+  [`task-board-schema.md`](./task-board-schema.md)). `Q3 '26` is current and holds `MVP` plus a few
+  high-value pull-ins.
 
 A ticket stays in its epic regardless of `Target` — the epic is the resurfacing anchor, not a
-graveyard. `Fast-follow` items surface in the **Fast-follow** board view (all epics, sorted by
-priority) for the post-launch sweep. Leave `Target` empty at capture; `/backlog` sets it, and
-distributes `Priority` **within** each Target band so both axes stay meaningful (see
+graveyard. `/backlog` fills `Target` **theme-grouped**: an epic's tickets stay together in one home
+quarter, with **priority driving cross-quarter overflow** (P0/P1 in the home quarter, P2/P3 spilling
+to the next), whole secondary/deferred epics pushed to the furthest planned quarter, and On-Hold
+tickets defaulting there too. Leave `Target` empty at capture; `/backlog` sets it (see
 [`backlog`](../skills/backlog/SKILL.md)).
 
 ## Body

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -1,39 +1,41 @@
 ---
 name: backlog
-description: Portfolio pass over the whole Notion Task Board Backlog, before /triage. Sees every raw ticket at once and assigns the comparative classification fields — Type, Epic, Target, then Priority under a forced distribution within each Target band. Does not rewrite bodies, resolve design, or change Status — tickets stay in Backlog, now sorted, for /triage to pull the most important first. Trigger on `/backlog`, "prioritize the backlog", "organize the board".
+description: Portfolio pass over the whole Notion Task Board Backlog, before /triage. Sees every raw ticket at once and assigns the comparative classification fields — Type, Epic, Priority (a board-wide urgency call), then Target (which quarter, theme-grouped by epic with priority driving cross-quarter overflow). Does not rewrite bodies, resolve design, or change Status — tickets stay in Backlog, now sorted, for /triage to pull the most important first. Trigger on `/backlog`, "prioritize the backlog", "organize the board".
 allowed-tools: Read, Grep, Glob, Bash, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page
 argument-hint: '[--full] [--epic <name>]'
 arguments:
   - name: --full
     description: Re-read and re-classify every ticket from scratch, not just the unclassified ones. Use periodically when priorities have drifted and you want a from-scratch re-rank. Default is incremental — trust existing fields, only new tickets cost body reads.
   - name: --epic <name>
-    description: Scope the sweep to one epic's Backlog tickets instead of the whole board. Priority is still distributed per Target band within that scope.
-lastUpdated: 2026-08-01T00:00:00Z
+    description: Scope the sweep to one epic's Backlog tickets instead of the whole board. The epic still gets a home quarter and its tickets overflow across quarters by priority within that scope.
+lastUpdated: 2026-08-05T00:00:00Z
 ---
 
 `/backlog` is the **portfolio pass** — it runs **before** `/triage`. Prioritization is comparative:
 you can't rank a ticket without seeing the others, so this pass takes the **whole Backlog at once**
-and assigns the four classification fields — **Type, Epic, Target, Priority**. It does **not** rewrite
+and assigns the four classification fields — **Type, Epic, Priority, Target**. It does **not** rewrite
 titles or bodies, resolve any design decision, write acceptance criteria, or change `Status`. Tickets
 stay in **`Backlog`**, now fully classified and sorted, so `/triage` always pulls the most important
 ones first.
 
-Board data source, field option lists, and voice all live in
-[`ticket-authoring.md`](../../rules/ticket-authoring.md). Read it before writing anything — this skill
-**owns** the classification fields that rule now attributes to it.
+The board **schema** (data sources, field option lists — including the live `Target` quarters) lives
+in [`task-board-schema.md`](../../rules/task-board-schema.md); **authoring** shape and the
+Priority/Target doctrine live in [`ticket-authoring.md`](../../rules/ticket-authoring.md). Read both
+before writing — this skill **owns** the classification fields those rules attribute to it.
 
-## Assign in order: Type → Epic → Target → Priority
+## Assign in order: Type → Epic → Priority → Target
 
-Priority is distributed **within** each Target band, so it can't be set until Target is. Work the four
-fields in that sequence.
+`Target` is now **theme-grouped and priority-aware** (below), so it needs each ticket's `Priority`
+already set to decide cross-quarter overflow. Set Priority before Target.
 
 **Incremental by default — the board is the cache.** Every classification this pass makes is persisted
 as the ticket's own fields, so a re-run reads them back for free and trusts them. Only tickets that
 are still **unclassified** (missing a field, i.e. added since the last sweep) get their bodies read
-and their fields set from scratch. The **distribution**, though, is always re-judged over the _whole_
-Backlog — a new ticket can crowd a band and nudge an existing ticket across a boundary — but that's
-cheap reasoning over field values already in hand, not more body reads. First run: everything is
-unclassified, so it reads the whole board once. Every run after: only the new tickets cost anything.
+and their fields set from scratch. The **placement**, though, is always re-judged over the _whole_
+Backlog — a new high-priority ticket can shift an epic's home quarter, or push an epic's tail into the
+next one — but that's cheap reasoning over field values already in hand, not more body reads. First
+run: everything is unclassified, so it reads the whole board once. Every run after: only the new
+tickets cost anything.
 
 Pass **`--full`** to override — re-read and re-classify every ticket from scratch, trusting no
 existing field. Reach for it periodically when priorities have drifted enough that the trusted
@@ -50,7 +52,8 @@ classifications are stale, not on the routine "I added a few tickets" run.
    ```
 
    No `ORDER BY` on `Priority`/`Target` here — this pass **sets** those, and their glyphs sort by
-   codepoint not urgency anyway (see triage). Order by `ID` and rank in judgment.
+   codepoint not urgency anyway (see [`task-board-schema.md`](../../rules/task-board-schema.md)). Order
+   by `ID` and rank in judgment.
 
 2. **Read bodies — unclassified tickets only** (or all, under `--full`). A ticket that already
    carries its fields is trusted; skip its body entirely. For the rest, `notion-fetch` anything too
@@ -62,54 +65,65 @@ classifications are stale, not on the routine "I added a few tickets" run.
 
 4. **Epic** — match the Epic Board. If nothing fits, **propose a new epic** per
    [`ticket-authoring.md` § Epics](../../rules/ticket-authoring.md) rather than force-fit — never
-   create one silently.
+   create one silently. The epic is the unit `Target` groups by, so every ticket needs one.
 
-5. **Target** — `MVP` ships before launch · `Fast-follow` first post-launch cycle · `Later` genuinely
-   deferred. This decides the band each ticket's Priority is distributed inside.
+5. **Priority — a board-wide urgency call.** `⇞P0` · `↑P1` · `↓P2` · `⇟P3`, judged comparatively
+   across the **whole** active set (not per quarter). Keep it honest against P0/P1 inflation — as a
+   rough board-wide shape, ~10% P0 (the true must-be-first), ~25% P1, ~40% P2, ~25% P3. This is a
+   guard, not a quota to satisfy exactly; a ticket's priority also feeds its epic's overflow in
+   step 6, so rank within each epic deliberately.
 
-6. **Priority — forced distribution, per Target band.** Priority and Target are **orthogonal**
-   ([two axes, don't collapse them](../../rules/ticket-authoring.md)): every band spans `P0`→`P3`, so
-   MVP does **not** become all-P0 and Later all-P3. Within each band, aim for this shape:
-
-   | Tier | Share of the band             |
-   | ---- | ----------------------------- |
-   | ⇞P0  | ~10% — the true must-be-first |
-   | ↑P1  | ~25%                          |
-   | ↓P2  | ~40%                          |
-   | ⇟P3  | ~25%                          |
-
-   **Relax below ~6 tickets:** a small band gets judgment, not a contorted quota. The distribution is
-   a guard against everything-is-P1 inflation, not a spreadsheet to satisfy exactly.
+6. **Target — which quarter, theme-grouped.** Options are `MVP` and the rolling quarters (`Q3 '26`,
+   `Q4 '26`, `Q1 '27` — read the live set from
+   [`task-board-schema.md`](../../rules/task-board-schema.md)). Assign by **epic**, not per ticket:
+   - **`MVP` stays `MVP`.** It's the launch-scope set; don't reband an MVP ticket unless it's clearly
+     not launch-gating. The current quarter (`Q3 '26`) is mostly consumed by MVP — keep it **lean**,
+     pulling in only a few genuinely high-value or already-in-flight (`Ready`/`Groomed`/`In Progress`)
+     tickets alongside it.
+   - **Give each epic a home quarter** by its strategic weight: launch-adjacent epics land in the
+     current/next quarter, secondary or deferred epics in the furthest planned one. An epic's tickets
+     **stay together** in that quarter…
+   - **…except priority-driven overflow.** Within an epic, `P0`/`P1` sit in the home quarter and
+     `P2`/`P3` spill to the next — so a big epic splits across two quarters by urgency, but never
+     scatters across all of them.
+   - **On-Hold and paused work defaults to the furthest planned quarter** (it isn't scheduled).
+   - Don't invent a quarter beyond the live option set. If work is further out than the furthest
+     option, park it there and note that a new quarter option may be warranted — adding one is a
+     schema edit (`notion-update-data-source`), the user's call.
 
 ## Checkpoint & write
 
-7. **Checkpoint.** One table for the whole sweep, grouped by Target band and sorted by proposed
-   Priority within it, so the distribution is visible at a glance:
+7. **Checkpoint.** One table for the whole sweep, **grouped by quarter and by epic within it**, so the
+   theme grouping and any cross-quarter overflow are visible at a glance:
 
-   | ID | Ticket | Type | Epic | Target | Priority | Δ (old → new) |
+   | Quarter | Epic | ID | Ticket | Type | Priority | Δ (old → new) |
 
-   Show every field's before → after where it changed. Stop for approval. If a band's shape looks off
-   to the user, re-balance and re-present — don't write a distribution they haven't seen.
+   Show every field's before → after where it changed. Call out any epic that overflows two quarters
+   and anything pulled into the current quarter. Stop for approval. If the shape looks off to the user
+   — an epic in the wrong quarter, too much pulled into the current one — re-balance and re-present;
+   don't write a plan they haven't seen.
 
-8. **Write** approved fields via `notion-update-page` — `Type`, `Epic`, `Target`, `Priority` only.
+8. **Write** approved fields via `notion-update-page` — `Type`, `Epic`, `Priority`, `Target` only.
    **Never** `Status`, title, or body. Sequential; if a write fails, report which and stop rather than
-   half-applying.
+   half-applying. After a large `Target` migration, verify with a row-level `WHERE id IN (…)` query,
+   not an aggregate count — Notion's `COUNT/GROUP BY` reads lag row writes.
 
 ## Self-heal
 
 This skill is in the `/triage`–`/groom`–`/work` class and heals the same way. The user will push back
-— a mis-ranked ticket, a band shape that's wrong for this board, a Type or Epic call that's off. Treat
-it as a **defect in this skill or the rules it embodies**, not just in the sweep. Route the lesson: a
-**process** miss (how this pass ranks, distributes, or sequences the four fields) → this skill; a
-**"what a ticket looks like" / field-semantics** miss (what a Target means, when a new epic is
-warranted, the distribution doctrine) → the single source,
-[`ticket-authoring.md`](../../rules/ticket-authoring.md). Ship it per
+— a mis-ranked ticket, an epic in the wrong quarter, too much pulled into the current one, a Type or
+Epic call that's off. Treat it as a **defect in this skill or the rules it embodies**, not just in the
+sweep. Route the lesson: a **process** miss (how this pass ranks, groups by quarter, or sequences the
+four fields) → this skill; a **"what a ticket looks like" / field-semantics** miss (what a `Target`
+quarter means, when a new epic is warranted, the theme-grouping doctrine) → the single sources,
+[`task-board-schema.md`](../../rules/task-board-schema.md) (schema) or
+[`ticket-authoring.md`](../../rules/ticket-authoring.md) (doctrine). Ship it per
 [`self-heal.md`](../../rules/self-heal.md) — the shared living-PR mechanics, its own `self-heal`
 worktree — separate from the backlog work itself.
 
 ## Guardrails
 
-- Only ever touch the Task Board named in the rule — never a backup or duplicate.
+- Only ever touch the Task Board named in the schema — never a backup or duplicate.
 - **Fields only, never `Status`.** Every ticket stays in `Backlog`. This is a pre-triage enrichment,
   not a stage gate.
 - **Never rewrite title or body.** If a ticket is too cryptic to classify, leave its unresolvable

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -84,9 +84,10 @@ as reused. Undecided copy keeps the ticket out of `Groomed`.
 
 ## Board constants
 
-**[`ticket-authoring.md`](../../rules/ticket-authoring.md) is the single source** for the board data
-sources, every field and its option list, the body section list, brevity rules, and voice. Read it
-before writing anything to the board. This skill declares only its lanes and its own passes.
+The board **schema** — data sources, every field and its option list — lives in
+[`task-board-schema.md`](../../rules/task-board-schema.md); the **body section list, brevity rules, and
+voice** live in [`ticket-authoring.md`](../../rules/ticket-authoring.md). Read both before writing
+anything to the board. This skill declares only its lanes and its own passes.
 
 - Lanes: pulls from `Needs More Info`; lands at `Groomed`; may park at `On Hold`. Never sets `Ready`
   / `In Progress` / `Review` / `Done` / `Blocked` — promoting `Groomed` → `Ready` is the user's gate.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -18,8 +18,9 @@ The Backlog it pulls from is normally already classified and priority-sorted by
 Priority → ID fetch below surfaces the most important tickets first. Triage no longer owns the
 classification fields; it only fills **stragglers** a `/backlog` sweep hasn't reached yet (see step 4).
 
-Board data source, field option lists, body sections, and voice all live in
-[`ticket-authoring.md`](../../rules/ticket-authoring.md). Read it before writing anything.
+The board **schema** (data sources, field option lists) lives in
+[`task-board-schema.md`](../../rules/task-board-schema.md); **body sections** and **voice** live in
+[`ticket-authoring.md`](../../rules/ticket-authoring.md). Read both before writing anything.
 
 ## Steps
 
@@ -30,11 +31,12 @@ Board data source, field option lists, body sections, and voice all live in
    FROM "collection://3630953c-224c-8065-8864-000bb9fe7bad"
    WHERE "Status" = 'Backlog'
      AND ("Assignee" IS NULL OR "Assignee" <> 'Me')   -- Me = hands off
-   ORDER BY CASE "Target"                              -- release first: MVP is most important
-              WHEN 'MVP'         THEN 0
-              WHEN 'Fast-follow' THEN 1
-              WHEN 'Later'       THEN 2
-              ELSE 3                                   -- unset Target sorts last → propose one
+   ORDER BY CASE "Target"                              -- quarter first: MVP / current quarter lead
+              WHEN 'MVP'     THEN 0
+              WHEN 'Q3 ''26' THEN 1
+              WHEN 'Q4 ''26' THEN 2
+              WHEN 'Q1 ''27' THEN 3
+              ELSE 9                                   -- unset Target sorts last → propose one
             END ASC,
             CASE "Priority"                            -- then urgency — rank, NOT the raw glyph string
               WHEN '⇞P0' THEN 0
@@ -46,11 +48,16 @@ Board data source, field option lists, body sections, and voice all live in
             "userDefined:ID" ASC
    ```
 
-   **`Target` leads, then `Priority`** — an `MVP` ticket outranks a `Fast-follow` one whatever their
-   priorities, and inside a release urgency breaks the tie. **Never `ORDER BY` either field directly.**
+   The `Target` `CASE` lists the **live quarter options** — refresh it from
+   [`task-board-schema.md`](../../rules/task-board-schema.md) when the roadmap rolls forward and a new
+   quarter is added.
+
+   **`Target` leads, then `Priority`** — an `MVP` ticket outranks a later-quarter one whatever their
+   priorities, and inside a quarter urgency breaks the tie. **Never `ORDER BY` either field directly.**
    The priority arrows sort by codepoint, not urgency — `↑`(P1, U+2191) `↓`(P2, U+2193) `⇞`(P0, U+21DE)
    `⇟`(P3, U+21DF) — so a raw string sort buries every `P0` below `P1`/`P2`, and a null leaps to the
-   top; `Target`'s options aren't ordered alphabetically either. Rank both with the `CASE`s above.
+   top; `Target`'s quarter options aren't ordered alphabetically either. Rank both with the `CASE`s
+   above.
 
 2. **Read** each ticket's page body via `notion-fetch` — the query returns properties only, and the
    user often writes real context into the raw ticket. Carry it through; don't re-derive from the name.

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -33,7 +33,8 @@ stays live for your review feedback (§ Review & feedback loop).
 ## Board constants
 
 - **Task Board** data source: `collection://3630953c-224c-8065-8864-000bb9fe7bad`. Full board
-  constants live in [`ticket-authoring.md`](../../rules/ticket-authoring.md).
+  constants (fields, options, relations) live in
+  [`task-board-schema.md`](../../rules/task-board-schema.md).
 - `Status` lanes this skill uses: pulls from `Ready`; claims to `In Progress`; lands at `Review`;
   parks stuck work at `Blocked`. Never sets `Done` / `Duplicate` / `Groomed`.
 - `Assignee`: `Fable` · `Opus` · `Sonnet` — the model each subagent is pinned to. **`Assignee = Me`


### PR DESCRIPTION
## Summary

Retires the `MVP / Fast-follow / Later` Target scheme (now migrated on the board to `MVP` + rolling quarters `Q3 '26 / Q4 '26 / Q1 '27`) across the ticketing docs, and pulls the board **schema** into a single referenced file so future field changes land in one place.

- **New `.claude/rules/task-board-schema.md`** — the single source for data sources, MCP server, default template, every field + option list, reciprocal `Blocked By`/`Blocks` relation, and the sort gotchas (codepoint-ordered glyphs, non-alphabetical quarters). Referenced by `ticket-authoring.md`, `backlog`, `triage`, `groom`, `work`, and the `ticket-author` agent.
- **`ticket-authoring.md`** — Board-constants section reduced to a pointer; "Priority vs Target" rewritten for the quarter model (MVP + rolling quarters, theme-grouped with priority-driven overflow).
- **`backlog` skill** — assignment order flips to Type → Epic → Priority → Target; Priority becomes a board-wide urgency call, Target is theme-grouped by epic with P0/P1 in the home quarter and P2/P3 spilling to the next; checkpoint table regrouped by quarter × epic.
- **`triage` skill** — the `ORDER BY CASE "Target"` that hardcoded `Fast-follow`/`Later` now ranks the live quarters.
- **`groom` / `work` / `ticket-author`** — constant-pointers redirected to the schema file.

Docs only — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)