### PR TITLE
TARO-331: Restructure how knowledge is delivered

### DIFF
--- a/.claude/knowledge-lint.json
+++ b/.claude/knowledge-lint.json
@@ -2,7 +2,7 @@
   "always_on": {
     "include": ["CLAUDE.md", ".claude/rules/*.md"],
     "line_caps": {
-      "enforced": false,
+      "enforced": true,
       "total": 250,
       "per_file": {
         "CLAUDE.md": 80

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -6,6 +6,31 @@ paths:
 
 # Architecture Conventions
 
+**Scope: `src/` — where things live and which doc governs them.**
+
+**TaroFlash** = spaced-repetition flashcard app (FSRS via `ts-fsrs`). Vue 3 SPA, Supabase backend.
+
+## Layout
+
+| Directory          | Purpose                                                                                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/api/`         | Supabase calls — RPC + table ops per entity: `billing`, `cards`, `decks`, `feedback`, `lessons`, `media`, `members`, `review-pacing`, `reviews` |
+| `src/components/`  | Vue components; `ui-kit/` and `layout-kit/` hold the base primitives                                                                            |
+| `src/composables/` | Reusable composition functions (modal, alert, prompt, shortcuts, settings, storage, fsrs, can, per-domain folders)                              |
+| `src/stores/`      | Pinia stores: `session`, `member`, `theme`, `notice-store`, `shortcut-store`, `taro-phone`                                                      |
+| `src/views/`       | Routed pages; `authenticated.vue` wraps the protected routes                                                                                    |
+| `src/styles/`      | Global CSS + TailwindCSS 4 config; `palettes.css` defines the color tokens                                                                      |
+| `src/sfx/`         | Custom audio engine behind the `v-sfx` directive (Howler.js was removed)                                                                        |
+| `types/`           | Shared TypeScript types — outside `src/`                                                                                                        |
+
+- **Routing** — public routes (welcome, auth callback, legal) vs authenticated routes behind
+  `authenticated.vue`. Main authenticated views: dashboard (deck list), deck study view.
+- **State** — session + member profile are global Pinia stores; most other state is local or
+  composable-scoped.
+- **Card text** — a plain `contenteditable` editor (`src/components/card/text-editor.vue`).
+
+## Docs
+
 Read the relevant doc before editing:
 
 - **Composing components** → [`architecture-composition`](../docs/architecture-composition.md)

--- a/.claude/rules/corpus.md
+++ b/.claude/rules/corpus.md
@@ -1,0 +1,39 @@
+---
+lastUpdated: 2026-08-08T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+  - 'supabase/**/*'
+---
+
+# Corpus — domain knowledge for the area you're touching
+
+**Scope: any change to app or backend code.** `corpus/` holds the durable domain truths — what is
+true about the system, in plain language — one altitude above `docs/` implementation reference. It
+cannot path-scope itself, so this file routes it.
+
+**Read the trap register first: [`corpus/hazards.md`](../../corpus/hazards.md).** Every known place
+the obvious assumption is quietly wrong, gathered across all domains. Generated — never hand-edit it;
+tag the topic instead.
+
+Then pull the topic for the area you're in:
+
+| Working in                                                     | Topic                              |
+| -------------------------------------------------------------- | ---------------------------------- |
+| `src/api/**`, cache invalidation, anything reading server data | `corpus/architecture/data-flow.md` |
+| `src/composables/can.ts`, RLS policies, any `can_` check       | `corpus/authz/permissions.md`      |
+| `src/api/cards/**`, `src/components/card/**`, card ordering    | `corpus/cards/cards.md`            |
+| `src/api/decks/**`, deck sharing / visibility                  | `corpus/decks/decks.md`            |
+| `src/api/feedback/**`, the public wall & moderation            | `corpus/feedback/feedback.md`      |
+| `src/api/media/**`, `supabase/functions/cleanup-media`         | `corpus/media/media.md`            |
+| `supabase/functions/transcribe-lesson`, lesson audio chains    | `corpus/media/audio-generation.md` |
+| `src/api/members/**`, `src/stores/member.ts`, signup           | `corpus/members/members.md`        |
+| `src/api/review-pacing/**`, per-deck dials & presets           | `corpus/pacing/pacing.md`          |
+| `src/composables/fsrs.ts`, `src/api/reviews/**`, FSRS          | `corpus/scheduling/scheduling.md`  |
+| `src/views/study-session/**`, a run through a pile             | `corpus/study/study.md`            |
+| `src/styles/**`, `src/stores/theme.ts`, palettes               | `corpus/theming/theming.md`        |
+
+[`corpus/map.md`](../../corpus/map.md) is the full index; [`corpus/CONTRIBUTING.md`](../../corpus/CONTRIBUTING.md)
+covers how topics are written. The `archivist` agent owns edits — don't rewrite a topic in passing.
+
+**A diff that contradicts a stated invariant is a bug.** A diff that changes one, or exposes a new
+hazard, is the archivist's trigger.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,37 @@
+# Branch & PR workflow
+
+**Scope: every branch, commit, and PR in this repo.** Always in context — commits have no file path
+to trigger on.
+
+1. **Only cut a new branch off `master`, or when I ask for one.** Already on a feature branch?
+   **Stay on it** — and if the scope widens past its name, rename in place (`git branch -m <old> <new>`)
+   rather than branching again. Small unrelated prior commits riding along is fine; a proliferation
+   of branches is not.
+2. **Check staleness.** At session start, verify the current branch isn't already merged (e.g.
+   `gh pr view --json state,mergedAt` or `git log master..HEAD`). If merged, branch fresh off `master`.
+3. **Commit in logical chunks.** Group related changes into separate commits with clear messages —
+   don't batch unrelated work into one commit. Commit freely as work progresses.
+4. **Conventional Commits, always.** `<type>(<scope>): <summary>` — `type` is one of `feat`, `fix`,
+   `perf`, `refactor`, `style`, `test`, `docs`, `chore`; `scope` is the touched area. `feat`/`fix`/`perf`
+   drive semantic-release version bumps (`release.config.cjs`) — get the type right, not just the
+   vibe. A breaking change gets a `BREAKING CHANGE:` footer or `!` after the type/scope (capped to a
+   minor bump pre-launch, see `release.config.cjs`).
+5. **Don't open PRs automatically.** Open or push a PR only when explicitly asked. Committing locally
+   is fine; surfacing the work as a PR is the user's call.
+6. **Squash iterative fixes.** Several attempts at the _same_ logical change collapse into one commit
+   before review. Don't ship `fix attempt 1` / `2` / `3`.
+   - **Not yet pushed:** `git reset --soft HEAD~N` then re-commit, or `git commit --amend --no-edit`.
+   - **Already pushed to a feature branch:** `git reset --soft HEAD~N && git commit`, then
+     `git push --force-with-lease`. Force-push is allowed on a feature branch you own; never on `master`.
+   - Logical chunks (a `feat(...)` and the test commit covering it) stay separate.
+7. **No Claude attribution.** Never add `Co-Authored-By: Claude` trailers, and never add the
+   "Generated with Claude Code" footer to PR bodies.
+8. **Stage specific paths, never `git add -A`.** I often have my own uncommitted edits in the tree; a
+   blanket add sweeps them into your commit, and a later `reset` then destroys them. Before any
+   `git reset --hard` or `reset --soft HEAD~N`, run `git status` and confirm every pending change is
+   yours — if the tree, or the commit being dropped, touches files you didn't author this session,
+   stop and stash mine first. (Lost work is recoverable via `git reflog` + `git checkout <hash> -- <paths>`.)
+9. **Check the PR isn't already merged before pushing follow-ups.** `gh pr view <num> --json state,mergedAt`
+   first — pushing to a merged branch strands the commit where it will never reach `master`.
+10. **Prefix PR comments with `🤖 Claude:`.** Comments post under my account, so without it I can't
+    tell your replies from my own.

--- a/.claude/rules/knowledge-addressing.md
+++ b/.claude/rules/knowledge-addressing.md
@@ -51,5 +51,5 @@ frontmatter, since a `paths:` rule is path-triggered rather than loaded every se
   exempt because its fixtures contain literal tokens. Nothing else earns a place there.
 - Caps are `line_caps` — 80 lines for `CLAUDE.md`, 250 for the always-on total. A starting
   calibration, not a measured figure.
-- `line_caps.enforced` is `false` until the always-on payload is restructured (TARO-331); breaches
-  report as warnings meanwhile. Flip it to `true` in the same change that lands under the caps.
+- `line_caps.enforced` is `true` — a breach fails CI. Set it to `false` only to land a deliberate,
+  temporary overshoot, and restore it in the change that gets back under.

--- a/.claude/rules/self-heal.md
+++ b/.claude/rules/self-heal.md
@@ -1,6 +1,9 @@
 # Self-heal
 
-**Every session, not just skill runs.** When the user corrects you, the artifact in front of you is
+**Scope: every user correction, in every session — not just skill runs.** Always in context, because
+a correction arrives without warning and has no file path to trigger on.
+
+When the user corrects you, the artifact in front of you is
 the symptom — the defect is in the rule or skill that let you get it wrong. Fix the
 artifact, then fix the thing that produced it.
 

--- a/.claude/rules/supabase.md
+++ b/.claude/rules/supabase.md
@@ -7,6 +7,20 @@ paths:
 
 # Supabase Conventions
 
+**Scope: `supabase/` and `src/api/` — the database, its policies, and the edge functions.**
+
+RLS gives multi-tenant isolation; complex reads go through PostgreSQL RPCs (e.g.
+`get_member_decks_with_due_count`); a trigger mints the `members` row on signup. Deno edge functions
+live in `supabase/functions/`: `cleanup-media`, `purge-accounts`, `request-account-deletion`,
+`create-subscription`, `manage-subscription`, `stripe-webhook`, `transcribe-lesson`, `translate-term`,
+`translate-transcript`, `transliterate-transcript`.
+
+Local Supabase: API on 54321, PostgreSQL on 54322. Start with `supabase start`.
+
+**Explain the SQL when asked.** Name the keywords the answer leans on (`using` vs `with check`,
+`security definer`, `stable`, `$$` quoting, `::` casting) rather than assuming the idiom is
+self-evident. Don't volunteer a lesson unprompted.
+
 ## Buckets in migrations, not config.toml
 
 Provision storage buckets via SQL migrations. `[storage.buckets.X]` in `config.toml` requires `supabase seed buckets` which doesn't run on deploy — stage/prod will diverge.
@@ -89,7 +103,7 @@ Raising a code the client matches on? Either pick a non-`PT` SQLSTATE, or use `P
 
 ## `INSERT … RETURNING` re-checks the SELECT policy
 
-`RETURNING` doesn't just check the INSERT policy's `WITH CHECK` — to hand the row back it also re-checks the table's **SELECT** policy against that new row, and fails with the *same* generic message (`new row violates row-level security policy`), so the error can't tell you which policy broke.
+`RETURNING` doesn't just check the INSERT policy's `WITH CHECK` — to hand the row back it also re-checks the table's **SELECT** policy against that new row, and fails with the _same_ generic message (`new row violates row-level security policy`), so the error can't tell you which policy broke.
 
 This bites whenever a default puts the new row into a state its own SELECT policy hides — a `visibility` defaulting to `internal`, a pending/hidden status. Encode "you can always read the row you just created" explicitly (`OR member_id = auth.uid()`) rather than relying on the general visibility condition. If a `RETURNING` RPC starts throwing a bare RLS violation right after a default changed, check the SELECT policy first.
 

--- a/.claude/rules/task-board-schema.md
+++ b/.claude/rules/task-board-schema.md
@@ -1,3 +1,13 @@
+---
+lastUpdated: 2026-08-08T00:00:00Z
+# Board vocabulary is dead weight in a code session — scoped so it loads only for board work.
+# Skills and the ticket-author agent pull it by name when the user asks for a ticket.
+paths:
+  - '.claude/skills/{triage,groom,backlog}/**'
+  - '.claude/agents/ticket-author.md'
+  - '.claude/rules/ticket-authoring.md'
+---
+
 # Task Board Schema
 
 **The single source of truth for the board's shape** — data sources, the MCP server, and every field
@@ -23,7 +33,7 @@ constants; change a field here once and every consumer follows.
 
 **Three hard limits of the Notion MCP.** `status`-type fields are special-cased: `notion-update-data-source`
 **cannot** add, rename or recolor `Status` options — only the user can, in the Notion UI (renaming
-preserves row mappings). `select`/`multi_select` options *are* editable. There is **no archive or
+preserves row mappings). `select`/`multi_select` options _are_ editable. There is **no archive or
 delete tool** — `notion-move-pages` only re-parents, so retiring a row means the user deletes it in the
 UI. Page titles, properties and body content are all editable via `notion-update-page`.
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -7,6 +7,9 @@ paths:
 
 # Writing tests
 
+**Scope: `tests/`.** Vitest on jsdom; `tests/fixtures/` holds the MSW handlers and Faker-based
+fixtures; coverage is enforced by CI on every PR.
+
 **Always read before editing any test:**
 
 - [`testing-failing-tests`](../docs/testing-failing-tests.md) — verify source before patching a failing test

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -1,3 +1,13 @@
+---
+lastUpdated: 2026-08-08T00:00:00Z
+# Board vocabulary is dead weight in a code session — scoped so it loads only for board work.
+# Skills and the ticket-author agent pull it by name when the user asks for a ticket.
+paths:
+  - '.claude/skills/{triage,groom,backlog}/**'
+  - '.claude/agents/ticket-author.md'
+  - '.claude/rules/task-board-schema.md'
+---
+
 # Ticket Authoring
 
 **The single source of truth for what a ticket looks like.** Body shape, brevity, voice, and which

--- a/.claude/rules/toolchain.md
+++ b/.claude/rules/toolchain.md
@@ -1,0 +1,44 @@
+# Toolchain
+
+**Scope: every command run in this repo.** Always in context — a session can shell out before it
+reads a single file.
+
+Project uses **Vite+** (`vp`), a unified toolchain wrapping Vite, Rolldown, Vitest, Oxlint, Oxfmt.
+Always use `vp` — never `pnpm`, `npm`, `vitest`, `oxlint`, `oxfmt` directly.
+
+## Commands
+
+```sh
+vp install          # Install dependencies (after pulling changes)
+vp dev              # Start dev server
+vp build            # Production build
+vp check            # Run format + lint + type-check together
+vp lint             # Lint only
+vp fmt              # Format only
+vp test             # Run tests with coverage
+vp test --watch     # Watch mode
+vp add <pkg>        # Add a dependency
+vp dlx <bin>        # Run a one-off binary (instead of npx/pnpm dlx)
+```
+
+## The type-check gate
+
+CI's authoritative type-check is `pnpm type-check` (`vue-tsc --build --force`), and it is **stricter
+than `vp check`** — `vp check` can report zero errors while `vue-tsc` fails. Run `pnpm type-check`
+before pushing anything that touches types; a green `vp check` is not evidence.
+
+## Never `pnpm`
+
+- **`vp install` after any dependency bump.** Never `pnpm up` / `pnpm install` directly — pnpm
+  rewrites the lockfile importer spec away from the `@latest` override, and CI's frozen-lockfile
+  check then fails with "specifiers in the lockfile don't match specifiers in package.json".
+- `pnpm type-check` is the sole exception, and only as the pre-push gate above.
+- **Upgrade a tool rather than working around it.** If a CLI is too old for a feature we want, offer
+  the upgrade — don't accumulate one-off `curl`/SQL workarounds. Work around only when upgrading is
+  genuinely blocked, and say why.
+
+## Imports
+
+- Build/config utilities from `vite-plus`, not `vite`: `import { defineConfig } from 'vite-plus'`
+- Test utilities from `vite-plus/test`, not `vitest`: `import { expect, test, vi } from 'vite-plus/test'`
+- Don't install `vitest`, `oxlint`, `oxfmt`, `tsdown` — bundled in Vite+

--- a/.claude/rules/vue-script-order.md
+++ b/.claude/rules/vue-script-order.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-08T00:00:00Z
+paths:
+  - 'src/**/*.vue'
+---
+
 # Vue `<script setup>` ordering
 
 Declarations live in fixed top-to-bottom order. No mid-file `ref` / `computed` / `function` definitions sprinkled near their first use.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "fp=$(jq -r '.tool_input.file_path // empty'); dir=$( [ -n \"$fp\" ] && dirname \"$fp\" || pwd ); branch=$(git -C \"$dir\" branch --show-current 2>/dev/null) || exit 0; [ \"$branch\" = \"master\" ] && echo 'On master \u2014 cut a branch before editing (see CLAUDE.md branch/PR workflow)' >&2 && exit 2; exit 0"
+            "command": "fp=$(jq -r '.tool_input.file_path // empty'); dir=$( [ -n \"$fp\" ] && dirname \"$fp\" || pwd ); branch=$(git -C \"$dir\" branch --show-current 2>/dev/null) || exit 0; [ \"$branch\" = \"master\" ] && echo 'On master \u2014 cut a branch before editing (see .claude/rules/git-workflow.md)' >&2 && exit 2; exit 0"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,120 +4,38 @@
 - **NEVER touch tests until I explicitly ask.** No checking, running, writing, or updating tests — not after edits, not after refactors, not for reported bugs, not for coverage, not "while I'm here." This holds even when tests clearly should change. At most, note in one line that tests may need attention, then leave them. I will tell you when it's test time. (User-invoked test skills/agents like `/update-tests` are the explicit ask.)
 - **Every correction is a defect in the rules, not just the artifact.** Fix what I pointed at, then run the lesson through `.claude/rules/self-heal.md` — every session, not just skill runs. `/heal` is the explicit verb for it.
 - **NEVER write user-facing copy without my sign-off.** Any new or changed string a user reads — button labels, headings, empty states, toasts, alerts, error messages, ticket ACs quoting copy — stops and asks. Offer at least 3 reasonably-varied options per line and let me pick; never choose for me, never defer it to "wording TBD". Reusing an existing string is fine, but say which one. This applies everywhere, not just in tickets.
-- **Never verify visually in the browser.** Don't open Chrome, curl the dev server, or screenshot a page to check that a change "looks right" — I always confirm visually myself and will give you that feedback directly. Your visual read is worse than mine, so it adds false confidence rather than verification. Driving the browser to *debug* something genuinely broken is fine and encouraged; the ban is on verification, not on debugging.
+- **Never verify visually in the browser.** Don't open Chrome, curl the dev server, or screenshot a page to check that a change "looks right" — I always confirm visually myself and will give you that feedback directly. Your visual read is worse than mine, so it adds false confidence rather than verification. Driving the browser to _debug_ something genuinely broken is fine and encouraged; the ban is on verification, not on debugging.
 - **"Rephrase that" means the framing missed, not just the length.** Re-explain in plain product terms — what the screen shows, what the user experiences — and strip the vocabulary of whatever library or subsystem the answer came from. Shorten in the same pass, but never only shorten.
-
-# Guidelines
-
-- Always use translation strings (e.g., `t('deck.settings-modal.title')`) instead of hardcoded text. If string not in `locales/en-us.json`, add it.
-- **Wiring logic doesn't license inventing UI.** When I ask you to wire up state, behaviour, or a composable, write the script side — refs, computeds, handlers — plus only the structural markup the logic actually needs (a template ref, a container something measures). Building UI out of **existing paradigms** (`ui-kit` / `layout-kit` primitives, an established pattern from a sibling view) is fine. Inventing novel controls, layouts, or one-off styled elements I didn't ask for is not — expose the state and let me build it.
+- **Wiring logic doesn't license inventing UI.** When I ask you to wire up state, behaviour, or a composable, write the script side — refs, computeds, handlers — plus only the structural markup the logic actually needs. Building UI out of **existing paradigms** (`ui-kit` / `layout-kit` primitives, an established pattern from a sibling view) is fine. Inventing novel controls, layouts, or one-off styled elements I didn't ask for is not — expose the state and let me build it.
+- Always use translation strings (e.g. `t('deck.settings-modal.title')`) instead of hardcoded text.
 - Confirm this file loaded by printing message to console on startup.
 
-## Backend (`supabase/`)
+# Where the knowledge lives
 
-- **Explain the SQL when asked.** Backend answers name the keywords they lean on (`using` vs
-  `with check`, `security definer`, `stable`, `$$` quoting, `::` casting) rather than assuming the
-  idiom is self-evident. Don't volunteer a lesson unprompted.
-- **NEVER `supabase db reset`.** Always use `supabase migrations up` to apply migrations. Apply migrations as you write them so errors surface immediately.
-- **Rule files auto-load by path:** editing `supabase/**` pulls `.claude/rules/supabase.md`; editing `src/api/**` pulls `.claude/rules/server-state.md`. Both are the source of truth for their domains.
+This file carries only the rules that hold everywhere. Everything else lives in a file that reaches
+you when it applies: **`.claude/rules/*.md` with a `paths:` list auto-load the moment you read a
+matching file** — don't go hunting for them, and don't restate them in tickets or code comments.
 
-## Cutting tickets
+Always in context alongside this file: [`toolchain`](.claude/rules/toolchain.md) (`vp` commands, never
+`pnpm`, the `pnpm type-check` gate) · [`git-workflow`](.claude/rules/git-workflow.md) (branching,
+Conventional Commits, PR etiquette) · [`self-heal`](.claude/rules/self-heal.md) (turning a correction
+into a rule change).
 
-"Cut a ticket for this" / "file that" / "add it to the board" → follow `.claude/rules/ticket-authoring.md`
-(board constants, field defaults, body templates, authoring voice). New tickets always land in
-`Backlog` — never `Ready`/`Queued`. For a batch, delegate to the `ticket-author` agent.
+| Working on                               | Loads / read                                                                                                                                                                                                                |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Anything in `src/` or `supabase/`        | [`corpus`](.claude/rules/corpus.md) — domain truths + the **trap register**, `corpus/hazards.md`                                                                                                                            |
+| Where code lives, which doc governs it   | [`architecture`](.claude/rules/architecture.md)                                                                                                                                                                             |
+| Any `.ts` / `.vue`                       | [`code-style`](.claude/rules/code-style.md), [`FE-formatting`](.claude/rules/FE-formatting.md), [`animations`](.claude/rules/animations.md), [`safari-gotchas`](.claude/rules/safari-gotchas.md)                            |
+| A `.vue` file                            | [`vue-templates`](.claude/rules/vue-templates.md), [`vue-script-order`](.claude/rules/vue-script-order.md), [`vue-props`](.claude/rules/vue-props.md), [`css`](.claude/rules/css.md), [`theming`](.claude/rules/theming.md) |
+| Copy, locales                            | [`i18n`](.claude/rules/i18n.md)                                                                                                                                                                                             |
+| `src/api/`, server data & caching        | [`server-state`](.claude/rules/server-state.md)                                                                                                                                                                             |
+| `src/composables/`                       | [`composables`](.claude/rules/composables.md)                                                                                                                                                                               |
+| `src/views/`                             | [`skeleton-loading`](.claude/rules/skeleton-loading.md), [`study-session-architecture`](.claude/rules/study-session-architecture.md)                                                                                        |
+| `src/sfx/`                               | [`sfx`](.claude/rules/sfx.md)                                                                                                                                                                                               |
+| `supabase/` — migrations, RLS, functions | [`supabase`](.claude/rules/supabase.md) — **never `supabase db reset`**, always `migration up`                                                                                                                              |
+| `tests/`                                 | [`testing`](.claude/rules/testing.md) and its siblings — only when I ask for tests                                                                                                                                          |
+| Skills and agents                        | [`skill-authoring`](.claude/rules/skill-authoring.md)                                                                                                                                                                       |
+| Tickets — "cut a ticket", "file that"    | [`ticket-authoring`](.claude/rules/ticket-authoring.md) + [`task-board-schema`](.claude/rules/task-board-schema.md) — read by name; they don't auto-load                                                                    |
 
-## Toolchain: Vite+
-
-Project uses **Vite+** (`vp`), unified toolchain wrapping Vite, Rolldown, Vitest, Oxlint, Oxfmt. Always use `vp` — never `pnpm`, `npm`, `vitest`, `oxlint`, `oxfmt` directly.
-
-### Common commands
-
-```sh
-vp install          # Install dependencies (after pulling changes)
-vp dev              # Start dev server
-vp build            # Production build
-vp check            # Run format + lint + type-check together
-vp lint             # Lint only
-vp fmt              # Format only
-vp test             # Run tests with coverage
-vp test --watch     # Watch mode
-vp add <pkg>        # Add a dependency
-vp dlx <bin>        # Run a one-off binary (instead of npx/pnpm dlx)
-```
-
-### Type-checking
-
-CI's authoritative type-check is `pnpm type-check` (`vue-tsc --build --force`), and it is **stricter
-than `vp check`** — `vp check` can report zero errors while `vue-tsc` fails. Run `pnpm type-check`
-before pushing anything that touches types; a green `vp check` is not evidence.
-
-### Keeping the toolchain current
-
-- **`vp install` after any dependency bump.** Never `pnpm up` / `pnpm install` directly — pnpm rewrites the lockfile importer spec away from the `@latest` override, and CI's frozen-lockfile check then fails with "specifiers in the lockfile don't match specifiers in package.json".
-- **Upgrade a tool rather than working around it.** If a CLI is too old for a feature we want, offer to upgrade it — don't accumulate one-off `curl`/SQL workarounds. Only work around when upgrading is genuinely blocked, and say why.
-
-### Critical import rules
-
-- Import build/config utilities from `vite-plus`, not `vite`: `import { defineConfig } from 'vite-plus'`
-- Import test utilities from `vite-plus/test`, not `vitest`: `import { expect, test, vi } from 'vite-plus/test'`
-- Don't install `vitest`, `oxlint`, `oxfmt`, `tsdown` — bundled in Vite+
-
-## Architecture
-
-**TaroFlash** = spaced repetition flashcard app (FSRS algorithm via `ts-fsrs`). Vue 3 SPA, Supabase backend.
-
-### Frontend (`src/`)
-
-| Directory          | Purpose                                                                                                                       |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| `src/api/`         | Supabase client calls — RPC functions and table operations, organized by entity (cards, decks, members, reviews, media, shop) |
-| `src/components/`  | Vue components; `ui-kit/` contains base primitives                                                                            |
-| `src/composables/` | Reusable composition functions (modal, toast, alert, study-session, shortcuts, theme, media-query)                            |
-| `src/stores/`      | Pinia stores: `session.ts` (auth state), `member.ts` (current user profile), `shortcut-store.ts`                              |
-| `src/views/`       | Routed page components; `authenticated.vue` is the layout wrapper for protected routes                                        |
-| `src/styles/`      | Global CSS and TailwindCSS 4 config; `palettes.css` defines color tokens                                                      |
-| `types/`           | Shared TypeScript type definitions (not inside `src/`)                                                                        |
-
-**Routing**: Public routes (welcome, auth callback, legal) vs authenticated routes protected by `authenticated.vue`. Main authenticated views: dashboard (deck list), deck study view.
-
-**State**: Session + member profile = global Pinia stores. Most other state local or composable-scoped.
-
-**Card text**: Cards use a plain `contenteditable` editor (`src/components/card/text-editor.vue`).
-
-**Sound effects**: Custom `v-sfx` directive plays audio via a lightweight custom engine (`src/sfx/`) — Howler.js was removed.
-
-### Backend (`supabase/`)
-
-| Directory              | Purpose                                                                            |
-| ---------------------- | ---------------------------------------------------------------------------------- |
-| `supabase/migrations/` | SQL migrations run via Supabase CLI (`supabase db reset` applies all + `seed.sql`) |
-| `supabase/functions/`  | Deno edge functions: `create-subscription` (Stripe), `cleanup-media`               |
-
-Database uses RLS for multi-tenant data isolation. Complex queries via PostgreSQL RPC functions (e.g., `get_member_decks_with_due_count`). Trigger auto-creates `members` row on user signup.
-
-### Testing (`tests/`)
-
-Tests use Vitest with jsdom. `tests/fixtures/` contains MSW handlers, Faker-based fixtures. Coverage enforced in CI (GitHub Actions runs on all PRs).
-
-## Local development
-
-- Local Supabase runs on port 54321 (API), 54322 (PostgreSQL). Start with `supabase start`.
-
-## Branch & PR workflow
-
-For any feature work or code changes:
-
-1. **Only cut a new branch off `master`, or when I ask for one.** Already on a feature branch? **Stay on it** — and if the scope widens past its name, rename in place (`git branch -m <old> <new>`) rather than branching again. Small unrelated prior commits riding along is fine; a proliferation of branches is not.
-2. **Check staleness.** At session start, verify the current branch isn't already merged (e.g. `gh pr view --json state,mergedAt` or `git log master..HEAD`). If merged, create a fresh branch off `master`.
-3. **Commit in logical chunks.** Group related changes into separate commits with clear messages — don't batch unrelated work into one commit. Commit freely as work progresses; don't wait for the end of the session.
-4. **Conventional Commits, always.** `<type>(<scope>): <summary>` — `type` is one of `feat`, `fix`, `perf`, `refactor`, `style`, `test`, `docs`, `chore`; `scope` is the touched area (component, view, api domain, `ci`, etc). `feat`/`fix`/`perf` drive semantic-release version bumps (`release.config.cjs`) — get the type right, not just the vibe. A breaking change gets a `BREAKING CHANGE:` footer or `!` after the type/scope (capped to a minor bump pre-launch, see `release.config.cjs`).
-5. **Don't open PRs automatically.** Open or push a PR only when explicitly asked. Committing locally is fine; surfacing the work as a PR is the user's call.
-6. **Squash iterative fixes.** When several attempts go into landing the _same_ logical change (initial fix → didn't work → second fix → third fix), collapse them into a single commit before review. Don't ship `fix attempt 1` / `fix attempt 2` / `fix attempt 3` as separate commits.
-   - **Not yet pushed:** `git reset --soft HEAD~N` then re-commit, or `git commit --amend --no-edit` for each follow-up before push.
-   - **Already pushed to a feature branch:** `git reset --soft HEAD~N && git commit` then `git push --force-with-lease`. Force-push is allowed on a feature branch you own; never on `master`.
-   - Logical chunks (e.g. `feat(...)` and the test commit covering it) stay separate. This rule applies only to repeated attempts at the same change.
-7. **No Claude attribution.** Never add `Co-Authored-By: Claude` trailers to commits, and never add the "Generated with Claude Code" footer to PR bodies.
-8. **Stage specific paths, never `git add -A`.** I often have my own uncommitted edits in the tree; a blanket add sweeps them into your commit, and a later `reset` then destroys them. Before any `git reset --hard` or `reset --soft HEAD~N`, run `git status` and confirm every pending change is yours — if the tree, or the commit being dropped, touches files you didn't author this session, stop and stash mine first. (Lost work is recoverable via `git reflog` + `git checkout <hash> -- <paths>`.)
-9. **Check the PR isn't already merged before pushing follow-ups.** `gh pr view <num> --json state,mergedAt` first — pushing to a merged branch strands the commit where it will never reach `master`. Branch fresh off `master` instead. Existing-branch pushes are only safe while the PR is open.
-10. **Prefix PR comments with `🤖 Claude:`.** Comments post under my account, so without it I can't tell your replies from my own.
+New tickets always land in `Backlog` — never `Ready`/`Queued`. For a batch, delegate to the
+`ticket-author` agent.


### PR DESCRIPTION
[TARO-331](https://app.notion.com/p/3b60953c224c81ca98c4c46428c223ac)

> **Stacked on [#514](https://github.com/TaroSprout/TaroFlash/pull/514) (TARO-330).** Base is `feat/knowledge-addressing-scheme`, not `master` — merge #514 first.

## Summary

- Spends the always-on budget on the right files: `CLAUDE.md` drops from 123 to 41 lines, carrying only golden rules plus a router to every other knowledge file. Total always-on payload goes 625 → 215.
- Path-scopes what shouldn't load every session — `vue-script-order.md` to Vue files, and the two board files to the board skills and the ticket-author that pull them by name.
- Closes the real delivery hole: `corpus/**` cannot use `paths:` frontmatter, so a new `.claude/rules/corpus.md` puts the trap register in front of anyone touching app or backend code and routes each area to its topic.
- New always-on `toolchain.md` (the `vp` command set, never-`pnpm`, the stricter `pnpm type-check` gate) and `git-workflow.md` (the branch/PR workflow, which has no file path to trigger on).
- Turns on TARO-330's line-cap enforcement now that the payload lands under both caps.

## Fixed in passing

- The `src/api` entity list named a domain that doesn't exist (`shop`) and omitted four that do; half the stores were undocumented; the architecture table recommended the `supabase db reset` the same file forbids.

## Worth a look

- `.claude/settings.json` changed — an existing hook's **message string** repointed at the new `git-workflow.md`. No hook added.
- `git-workflow.md` is a new always-on file the ticket's criteria didn't name; it exists because commit conventions have no path to scope against.