### PR TITLE
Self-heal: comments shouldn't borrow a library's vocabulary

### DIFF
--- a/.claude/docs/code-style-comments.md
+++ b/.claude/docs/code-style-comments.md
@@ -6,6 +6,19 @@ Comment the non-obvious _why_, never the _what_. Most code needs none — a clea
 - **No narration.** Don't restate the next line (`// loop over items`) or label a section (`// setup`) — blank-line phases already segment a body ([`code-style-phases`](./code-style-phases.md)).
 - **None in `<template>` markup** — see [`vue-templates`](../rules/vue-templates.md). Improve `data-testid` / slot / component names instead.
 - **JSDoc on exported composable fns** stays tight — lead with behaviour, skip restating types ([`composables`](../rules/composables.md)).
+- **Don't borrow a library's vocabulary.** Explain in terms the reader can observe — what the screen shows, what the user sees — not the dependency's internal nouns (`stale`, `active entry`, `prefix filter`, `hydration`). Name the API being called; never assume the reader holds its mental model. A comment that only lands for someone who has read the library's source is a comment that doesn't land.
+
+Bad — only parses if you know how the query cache thinks:
+
+```ts
+// Stale-marking hits every match; refetching only hits mounted queries.
+```
+
+Good — same fact, observable terms:
+
+```ts
+// Flags every affected deck as out of date, but only re-downloads the one on screen.
+```
 
 Bad — three lines narrating one branch:
 


### PR DESCRIPTION
## Summary

Comments written in a dependency's internal nouns — *stale-marking*, *active queries*, *prefix filter* — only land for a reader who has already read that library. Adds that as a rule in `code-style-comments`.

Surfaced on #511, where the Pinia Colada invalidation helper's comments were unreadable without knowing how Colada's cache works. The existing rules cover length and why-not-what, but nothing said who the audience is.

## Changes

- `.claude/docs/code-style-comments.md` — new bullet plus a short bad/good pair