### PR TITLE
TARO-330: Knowledge addressing scheme and pointer lint

### DIFF
--- a/.claude/knowledge-lint.json
+++ b/.claude/knowledge-lint.json
@@ -1,0 +1,28 @@
+{
+  "always_on": {
+    "include": ["CLAUDE.md", ".claude/rules/*.md"],
+    "line_caps": {
+      "enforced": false,
+      "total": 250,
+      "per_file": {
+        "CLAUDE.md": 80
+      }
+    }
+  },
+  "slugs": {
+    "retired_ledger": ".claude/knowledge/retired-slugs.md",
+    "declare_in": ["CLAUDE.md", "AGENTS.md", ".claude/**/*.md", "corpus/**/*.md"],
+    "cite_in": [
+      "CLAUDE.md",
+      "AGENTS.md",
+      ".claude/**/*.md",
+      "corpus/**/*.md",
+      "src/**/*.{ts,js,vue}",
+      "tests/**/*.{ts,js,vue}",
+      "scripts/**/*.{ts,js,mjs}",
+      "supabase/**/*.{sql,ts}",
+      ".github/**/*.yml"
+    ],
+    "exempt": ["supabase/migrations/**"]
+  }
+}

--- a/.claude/knowledge-lint.json
+++ b/.claude/knowledge-lint.json
@@ -23,6 +23,6 @@
       "supabase/**/*.{sql,ts}",
       ".github/**/*.yml"
     ],
-    "exempt": ["supabase/migrations/**"]
+    "exempt": ["supabase/migrations/**", "tests/unit/scripts/knowledge-lint.test.js"]
   }
 }

--- a/.claude/knowledge/retired-slugs.md
+++ b/.claude/knowledge/retired-slugs.md
@@ -1,0 +1,12 @@
+# Retired slugs
+
+Slugs are never reused. When a fact goes, its slug moves here with a one-line epitaph and every
+citation is deleted. Re-declaring a slug listed below fails `pnpm knowledge:check`.
+
+Format — one line each, em dash before the epitaph:
+
+`- [K:some-retired-slug] — what the fact said, and why it went.`
+
+<!-- entries below; this file is exempt from the declaration scan, so a slug here is retired, not declared -->
+
+_None retired yet._

--- a/.claude/rules/knowledge-addressing.md
+++ b/.claude/rules/knowledge-addressing.md
@@ -46,8 +46,9 @@ a breached line cap.
 caps, and the scan scope. Always-on = the `always_on.include` globs minus any file carrying `paths:`
 frontmatter, since a `paths:` rule is path-triggered rather than loaded every session.
 
-- `supabase/migrations/**` is exempt from the citation scan: migrations are append-only, so a
-  pointer written into one can never be corrected.
+- `slugs.exempt` skips the citation scan. `supabase/migrations/**` is exempt because migrations are
+  append-only, so a pointer written into one can never be corrected; the checker's own test file is
+  exempt because its fixtures contain literal tokens. Nothing else earns a place there.
 - Caps are `line_caps` — 80 lines for `CLAUDE.md`, 250 for the always-on total. A starting
   calibration, not a measured figure.
 - `line_caps.enforced` is `false` until the always-on payload is restructured (TARO-331); breaches

