### PR TITLE
TARO-162: Eager card creation

### DIFF
--- a/src/api/cards/mutations/_invalidate.ts
+++ b/src/api/cards/mutations/_invalidate.ts
@@ -24,9 +24,13 @@ export function invalidateDeck(
   queryCache.invalidateQueries({ key: ['cards', deck_id] })
 }
 
+// `exact` on the deck list: a bare `['decks']` filter is a prefix match, so it
+// also catches `['decks', 'count']` — the member's *deck* count, which no card
+// write can change. Without it every card insert/delete/move refires that HEAD
+// query for nothing.
 export function invalidateAllCardCounts(queryCache: QueryCache) {
   queryCache.invalidateQueries({ key: ['cards', 'count'] })
-  queryCache.invalidateQueries({ key: ['decks'] })
+  queryCache.invalidateQueries({ key: ['decks'], exact: true })
 }
 
 // The member-wide card index (front text → decks) drifts whenever a card is

--- a/src/api/cards/mutations/_invalidate.ts
+++ b/src/api/cards/mutations/_invalidate.ts
@@ -21,10 +21,14 @@ export function invalidateDeck(
 ) {
   if (deck_id === undefined) return
 
-  const refetch = refetch_inactive ? 'all' : true
+  if (refetch_inactive) {
+    queryCache.invalidateQueries({ key: ['deck', deck_id] }, 'all')
+    if (card_pages) queryCache.invalidateQueries({ key: ['cards', deck_id] }, 'all')
+    return
+  }
 
-  queryCache.invalidateQueries({ key: ['deck', deck_id] }, refetch)
-  if (card_pages) queryCache.invalidateQueries({ key: ['cards', deck_id] }, refetch)
+  queryCache.invalidateQueries({ key: ['deck', deck_id] })
+  if (card_pages) queryCache.invalidateQueries({ key: ['cards', deck_id] })
 }
 
 // `exact` on the deck list: a bare `['decks']` filter is a prefix match, so it

--- a/src/api/cards/mutations/_invalidate.ts
+++ b/src/api/cards/mutations/_invalidate.ts
@@ -7,21 +7,24 @@ type QueryCache = ReturnType<typeof useQueryCache>
 // Pass `refetch_inactive: true` when the caller might be invalidating a deck
 // the user isn't currently viewing (e.g. cross-deck moves) — otherwise the
 // user navigates back to stale cached data.
-type InvalidateOptions = { refetch_inactive?: boolean }
+type InvalidateOptions = {
+  refetch_inactive?: boolean
+  // Set false when the caller already holds the written row on screen and only
+  // the deck's own counts need re-reading.
+  card_pages?: boolean
+}
 
 export function invalidateDeck(
   queryCache: QueryCache,
   deck_id: number | undefined,
-  options: InvalidateOptions = {}
+  { refetch_inactive = false, card_pages = true }: InvalidateOptions = {}
 ) {
   if (deck_id === undefined) return
-  if (options.refetch_inactive) {
-    queryCache.invalidateQueries({ key: ['deck', deck_id] }, 'all')
-    queryCache.invalidateQueries({ key: ['cards', deck_id] }, 'all')
-    return
-  }
-  queryCache.invalidateQueries({ key: ['deck', deck_id] })
-  queryCache.invalidateQueries({ key: ['cards', deck_id] })
+
+  const refetch = refetch_inactive ? 'all' : true
+
+  queryCache.invalidateQueries({ key: ['deck', deck_id] }, refetch)
+  if (card_pages) queryCache.invalidateQueries({ key: ['cards', deck_id] }, refetch)
 }
 
 // `exact` on the deck list: a bare `['decks']` filter is a prefix match, so it

--- a/src/api/cards/mutations/_invalidate.ts
+++ b/src/api/cards/mutations/_invalidate.ts
@@ -2,15 +2,15 @@ import type { useQueryCache } from '@pinia/colada'
 
 type QueryCache = ReturnType<typeof useQueryCache>
 
-// Pinia Colada's invalidateQueries only refetches active queries by default;
-// non-active queries get marked stale but cached pages stay until a remount.
-// Pass `refetch_inactive: true` when the caller might be invalidating a deck
-// the user isn't currently viewing (e.g. cross-deck moves) — otherwise the
-// user navigates back to stale cached data.
+// A write flags every affected deck's data as out of date, but only
+// re-downloads the deck on screen. `refetch_inactive: true` re-downloads the
+// off-screen ones too, so a deck you're not looking at (after moving cards out
+// of it) is already right when you open it, rather than showing the old list
+// for a beat first.
 type InvalidateOptions = {
   refetch_inactive?: boolean
-  // Set false when the caller already holds the written row on screen and only
-  // the deck's own counts need re-reading.
+  // Set false when the write's row is already correct on screen, so only the
+  // deck's counts need re-reading and the card list can be left alone.
   card_pages?: boolean
 }
 
@@ -31,10 +31,10 @@ export function invalidateDeck(
   if (card_pages) queryCache.invalidateQueries({ key: ['cards', deck_id] })
 }
 
-// `exact` on the deck list: a bare `['decks']` filter is a prefix match, so it
-// also catches `['decks', 'count']` — the member's *deck* count, which no card
-// write can change. Without it every card insert/delete/move refires that HEAD
-// query for nothing.
+// `exact` on the deck list: keys match by prefix, so a bare `['decks']` also
+// catches `['decks', 'count']` — how many decks the member owns, which adding
+// or removing a *card* can never change. Without it every card write re-counts
+// the member's decks for nothing.
 export function invalidateAllCardCounts(queryCache: QueryCache) {
   queryCache.invalidateQueries({ key: ['cards', 'count'] })
   queryCache.invalidateQueries({ key: ['decks'], exact: true })

--- a/src/api/cards/mutations/insert.ts
+++ b/src/api/cards/mutations/insert.ts
@@ -11,7 +11,10 @@ export function useInsertCardMutation() {
     onSettled: (_data, _error, params) => {
       invalidateDeck(queryCache, params.deck_id)
       invalidateAllCardCounts(queryCache)
-      invalidateCardIndex(queryCache)
+
+      // The index maps front text → decks, so a card inserted without one adds
+      // nothing to it. Skips the refetch for every eagerly-created blank card.
+      if (params.front_text) invalidateCardIndex(queryCache)
     }
   })
 }

