### PR TITLE
TARO-335: Move the corpus into the new scheme and build the trap register

### DIFF
--- a/.claude/rules/corpus-authoring.md
+++ b/.claude/rules/corpus-authoring.md
@@ -45,8 +45,7 @@ scoped to `corpus/`, never mixed into a code commit, so the user takes or drops 
 
 One **topic** per file — a subsystem you would sit down to understand (Media, Permissions), not a
 single atomic fact, carrying enough context that any one idea in it is graspable without hunting.
-`map.md` is the root index; `hazards.md` is generated from the `hazard: true` tag and is never
-hand-edited.
+`map.md` is the root index; `hazards.md` is the trap roll-call — see below.
 
 Frontmatter is `id`, `domain`, `status` (`current`/`deprecated`), `hazard`, `related`, `updated`.
 **`id` is permanent** — rename the file freely, never change a shipped `id`; it is the address deep
@@ -88,7 +87,17 @@ A hazard is a place where the obvious assumption is quietly wrong and it costs y
 class of thing than a fact, given elevated treatment so nobody misses it. It gets a **hazard block**
 (`> [!HAZARD]`) high in the topic, right after the lead, stating the trap in one strong line plus
 the flip-side framing and a link to the deep walkthrough, and the topic's frontmatter sets
-`hazard: true` so the generated index gathers it.
+`hazard: true`.
+
+**The block is the trap's only text.** It declares the trap's permanent `[K:<slug>]`
+([`knowledge-addressing`](./knowledge-addressing.md)), and nothing else restates it:
+
+- `hazards.md` lists the slug, its topic, and where it's echoed — one line each, no prose to drift.
+- Every trap is **echoed** in the directory it bites, as a one-line `→[K:<slug>]` comment carrying a
+  label and nothing more, so it reaches whoever is standing on it without being read every session.
+  A trap with no directory to echo into is listed in `CLAUDE.md` instead.
+- **Anchor a schema fact in `supabase/schemas/`, never in `supabase/migrations/`** — a migration is
+  append-only, so a pointer written into one can never be corrected.
 
 Three tells, hunted actively on any domain-level change:
 

--- a/.claude/rules/corpus.md
+++ b/.claude/rules/corpus.md
@@ -11,11 +11,13 @@ paths:
 true about the system, in plain language — one altitude above the implementation detail in a rule's
 spokes. It cannot path-scope itself, so this file routes it.
 
-**Read the trap register first: [`corpus/hazards.md`](../../corpus/hazards.md).** Every known place
-the obvious assumption is quietly wrong, gathered across all domains. Generated — never hand-edit it;
-tag the topic instead.
+**Traps come to you, not the other way round.** A `→[K:<slug>]` comment in the file you're editing
+names a place the obvious assumption is quietly wrong; resolve it with `grep -rn '\[K:<slug>\]'
+corpus/` and read the topic before you change anything around it.
+[`corpus/hazards.md`](../../corpus/hazards.md) is the roll-call of every one — a slug and a topic
+per line, no prose to drift. Never hand-edit an entry's text; it lives in the topic.
 
-Then pull the topic for the area you're in:
+Pull the topic for the area you're in:
 
 | Working in                                                     | Topic                              |
 | -------------------------------------------------------------- | ---------------------------------- |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,11 @@ Always in context alongside this file: [`toolchain`](.claude/rules/toolchain.md)
 every artifact shares; each `*-authoring` sibling adds what is specific to a rule, ticket, corpus
 topic, test, commit, or reply — and [`rule-authoring`](.claude/rules/rule-authoring.md) shapes them all.
 
+**Traps reach you as `→[K:<slug>]` comments in the code** — resolve one with `grep -rn '\[K:<slug>\]' corpus/` and read the topic before you change what's around it. A trap with no directory to echo into is listed here by slug and one line; there are none today.
+
 | Working on                               | Loads / read                                                                                                                                                                                                                |
 | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Anything in `src/` or `supabase/`        | [`corpus`](.claude/rules/corpus.md) — domain truths + the **trap register**, `corpus/hazards.md`                                                                                                                            |