--- a/.claude/rules/knowledge-addressing.md
+++ b/.claude/rules/knowledge-addressing.md
@@ -1,0 +1,54 @@
+---
+lastUpdated: 2026-08-08T00:00:00Z
+paths:
+  - 'CLAUDE.md'
+  - 'AGENTS.md'
+  - '.claude/**/*.md'
+  - 'corpus/**/*.md'
+---
+
+# Knowledge addressing
+
+Every citable fact, rule, or trap gets a permanent slug, so anything can point at it and one grep
+says whether it is still referenced. Headings get reworded and files get split — a slug survives
+both, so renaming or splitting a knowledge file breaks no citation.
+
+## Slugs [K:knowledge-slug-format]
+
+- **Declare** with a bare `[K:<kebab-slug>]`, exactly once across the whole knowledge layer, on the
+  line the fact lives on — usually trailing a heading or a bullet.
+- **Cite** with `→[K:<slug>]`, from anywhere: source, tests, another knowledge file.
+- Kebab-case only (`[a-z0-9-]`). Name the fact, not the file it currently sits in.
+- **Resolve** a citation with one grep, no judgement — the declaration is the hit without the arrow:
+  `grep -rn '\[K:<slug>\]' .`
+- **Inbound reference count** is that same grep: hits minus the one declaration.
+
+## Where a slug may be declared [K:knowledge-declaration-sites]
+
+Only in the knowledge files listed under `slugs.declare_in` in
+[`.claude/knowledge-lint.json`](../knowledge-lint.json) — `CLAUDE.md`, `AGENTS.md`, `.claude/**`,
+`corpus/**`. A bare token anywhere else is a stray citation missing its arrow, and fails the check.
+
+## Retirement [K:knowledge-slug-retirement]
+
+A slug is **never reused**. When the fact goes, move the slug to
+[`retired-slugs.md`](../knowledge/retired-slugs.md) as `- [K:<slug>] — <one-line epitaph>` and
+delete every citation. Re-declaring or citing a retired slug fails the check.
+
+## The check [K:knowledge-lint]
+
+`pnpm knowledge:check` (`scripts/knowledge-lint.mjs`) runs on every PR as its own CI job — always,
+never behind a paths filter, so a run that never happened is visible rather than silent. It fails on
+an unresolvable citation, a slug declared twice, a stray declaration, a malformed ledger entry, and
+a breached line cap.
+
+`.claude/knowledge-lint.json` is the **single declared place** for the always-on file list, the
+caps, and the scan scope. Always-on = the `always_on.include` globs minus any file carrying `paths:`
+frontmatter, since a `paths:` rule is path-triggered rather than loaded every session.
+
+- `supabase/migrations/**` is exempt from the citation scan: migrations are append-only, so a
+  pointer written into one can never be corrected.
+- Caps are `line_caps` — 80 lines for `CLAUDE.md`, 250 for the always-on total. A starting
+  calibration, not a measured figure.
+- `line_caps.enforced` is `false` until the always-on payload is restructured (TARO-331); breaches
+  report as warnings meanwhile. Flip it to `true` in the same change that lands under the caps.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,25 @@ jobs:
       - name: Run type-check
         run: pnpm type-check
 
+  # Deliberately unconditional — no paths filter, no `needs`. A required status
+  # that skips is indistinguishable from one that passed.
+  knowledge:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Check knowledge pointers and always-on budget
+        run: node scripts/knowledge-lint.mjs
+
   test:
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push'

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "type-check": "vue-tsc --build --force",
     "lint": "oxlint",
     "format": "vp fmt src/",
+    "knowledge:check": "node scripts/knowledge-lint.mjs",
     "build:email-templates": "node scripts/build-email-templates.mjs",
     "gen:palette-css": "node scripts/gen-palette-css.ts",
     "docs:dev": "vitepress dev docs --port 8080",