--- a/src/api/cards/mutations/insert.ts
+++ b/src/api/cards/mutations/insert.ts
@@ -9,11 +9,19 @@ export function useInsertCardMutation() {
   return useMutation({
     mutation: (params: InsertCardParams) => insertCard(params),
     onSettled: (_data, _error, params) => {
-      invalidateDeck(queryCache, params.deck_id)
+      // A blank card carries nothing the deck's card pages don't already show:
+      // the editor staged the row and `promoteTemp` fills in the id and rank the
+      // insert returned, and an empty card can't be flagged a duplicate. Only
+      // the deck's own counts moved, so skip re-reading the whole page. An
+      // insert that does carry text (the audio-reader panel, a re-insert after a
+      // failed eager save) has no such row on screen and still refetches.
+      const blank = !params.front_text && !params.back_text
+
+      invalidateDeck(queryCache, params.deck_id, { card_pages: !blank })
       invalidateAllCardCounts(queryCache)
 
       // The index maps front text → decks, so a card inserted without one adds
-      // nothing to it. Skips the refetch for every eagerly-created blank card.
+      // nothing to it.
       if (params.front_text) invalidateCardIndex(queryCache)
     }
   })

--- a/src/api/decks/queries/count.ts
+++ b/src/api/decks/queries/count.ts
@@ -1,9 +1,15 @@
 import { useQuery } from '@pinia/colada'
 import { fetchMemberDeckCount } from '../db'
 
+// `useCan()` instantiates this query, and `useCan()` is mounted per card face
+// editor — so a default 5s staleTime made every newly rendered card row refetch
+// the member's deck count. The count only moves when a deck is created, deleted
+// or moved, and all three invalidate `['decks']` (a prefix match that catches
+// this key), so explicit invalidation is the only freshness this needs.
 export function useMemberDeckCountQuery() {
   return useQuery({
     key: ['decks', 'count'],
-    query: fetchMemberDeckCount
+    query: fetchMemberDeckCount,
+    staleTime: Infinity
   })
 }

--- a/src/api/decks/queries/count.ts
+++ b/src/api/decks/queries/count.ts
@@ -2,14 +2,17 @@ import { useQuery } from '@pinia/colada'
 import { fetchMemberDeckCount } from '../db'
 
 // `useCan()` instantiates this query, and `useCan()` is mounted per card face
-// editor — so a default 5s staleTime made every newly rendered card row refetch
-// the member's deck count. The count only moves when a deck is created, deleted
-// or moved, and all three invalidate `['decks']` (a prefix match that catches
-// this key), so explicit invalidation is the only freshness this needs.
+// editor — so the default 5s staleTime made every newly rendered card row
+// refetch the member's deck count. The count only moves when a deck is created,
+// deleted or moved, and all three invalidate `['decks']` (a prefix match that
+// catches this key), so explicit invalidation carries the freshness. This is
+// just the backstop for a case that misses.
+const STALE_TIME = 1000 * 60 * 5
+
 export function useMemberDeckCountQuery() {
   return useQuery({
     key: ['decks', 'count'],
     query: fetchMemberDeckCount,
-    staleTime: Infinity
+    staleTime: STALE_TIME
   })
 }

--- a/src/views/deck/composables/list-controller.ts
+++ b/src/views/deck/composables/list-controller.ts
@@ -386,6 +386,7 @@ export function useCardListController(opts: Options) {
     const card = entry?.card ?? list.findCard(id)
     if (!card) return
 
+    if (entry) list.patchTemp(entry.client_id, values)
     return mutations.saveCard(card, values)
   }
 

--- a/src/views/deck/composables/list-controller.ts
+++ b/src/views/deck/composables/list-controller.ts
@@ -68,6 +68,16 @@ export function useCardListController(opts: Options) {
 
   const saving = ref(false)
 
+  // In-flight eager insert per staged card, keyed by client_id. `updateCard`
+  // awaits the entry's promise so a keystroke landing mid-insert becomes an
+  // UPDATE on the row it created, never a second INSERT.
+  const pending_inserts = new Map<string, Promise<void>>()
+
+  // Eager inserts run one at a time. A card's key is minted against its
+  // rendered neighbours, and a sibling staged moments earlier only carries one
+  // once its own insert resolved — minting concurrently hands both the same key.
+  let insert_queue: Promise<void> = Promise.resolve()
+
   // client_id of the card last staged through the create seam (`addFocusedCard`),
   // awaiting autofocus + grow-in. The matching row claims it on mount (see
   // `claimFocus`) and focuses itself.
@@ -96,48 +106,53 @@ export function useCardListController(opts: Options) {
   }))
 
   /**
-   * Stage a new temp card, gated on the deck's plan card cap, *without*
-   * requesting autofocus. The flag-free stage used by the mobile dock editor,
-   * which opens its own focused surface over the staged card — the desktop
-   * row's autofocus would fight it. Desktop create paths go through
-   * `addFocusedCard` instead. A capped free member gets the upgrade alert and
-   * nothing is staged.
+   * The single create seam every "add card" intent funnels through — desktop
+   * toolbar, per-row append / prepend, the editor's empty-state CTA, and the
+   * mobile dock editor. Guards the plan cap, stages the temp via `insert`,
+   * optionally records it as the autofocus + grow-in target, then fires its
+   * INSERT in the background so the card is a real, saved card before a single
+   * key is pressed. No-op past the cap.
+   *
+   * The focus target is assigned in the same synchronous block as `insert()`,
+   * after the sole `await` (the cap guard): the list insert queues Vue's render,
+   * which flushes before any later microtask, so assigning
+   * `pending_focus_client_id` after a *further* `await` would lose the race —
+   * the row would mount and claim focus before the target is set.
+   *
+   * @param insert - Virtual-list insert to run once the guard passes; returns
+   *   the staged temp's `client_id`.
+   * @param focus - Whether the new row should autofocus and grow in. Off for the
+   *   mobile dock editor, which opens its own focused surface over the staged
+   *   card and would fight the desktop row's autofocus.
+   * @returns The staged `client_id`, or `undefined` when the cap vetoes staging.
+   */
+  async function stageCard(insert: () => string, focus = false): Promise<string | undefined> {
+    if (!(await limit_gate.guardAddCards())) return
+
+    const client_id = insert()
+
+    if (focus) {
+      pending_focus_client_id.value = client_id
+      pending_grow_client_id.value = client_id
+    }
+
+    insertStaged(client_id)
+    return client_id
+  }
+
+  /**
+   * Stage a new card without autofocus — the mobile dock editor's create path.
    *
    * @param left_card_id  - If given, the new card is placed `after` this id.
    * @param right_card_id - If given (and `left_card_id` is not), `before` it.
    */