+| Anything in `src/` or `supabase/`        | [`corpus`](.claude/rules/corpus.md) — domain truths + the trap roll-call, `corpus/hazards.md`                                                                                                                               |
 | Where code lives, which doc governs it   | [`architecture`](.claude/rules/architecture.md)                                                                                                                                                                             |
 | Any `.ts` / `.vue`                       | [`code-style`](.claude/rules/code-style.md), [`FE-formatting`](.claude/rules/FE-formatting.md), [`animations`](.claude/rules/animations.md), [`safari-gotchas`](.claude/rules/safari-gotchas.md)                            |
 | A `.vue` file                            | [`vue-templates`](.claude/rules/vue-templates.md), [`vue-script-order`](.claude/rules/vue-script-order.md), [`vue-props`](.claude/rules/vue-props.md), [`css`](.claude/rules/css.md), [`theming`](.claude/rules/theming.md) |

--- a/corpus/architecture/data-flow.md
+++ b/corpus/architecture/data-flow.md
@@ -28,7 +28,7 @@ The cache doesn't refresh itself. Something has to say "the decks I remembered a
 stale now." Getting that _something_ right — always, and in exactly one place — is
 what this topic is about.
 
-> [!HAZARD] **A write that succeeds but forgets to mark the right thing stale leaves the screen showing old data — and nothing anywhere reports an error.**
+> [!HAZARD] [K:silent-stale-cache] **A write that succeeds but forgets to mark the right thing stale leaves the screen showing old data — and nothing anywhere reports an error.**
 > The convenience below is that a caller never thinks about the cache. The flip
 > side is that when the cache _does_ drift, there's no error to chase and no clue
 > at the call site: the save worked, the server is correct, and the screen quietly

--- a/corpus/authz/permissions.md
+++ b/corpus/authz/permissions.md
@@ -26,7 +26,7 @@ That check gets asked in two very different spots:
 Only the server's answer counts. What the screen does with it is a courtesy — it
 keeps people from reaching for buttons they can't use.
 
-> [!HAZARD] **Widen a permission, and every query that was leaning on the old, tighter rule silently widens with it — including screens you forgot were leaning on it.**
+> [!HAZARD] [K:permission-widening-ripples] **Widen a permission, and every query that was leaning on the old, tighter rule silently widens with it — including screens you forgot were leaning on it.**
 > This is the flip side of the "change it in one place" convenience below. The
 > same wiring that updates every screen at once will also ripple a loosened rule
 > into queries you never meant to touch — turning an ordinary dashboard into a

--- a/corpus/cards/cards.md
+++ b/corpus/cards/cards.md
@@ -46,7 +46,7 @@ already knows where it belongs. What makes this safe is that a deck has exactly
 one owner, so there is never a second person minting keys into the same deck at
 the same moment.
 
-> [!HAZARD] **The keys are text, and only sort correctly because the column overrides the database's default sorting rules.**
+> [!HAZARD] [K:card-rank-byte-collation] **The keys are text, and only sort correctly because the column overrides the database's default sorting rules.**
 > Sort keys are compared as plain text. The database's default text collation is
 > locale-aware — it reorders letters by case, so `a` and `A` don't land where a
 > character-by-character comparison would put them. Under that default the server

--- a/corpus/decks/decks.md
+++ b/corpus/decks/decks.md
@@ -28,7 +28,7 @@ entire sharing model.
 The dashboard asks for _your_ decks and shows each one with a count of the cards
 due today.
 
-> [!HAZARD] **Making a deck public lets other people _read_ it — never _study_ it.**
+> [!HAZARD] [K:public-is-read-only] **Making a deck public lets other people _read_ it — never _study_ it.**
 > "Public" sounds like "shared, and everyone builds their own progress on it." It
 > isn't. Recording a review is gated to the card's owner, and the progress table
 > holds exactly **one** row per card for the whole platform — not one per viewer.