--- a/scripts/knowledge-lint.mjs
+++ b/scripts/knowledge-lint.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * Checks the knowledge addressing scheme: slug declarations, citations, the
+ * retired-slug ledger, and the always-on line budget.
+ *
+ * Run with `pnpm knowledge:check`. Config lives in .claude/knowledge-lint.json —
+ * the single declared place for the always-on file list and the caps.
+ * See .claude/rules/knowledge-addressing.md.
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const CONFIG_PATH = '.claude/knowledge-lint.json'
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'coverage',
+  '.vitest-reports',
+  '.claude/worktrees'
+])
+
+// `→[K:<slug>]` cites, bare `[K:<slug>]` declares. Angle-bracket placeholders in
+// prose (`[K:<kebab-slug>]`) deliberately fall outside the character class.
+const TOKEN = /(→\s*)?\[K:([A-Za-z0-9_-]+)\]/g
+const KEBAB = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const LEDGER_ENTRY = /^\s*[-*]\s*\[K:([A-Za-z0-9_-]+)\]\s*—\s*(.*)$/
+// A rule carrying `paths:` frontmatter is path-triggered, not always-on.
+const SCOPED_FRONTMATTER = /^---\r?\n[\s\S]*?^paths:/m
+
+function expandBraces(glob) {
+  const match = /\{([^{}]*)\}/.exec(glob)
+  if (!match) return [glob]
+
+  return match[1]
+    .split(',')
+    .flatMap((option) =>
+      expandBraces(glob.slice(0, match.index) + option + glob.slice(match.index + match[0].length))
+    )
+}
+
+function globToRegExp(glob) {
+  let out = ''
+
+  for (let i = 0; i < glob.length; i++) {
+    const char = glob[i]
+    if (char === '*' && glob[i + 1] === '*' && glob[i + 2] === '/') {
+      out += '(?:.*/)?'
+      i += 2
+      continue
+    }
+    if (char === '*' && glob[i + 1] === '*') {
+      out += '.*'
+      i += 1
+      continue
+    }
+    if (char === '*') {
+      out += '[^/]*'
+      continue
+    }
+    if (char === '?') {
+      out += '[^/]'
+      continue
+    }
+    out += char.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  }
+
+  return new RegExp(`^${out}$`)
+}
+
+function matchesAny(path, globs) {
+  return globs.flatMap(expandBraces).some((glob) => globToRegExp(glob).test(path))
+}
+
+function listFiles(root, dir = root, found = []) {
+  for (const entry of readdirSync(dir)) {
+    const absolute = join(dir, entry)
+    const path = relative(root, absolute)
+    if (SKIP_DIRS.has(entry) || SKIP_DIRS.has(path)) continue
+
+    if (statSync(absolute).isDirectory()) {
+      listFiles(root, absolute, found)
+      continue
+    }
+    found.push(path)
+  }
+
+  return found
+}
+
+function countLines(text) {
+  const lines = text.split('\n')
+  return lines.at(-1) === '' ? lines.length - 1 : lines.length
+}
+
+/** Every `[K:…]` token in a file, tagged as citation or declaration. */
+function collectTokens(path, text) {
+  const tokens = []
+
+  for (const [index, line] of text.split('\n').entries()) {
+    for (const match of line.matchAll(TOKEN)) {
+      tokens.push({ path, line: index + 1, slug: match[2], cites: Boolean(match[1]) })
+    }
+  }
+
+  return tokens
+}
+
+/** Retired slugs and their epitaphs; a malformed entry is an error, not an epitaph. */
+function readLedger(root, ledgerPath) {
+  const errors = []
+  const retired = new Map()
+  const absolute = join(root, ledgerPath)
+  if (!existsSync(absolute)) return { retired, errors }
+
+  for (const [index, line] of readFileSync(absolute, 'utf8').split('\n').entries()) {
+    if (!line.trimStart().startsWith('-') || !line.includes('[K:')) continue
+
+    const entry = LEDGER_ENTRY.exec(line)
+    if (!entry || !entry[2].trim()) {
+      errors.push(`${ledgerPath}:${index + 1} — ledger entry needs \`- [K:<slug>] — <epitaph>\``)
+      continue
+    }
+    retired.set(entry[1], { epitaph: entry[2].trim(), line: index + 1 })
+  }
+
+  return { retired, errors }
+}
+
+function checkDeclarations(tokens, retired, ledgerPath) {
+  const errors = []
+  const declared = new Map()
+
+  for (const token of tokens.filter((candidate) => !candidate.cites)) {
+    const at = `${token.path}:${token.line}`
+    if (!KEBAB.test(token.slug)) {
+      errors.push(`${at} — [K:${token.slug}] is not a kebab-case slug`)
+      continue
+    }
+    if (retired.has(token.slug)) {
+      errors.push(`${at} — [K:${token.slug}] is retired in ${ledgerPath}; slugs are never reused`)
+      continue
+    }
+
+    const first = declared.get(token.slug)
+    if (first) {
+      errors.push(`${at} — [K:${token.slug}] already declared at ${first}`)
+      continue
+    }
+    declared.set(token.slug, at)
+  }
+
+  return { declared, errors }
+}
+
+function checkCitations(tokens, declared, retired, ledgerPath) {
+  return tokens
+    .filter((token) => token.cites && !declared.has(token.slug))
+    .map((token) => {
+      const at = `${token.path}:${token.line}`
+      const retirement = retired.get(token.slug)
+      if (retirement)
+        return `${at} — →[K:${token.slug}] is retired (${ledgerPath}:${retirement.line})`
+      return `${at} — →[K:${token.slug}] resolves to no declaration`
+    })
+}
+
+function checkLineCaps(root, files, alwaysOn) {
+  const breaches = []
+  const caps = alwaysOn.line_caps
+  let total = 0
+
+  for (const path of files.filter((file) => matchesAny(file, alwaysOn.include))) {
+    const text = readFileSync(join(root, path), 'utf8')
+    if (SCOPED_FRONTMATTER.test(text)) continue
+
+    const lines = countLines(text)
+    total += lines
+
+    const cap = caps.per_file?.[path]
+    if (cap && lines > cap) breaches.push(`${path} is ${lines} lines, over its ${cap}-line cap`)
+  }
+
+  if (total > caps.total) {
+    breaches.push(`always-on payload is ${total} lines, over the ${caps.total}-line cap`)
+  }
+
+  // Caps stay advisory until the payload is restructured (TARO-331).
+  return {
+    errors: caps.enforced === false ? [] : breaches,
+    warnings: caps.enforced === false ? breaches : [],
+    total
+  }
+}
+
+export function lintKnowledge(root) {
+  const config = JSON.parse(readFileSync(join(root, CONFIG_PATH), 'utf8'))
+  const { slugs, always_on } = config
+  const files = listFiles(root)
+
+  const ledger = readLedger(root, slugs.retired_ledger)
+  const cited = files.filter(
+    (path) => matchesAny(path, slugs.cite_in) && !matchesAny(path, slugs.exempt)
+  )
+  const tokens = cited
+    .filter((path) => path !== slugs.retired_ledger)
+    .flatMap((path) => collectTokens(path, readFileSync(join(root, path), 'utf8')))
+
+  const declarable = new Set(files.filter((path) => matchesAny(path, slugs.declare_in)))
+  const misplaced = tokens
+    .filter((token) => !token.cites && !declarable.has(token.path))
+    .map(
+      (token) => `${token.path}:${token.line} — [K:${token.slug}] declared outside a knowledge file`
+    )
+
+  const declarations = checkDeclarations(
+    tokens.filter((token) => declarable.has(token.path)),
+    ledger.retired,
+    slugs.retired_ledger
+  )
+  const citations = checkCitations(
+    tokens,
+    declarations.declared,
+    ledger.retired,
+    slugs.retired_ledger
+  )
+  const caps = checkLineCaps(root, files, always_on)
+
+  return {
+    errors: [...ledger.errors, ...declarations.errors, ...misplaced, ...citations, ...caps.errors],
+    warnings: caps.warnings,
+    stats: {
+      declared: declarations.declared.size,
+      retired: ledger.retired.size,
+      citations: tokens.filter((token) => token.cites).length,
+      alwaysOnLines: caps.total
+    }
+  }
+}
+
+function main() {
+  const root = process.argv[2] ?? process.cwd()
+  const { errors, warnings, stats } = lintKnowledge(root)
+
+  for (const warning of warnings) console.error(`::warning::${warning}`)
+  for (const error of errors) console.error(`::error::${error}`)
+
+  console.log(
+    `knowledge-lint: ${stats.declared} slugs, ${stats.citations} citations, ` +
+      `${stats.retired} retired, ${stats.alwaysOnLines} always-on lines`
+  )
+  if (errors.length) process.exit(1)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main()

--- a/tests/unit/scripts/knowledge-lint.test.js
+++ b/tests/unit/scripts/knowledge-lint.test.js
@@ -1,0 +1,297 @@
+import { describe, test, expect, afterEach } from 'vite-plus/test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { lintKnowledge } from '../../../scripts/knowledge-lint.mjs'
+
+// Every test builds its own throwaway root under os.tmpdir() with its own
+// .claude/knowledge-lint.json — never assert against the real repo's
+// knowledge files, which churn independently of this lint spine.
+
+const DEFAULT_CONFIG = {
+  always_on: {
+    include: ['CLAUDE.md', '.claude/rules/*.md'],
+    line_caps: {
+      enforced: false,
+      total: 250,
+      per_file: { 'CLAUDE.md': 80 }
+    }
+  },
+  slugs: {
+    retired_ledger: '.claude/knowledge/retired-slugs.md',
+    declare_in: ['CLAUDE.md', 'AGENTS.md', '.claude/**/*.md', 'corpus/**/*.md'],
+    cite_in: [
+      'CLAUDE.md',
+      'AGENTS.md',
+      '.claude/**/*.md',
+      'corpus/**/*.md',
+      'src/**/*.{ts,js,vue}',
+      'tests/**/*.{ts,js,vue}',
+      'scripts/**/*.{ts,js,mjs}',
+      'supabase/**/*.{sql,ts}',
+      '.github/**/*.yml'
+    ],
+    exempt: ['supabase/migrations/**']
+  }
+}
+
+const createdRoots = []
+
+afterEach(() => {
+  while (createdRoots.length) {
+    const root = createdRoots.pop()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+/** Builds a temp fixture root with the given config + files, returns its path. */
+function makeRoot(files = {}, configOverrides = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'knowledge-lint-'))
+  createdRoots.push(root)
+
+  const config = { ...DEFAULT_CONFIG, ...configOverrides }
+  mkdirSync(join(root, '.claude'), { recursive: true })
+  writeFileSync(join(root, '.claude/knowledge-lint.json'), JSON.stringify(config, null, 2))
+
+  for (const [relPath, content] of Object.entries(files)) {
+    const absolute = join(root, relPath)
+    mkdirSync(dirname(absolute), { recursive: true })
+    writeFileSync(absolute, content)
+  }
+
+  return root
+}
+
+describe('lintKnowledge — citations', () => {
+  test('a citation naming a slug with no bare declaration is an error', () => {
+    const root = makeRoot({
+      '.claude/rules/foo.md': 'See →[K:missing-slug] for details.\n'
+    })
+
+    const { errors } = lintKnowledge(root)
+
+    expect(errors).toEqual([expect.stringContaining('.claude/rules/foo.md:1')])
+    expect(errors[0]).toMatch(/missing-slug/)
+    expect(errors[0]).toMatch(/resolves to no declaration/)
+  })
+
+  test('a citation whose slug is declared is not an error', () => {
+    const root = makeRoot({
+      '.claude/rules/foo.md': '[K:my-slug] declares the concept.\n',
+      '.claude/rules/bar.md': 'Cite it: →[K:my-slug].\n'
+    })
+
+    const { errors, stats } = lintKnowledge(root)
+
+    expect(errors).toEqual([])
+    expect(stats.declared).toBe(1)
+    expect(stats.citations).toBe(1)
+  })
+
+  test('a citation inside supabase/migrations/** is exempt even when unresolvable', () => {
+    const root = makeRoot({
+      'supabase/migrations/00001_init.sql': '-- →[K:never-declared] append-only note\n'
+    })
+
+    const { errors } = lintKnowledge(root)
+
+    expect(errors).toEqual([])
+  })
+})
+
+describe('lintKnowledge — declarations', () => {
+  test('the same slug declared in two knowledge files errors naming both sites', () => {
+    const root = makeRoot({
+      '.claude/rules/a.md': '[K:dup-slug] first declaration.\n',
+      '.claude/rules/b.md': '[K:dup-slug] second declaration.\n'
+    })
+
+    const { errors } = lintKnowledge(root)
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('a.md:1')
+    expect(errors[0]).toContain('b.md:1')
+  })
+
+  test('a bare declaration outside slugs.declare_in globs errors as declared outside a knowledge file', () => {
+    const root = makeRoot({
+      'src/foo.ts': 'const x = 1 // [K:stray-slug]\n'
+    })
+
+    const { errors } = lintKnowledge(root)
+
+    expect(errors).toEqual([expect.stringContaining('declared outside a knowledge file')])
+    expect(errors[0]).toContain('src/foo.ts:1')
+  })
+
+  test('a non-kebab-case slug errors', () => {
+    const root = makeRoot({
+      '.claude/rules/foo.md': '[K:Not_Kebab] declared here.\n'
+    })
+
+    const { errors } = lintKnowledge(root)
+
+    expect(errors).toEqual([expect.stringContaining('is not a kebab-case slug')])
+  })
+
+  test('brace-alternation and ** globs both resolve nested extensions', () => {
+    const root = makeRoot({
+      'src/deep/nested/path/thing.js': '// [K:nested-stray]\n',
+      'src/top.ts': '// [K:top-stray]\n'
+    })
+
+    const { errors } = lintKnowledge(root)
+
+    expect(errors).toHaveLength(2)
+    expect(errors.some((error) => error.includes('src/deep/nested/path/thing.js:1'))).toBe(true)
+    expect(errors.some((error) => error.includes('src/top.ts:1'))).toBe(true)
+  })
+})
+
+describe('lintKnowledge — retired-slug ledger', () => {
+  test('a slug in the retired ledger may never be re-declared', () => {
+    const root = makeRoot({
+      '.claude/knowledge/retired-slugs.md': '- [K:old-slug] — replaced by new-thing\n',
+      '.claude/rules/foo.md': '[K:old-slug] redeclared after retirement.\n'
+    })
+
+    const { errors } = lintKnowledge(root)
+
+    expect(errors).toEqual([expect.stringContaining('is retired')])
+    expect(errors[0]).toContain('old-slug')
+  })
+
+  test('citing a retired slug errors as retired rather than as unresolved', () => {
+    const root = makeRoot({
+      '.claude/knowledge/retired-slugs.md': '- [K:old-slug] — replaced by new-thing\n',
+      '.claude/rules/foo.md': 'Still points at →[K:old-slug] somehow.\n'
+    })
+
+    const { errors } = lintKnowledge(root)
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/retired/)
+    expect(errors[0]).not.toMatch(/resolves to no declaration/)
+  })
+
+  test('a malformed ledger entry with no epitaph is an error', () => {
+    const root = makeRoot({
+      '.claude/knowledge/retired-slugs.md': '- [K:bad-entry]\n'
+    })
+
+    const { errors } = lintKnowledge(root)
+
+    expect(errors).toEqual([expect.stringContaining('.claude/knowledge/retired-slugs.md:1')])
+    expect(errors[0]).toMatch(/epitaph/)
+  })
+
+  test('the ledger file itself is excluded from token scanning', () => {
+    const root = makeRoot({
+      '.claude/knowledge/retired-slugs.md': '- [K:excluded-slug] — reason it retired\n',
+      '.claude/rules/foo.md': 'Cite →[K:excluded-slug] once more.\n'
+    })
+
+    const { errors, stats } = lintKnowledge(root)
+
+    // Ledger entries never count as declarations, so the citation resolves
+    // via the retired-slug path, not the "already declared" or clean-resolve path.
+    expect(stats.declared).toBe(0)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/retired/)
+  })
+
+  test('a root with no retired-ledger file lints cleanly', () => {
+    const root = makeRoot({
+      '.claude/rules/foo.md': '[K:some-slug] declared normally.\n'
+    })
+
+    const { errors, stats } = lintKnowledge(root)
+
+    expect(errors).toEqual([])
+    expect(stats.retired).toBe(0)
+  })
+})
+
+describe('lintKnowledge — always-on line accounting', () => {
+  test('a scoped rule file (paths: frontmatter) is excluded from the always-on total', () => {
+    const root = makeRoot({
+      'CLAUDE.md': 'line one\nline two\nline three\n',
+      '.claude/rules/scoped.md': [
+        '---',
+        'paths: src/**',
+        '---',
+        'this content should not count',
+        'toward the always-on total',
+        'because it is path-triggered'
+      ].join('\n')
+    })
+
+    const { stats } = lintKnowledge(root)
+
+    expect(stats.alwaysOnLines).toBe(3)
+  })
+
+  test('an unscoped always-on file is included in the total', () => {
+    const root = makeRoot({
+      'CLAUDE.md': 'line one\nline two\n',
+      '.claude/rules/plain.md': 'rule line one\nrule line two\nrule line three\n'
+    })
+
+    const { stats } = lintKnowledge(root)
+
+    expect(stats.alwaysOnLines).toBe(5)
+  })
+})
+
+describe('lintKnowledge — line caps', () => {
+  test('line-cap breaches land in warnings, not errors, when enforced is false', () => {
+    const root = makeRoot(
+      { 'CLAUDE.md': 'one\ntwo\nthree\nfour\nfive\n' },
+      {
+        always_on: {
+          include: ['CLAUDE.md'],
+          line_caps: { enforced: false, total: 2, per_file: { 'CLAUDE.md': 2 } }
+        }
+      }
+    )
+
+    const { errors, warnings } = lintKnowledge(root)
+
+    expect(errors).toEqual([])
+    expect(warnings).toHaveLength(2)
+    expect(warnings.some((warning) => warning.includes('CLAUDE.md is 5 lines'))).toBe(true)
+    expect(warnings.some((warning) => warning.includes('always-on payload is 5 lines'))).toBe(true)
+  })
+
+  test('the same line-cap breaches land in errors, not warnings, when enforced is true', () => {
+    const root = makeRoot(
+      { 'CLAUDE.md': 'one\ntwo\nthree\nfour\nfive\n' },
+      {
+        always_on: {
+          include: ['CLAUDE.md'],
+          line_caps: { enforced: true, total: 2, per_file: { 'CLAUDE.md': 2 } }
+        }
+      }
+    )
+
+    const { errors, warnings } = lintKnowledge(root)
+
+    expect(warnings).toEqual([])
+    expect(errors).toHaveLength(2)
+    expect(errors.some((error) => error.includes('CLAUDE.md is 5 lines'))).toBe(true)
+    expect(errors.some((error) => error.includes('always-on payload is 5 lines'))).toBe(true)
+  })
+
+  test('a root with no docs/ directory still lints cleanly', () => {
+    const root = makeRoot({
+      'CLAUDE.md': 'a fine, unremarkable file\n'
+    })
+
+    const { errors, warnings, stats } = lintKnowledge(root)
+
+    expect(errors).toEqual([])
+    expect(warnings).toEqual([])
+    expect(stats.declared).toBe(0)
+    expect(stats.citations).toBe(0)
+  })
+})