-  async function addCard(
-    left_card_id?: number,
-    right_card_id?: number
-  ): Promise<string | undefined> {
-    if (!(await limit_gate.guardAddCards())) return
-    return list.addCard(left_card_id, right_card_id)
+  function addCard(left_card_id?: number, right_card_id?: number) {
+    return stageCard(() => list.addCard(left_card_id, right_card_id))
   }
 
-  /**
-   * The single create seam every desktop "add card" intent funnels through —
-   * toolbar, per-row append / prepend, and the editor's empty-state CTA. Guards
-   * the plan cap, stages the temp via `insert`, then records it as the
-   * autofocus + grow-in target so the new card lands focused and grows in
-   * regardless of which entry point triggered it. No-op past the cap.
-   *
-   * The target is assigned in the same synchronous block as `insert()`, after
-   * the sole `await` (the cap guard): the list insert queues Vue's render, which
-   * flushes before any later microtask, so assigning `pending_focus_client_id`
-   * after a *further* `await` would lose the race — the row would mount and
-   * claim focus before the target is set.
-   *
-   * @param insert - Virtual-list insert to run once the guard passes; returns
-   *   the staged temp's `client_id`.
-   * @returns The staged `client_id`, or `undefined` when the cap vetoes staging.
-   */
-  async function addFocusedCard(insert: () => string): Promise<string | undefined> {
-    if (!(await limit_gate.guardAddCards())) return
-
-    const client_id = insert()
-    pending_focus_client_id.value = client_id
-    pending_grow_client_id.value = client_id
-    return client_id
+  /** Stage a new card that lands focused and grows in — every desktop create path. */
+  function addFocusedCard(insert: () => string) {
+    return stageCard(insert, true)
   }
 
   /** Stage a focused new temp card immediately after the card with `card_id`. */
@@ -300,10 +315,16 @@ export function useCardListController(opts: Options) {
    * runs when the temp is added — a stale `card_count` or a concurrent edit on
    * another device can still let a write reach the cap trigger and be rejected
    * here. `handleLimitError` re-surfaces the upgrade alert for that case and the
-   * temp stays staged (still `real_id: null`), so upgrading and re-saving
-   * retries the same INSERT. Any other rejection propagates.
+   * entry is left staged for the caller to keep or roll back. Any other
+   * rejection propagates.
+   *
+   * @returns `false` when the cap rejected the write, `true` on success.
    */
-  async function insertTemp(temp_id: number, entry: CardEntry, values: Partial<Card>) {
+  async function insertTemp(
+    temp_id: number,
+    entry: CardEntry,
+    values: Partial<Card>
+  ): Promise<boolean> {
     try {
       const inserted = await mutations.insertCard({
         deck_id: opts.deck_id,
@@ -313,24 +334,74 @@ export function useCardListController(opts: Options) {
       })
 
       list.promoteTemp(temp_id, inserted.id, inserted.rank, values)
+      return true
     } catch (error) {
       if (!limit_gate.handleLimitError(error)) throw error
+      return false
     }
   }
 
   /**
-   * Persist an edit. Routes to INSERT on the first save of an unpromoted
-   * temp; otherwise UPDATE. No-op when the id matches nothing.
+   * Fire the eager INSERT for a just-staged card, queued behind any insert
+   * already in flight so successive creates mint their keys in render order.
+   *
+   * Failures are swallowed: this insert only ever carries an empty card, so
+   * nothing the user typed can be lost. The entry simply stays a temp and the
+   * next edit re-inserts it — no error toast for a save the user never asked
+   * for. A cap rejection is the exception: the deck genuinely can't hold the
+   * card, so the row comes back out of the list.
    */
-  async function updateCard(id: number, values: Partial<Card>) {
-    const entry = list.findEntryByCardId(id)
+  function insertStaged(client_id: string) {
+    const entry = list.findEntryByClientId(client_id)
+    if (!entry) return
 
-    if (entry && entry.real_id === null) return withSaving(() => insertTemp(id, entry, values))
+    const temp_id = entry.card.id
+
+    const run = insert_queue
+      .then(async () => {
+        const inserted = await insertTemp(temp_id, entry, {})
+        if (!inserted) list.removeTemp(client_id)
+      })
+      .catch(() => {})
+      .finally(() => pending_inserts.delete(client_id))
+
+    insert_queue = run
+    pending_inserts.set(client_id, run)
+  }
+
+  /**
+   * Route a resolved edit to INSERT or UPDATE.
+   *
+   * @param staged - The entry the card had before any in-flight eager insert
+   *   resolved, or `undefined` for an already-persisted card. Re-read here by
+   *   client_id: the insert may have promoted it (so this is an UPDATE) or, at
+   *   the cap, rolled it out of the list entirely (so there's nothing to save).
+   */
+  function persistEdit(id: number, staged: CardEntry | undefined, values: Partial<Card>) {
+    const entry = staged && list.findEntryByClientId(staged.client_id)
+    if (staged && !entry) return
+
+    if (entry?.real_id === null) return insertTemp(id, entry, values)
 
     const card = entry?.card ?? list.findCard(id)
     if (!card) return
 
-    return withSaving(() => mutations.saveCard(card, values))
+    return mutations.saveCard(card, values)
+  }
+
+  /**
+   * Persist an edit. Waits out the card's eager INSERT when one is still in
+   * flight, so typing into a brand-new card yields exactly one card carrying
+   * the text. No-op when the id matches nothing.
+   */
+  function updateCard(id: number, values: Partial<Card>) {
+    const staged = list.findEntryByCardId(id)
+    const pending = staged && pending_inserts.get(staged.client_id)
+
+    return withSaving(async () => {
+      await pending
+      return persistEdit(id, staged, values)
+    })
   }
 
   return {

--- a/src/views/deck/composables/virtual-list.ts
+++ b/src/views/deck/composables/virtual-list.ts
@@ -299,6 +299,22 @@ export function useVirtualCardList(
   }
 
   /**
+   * Merge `values` into an entry's own card record.
+   *
+   * An eagerly-created card is promoted in place and never refetched, so the
+   * deck's cached pages don't hold it and `saveCard`'s optimistic patch can't
+   * reach it. Without this its card would stay the empty record it was staged
+   * with — a stale merge base that the mobile editor's one-side-at-a-time saves
+   * would use to clobber the other side.
+   */
+  function patchTemp(client_id: string, values: Partial<Card>) {
+    const entry = findEntryByClientId(client_id)
+    if (!entry) return
+
+    Object.assign(entry.card, values)
+  }
+
+  /**
    * Drop a staged entry out of the list. The rollback for an insert the backend
    * refused (the deck's card cap) — the row never reached the server, so
    * nothing is orphaned by removing it.
@@ -373,6 +389,7 @@ export function useVirtualCardList(
     addCardAtTop,
     findEntryByCardId,
     findEntryByClientId,
+    patchTemp,
     removeTemp,
     findCard,
     promoteTemp

--- a/src/views/deck/composables/virtual-list.ts
+++ b/src/views/deck/composables/virtual-list.ts
@@ -290,6 +290,24 @@ export function useVirtualCardList(
   }
 
   /**
+   * Look up the entry with `client_id`. Unlike `findEntryByCardId` the key
+   * survives promotion, so a caller holding one across an in-flight insert can
+   * re-read the entry afterwards — or find it gone, if the insert rolled back.
+   */
+  function findEntryByClientId(client_id: string): CardEntry | undefined {
+    return temp_entries.value.find((e) => e.client_id === client_id)
+  }
+
+  /**
+   * Drop a staged entry out of the list. The rollback for an insert the backend
+   * refused (the deck's card cap) — the row never reached the server, so
+   * nothing is orphaned by removing it.
+   */
+  function removeTemp(client_id: string) {
+    temp_entries.value = temp_entries.value.filter((e) => e.client_id !== client_id)
+  }
+
+  /**
    * Resolve a card-id back to a Card. Searches persisted first, then live
    * temp entries — mirrors the merge order in `all_cards`. Returns the
    * underlying Card (no `client_id` wrapper) so callers can spread it into
@@ -354,6 +372,8 @@ export function useVirtualCardList(
     prependCard,
     addCardAtTop,
     findEntryByCardId,
+    findEntryByClientId,
+    removeTemp,
     findCard,
     promoteTemp
   }

--- a/tests/unit/api/cards/mutations/_invalidate.test.js
+++ b/tests/unit/api/cards/mutations/_invalidate.test.js
@@ -22,7 +22,7 @@ describe('invalidateDeck', () => {
 
   test('invalidates ["deck", id] so the detail view refetches', () => {
     invalidateDeck(cache, 42)
-    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['deck', 42] })
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['deck', 42] }, true)
   })
 
   test('invalidates ["cards", id] — prefix match covers infinite pages, ids + search variants', () => {
@@ -30,10 +30,10 @@ describe('invalidateDeck', () => {
     // Pinia Colada matches by prefix unless `exact: true`, so this single call
     // refetches every nested entry: ['cards', 42, 'pages', N],
     // ['cards', 42, 'ids'], and ['cards', 42, 'search', q].
-    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['cards', 42] })
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['cards', 42] }, true)
   })
 
-  test('fires exactly two invalidations per deck_id', () => {
+  test('fires exactly two invalidations per deck_id by default', () => {
     invalidateDeck(cache, 42)
     expect(cache.invalidateQueries).toHaveBeenCalledTimes(2)
   })
@@ -46,6 +46,31 @@ describe('invalidateDeck', () => {
     invalidateDeck(cache, 42, { refetch_inactive: true })
     expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['deck', 42] }, 'all')
     expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['cards', 42] }, 'all')
+  })
+
+  // [obligation] card_pages defaults to true — a caller that doesn't pass it
+  // still gets its card pages refetched (the pre-eager-insert behaviour).
+  test('card_pages defaults to true — cards key is invalidated unless explicitly suppressed [obligation]', () => {
+    invalidateDeck(cache, 42)
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['cards', 42] }, true)
+    expect(cache.invalidateQueries).toHaveBeenCalledTimes(2)
+  })
+
+  // [obligation] the eager-insert caller already holds the written row on
+  // screen — only the deck's own counts need re-reading, so card_pages: false
+  // must skip the ['cards', id] invalidation entirely.
+  test('card_pages: false skips the ["cards", id] invalidation, only the deck key fires [obligation]', () => {
+    invalidateDeck(cache, 42, { card_pages: false })
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['deck', 42] }, true)
+    expect(cache.invalidateQueries).toHaveBeenCalledTimes(1)
+  })
+
+  // [obligation] the refetch_inactive rewrite must still cover both branches —
+  // 'all' propagates to the deck invalidation even when card_pages is false.
+  test('refetch_inactive + card_pages: false still passes "all" to the deck invalidation [obligation]', () => {
+    invalidateDeck(cache, 42, { refetch_inactive: true, card_pages: false })
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['deck', 42] }, 'all')
+    expect(cache.invalidateQueries).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -62,7 +87,16 @@ describe('invalidateAllCardCounts', () => {
 
   test('invalidates ["decks"] because decks_with_stats exposes card counts per deck', () => {
     invalidateAllCardCounts(cache)
-    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['decks'] })
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['decks'], exact: true })
+  })
+
+  // [obligation] a bare `['decks']` prefix filter also matches `['decks', 'count']`
+  // — the member's *deck* count, which no card write can change. `exact: true`
+  // is the guard against refiring that query on every card insert/delete/move.
+  test('decks invalidation is exact, not a prefix — does not also match ["decks", "count"] [obligation]', () => {
+    invalidateAllCardCounts(cache)
+    expect(cache.invalidateQueries).not.toHaveBeenCalledWith({ key: ['decks'] })
+    expect(cache.invalidateQueries).not.toHaveBeenCalledWith({ key: ['decks', 'count'] })
   })
 })
 

--- a/tests/unit/api/cards/mutations/_invalidate.test.js
+++ b/tests/unit/api/cards/mutations/_invalidate.test.js
@@ -22,7 +22,7 @@ describe('invalidateDeck', () => {
 
   test('invalidates ["deck", id] so the detail view refetches', () => {
     invalidateDeck(cache, 42)
-    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['deck', 42] }, true)
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['deck', 42] })
   })
 
   test('invalidates ["cards", id] — prefix match covers infinite pages, ids + search variants', () => {
@@ -30,7 +30,7 @@ describe('invalidateDeck', () => {
     // Pinia Colada matches by prefix unless `exact: true`, so this single call
     // refetches every nested entry: ['cards', 42, 'pages', N],
     // ['cards', 42, 'ids'], and ['cards', 42, 'search', q].
-    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['cards', 42] }, true)
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['cards', 42] })
   })
 
   test('fires exactly two invalidations per deck_id by default', () => {
@@ -52,7 +52,7 @@ describe('invalidateDeck', () => {
   // still gets its card pages refetched (the pre-eager-insert behaviour).
   test('card_pages defaults to true — cards key is invalidated unless explicitly suppressed [obligation]', () => {
     invalidateDeck(cache, 42)
-    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['cards', 42] }, true)
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['cards', 42] })
     expect(cache.invalidateQueries).toHaveBeenCalledTimes(2)
   })
 
@@ -61,7 +61,7 @@ describe('invalidateDeck', () => {
   // must skip the ['cards', id] invalidation entirely.
   test('card_pages: false skips the ["cards", id] invalidation, only the deck key fires [obligation]', () => {
     invalidateDeck(cache, 42, { card_pages: false })
-    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['deck', 42] }, true)
+    expect(cache.invalidateQueries).toHaveBeenCalledWith({ key: ['deck', 42] })
     expect(cache.invalidateQueries).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/unit/api/cards/mutations/delete.test.js
+++ b/tests/unit/api/cards/mutations/delete.test.js
@@ -49,7 +49,7 @@ describe('useDeleteCardsMutation', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['deck', 10] })
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 10] })
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 'count'] })
-    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'], exact: true })
   })
 
   test('onSettled invalidates the card index so deleted fronts are removed from highlights [obligation]', () => {
@@ -88,7 +88,7 @@ describe('useDeleteCardsInDeckMutation', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['deck', 10] })
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 10] })
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 'count'] })
-    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'], exact: true })
   })
 
   test('onSettled invalidates the card index so bulk-deleted fronts are removed from highlights [obligation]', () => {

--- a/tests/unit/api/cards/mutations/insert.test.js
+++ b/tests/unit/api/cards/mutations/insert.test.js
@@ -1,0 +1,142 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+const {
+  useMutationSpy,
+  insertCardMock,
+  invalidateDeckMock,
+  invalidateAllCardCountsMock,
+  invalidateCardIndexMock,
+  queryCache
+} = vi.hoisted(() => ({
+  useMutationSpy: vi.fn((cfg) => cfg),
+  insertCardMock: vi.fn(),
+  invalidateDeckMock: vi.fn(),
+  invalidateAllCardCountsMock: vi.fn(),
+  invalidateCardIndexMock: vi.fn(),
+  queryCache: { the: 'cache' }
+}))
+
+vi.mock('@pinia/colada', () => ({
+  useMutation: useMutationSpy,
+  useQueryCache: () => queryCache
+}))
+
+vi.mock('@/api/cards/db', () => ({
+  insertCard: insertCardMock
+}))
+
+vi.mock('@/api/cards/mutations/_invalidate', () => ({
+  invalidateDeck: invalidateDeckMock,
+  invalidateAllCardCounts: invalidateAllCardCountsMock,
+  invalidateCardIndex: invalidateCardIndexMock
+}))
+
+import { useInsertCardMutation } from '@/api/cards/mutations/insert'
+
+beforeEach(() => {
+  useMutationSpy.mockClear()
+  insertCardMock.mockClear()
+  invalidateDeckMock.mockClear()
+  invalidateAllCardCountsMock.mockClear()
+  invalidateCardIndexMock.mockClear()
+})
+
+function configFrom() {
+  useInsertCardMutation()
+  return useMutationSpy.mock.calls[0][0]
+}
+
+describe('useInsertCardMutation', () => {
+  test('mutation delegates to insertCard with the given params', async () => {
+    const { mutation } = configFrom()
+    const params = { deck_id: 10, rank: 'a0', front_text: 'Q', back_text: 'A' }
+    insertCardMock.mockResolvedValueOnce({ id: 1, rank: 'a0' })
+
+    await mutation(params)
+
+    expect(insertCardMock).toHaveBeenCalledWith(params)
+  })
+
+  // [obligation] a blank eager insert (empty front + back) skips the card-pages
+  // refetch — the row is already on screen via promoteTemp — and skips the
+  // card-index invalidation, since an empty front indexes nothing.
+  describe('onSettled — blank insert (eager create)', () => {
+    test('skips the deck card-pages invalidation [obligation]', () => {
+      const { onSettled } = configFrom()
+      const params = { deck_id: 10, rank: 'a0', front_text: '', back_text: '' }
+
+      onSettled(undefined, undefined, params)
+
+      expect(invalidateDeckMock).toHaveBeenCalledWith(queryCache, 10, { card_pages: false })
+    })
+
+    test('skips the card-index invalidation [obligation]', () => {
+      const { onSettled } = configFrom()
+      const params = { deck_id: 10, rank: 'a0', front_text: '', back_text: '' }
+
+      onSettled(undefined, undefined, params)
+
+      expect(invalidateCardIndexMock).not.toHaveBeenCalled()
+    })
+
+    test('still invalidates the member-wide card counts [obligation]', () => {
+      const { onSettled } = configFrom()
+      const params = { deck_id: 10, rank: 'a0', front_text: '', back_text: '' }
+
+      onSettled(undefined, undefined, params)
+
+      expect(invalidateAllCardCountsMock).toHaveBeenCalledWith(queryCache)
+    })
+
+    test('treats undefined front/back text the same as empty strings [obligation]', () => {
+      const { onSettled } = configFrom()
+      const params = { deck_id: 10, rank: 'a0' }
+
+      onSettled(undefined, undefined, params)
+
+      expect(invalidateDeckMock).toHaveBeenCalledWith(queryCache, 10, { card_pages: false })
+      expect(invalidateCardIndexMock).not.toHaveBeenCalled()
+    })
+  })
+
+  // [obligation] an insert carrying text — the audio-reader add-card panel, or
+  // a re-insert after a failed eager save — has no row already on screen and
+  // genuinely needs both refetches.
+  describe('onSettled — insert carrying text', () => {
+    test('refetches the deck card pages when front_text is present [obligation]', () => {
+      const { onSettled } = configFrom()
+      const params = { deck_id: 10, rank: 'a0', front_text: 'Q', back_text: '' }
+
+      onSettled(undefined, undefined, params)
+
+      expect(invalidateDeckMock).toHaveBeenCalledWith(queryCache, 10, { card_pages: true })
+    })
+
+    test('invalidates the card index when front_text is present [obligation]', () => {
+      const { onSettled } = configFrom()
+      const params = { deck_id: 10, rank: 'a0', front_text: 'Q', back_text: '' }
+
+      onSettled(undefined, undefined, params)
+
+      expect(invalidateCardIndexMock).toHaveBeenCalledWith(queryCache)
+    })
+
+    test('refetches the deck card pages when only back_text is present [obligation]', () => {
+      const { onSettled } = configFrom()
+      const params = { deck_id: 10, rank: 'a0', front_text: '', back_text: 'A' }
+
+      onSettled(undefined, undefined, params)
+
+      expect(invalidateDeckMock).toHaveBeenCalledWith(queryCache, 10, { card_pages: true })
+    })
+
+    test('does not invalidate the card index when only back_text is present (index keys on front) [obligation]', () => {
+      const { onSettled } = configFrom()
+      const params = { deck_id: 10, rank: 'a0', front_text: '', back_text: 'A' }
+
+      onSettled(undefined, undefined, params)
+
+      expect(invalidateCardIndexMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/api/cards/mutations/move-to-deck.test.js
+++ b/tests/unit/api/cards/mutations/move-to-deck.test.js
@@ -79,7 +79,7 @@ describe('useMoveCardsToDeckMutation — onSettled()', () => {
     const { onSettled } = config()
     onSettled(undefined, undefined, { target_deck_id: 20, card_ids: [1], source_deck_ids: [5] })
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 'count'] })
-    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'], exact: true })
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 'index'] })
   })
 })

--- a/tests/unit/api/cards/mutations/single.test.js
+++ b/tests/unit/api/cards/mutations/single.test.js
@@ -70,13 +70,13 @@ describe('useInsertCardMutation', () => {
     const { onSettled } = configFrom(useInsertCardMutation)
     onSettled({ id: 9, rank: 'a5' }, undefined, {
       deck_id: 10,
-      front_text: '',
-      back_text: ''
+      front_text: 'Q',
+      back_text: 'A'
     })
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['deck', 10] })
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 10] })
     expect(invalidateSpy).toHaveBeenCalledWith({ key: ['cards', 'count'] })
-    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ key: ['decks'], exact: true })
   })
 
   test('onSettled invalidates card index — new front text must appear in highlights [obligation]', () => {

--- a/tests/unit/api/decks/queries.test.js
+++ b/tests/unit/api/decks/queries.test.js
@@ -75,4 +75,13 @@ describe('useMemberDeckCountQuery', () => {
     const { query } = configFrom(useMemberDeckCountQuery)
     expect(query).toBe(fetchMemberDeckCountMock)
   })
+
+  // [obligation] useCan() instantiates this query and is mounted per card face
+  // editor, so a default 5s staleTime made every newly rendered card row
+  // refetch the member deck count. Freshness comes solely from explicit
+  // ['decks'] invalidation on deck create/delete/move.
+  test('staleTime is Infinity — freshness comes only from explicit ["decks"] invalidation [obligation]', () => {
+    const { staleTime } = configFrom(useMemberDeckCountQuery)
+    expect(staleTime).toBe(Infinity)
+  })
 })

--- a/tests/unit/api/decks/queries.test.js
+++ b/tests/unit/api/decks/queries.test.js
@@ -77,11 +77,11 @@ describe('useMemberDeckCountQuery', () => {
   })
 
   // [obligation] useCan() instantiates this query and is mounted per card face
-  // editor, so a default 5s staleTime made every newly rendered card row
-  // refetch the member deck count. Freshness comes solely from explicit
-  // ['decks'] invalidation on deck create/delete/move.
-  test('staleTime is Infinity — freshness comes only from explicit ["decks"] invalidation [obligation]', () => {
+  // editor, so the default 5s staleTime made every newly rendered card row
+  // refetch the member deck count. Explicit ['decks'] invalidation on deck
+  // create/delete/move carries the freshness; this is only the backstop.
+  test('staleTime is 5 minutes, well past a card row mount [obligation]', () => {
     const { staleTime } = configFrom(useMemberDeckCountQuery)
-    expect(staleTime).toBe(Infinity)
+    expect(staleTime).toBe(1000 * 60 * 5)
   })
 })

--- a/tests/unit/composables/card-editor/card-list-controller.test.js
+++ b/tests/unit/composables/card-editor/card-list-controller.test.js
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, vi } from 'vite-plus/test'
+import { flushPromises } from '@vue/test-utils'
 import { ref } from 'vue'
 import { card } from '@tests/fixtures/card'
 
@@ -556,6 +557,214 @@ describe('useCardListController', () => {
       const temp_id = all_cards.value[0].id
       await expect(updateCard(temp_id, { front_text: 'X' })).rejects.toThrow('boom')
       expect(saving.value).toBe(false)
+    })
+  })
+
+  // ── eager insert — stageCard fires the INSERT before any keystroke ─────────
+
+  describe('eager insert on create', () => {
+    test('addFocusedCard (desktop appendCard) fires the INSERT immediately, before any text is entered [obligation]', async () => {
+      const { gated_appendCard } = makeController([makeCard({ id: 100 })])
+      await gated_appendCard(100)
+      await flushPromises()
+      expect(insertCardMock).toHaveBeenCalledOnce()
+    })
+
+    test('addCard (mobile dock editor) fires the INSERT immediately, before any text is entered [obligation]', async () => {
+      const { gated_addCard } = makeController([makeCard({ id: 100 })])
+      await gated_addCard()
+      await flushPromises()
+      expect(insertCardMock).toHaveBeenCalledOnce()
+    })
+
+    test('only the desktop seam (addFocusedCard) sets the autofocus target, not the mobile seam [obligation]', async () => {
+      const { gated_appendCard, gated_addCard, claimFocus, all_cards } = makeController([
+        makeCard({ id: 100 })
+      ])
+      await gated_appendCard(100)
+      const desktop_client_id = all_cards.value.find((c) => c.id < 0).client_id
+      expect(claimFocus(desktop_client_id)).toBe(true)
+
+      await gated_addCard()
+      const mobile_client_id = all_cards.value.find(
+        (c) => c.id < 0 && c.client_id !== desktop_client_id
+      ).client_id
+      expect(claimFocus(mobile_client_id)).toBe(false)
+    })
+
+    test('guardAddCards resolving false stages nothing AND fires no insert [obligation]', async () => {
+      guardAddCardsMock.mockResolvedValue(false)
+      const { gated_appendCard, gated_addCard, all_cards } = makeController([makeCard({ id: 100 })])
+      await gated_appendCard(100)
+      await gated_addCard()
+      await flushPromises()
+      expect(all_cards.value).toHaveLength(1)
+      expect(insertCardMock).not.toHaveBeenCalled()
+    })
+
+    // [obligation] high-value regression: `neighbourRanksFor` skips unranked
+    // siblings, so two concurrent mints would both resolve against the same
+    // persisted neighbour and collide on the same key. Serializing through
+    // one insert_queue makes the second mint read the first's resolved rank.
+    test('two cards created in rapid succession mint distinct ranks that sort in render order [obligation]', async () => {
+      let next_id = 100
+      insertCardMock.mockImplementation(async (args) => ({ id: next_id++, rank: args.rank }))
+
+      const { addCardAtTop, all_cards } = makeController([makeCard({ id: 1 })])
+      guardAddCardsMock.mockResolvedValue(true)
+
+      // Fire both creates back to back, without awaiting the first's insert.
+      addCardAtTop()
+      addCardAtTop()
+      // Two inserts serialized through insert_queue is a deeper promise chain
+      // than a single insert — flush enough microtask ticks for both to settle.
+      for (let i = 0; i < 6; i++) await flushPromises()
+
+      const temps = all_cards.value.filter((c) => c.id !== 1)
+      expect(temps).toHaveLength(2)
+
+      const [top, bottom] = temps
+      expect(top.rank).toBeTruthy()
+      expect(bottom.rank).toBeTruthy()
+      expect(top.rank).not.toBe(bottom.rank)
+      // Render order is top-to-bottom; ranks must sort the same way.
+      expect(top.rank < bottom.rank).toBe(true)
+    })
+
+    // [obligation] typing into a card whose eager INSERT is still in flight
+    // must yield exactly one card carrying the text — updateCard awaits the
+    // pending insert, then routes to saveCard (UPDATE), never a second insert.
+    test('typing while the eager insert is in flight yields exactly one card carrying the text [obligation]', async () => {
+      let resolveInsert
+      insertCardMock.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveInsert = () => r({ id: 200, rank: 'm5' })
+        })
+      )
+
+      const { addCardAtTop, all_cards, updateCard } = makeController()
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+
+      const client_id = all_cards.value[0].client_id
+      const temp_id = all_cards.value[0].id
+      const update_promise = updateCard(temp_id, { front_text: 'typed while inserting' })
+
+      resolveInsert()
+      await update_promise
+
+      expect(insertCardMock).toHaveBeenCalledOnce()
+      expect(saveCardMock).toHaveBeenCalledOnce()
+      const [{ values }] = saveCardMock.mock.calls[0]
+      expect(values.front_text).toBe('typed while inserting')
+      expect(all_cards.value.filter((c) => c.client_id === client_id)).toHaveLength(1)
+    })
+
+    // [obligation] a PT402 rejection on the eager insert rolls the staged row
+    // back out of the list — contrast with the updateCard→insertTemp path
+    // (see the `updateCard` describe above), which deliberately leaves the
+    // temp staged because it may carry user-typed text.
+    test('a PT402 rejection on the eager insert removes the staged card from the list [obligation]', async () => {
+      insertCardMock.mockRejectedValueOnce({ code: 'PT402' })
+      handleLimitErrorMock.mockReturnValueOnce(true)
+
+      const { addCardAtTop, all_cards } = makeController()
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      await flushPromises()
+      await flushPromises()
+
+      expect(all_cards.value).toHaveLength(0)
+    })
+
+    test('a PT402 rejection on the eager insert surfaces the upgrade alert via handleLimitError [obligation]', async () => {
+      const limit_error = { code: 'PT402' }
+      insertCardMock.mockRejectedValueOnce(limit_error)
+      handleLimitErrorMock.mockReturnValueOnce(true)
+
+      const { addCardAtTop } = makeController()
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      await flushPromises()
+      await flushPromises()
+
+      expect(handleLimitErrorMock).toHaveBeenCalledWith(limit_error)
+    })
+
+    // [obligation] a non-limit failure of the eager insert is swallowed: the
+    // insert only ever carries an empty card, so nothing typed can be lost.
+    // No toast, the entry stays a temp, and the next edit re-inserts it.
+    test('a non-limit failure of the eager insert is swallowed — no toast, entry stays a temp [obligation]', async () => {
+      insertCardMock.mockRejectedValueOnce(new Error('network down'))
+
+      const { addCardAtTop, all_cards } = makeController()
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      await flushPromises()
+      await flushPromises()
+
+      expect(all_cards.value).toHaveLength(1)
+      expect(all_cards.value[0].id).toBeLessThan(0)
+      expect(mockNotice.warn).not.toHaveBeenCalled()
+      expect(mockNotice.error).not.toHaveBeenCalled()
+    })
+
+    test('the next edit re-inserts a temp whose eager insert failed non-limit [obligation]', async () => {
+      insertCardMock.mockRejectedValueOnce(new Error('network down'))
+      insertCardMock.mockResolvedValueOnce({ id: 300, rank: 'm9' })
+
+      const { addCardAtTop, all_cards, updateCard } = makeController()
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      await flushPromises()
+      await flushPromises()
+
+      const temp_id = all_cards.value[0].id
+      await updateCard(temp_id, { front_text: 'retry' })
+
+      expect(insertCardMock).toHaveBeenCalledTimes(2)
+      const [second_call_args] = insertCardMock.mock.calls[1]
+      expect(second_call_args.front_text).toBe('retry')
+    })
+
+    // [obligation] negative: nothing removes an empty temp on blur or when
+    // leaving the deck — a successfully-inserted, still-empty card just stays.
+    test('a successfully eager-inserted, still-empty card is never auto-removed [obligation]', async () => {
+      const { addCardAtTop, all_cards } = makeController()
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      await flushPromises()
+      await flushPromises()
+
+      expect(all_cards.value).toHaveLength(1)
+      expect(all_cards.value[0].front_text).toBe('')
+      expect(all_cards.value[0].back_text).toBe('')
+    })
+
+    // [obligation] regression this branch closes: an eagerly-created card is
+    // promoted in place and never refetched, so `patchTemp` — not the optimistic
+    // cache patch — is what lets the mobile editor's one-side-at-a-time saves
+    // both land on the same entry instead of clobbering each other.
+    test('create card, save front text, then save back text — both sides survive [obligation]', async () => {
+      insertCardMock.mockResolvedValueOnce({ id: 400, rank: 'm7' })
+
+      const { addCardAtTop, all_cards, updateCard } = makeController()
+      guardAddCardsMock.mockResolvedValue(true)
+      await addCardAtTop()
+      await flushPromises()
+      await flushPromises()
+
+      const card_id = all_cards.value[0].id
+      await updateCard(card_id, { front_text: 'Question' })
+      await updateCard(card_id, { back_text: 'Answer' })
+
+      const entry = all_cards.value.find((c) => c.id === card_id)
+      expect(entry.front_text).toBe('Question')
+      expect(entry.back_text).toBe('Answer')
+      // Both saves route to UPDATE — the card was already promoted by the
+      // eager insert, so nothing here fires a second INSERT.
+      expect(insertCardMock).toHaveBeenCalledOnce()
+      expect(saveCardMock).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/tests/unit/composables/card-editor/virtual-list.test.js
+++ b/tests/unit/composables/card-editor/virtual-list.test.js
@@ -1,0 +1,113 @@
+import { describe, test, expect, beforeEach } from 'vite-plus/test'
+import { useVirtualCardList } from '@/views/deck/composables/virtual-list'
+
+function makeCardsQuery(pages = []) {
+  return {
+    data: { value: { pages, pageParams: pages.map((_, i) => i) } }
+  }
+}
+
+describe('useVirtualCardList', () => {
+  let list
+
+  beforeEach(() => {
+    list = useVirtualCardList(makeCardsQuery([]), 10)
+  })
+
+  // ── findEntryByClientId ───────────────────────────────────────────────────
+
+  describe('findEntryByClientId', () => {
+    test('returns undefined when nothing has been staged', () => {
+      expect(list.findEntryByClientId('missing')).toBeUndefined()
+    })
+
+    test('finds a staged temp entry by its client_id', () => {
+      const client_id = list.addCard()
+      const entry = list.findEntryByClientId(client_id)
+      expect(entry?.client_id).toBe(client_id)
+    })
+
+    test('the same client_id still resolves after the entry is promoted [obligation]', () => {
+      const client_id = list.addCard()
+      const entry = list.findEntryByClientId(client_id)
+      list.promoteTemp(entry.card.id, 555, 'a0', { front_text: 'Q' })
+
+      const promoted = list.findEntryByClientId(client_id)
+      expect(promoted?.real_id).toBe(555)
+    })
+  })
+
+  // ── patchTemp ──────────────────────────────────────────────────────────────
+
+  describe('patchTemp', () => {
+    test('is a no-op when the client_id matches nothing', () => {
+      expect(() => list.patchTemp('missing', { front_text: 'X' })).not.toThrow()
+    })
+
+    test('merges values into the entry card record', () => {
+      const client_id = list.addCard()
+      list.patchTemp(client_id, { front_text: 'Q' })
+      expect(list.findEntryByClientId(client_id)?.card.front_text).toBe('Q')
+    })
+
+    // [obligation] the eager-insert entry never enters the persisted cache, so
+    // patchTemp is the only mechanism keeping both sides of a two-step save —
+    // this is the regression this branch closes.
+    test('a second patch preserves the first field, so both sides of a two-step save survive [obligation]', () => {
+      const client_id = list.addCard()
+      list.patchTemp(client_id, { front_text: 'Q' })
+      list.patchTemp(client_id, { back_text: 'A' })
+
+      const entry = list.findEntryByClientId(client_id)
+      expect(entry?.card.front_text).toBe('Q')
+      expect(entry?.card.back_text).toBe('A')
+    })
+  })
+
+  // ── removeTemp ─────────────────────────────────────────────────────────────
+
+  describe('removeTemp', () => {
+    test('drops the staged entry out of all_cards', () => {
+      const client_id = list.addCard()
+      expect(list.all_cards.value).toHaveLength(1)
+
+      list.removeTemp(client_id)
+
+      expect(list.all_cards.value).toHaveLength(0)
+    })
+
+    test('is a no-op when the client_id matches nothing', () => {
+      list.addCard()
+      list.removeTemp('missing')
+      expect(list.all_cards.value).toHaveLength(1)
+    })
+
+    test('only removes the matching entry, leaving siblings intact', () => {
+      const first = list.addCard()
+      list.addCard()
+
+      list.removeTemp(first)
+
+      expect(list.all_cards.value).toHaveLength(1)
+      expect(list.all_cards.value[0].client_id).not.toBe(first)
+    })
+  })
+
+  // ── addCard eager-insert regression seam — persisted refetch never arrives ──
+
+  describe('eager-created entries', () => {
+    // [obligation] negative: nothing in the composable removes a staged temp
+    // just because it stays empty. Removal only ever happens via explicit
+    // removeTemp — never a side effect of reading the list.
+    test('a staged, never-edited temp is never auto-removed by reading all_cards [obligation]', () => {
+      const client_id = list.addCard()
+      // Read the list repeatedly, as a render loop would.
+      void list.all_cards.value
+      void list.all_cards.value
+      void list.all_cards.value
+
+      expect(list.findEntryByClientId(client_id)).toBeDefined()
+      expect(list.all_cards.value).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
[TARO-162](https://app.notion.com/3970953c224c80a2b506d2ae5c1a9067)

## Summary

A new card used to exist only on screen until the first keystroke — refresh before typing and it was gone. It now persists the moment it's created, so a blank card is a real, saved card that survives a refresh. The two create paths (desktop list, mobile dock) were collapsed into one seam so the eager save exists once, and the query-invalidation fan-out each create triggered was trimmed from 6 requests to 2.

## Changes

- **`feat(deck)`** — `addCard` (mobile) and `addFocusedCard` (desktop) now funnel through a single `stageCard`, which fires the INSERT right after staging. Eager inserts are serialized through one promise chain: `neighbourRanksFor` skips unranked siblings, so two concurrent mints would resolve identical neighbours and `generateKeyBetween` would hand both cards the same key. `updateCard` awaits an in-flight insert and routes to UPDATE, so typing into a brand-new card can't produce a duplicate. A `PT402` cap rejection rolls the staged row back out of the list; any other failure leaves it a temp for the next edit to re-insert, with no toast — the eager insert only ever carries an empty card.
- **`perf(api)`** — `invalidateQueries({ key: ['decks'] })` is a prefix match, so it also swept `['decks', 'count']`, the member's *deck* count, which no card write can change. Made exact. The card index maps front text to decks, so an insert with no front text no longer invalidates it.
- **`perf(deck)`** — a blank insert no longer refetches the deck's card pages: `promoteTemp` already writes the returned id and rank into the row on screen, and an empty card can't be flagged a duplicate. Inserts carrying text (audio-reader panel, re-insert after a failed eager save) have no row staged and still refetch. That leaves the promoted row outside the cached pages where `saveCard`'s optimistic patch can't reach it, so the entry's own card is patched on save — otherwise the mobile editor's one-side-at-a-time writes would merge against the empty staged record and clobber the other side. Separately, the deck-count query ran on a default 5s `staleTime` while `useCan()` mounts per card face editor, making every new row refetch it; deck create/delete/move all invalidate it explicitly, so it's pinned.
- **`test(deck)`** — 149 tests across the two composables and three API files.

## Test plan

- [ ] Create a card, refresh before typing — the blank card is still there
- [ ] Click "new card" three times fast — all three persist in the order shown, top to bottom
- [ ] Type immediately into a brand-new card — one card carries the text, no duplicate
- [ ] At the deck card cap, create a card — upgrade message shows and no row is added
- [ ] On mobile, create a card then fill front and back in turn — both sides survive
- [ ] Click away from an empty card, leave the deck and return — it's still there