--- a/corpus/feedback/feedback.md
+++ b/corpus/feedback/feedback.md
@@ -22,7 +22,7 @@ Two things a member can do to a post:
 A smaller group — the moderators — can do a third thing: decide which posts the
 wall shows, and mark where each one stands.
 
-> [!HAZARD] **A new submission does not land on the wall. It waits, unseen, until a moderator lets it through.**
+> [!HAZARD] [K:posts-hidden-until-published] **A new submission does not land on the wall. It waits, unseen, until a moderator lets it through.**
 > Posting feels finished — the member gets a "thanks, submitted" and the box
 > closes. But every fresh post starts _hidden_, and the wall only ever shows the
 > ones a moderator has published. So the obvious assumption — "I posted it, it's

--- a/corpus/hazards.md
+++ b/corpus/hazards.md
@@ -1,117 +1,31 @@
 # Hazards
 
-Every known **system hole** across the corpus, gathered in one place. A hazard is
-somewhere the obvious assumption is quietly wrong and it costs you.
+The roll-call of every known **system hole** — somewhere the obvious assumption
+is quietly wrong and it costs you. One line each, ordered roughly by blast
+radius: data loss and silent corruption first, design ceilings and footguns last.
 
-> **Generated — do not hand-edit.** Built from every topic with `hazard: true` in
-> its frontmatter. To add or change an entry, edit the topic; to review before
-> touching an area, read this. See [corpus-authoring → Hazards](../.claude/rules/corpus-authoring.md#hazards).
+> **A roll-call, not a store.** Each trap's full text lives in its topic, at the
+> slug named here — `grep -rn '\[K:<slug>\]' corpus/` lands on it. This file
+> restates nothing, so it cannot drift. To add or change a trap, edit the topic;
+> see [corpus-authoring → Hazards](../.claude/rules/corpus-authoring.md#hazards).
 
-Roughly ordered by blast radius — data loss and silent corruption first, design
-ceilings and footguns last.
+You don't read this list to work. Each trap is echoed as a `→[K:<slug>]` pointer
+in the directory it bites, so it reaches you when you're standing on it.
 
----
+| Trap                                          | Topic                | Echoed at                                  |
+| --------------------------------------------- | -------------------- | ------------------------------------------ |
+| →[K:unconfirmed-review-loss]                  | [[study]]            | `src/views/study-session/composables/`     |
+| →[K:stall-reaper-strands-slow-jobs]           | [[audio-generation]] | `supabase/functions/transcribe-lesson/`    |
+| →[K:card-rank-byte-collation]                 | [[cards]]            | `supabase/schemas/40_cards/`               |
+| →[K:ownership-stamp-empty-under-service-role] | [[members]]          | `supabase/schemas/` (`set_member_id`)      |
+| →[K:permission-widening-ripples]              | [[permissions]]      | `supabase/schemas/` (the `can_` functions) |
+| →[K:media-lifetime-follows-notes]             | [[media]]            | `src/api/media/`                           |
+| →[K:client-owns-the-schedule]                 | [[scheduling]]       | `src/views/study-session/`                 |
+| →[K:silent-stale-cache]                       | [[data-flow]]        | `src/api/reviews/mutations/`               |
+| →[K:pin-is-presence-not-difference]           | [[pacing]]           | `src/api/review-pacing/`                   |
+| →[K:closed-color-set-fails-bare]              | [[theming]]          | `src/utils/palette/`                       |
+| →[K:public-is-read-only]                      | [[decks]]            | `src/api/decks/`                           |
+| →[K:posts-hidden-until-published]             | [[feedback]]         | `src/api/feedback/`                        |
 
-### A failed review save is silently abandoned
-
-**[[study]]** · study
-
-A card is marked reviewed locally the instant it's rated — before the async save
-runs. If the save fails, the card is already logged as done; the offered "refresh"
-rebuilds it as already-reviewed and never retries. The review is lost and the
-card's server schedule stays stale.
-
-### The stall-reaper strands healthy long-running jobs
-
-**[[audio-generation]]** · media
-
-A stuck job and a slow-but-alive job look identical. The 10-minute sweep that
-rescues genuinely-dead chains also reaps a step that legitimately runs long — and
-its late write lands on an already-`failed` row the chain trigger won't re-fire,
-stranding completed work. (Retry must also clear the half-built transcript, or
-transcription appends onto it.)
-
-### Card ordering integrity lives in RPC discipline, not the schema
-
-**[[cards]]** · cards
-
-Sort keys are compared as text, and the database's default collation is
-locale-aware — it reorders by case, so the server would sort keys differently
-from the app that minted them. The column pins byte-order collation to prevent
-it; nothing announces this, so a new ordering column or index added without the
-same collation silently reintroduces the bug.
-
-### The ownership stamp is empty under a backend job
-
-**[[members]]** · members
-
-Ownership is stamped from `auth.uid()`, which is NULL under the service-role
-client (which also bypasses RLS). A privileged job's insert either fails loudly on
-a NOT-NULL owner column, or silently lands an unreachable, orphaned row on a
-nullable one — past the isolation wall that would have caught it.
-
-### Widening a permission ripples everywhere
-
-**[[permissions]]** · authz
-
-Loosen one `can_` rule and every query leaning on the old, tighter rule silently
-widens too — including ordinary screens you forgot were trusting it. A screen that
-must stay narrow has to scope itself; the permission can't.
-
-### A file lives or dies by its notes, not the bucket
-
-**[[media]]** · media
-
-The hourly cleanup treats any file with no live note pointing at it as garbage.
-Delete a shared file directly and you break every other card using it; leave a
-file in a media bucket untracked and the next sweep eats it.
-
-### The client is the source of scheduling truth
-
-**[[scheduling]]** · scheduling
-
-FSRS runs on the device; the server only stores what the client computed and never
-recomputes or checks it. A stale app, a different algorithm version, or two devices
-reviewing the same card can quietly write schedules under different math — and the
-database can't tell.
-
-### A forgotten cache invalidation fails silent
-
-**[[data-flow]]** · architecture
-
-A write that succeeds but forgets to mark the right cache entry stale leaves the
-screen showing old data — no error, no clue at the call site. The "callers never
-touch the cache" convenience means drift has no guard but discipline.
-
-### A pin that matches the preset silently detaches
-
-**[[pacing]]** · pacing
-
-A dial is "pinned" purely because its key is present in the override bag — value is
-never compared to the preset. Pin a dial to the preset's own value and it looks
-identical, but it has detached: later preset edits move every deck except that one.
-
-### An out-of-set color renders bare, with no error
-
-**[[theming]]** · theming
-
-The color set is closed — the root reset wipes every default shade and re-adds only
-curated ones. Reach for a color outside it (a leftover default class, a token typo)
-and it resolves to nothing: no fallback, no warning, an element rendered bare.
-
-### Public means read-only — the model holds one studier per card
-
-**[[decks]]** · decks
-
-"Public" grants read visibility only. Recording a review is gated to the card's
-owner, and the progress table holds exactly one row per card platform-wide — so
-there is nowhere to store a second viewer's study state. Shared study can't be
-expressed in the current model.
-
-### A submitted post is hidden until a moderator publishes it
-
-**[[feedback]]** · feedback
-
-Every fresh post starts held back and the wall shows only published ones — so "I
-posted it, it's on the board" is quietly false, even to the author. The board is a
-curated shortlist, not a raw inbox; nothing tells the member.
+A trap with no directory to echo it into is listed in `CLAUDE.md` instead, so it
+is paid for in every session. There are none today.

--- a/corpus/media/audio-generation.md
+++ b/corpus/media/audio-generation.md
@@ -28,7 +28,7 @@ The lesson carries a status through this — _processing_ while the chain runs,
 _ready_ when it finishes, _failed_ if a step gives up. A reader only sees the
 finished thing.
 
-> [!HAZARD] **A stuck job and a slow-but-healthy job look identical — so the safety net that rescues the first will strangle the second.**
+> [!HAZARD] [K:stall-reaper-strands-slow-jobs] **A stuck job and a slow-but-healthy job look identical — so the safety net that rescues the first will strangle the second.**
 > Nothing watches a step from the inside. The only sign a lesson is still alive
 > is that it wrote something recently; go quiet for ten minutes and a background
 > sweep declares it dead and marks it failed. That's what rescues a job whose

--- a/corpus/media/media.md
+++ b/corpus/media/media.md
@@ -26,7 +26,7 @@ So a file is never thrown away the moment a card stops using it. It stays until
 _nothing_ — no card, deck, or lesson — points to it. Then a background cleanup
 job quietly removes it.
 
-> [!HAZARD] **A file lives or dies by its notes — not by the bucket it sits in.**
+> [!HAZARD] [K:media-lifetime-follows-notes] **A file lives or dies by its notes — not by the bucket it sits in.**
 > The cleanup job decides a file is garbage the instant no live note points at
 > it. That makes the note the file's lifeline, with a blade on each side: delete
 > a _shared_ file directly and you yank it out from under every other card still

--- a/corpus/members/members.md
+++ b/corpus/members/members.md
@@ -23,7 +23,7 @@ From then on, almost everything you make carries a quiet stamp of your name.
 That stamp is what keeps your stuff yours and everyone else's out of reach. You
 never write it; the app writes it for you, from whoever you're signed in as.
 
-> [!HAZARD] **The ownership stamp is copied from _whoever is asking_ — and a trusted backend job asks as nobody.**
+> [!HAZARD] [K:ownership-stamp-empty-under-service-role] **The ownership stamp is copied from _whoever is asking_ — and a trusted backend job asks as nobody.**
 > Stamping "this belongs to you" from the signed-in person is exactly what makes
 > it effortless — you never have to set it. The flip side: a privileged backend
 > job runs with _no_ signed-in person, so the stamp comes back **empty**. On a
@@ -106,7 +106,7 @@ were revoked still reads as signed in.
 
 A member scheduled for deletion is suspended by a single stored date. Ownership
 rules don't read the signed-in identity directly — they read a function that
-returns it normally and returns *nobody* once that date is set, so one flag empties
+returns it normally and returns _nobody_ once that date is set, so one flag empties
 every table the member owns at once.
 
 Two rules deliberately keep reading the raw identity: a member reading their **own**

--- a/corpus/pacing/pacing.md
+++ b/corpus/pacing/pacing.md
@@ -30,7 +30,7 @@ Where does a single dial's number actually come from? Walk down a ladder:
 The first rung that answers wins — dial by dial, not deck by deck. A deck can
 pin two dials and let a preset drive the other five.
 
-> [!HAZARD] **A pin that matches the preset is still a pin — and it quietly stops following the preset from then on.**
+> [!HAZARD] [K:pin-is-presence-not-difference] **A pin that matches the preset is still a pin — and it quietly stops following the preset from then on.**
 > A dial is "pinned" purely because it's _present_ in the deck's override bag —
 > nothing compares its value to the preset. So dialing a control to the exact
 > number the preset already shows still pins it. It looks identical today, but

--- a/corpus/scheduling/scheduling.md
+++ b/corpus/scheduling/scheduling.md
@@ -25,7 +25,7 @@ Each deck tunes the algorithm with its own pacing — how much you want to
 remember, how gently new cards ramp up, how far out reviews may land. So the very
 same rating can schedule two decks differently.
 
-> [!HAZARD] **The schedule is computed on your device — the database only stores what your device tells it.**
+> [!HAZARD] [K:client-owns-the-schedule] **The schedule is computed on your device — the database only stores what your device tells it.**
 > The algorithm runs in the browser during a session; the server just records the
 > due date and stats the client already worked out. It never recomputes or checks
 > them. The upside is real — there's no second copy of the algorithm to keep in

--- a/corpus/study/study.md
+++ b/corpus/study/study.md
@@ -4,7 +4,7 @@ domain: study
 status: current
 hazard: true
 related: [scheduling, media]
-updated: 2026-07-23
+updated: 2026-08-08
 ---
 
 # Study session
@@ -27,14 +27,18 @@ A session walks through four stages, in order:
 2. you **study** the pile;
 3. it shows a **summary** of how the run went.
 
-> [!HAZARD] **A card is marked reviewed the instant you rate it — locally, before the server confirms the save.**
-> Rating a card advances the pile and records the result on the spot; the actual
-> save to the server fires _after_, on its own. That ordering is what makes each
-> review land the moment you make it — but its flip side is a trap. If the save
-> fails, the card is already logged as done in the session's saved progress. The
-> error offers a **refresh** — and refreshing rebuilds that card as
-> already-reviewed, so it's never shown again and never retried. The review is
-> silently gone, and the card's schedule on the server stays stale.
+> [!HAZARD] [K:unconfirmed-review-loss] **The session's verdict on a save is not the server's — and a rating only survives if the session hears back before the run ends.**
+> Rating a card advances the pile on the spot and sends the save off on its own,
+> which is what makes each review land the moment you make it. The save is
+> stubborn: three quick retries, then one more when the connection comes back.
+> The flip side is that its answer has a deadline. When you rate the last card
+> the session waits **one second** for anything still in the air, then writes off
+> whatever hasn't answered — you get a "Save failed" notice and that card drops
+> out of the summary, even for a write that reaches the server a moment later.
+> Offline, the retry that waits for the connection never gets to run before that
+> cutoff. And nothing carries a rating past the tab: the resume snapshot keeps
+> only confirmed reviews, so a rating still in the air when the tab closes is
+> gone with nothing to show it existed.
 > [See how a review is saved ↓](#reviews-save-as-you-go)
 
 ## One pile, whatever the decks
@@ -69,15 +73,20 @@ summary of what you _did_ review — it isn't thrown away.
 Rating a card doesn't wait for the end. Each review is sent to the server the
 instant you make it, one at a time, as you move through the pile.
 
+A send that doesn't get through is tried again — three more times in quick
+succession, and once more the moment the connection returns. Only after all of
+those does the session give up, tell you the save failed, and put the card back
+in the queue for a later run.
+
 So the summary at the end isn't the save — by the time you get there, every
-review is already recorded. The end-of-session step only refreshes the deck
-counts so the dashboard reflects your work.
+review it lists is already recorded. The end-of-session step only refreshes the
+deck counts so the dashboard reflects your work.
 
 > [!WATCH]
-> Because reviews are already on the server card-by-card, closing the tab
-> mid-run loses no _grades_ — everything you rated is saved. What's lost is only
-> the in-tab progress marker that lets a session resume (see below); the reviews
-> themselves survive.
+> Because reviews go one at a time as you rate, closing the tab mid-run loses no
+> _grades_ that have already been confirmed. What's lost is the in-tab progress
+> marker that lets a session resume (see below) — and any rating still waiting on
+> its answer at that moment.
 
 ## Refreshing drops you back in
 

--- a/corpus/theming/theming.md
+++ b/corpus/theming/theming.md
@@ -28,7 +28,7 @@ The three switches:
 3. **depth** — how raised a thing is: the flat page, a panel lifted off it, a
    dialog floating above.
 
-> [!HAZARD] **The set of colors is closed — and a color that isn't in it resolves to nothing at all, with no error.**
+> [!HAZARD] [K:closed-color-set-fails-bare] **The set of colors is closed — and a color that isn't in it resolves to nothing at all, with no error.**
 > The app deliberately wipes every stock color its styling toolkit ships with,
 > keeping only its own curated set. The upside is that every color on screen is
 > on-theme and dark-mode-correct by construction. The flip side: reach for a

--- a/src/api/decks/db/index.ts
+++ b/src/api/decks/db/index.ts
@@ -46,6 +46,7 @@ export async function fetchMemberDeckCount(): Promise<number> {
   return count ?? 0
 }
 
+// Trap: public means read-only, not shared study →[K:public-is-read-only]
 export async function upsertDeck(deck: Deck): Promise<Deck> {
   const { data, error } = await supabase.rpc('save_deck', {
     p_deck_id: deck.id ?? null,

--- a/src/api/feedback/db/index.ts
+++ b/src/api/feedback/db/index.ts
@@ -24,6 +24,7 @@ export type SubmitFeedbackParams = {
   type: FeedbackType
 }
 
+// Trap: a new post is hidden until a moderator publishes it →[K:posts-hidden-until-published]
 export async function submitFeedback(params: SubmitFeedbackParams): Promise<FeedbackItem> {
   const { data, error } = await supabase.rpc('submit_feedback', {
     p_title: params.title,

--- a/src/api/media/db/index.ts
+++ b/src/api/media/db/index.ts
@@ -30,6 +30,7 @@ export function cardImageUrl(path: string): string {
   return getImageUrl('member-images', path)
 }
 
+// Trap: a file lives or dies by its notes, not the bucket →[K:media-lifetime-follows-notes]
 export async function insertMedia(params: Media): Promise<void> {
   if (!params.card_id && !params.deck_id) {
     throw new Error('insertMedia requires either card_id or deck_id')

--- a/src/api/review-pacing/mutations/save-deck-pacing.ts
+++ b/src/api/review-pacing/mutations/save-deck-pacing.ts
@@ -7,6 +7,7 @@ import { saveDeckPacing, type DeckPacing } from '../db'
  * re-pointed preset link) has to land immediately too — waiting for the modal's
  * Save would leave the two halves disagreeing until then.
  */
+// Trap: a pin is presence, not difference →[K:pin-is-presence-not-difference]
 export function useSaveDeckPacingMutation() {
   const queryCache = useQueryCache()
   return useMutation({

--- a/src/api/reviews/mutations/save.ts
+++ b/src/api/reviews/mutations/save.ts
@@ -9,6 +9,7 @@ export type SaveReviewVars = {
   log: ReviewLog
 }
 
+// Trap: a missed invalidation fails silently →[K:silent-stale-cache]
 export function useSaveReviewMutation() {
   const queryCache = useQueryCache()
   return useMutation({

--- a/src/utils/palette/registry.ts
+++ b/src/utils/palette/registry.ts
@@ -27,6 +27,7 @@
  * After editing this file run `pnpm gen:palette-css` to regenerate
  * src/styles/palettes.gen.css.
  */
+// Trap: the color set is closed; an out-of-set color renders bare →[K:closed-color-set-fails-bare]
 export const PALETTES = {
   blue: {
     light: { accent: 'blue-500', accentMuted: 'blue-400', onAccent: 'brown-100' },

--- a/src/views/study-session/composables/session-engine.ts
+++ b/src/views/study-session/composables/session-engine.ts
@@ -26,6 +26,7 @@ type ReviewState = 'unreviewed' | 'pending' | 'saved' | 'failed'
  * card is reviewed. Anything unresolved at the deadline is treated as `failed`
  * so the summary is never held on a stalled network.
  */
+// Trap: unconfirmed review loss →[K:unconfirmed-review-loss]
 const SUMMARY_HOLD_MS = 1000
 
 /** loading -> cover -> studying -> summary. The single lifecycle source. */

--- a/src/views/study-session/deck-resolution.ts
+++ b/src/views/study-session/deck-resolution.ts
@@ -50,6 +50,7 @@ const FALLBACK_FSRS = new FSRS(generatorParameters({ enable_fuzz: true }))
 
 const DeckResolutionKey: InjectionKey<DeckResolution> = Symbol('study-session.deck-resolution')
 
+// Trap: the client owns the schedule →[K:client-owns-the-schedule]
 function buildScheduler(deck: SessionDeck): FSRS {
   return new FSRS(
     generatorParameters({

--- a/supabase/functions/transcribe-lesson/worker.ts
+++ b/supabase/functions/transcribe-lesson/worker.ts
@@ -261,6 +261,7 @@ async function runTransliterate(admin: SupabaseClient, lesson: LessonRow): Promi
 // a live phase-in-progress from a dead one. Unlike the old worker, a failed
 // write THROWS (caught by processLessonPhase → settleFailed) rather than being
 // silently swallowed, so a row never advances on a write that didn't land.
+// Trap: the reaper strands healthy slow jobs →[K:stall-reaper-strands-slow-jobs]
 async function update(
   admin: SupabaseClient,
   id: number,

--- a/supabase/schemas/10_shared.sql
+++ b/supabase/schemas/10_shared.sql
@@ -83,6 +83,7 @@ GRANT ALL ON FUNCTION public.auth_role() TO authenticated;
 GRANT ALL ON FUNCTION public.auth_role() TO service_role;
 
 
+-- Trap: widening a capability ripples into every query leaning on it →[K:permission-widening-ripples]
 CREATE FUNCTION public.can_manage_members() RETURNS boolean
     LANGUAGE sql STABLE
     SET search_path TO 'public'
@@ -131,6 +132,7 @@ GRANT ALL ON FUNCTION public.can_read_lesson_audio() TO service_role;
 GRANT ALL ON FUNCTION public.can_read_lesson_audio() TO authenticated;
 
 
+-- Trap: the ownership stamp is empty under the service role →[K:ownership-stamp-empty-under-service-role]
 CREATE FUNCTION public.set_member_id() RETURNS trigger
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$

--- a/supabase/schemas/40_cards/00_tables.sql
+++ b/supabase/schemas/40_cards/00_tables.sql
@@ -23,6 +23,7 @@ CREATE TABLE public.cards (
     back_text text,
     deck_id bigint,
     member_id uuid,
+    -- Trap: card rank needs byte-order collation →[K:card-rank-byte-collation]
     rank text COLLATE pg_catalog."C" NOT NULL,
     note text
 );


### PR DESCRIPTION
[TARO-335](https://app.notion.com/p/3b60953c224c819381acecc090e548de)

> **Stacked on [#518](https://github.com/TaroSprout/TaroFlash/pull/518) (TARO-334).** Merge that first.

## Summary

- All 12 `[!HAZARD]` blocks now declare a permanent `[K:<slug>]`, and each is echoed where it bites as a one-line `→[K:<slug>]` label comment carrying no claim of its own — so the echo can't drift from the trap.
- `corpus/hazards.md` goes 117 → 32 lines: a roll-call of slug, topic and echo site, restating nothing. Trades 117 always-on lines for ~one line paid only where each trap applies.
- Schema traps anchor in `supabase/schemas/`; nothing was written into `supabase/migrations/`.

## The stale trap, rewritten

The top-ranked trap claimed a failed review save is never retried — false since July. Corrected to the residual hole: the save retries 3x plus once on reconnect, but the session gives anything still in flight one second when the last card is rated, then writes it off. Offline, the reconnect retry never runs before that cutoff, and nothing carries a rating past the tab since the resume snapshot keeps only confirmed reviews. `study.md` realigned so nothing contradicts.

## Worth knowing

- **AC 1 was already satisfied** by TARO-333, which moved `corpus/CONTRIBUTING.md` to `.claude/rules/corpus-authoring.md`. Not redone.
- **AC 5 is vacuous as written** — every one of the 12 traps has a directory home, so the always-on list of homeless traps is empty. `CLAUDE.md` states the rule and says there are none today rather than listing nothing.
- **AC 6 needed no new code** — the existing `scripts/knowledge-lint.mjs` citation check already fails an echo naming an unresolvable slug. Verified with a scratch fixture.