### PR DESCRIPTION
[TARO-330](https://app.notion.com/p/3b60953c224c8149a44bdf06ff7fad81)

## Summary

- Gives every citable fact a permanent `[K:<slug>]` address and `→[K:<slug>]` citation form, so pointers survive headings being reworded and files being split.
- Adds `scripts/knowledge-lint.mjs` plus an unconditional `knowledge` CI job: unresolved citations, duplicate declarations, malformed slugs and re-declared retired slugs all fail the build. The job carries no `needs` and no paths filter, so a skip cannot masquerade as a pass.
- `.claude/knowledge-lint.json` is the single declared place for the always-on globs, line caps and exemptions — `supabase/migrations/**` is exempt because migrations are append-only and a pointer written into one can never be corrected.

## Not done in this PR

- **Mass slug annotation.** Only the new rule file carries slugs; the existing corpus is unannotated. Doing it here would have collided head-on with TARO-331's content reshuffle and TARO-332's `docs/` deletion. Follow-up ticket to come.
- **Line-cap enforcement** ships off (`line_caps.enforced: false`) because `CLAUDE.md` is 123 lines on master. TARO-331 stacks on this branch and flips it on once the payload lands under the caps.
- **Required status** needs a branch-protection toggle on `master` for the `knowledge` check — a repo setting, not a code change.