### PR TITLE
TARO-339: Comment sweep — deck views

### DIFF
--- a/corpus/decks/_map.md
+++ b/corpus/decks/_map.md
@@ -3,3 +3,4 @@
 A member's boxes of cards — ownership, sharing, and due counts.
 
 - [[decks]] — one owner, one public/private switch; public means read-only, not shared study ⚠️
+- [[deck-card-editor]] — a new card is a local placeholder that saves itself in the background; focus target must be claimed the same tick it's staged ⚠️

--- a/corpus/decks/card-editor.md
+++ b/corpus/decks/card-editor.md
@@ -1,0 +1,68 @@
+---
+id: deck-card-editor
+domain: decks
+status: current
+hazard: true
+related: [decks, cards]
+updated: 2026-08-08
+---
+
+# Deck card editor
+
+How the deck editor's card list stays responsive while cards are still saving, and how a freshly
+added row ends up focused without a race.
+
+A card you just added isn't real yet. Typing a fresh card into existence takes a network
+round-trip, but the editor doesn't make you wait for it — it drops a placeholder row in immediately
+and saves it behind the scenes.
+
+> [!HAZARD] [K:deck-focus-microtask-ordering] **The new row's autofocus target has to be set in the
+> same tick as the placeholder, not after.**
+> Staging a card queues Vue's own render of the new row, and that render flushes before any
+> `await` further down the same function gets a chance to run. Set the focus target after one more
+> `await`, and the row has already mounted and asked "is this me?" before the answer exists — it
+> comes back false and nothing gets focused. The rule in code: assign in the same tick as insert,
+> the row mounts before any later microtask.
+
+## A new card starts as a placeholder, not a row in the database
+
+The moment you ask for a new card, it gets a local id and a spot in the list — before any request
+has gone out. That placeholder card saves itself in the background the instant it's created, so by
+the time you've typed your first letter it's usually already a real, saved card.
+
+The list only cares whether a card is a placeholder or a real one for one thing: whether the next
+edit should create the row or update it. Everything else about rendering it is identical.
+
+## The placeholder and the real row are the same row on screen
+
+When the placeholder's save finishes, the server hands back the row's real id — but the on-screen
+card doesn't remount to show it. It keeps the same identity it had as a placeholder, so the editor
+you were typing into stays exactly where it was.
+
+> [K:deck-temp-card-handoff] The placeholder is assigned a stable identity when it's first staged.
+> That identity carries over once the save resolves and gets reused again when the card's real data
+> arrives from the server — so on screen it reads as one continuous row, never a swap.
+
+Losing that continuity would mean every fresh card blinks and drops focus the instant its first
+save lands — mid-keystroke, for the fastest typists.
+
+## Only one card can be waiting for focus at a time
+
+Several "add a card" actions across the editor — the toolbar button, a per-row insert, the
+empty-state button — all funnel through one seam that can mark a single card as "this is the one
+that should focus itself and animate in." A card claims that mark once, the first time it renders,
+and then it's gone — nobody else can claim it after.
+
+> [K:deck-editor-focus-claim] One pending target at a time, claimed exactly once on mount. This is
+> what stops two cards added in quick succession from fighting over the same autofocus — the first
+> to render wins it, the second finds nothing left to claim.
+
+## What this isn't
+
+- **Not what a card is.** Front/back text, ordering, duplicates — [[cards]].
+- **Not who can see the deck.** Ownership and the public/private switch — [[decks]].
+- **Not the SQL or the insert RPC.** Table shape and the mutation call are code detail.
+
+## Related
+
+[[decks]] · [[cards]]

--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -21,9 +21,8 @@ const front_input = useTemplateRef('front-input')
 
 const focused = ref(false)
 
-// Local editor state is the source of truth while the component is mounted.
-// Initialised from the card prop; later cache updates are ignored so
-// incoming refetches can't clobber what the user has typed.
+// Source of truth while mounted — later cache updates are ignored so a
+// refetch can't clobber what the user has typed.
 const front_text = ref(card.front_text ?? '')
 const back_text = ref(card.back_text ?? '')
 const save_failed = ref(false)
@@ -33,21 +32,16 @@ const { is_selecting } = selection
 
 const { flagWindowBlur, consumeWindowRefocus } = useWindowRefocusGuard()
 
-// On mount a row claims two independent one-shot signals. Focus: a card staged
-// by the toolbar's "new card" intent, or one reached via the grid's "Edit"
-// action, lands the user in the front editor. Grow-in: only a freshly-added card
-// reveals with the height animation — edit-navigation sets no grow target, so
-// scrolling to an existing card focuses it without animating its height. Both
-// claims are gated so ordinary scroll-mounted rows fire neither.
+// Claims its two one-shot signals on mount: focus (front editor) and grow-in
+// (height reveal). Both are gated so an ordinary scroll-mounted row fires
+// neither. →[K:deck-editor-focus-claim]
 onMounted(() => {
   if (claimFocus(card.client_id)) focusEditor()
   if (claimGrow(card.client_id) && list_item_card.value) expandListItemIn(list_item_card.value)
 })
 
-// Persist both sides from local state, not just the edited one: the merge base
-// in the save path is the cached card, so sending a single side would let it
-// clobber the other side with stale cache data. Local refs are the source of
-// truth while mounted, so they carry the complete, current card.
+// Sends both sides, not just the edited one — the save path's merge base is
+// the cached card, so a single side would let it clobber the other with stale data.
 async function onUpdate(side: 'front' | 'back', text: string) {
   if (side === 'front') front_text.value = text
   else back_text.value = text
@@ -62,10 +56,8 @@ async function onUpdate(side: 'front' | 'back', text: string) {
   }
 }
 
-// Autofocusing a freshly-added card is programmatic, not the user landing on
-// it — flag the synchronous focusin so onFocusIn stays silent. The action that
-// added the card owns that sound. queueMicrotask clears the flag after the
-// current turn in case focus() no-ops and focusin never fires.
+// Flags a programmatic autofocus so onFocusIn stays silent — the add action
+// owns that sound. Cleared on the next microtask in case focus() no-ops.
 let programmatic_focus = false
 function focusEditor() {
   if (focused.value) return
@@ -74,27 +66,22 @@ function focusEditor() {
   queueMicrotask(() => (programmatic_focus = false))
 }
 
-// Whether a node lives inside any card in the editor (its own card or another).
-// Lets us tell "focus moved between cards" from "focus entered/left the editor".
+/** Whether a node lives inside any card in the editor, to tell "moved between cards" from "left the editor". */
 function withinAnyCard(node: EventTarget | null) {
   return (node as HTMLElement | null)?.closest?.('[data-testid="list-item-card"]') != null
 }
 
-// Gate the sfx on contenteditable focus so the image button doesn't trigger it.
-// Arriving from another card (or the other side) clicks; arriving from outside
-// every card — i.e. activating a card when none was — slides up.
+// Gated on contenteditable focus so the image button doesn't trigger it.
 function onFocusIn(e: FocusEvent) {
   if (!(e.target as HTMLElement | null)?.isContentEditable) return
 
-  // The browser restoring focus after the window comes back isn't a user
-  // action — stay silent, but still track that we hold focus again.
+  // A window-refocus isn't a user action — stay silent.
   if (consumeWindowRefocus()) {
     focused.value = true
     return
   }
 
-  // Programmatic autofocus (a freshly-added card) isn't a user landing on the
-  // card — stay silent so it doesn't collide with the add action's own sound.
+  // Programmatic autofocus isn't a user landing on the card either.
   if (programmatic_focus) {
     programmatic_focus = false
     focused.value = true
@@ -105,16 +92,13 @@ function onFocusIn(e: FocusEvent) {
   focused.value = true
 }
 
-// When an editor blurs to outside every card, the active card was deselected
-// with nothing new picked up — drop it.
 function onFocusOut(e: FocusEvent) {
   focused.value = list_item_card.value?.contains(e.relatedTarget as Node | null) ?? false
 
   const left_editor = (e.target as HTMLElement | null)?.isContentEditable ?? false
   if (!left_editor) return
 
-  // A window blur (switching apps) blurs the editor without the user choosing
-  // to — flag the round-trip so the matching refocus stays silent, no drop.
+  // A window blur isn't the user leaving the card — flag the round-trip so the matching refocus stays silent.
   if (!document.hasFocus()) return flagWindowBlur()
 
   if (!withinAnyCard(e.relatedTarget)) emitSfx('card_drop')

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -37,18 +37,15 @@ function onClick(e: MouseEvent) {
     return
   }
 
-  // If the click is on a button, let the button handle it
-  // Prevent default to avoid stealing focus state
+  // Let a button handle its own click instead of stealing focus.
   if (closest('button')) {
     e.preventDefault()
     return
   }
 
-  // If the click IS NOT on an input, prevent default to avoid stealing focus state
-  // If the click IS on an input, we expect it to steal focus and don't want to prevent that here
+  // Only a contenteditable is allowed to steal focus.
   if (!closest('[contenteditable]')) e.preventDefault()
 
-  // focus the card's front-text editor if the card doesn't already have focus
   if (!list_item_card.value?.hasFocusWithin()) list_item_card.value?.focusEditor()
 }
 </script>

--- a/src/views/deck/card-editor/list.vue
+++ b/src/views/deck/card-editor/list.vue
@@ -47,8 +47,7 @@ const reorder = useReorderDrag({
   count: () => all_cards.value.length,
   enabled: () => is_above_md.value && !selection.is_selecting.value && can_reorder.value,
   topInset: () => sticky_toolbar?.getBoundingClientRect().bottom ?? 0,
-  // Clean, transform-immune scroll bound that grows as infinite-scroll loads
-  // more rows mid-drag, so auto-scroll past the load threshold keeps going.
+  // Grows as infinite-scroll loads more rows mid-drag, so auto-scroll past the load threshold keeps going.
   maxScroll: () => scroll_margin.value + virtualizer.value.getTotalSize() - window.innerHeight,
   onReorder: reorderCard
 })
@@ -60,8 +59,7 @@ const virtualizer = useWindowVirtualizer(
     overscan: OVERSCAN,
     scrollMargin: scroll_margin.value,
     getItemKey: (i: number) => all_cards.value[i].client_id,
-    // Keep the dragged row in the rendered range even after auto-scroll carries
-    // its slot out of the overscan window — otherwise it unmounts mid-drag.
+    // Keeps the dragged row rendered past the overscan window so it doesn't unmount mid-drag.
     rangeExtractor: (range) => {
       const indexes = defaultRangeExtractor(range)
       const dragging = reorder.dragging_index.value
@@ -71,29 +69,19 @@ const virtualizer = useWindowVirtualizer(
   }))
 )
 
-// The list flows in the page below the sticky toolbar (and, below xl, the
-// hero), so the window virtualizer needs the list's document offset to map
-// page scroll onto row positions. Measure the container, not the list itself:
-// during a mode-swap the list is briefly transformed (it slides into place),
-// which would corrupt its own rect — the container stays in flow.
+// Measures the parent, not the list itself — the list is transformed during
+// a mode-swap, which would corrupt its own rect.
 function measureScrollMargin() {
   const container = list_el.value?.parentElement
   if (!container) return
   scroll_margin.value = container.getBoundingClientRect().top + window.scrollY
-  // scrollMargin flows into the virtualizer's options reactively, but its own
-  // scroll-offset tracking doesn't otherwise know to resync against it — an
-  // explicit measure() keeps the two from racing (see the resize debounce
-  // below for why this can otherwise fire mid-scroll).
+  // Explicit measure() keeps the virtualizer's own scroll-offset tracking from racing scrollMargin.
   virtualizer.value.measure()
 }
 
-// The mobile dock publishing its live height resizes the page body (see
-// mobile-dock-host.vue), which can itself be driven by --edge-safe-padding
-// changing live while the visual viewport resizes during a scroll gesture on
-// mobile Chrome. Observing document.body means that cascade fires this
-// mid-scroll, computing `scroll_margin` from a `window.scrollY` snapshot
-// that's still moving — debounce so a resize burst settles once the scroll
-// (and the cascade it triggered) has actually stopped.
+// Debounced so a resize burst (the mobile dock's live height, cascading from
+// --edge-safe-padding) settles after scroll stops, instead of measuring
+// scroll_margin from a window.scrollY snapshot that's still moving.
 const RESIZE_DEBOUNCE_MS = 120
 let resize_timer: ReturnType<typeof setTimeout> | undefined
 function onBodyResize() {
@@ -101,9 +89,6 @@ function onBodyResize() {
   resize_timer = setTimeout(measureScrollMargin, RESIZE_DEBOUNCE_MS)
 }
 
-// Start a drag and, when it actually begins (gated to md+ / not selecting),
-// lift the grabbed row. The element is held so the matching drop can settle it
-// back — the drop fires from a window pointerup, not a DOM event on the row.
 function onReorderStart(index: number, event: PointerEvent) {
   reorder.start(index, event)
   if (reorder.dragging_index.value === null) return
@@ -112,13 +97,7 @@ function onReorderStart(index: number, event: PointerEvent) {
   if (lifted_row) liftListItem(lifted_row)
 }
 
-/**
- * Map a card's client_id to its row index and scroll it into view — works
- * for cards outside the current virtual-scroll window (the virtualizer
- * computes the offset from the fixed row pitch, no measurement needed).
- * Registered with the controller on mount so `editCard` can reach it without
- * a template-ref chain through the mode-stack's dynamic panes.
- */
+/** Map a card's client_id to its row index and scroll it into view, even outside the current virtual window. */
 function scrollToCard(client_id: string) {
   const index = all_cards.value.findIndex((c) => c.client_id === client_id)
   if (index === -1) return
@@ -127,10 +106,9 @@ function scrollToCard(client_id: string) {
 }
 
 let resize_observer: ResizeObserver | undefined
-// The sticky toolbar (md+) covers the top of the list; its viewport-space
-// bottom is the inset where drag auto-scroll-up should start.
+// Viewport-space bottom of the sticky toolbar (md+) — the inset drag auto-scroll-up starts from.
 let sticky_toolbar: HTMLElement | null = null
-// The row lifted on pickup, held so the drop can settle it back to rest.
+// Held so the matching drop, which fires from a window pointerup, can settle it back.
 let lifted_row: HTMLElement | null = null
 
 onMounted(() => {

--- a/src/views/deck/card-grid/grid-item.vue
+++ b/src/views/deck/card-grid/grid-item.vue
@@ -29,9 +29,8 @@ function onMenuSelect(option: DropdownOption) {
   onMenuOptionSelect(option, card.id!)
 }
 
-// A touch hold opens the corner more-menu; a plain tap still flows through the
-// click path (flip / select / mobile editor). In rearrange mode the grid owns
-// pointerdown (drag pickup), and mouse holds stay inert — desktop hovers the menu.
+// A touch hold opens the corner more-menu; the grid itself owns pointerdown
+// in rearrange mode, and mouse holds stay inert — desktop hovers the menu.
 function onPointerdown(event: PointerEvent) {
   if (rearranging || is_selecting.value || event.pointerType === 'mouse') return
   options_hold.arm(event, () => dropdown.value?.show())
@@ -63,14 +62,10 @@ function onCardClick() {
     return
   }
 
-  // Below md the grid is read-only — a tap opens the focused dock editor on
-  // this card instead of flipping it in place. openCard handles that and
-  // returns true; at md+ it returns false and we flip in place below.
+  // Below md a tap opens the dock editor instead of flipping in place.
   if (surface.openCard(card.client_id)) return
 
-  // A click that ends a drag-selection of the card's text shouldn't also flip.
-  // A plain click collapses the selection on mousedown, so this only catches
-  // the release of a real selection.
+  // A click ending a text drag-selection shouldn't also flip.
   const sel = window.getSelection()
   if (sel && !sel.isCollapsed) return
 
@@ -78,16 +73,13 @@ function onCardClick() {
   emitSfx(active_side.value === 'back' ? 'transition_up' : 'transition_down')
 }
 
-// Spamming the flip racks up the browser's click counter, whose double/triple
-// clicks word- and line-select the card content. Suppress the default selection
-// on those multi-clicks only — a single click (and a deliberate click-drag to
-// select) keeps `detail === 1`, so manual selection still works.
+// Suppresses text selection only on a multi-click (`detail > 1`) — spamming
+// the flip would otherwise word/line-select the card content.
 function onCardMouseDown(e: MouseEvent) {
   if (e.detail > 1) e.preventDefault()
 }
 
-// The grid's default face is a live setting — resync even a card the user
-// flipped by hand back to the new default.
+// Resyncs even a card the user flipped by hand, when the grid's default face changes.
 watch(
   () => side,
   (new_side) => (active_side.value = new_side)

--- a/src/views/deck/card-grid/scroll-grid.vue
+++ b/src/views/deck/card-grid/scroll-grid.vue
@@ -41,8 +41,7 @@ const grid_el = useTemplateRef<HTMLElement>('grid_el')
 const sentinel = useTemplateRef<HTMLElement>('sentinel')
 const container_width = ref(0)
 const scroll_margin = ref(0)
-// container_width starts at 0, so columns/row_count fall back to a single tall
-// column for one frame — gate the rendered height on this so that never paints.
+// Gates the rendered height so the single-tall-column fallback frame never paints.
 const measured = ref(false)
 
 const { cell_width, gap, columns, row_count, row_pitch, itemPosition } = useCardGrid(
@@ -51,16 +50,13 @@ const { cell_width, gap, columns, row_count, row_pitch, itemPosition } = useCard
   () => displayed_cards.value.length
 )
 
-// Reordering shares the editor list's engine — same sounds, same gap-shift feel.
-// Only the geometry differs: a card's ideal slot is read in 2-D (column + row),
-// and a gap-shift is the px gap to the neighbouring cell, so a card wrapping a
-// row edge animates to the next row for free.
+// Shares the editor list's reorder engine; only the geometry differs — a
+// card's ideal slot is read in 2-D (column + row).
 const reorder = useReorderDrag({
   count: () => displayed_cards.value.length,
   enabled: () => is_rearranging.value && !is_active.value,
   topInset: () => sticky_toolbar?.getBoundingClientRect().bottom ?? 0,
-  // Clean, transform-immune scroll bound that grows as infinite-scroll loads
-  // more rows mid-drag, so auto-scroll past the sentinel keeps going.
+  // Grows as infinite-scroll loads more rows mid-drag, so auto-scroll past the sentinel keeps going.
   maxScroll: () => scroll_margin.value + virtualizer.value.getTotalSize() - window.innerHeight,
   onReorder: reorderCard,
   geometry: {
@@ -80,8 +76,7 @@ const virtualizer = useWindowVirtualizer(
     estimateSize: () => row_pitch.value,
     overscan: OVERSCAN,
     scrollMargin: scroll_margin.value,
-    // Keep the dragged card's row rendered even after auto-scroll carries it out
-    // of the overscan window — otherwise the card unmounts mid-drag.
+    // Keeps the dragged card's row rendered past the overscan window so it doesn't unmount mid-drag.
     rangeExtractor: (range) => {
       const rows = defaultRangeExtractor(range)
       const dragging = reorder.dragging_index.value
@@ -94,9 +89,8 @@ const virtualizer = useWindowVirtualizer(
   }))
 )
 
-// Flatten the virtualizer's visible rows into individual positioned cards, so
-// each card is laid out (and dragged) on its own. The per-card transform is the
-// seam the reorder engine's live offset is added on top of.
+// Flattens the virtualizer's visible rows into individually positioned cards,
+// so each one's transform is the seam the reorder engine's live offset adds to.
 const visible_items = computed(() => {
   const cols = columns.value
   const total = displayed_cards.value.length
@@ -114,37 +108,27 @@ const visible_items = computed(() => {
 })
 
 let resize_observer: ResizeObserver | undefined
-// The sticky toolbar (md+) covers the top of the grid; its viewport-space
-// bottom is the inset where drag auto-scroll-up should start.
+// Viewport-space bottom of the sticky toolbar (md+) — the inset drag auto-scroll-up starts from.
 let sticky_toolbar: HTMLElement | null = null
-// The card lifted on pickup, held so the matching drop can settle it back — the
-// drop fires from a window pointerup, not a DOM event on the card.
+// Held so the matching drop, which fires from a window pointerup rather than
+// a DOM event on the card, can settle it back.
 let lifted_card: HTMLElement | null = null
 
-// Measure the container, not the grid itself: during a mode-swap the grid pane
-// is transformed (it scales + drops out of flow), which would corrupt its own
-// rect. The parent stays in flow, so its width and document offset stay true.
+// Measures the parent, not the grid pane itself — the pane is transformed
+// during a mode-swap, which would corrupt its own rect.
 function measureLayout() {
   const container = grid_el.value?.parentElement
   if (!container) return
   container_width.value = container.clientWidth
   scroll_margin.value = container.getBoundingClientRect().top + window.scrollY
   measured.value = true
-  // scrollMargin flows into the virtualizer's options reactively, but its own
-  // scroll-offset tracking doesn't otherwise know to resync against it — an
-  // explicit measure() keeps the two from racing (see the resize debounce
-  // below for why this can otherwise fire mid-scroll).
+  // Explicit measure() keeps the virtualizer's own scroll-offset tracking from racing scrollMargin.
   virtualizer.value.measure()
 }
 
-// The dock publishing its live height resizes the page body (see
-// mobile-dock-host.vue), which can itself be driven by --edge-safe-padding
-// changing live while the visual viewport resizes during a scroll gesture on
-// mobile Chrome. Observing document.body means that cascade fires this
-// mid-scroll, computing `scroll_margin` from a `window.scrollY` snapshot
-// that's still moving — debounce so a resize burst settles once the scroll
-// (and the cascade it triggered) has actually stopped, instead of feeding the
-// virtualizer a scroll_margin that's already stale by the time it's set.
+// Debounced so a resize burst (the mobile dock's live height, cascading from
+// --edge-safe-padding) settles after scroll stops, instead of measuring
+// scroll_margin from a window.scrollY snapshot that's still moving.
 const RESIZE_DEBOUNCE_MS = 120
 let resize_timer: ReturnType<typeof setTimeout> | undefined
 function onBodyResize() {
@@ -152,15 +136,13 @@ function onBodyResize() {
   resize_timer = setTimeout(measureLayout, RESIZE_DEBOUNCE_MS)
 }
 
-// The drag/gap-shift offset (px) the reorder engine wants applied to the card at
-// `index`, on top of its resting slot position. Empty until a drag is live.
+/** The reorder engine's live gap-shift offset (px) for the card at `index`, on top of its resting slot. */
 function dragTransform(index: number) {
   const offset = reorder.dragOffset(index)
   return `translate(${offset.x}px, ${offset.y}px)`
 }
 
-// Idle iOS-style jiggle: vary phase and tempo per card off its index so the grid
-// shimmers organically instead of beating in unison.
+// Varies phase and tempo per card off its index so the idle jiggle shimmers organically, not in unison.
 function jiggleStyle(index: number) {
   return {
     '--jiggle-delay': `${-(index % 11) * 47}ms`,
@@ -168,8 +150,6 @@ function jiggleStyle(index: number) {
   }
 }
 
-// Begin a drag and, once it actually starts (gated to rearrange mode), lift the
-// grabbed card. The element is held so the matching drop can settle it back.
 function beginDrag(index: number, event: PointerEvent) {
   reorder.start(index, event)
   if (reorder.dragging_index.value === null) return
@@ -178,9 +158,7 @@ function beginDrag(index: number, event: PointerEvent) {
   if (lifted_card) liftListItem(lifted_card)
 }
 
-// Mouse picks up immediately; touch waits out a press-and-hold so a plain swipe
-// still scrolls the grid. The hold aborts the moment the finger drifts. Outside
-// rearrange mode each grid item owns its own long-press (see grid-item.vue).
+// Touch waits out a press-and-hold so a plain swipe still scrolls the grid; mouse picks up immediately.
 function onItemPointerdown(index: number, event: PointerEvent) {
   if (!is_rearranging.value || is_active.value) return
 

--- a/src/views/deck/card-grid/use-card-grid.ts
+++ b/src/views/deck/card-grid/use-card-grid.ts
@@ -17,15 +17,8 @@ export type GridItemPosition = { x: number; y: number }
 
 /**
  * Grid geometry for the deck card grid. Pure arithmetic off the discrete size
- * level — every cell is a uniform, known size, so row pitch and per-card offsets
- * need no DOM measurement and the grid can be window-virtualized by row.
- *
- * @param grid_size       - Active size level (Small / Base / Full).
- * @param container_width - Measured inner width of the scroll container, used to
- *                          derive the column count. Defaults to 0 (skeleton use,
- *                          which only needs `grid_style`).
- * @param item_count      - Total cards on screen, used for row count + per-row
- *                          centering of the trailing partial row.
+ * level — every cell is a uniform, known size, so row pitch and per-card
+ * offsets need no DOM measurement and the grid can be window-virtualized.
  */
 export function useCardGrid(
   grid_size: MaybeRefOrGetter<CardGridSize>,
@@ -52,11 +45,8 @@ export function useCardGrid(
   }))
 
   /**
-   * Absolute (x, y) px offset of the card at `index` within the virtual
-   * viewport. The whole grid is centered on a full row's width, so every row —
-   * including the trailing partial one — shares the same left edge and fills
-   * left-to-right (mirrors the grid's `justify-center`). This is the seam a
-   * future drag-to-reorder layer adds its live offset on top of.
+   * Absolute (x, y) px offset of the card at `index`. Every row, including a
+   * trailing partial one, shares the same centered left edge.
    */
   function itemPosition(index: number): GridItemPosition {
     const cols = columns.value

--- a/src/views/deck/composables/actions.ts
+++ b/src/views/deck/composables/actions.ts
@@ -23,12 +23,7 @@ type Args = {
 /**
  * Intent handlers for the deck-editor: confirm + delete, open + move, enter
  * selection, exit mode. Composes modal / alert / sfx around the underlying
- * mutations so the controller doesn't carry that UI baggage. Flows that end
- * editing hand control back to the deck-view shell via `shell.exitMode()`.
- *
- * @example
- * const actions = useCardActions({ list, selection, mutations, deck_id, shell })
- * actions.onDeleteCards(card_id)
+ * mutations so the controller doesn't carry that UI baggage.
  */
 export function useCardActions({ list, selection, mutations, deck_query, deck_id, shell }: Args) {
   const { t } = useI18n()

--- a/src/views/deck/composables/bulk-actions.ts
+++ b/src/views/deck/composables/bulk-actions.ts
@@ -5,13 +5,7 @@ import { cardEditorKey } from './list-controller'
 
 /**
  * Reactive labels + handlers shared by the bulk-actions stack (deck hero
- * overlay + mobile dock). Both surfaces drive the same selection state,
- * so they share the same `select-all` toggling, cancel sfx, and label
- * flipping.
- *
- * @example
- * const { select_all_label, has_selection,
- *         onToggleSelectAll, onCancel } = useBulkActions()
+ * overlay + mobile dock) — both surfaces drive the same selection state.
  */
 export function useBulkActions() {
   const { t } = useI18n()

--- a/src/views/deck/composables/card-search.ts
+++ b/src/views/deck/composables/card-search.ts
@@ -7,25 +7,10 @@ export type CardSearch = ReturnType<typeof useCardSearch>
 export const cardSearchKey = Symbol('cardSearch') as InjectionKey<CardSearch>
 
 /**
- * In-deck card search UI state. Owns the search bar's visibility, the query
- * text, and the derived display flags. Filtering itself is handled server-side
- * by the `get_cards_in_deck` RPC — this composable just tracks what the user
- * typed and whether the bar is open.
- *
- * `displayed_cards` is a pass-through of the already-filtered `all_cards` from
- * the list controller; `is_loading` and `no_results` reflect the controller's
- * query state while a search is active.
- *
- * @param query_ref   - Shared ref the search bar writes to; also fed into
- *                      `useCardsInDeckInfiniteQuery` as its `search_query` arg.
- * @param all_cards   - The controller's current card list (RPC-filtered).
- * @param is_querying - True while the controller's infinite query is in flight.
- *
- * @example
- * const search_query = ref('')
- * const editor = useCardListController({ ..., search_query })
- * const search = useCardSearch(search_query, editor.list.all_cards, editor.isLoading)
- * provide(cardSearchKey, search)
+ * In-deck card search UI state — the search bar's visibility, the query text,
+ * and the derived display flags. Filtering itself is server-side, via
+ * `get_cards_in_deck`; `displayed_cards` is a pass-through of the already
+ * filtered `all_cards`.
  */
 export function useCardSearch(
   query_ref: Ref<string>,

--- a/src/views/deck/composables/edit-menu.ts
+++ b/src/views/deck/composables/edit-menu.ts
@@ -11,14 +11,10 @@ export type CardEditMenu = ReturnType<typeof useCardEditMenu>
 
 /**
  * Shared wiring for the deck view's edit affordance, used by both the desktop
- * deck-hero dropdown and the mobile footer dropdown so their options and actions
- * never drift. `options` covers select / rearrange / appearance (the trigger-only
- * footer prepends its own `edit` entry). `primaryAction`/`startEditing` are the
- * primary edit action — the dock editor below md, desktop edit mode at md+.
+ * deck-hero dropdown and the mobile footer dropdown so their options and
+ * actions never drift.
  *
- * All options disable while rearranging — bulk-select toggles don't work
- * mid-drag, so nothing else in the menu should be reachable either. Stopping
- * happens via the yellow primary button (desktop) or footer button (mobile).
+ * All options disable while rearranging — nothing else in the menu should be reachable mid-drag.
  */
 export function useCardEditMenu() {
   const { t } = useI18n()

--- a/src/views/deck/composables/editor-breakpoint-sync.ts
+++ b/src/views/deck/composables/editor-breakpoint-sync.ts
@@ -7,15 +7,8 @@ import type { MobileCardEditor } from '../mobile-editor/use-mobile-card-editor'
 /**
  * Keep the active card-editing surface aligned with the viewport. Desktop edit
  * mode and the mobile dock editor are two faces of one intent, picked once at
- * open time; resizing across the `md` breakpoint would otherwise strand the user
- * in the surface that no longer fits. On each cross this tears down the current
- * surface and opens the other on the same card. The unsaved staged card is a
- * temp already living in `all_cards`, so it survives the swap either way.
- *
- * @param shell - The deck-view shell; owns desktop `mode`.
- * @param editor - The card-list controller; its `pending_focus_client_id` queues
- *   a desktop row for autofocus so grow lands on the right card.
- * @param mobile_editor - The mobile dock editor; the cursor into `all_cards`.
+ * open time; resizing across the `md` breakpoint tears down the current
+ * surface and opens the other on the same card.
  */
 export function useEditorBreakpointSync(
   shell: DeckViewShell,

--- a/src/views/deck/composables/editor-surface.ts
+++ b/src/views/deck/composables/editor-surface.ts
@@ -7,16 +7,9 @@ import { mobileCardEditorKey } from '@/views/deck/mobile-editor/use-mobile-card-
 export type EditorSurface = ReturnType<typeof useEditorSurface>
 
 /**
- * Single source of truth for *which* card-editing surface the deck view uses at
- * the current viewport. Below the `md` breakpoint the mobile dock editor is the
- * deck's only editing surface; at md+ it's the desktop mode-stack. Every entry
- * point — empty-state CTA, mobile dock button, edit menu, card tap — routes
- * through here so the breakpoint and the surface choice can never drift apart.
- *
- * @example
- * const surface = useEditorSurface()
- * surface.openNewCard()            // stage + open on the fitting surface
- * if (surface.openCard(id)) return // mobile handled it; desktop falls through
+ * Single source of truth for *which* card-editing surface the deck view uses
+ * at the current viewport — the mobile dock editor below `md`, the desktop
+ * mode-stack at md+. Every entry point routes through here.
  */
 export function useEditorSurface() {
   const editor = inject(cardEditorKey, null)

--- a/src/views/deck/composables/list-controller.ts
+++ b/src/views/deck/composables/list-controller.ts
@@ -17,36 +17,17 @@ export const cardEditorKey = Symbol('cardEditor') as InjectionKey<CardListContro
 
 type Options = {
   deck_id: number
-  // intent actions hand control back to the shell: `exitMode` when a flow ends
-  // editing, `setMode` when `newCard` drops the user into edit mode
   shell: Pick<DeckViewShell, 'exitMode' | 'setMode' | 'sort_by'>
   search_query: Ref<string>
 }
 
 /**
- * Single root composable for the deck-editor card list. Wires the infinite
- * cards query, deck query, virtual list, selection, mutations, and intent
- * actions together, and exposes the consolidated surface a single
- * `provide(cardEditorKey)` hands to every consumer (list, grid, list-item,
- * list-item-card, card-importer, mode-toolbar, deck-hero).
+ * Root composable for the deck-editor card list — wires the cards query, deck
+ * query, virtual list, selection, mutations, and intent actions into the one
+ * surface `provide(cardEditorKey)` hands to every consumer.
  *
- * Pure card-data concerns: which mode/pane is on screen lives in
- * `useDeckViewShell`. Selection is orthogonal to mode: `is_selecting` flips on
- * the moment any card is selected, regardless of which mode is active. Also
- * owns the `saving` flag and the INSERT-vs-UPDATE routing in `updateCard`.
- *
- * Calls `useDeckQuery` once internally and forwards `deck.card_count` into
- * `useCardSelection`. Pinia Colada dedupes by key, so other consumers (e.g.
- * the deck overview panel) holding the same handle share the cache entry.
- *
- * @param opts.deck_id - Numeric deck id this controller is scoped to.
- * @param opts.shell - The deck-view shell; intent actions call its `exitMode`
- *   when a flow ends editing (e.g. deleting the whole selection).
- *
- * @example
- * const shell = useDeckViewShell()
- * const editor = useCardListController({ deck_id, shell })
- * provide(cardEditorKey, editor)
+ * Selection is orthogonal to mode: `is_selecting` flips on regardless of
+ * which mode is active.
  */
 export function useCardListController(opts: Options) {
   const { t } = useI18n()
@@ -68,36 +49,28 @@ export function useCardListController(opts: Options) {
 
   const saving = ref(false)
 
-  // In-flight eager insert per staged card, keyed by client_id. `updateCard`
-  // awaits the entry's promise so a keystroke landing mid-insert becomes an
-  // UPDATE on the row it created, never a second INSERT.
+  // `updateCard` awaits a staged card's entry here, so a keystroke landing
+  // mid-insert becomes an UPDATE on the row it created, never a second INSERT.
   const pending_inserts = new Map<string, Promise<void>>()
 
-  // Eager inserts run one at a time. A card's key is minted against its
-  // rendered neighbours, and a sibling staged moments earlier only carries one
-  // once its own insert resolved — minting concurrently hands both the same key.
+  // Chains eager inserts one after another, so a key is always minted against
+  // neighbours whose own insert already resolved.
   let insert_queue: Promise<void> = Promise.resolve()
 
-  // client_id of the card last staged through the create seam (`addFocusedCard`),
-  // awaiting autofocus + grow-in. The matching row claims it on mount (see
-  // `claimFocus`) and focuses itself.
+  // client_id awaiting autofocus + grow-in, claimed once on mount. →[K:deck-editor-focus-claim]
   const pending_focus_client_id = ref<string | null>(null)
 
-  // client_id of a freshly-added card awaiting its grow-in reveal. Set by the
-  // create seam (`addFocusedCard`) — never by `editCard`, which navigates to an
-  // existing card and must not animate its height. Claimed once on mount.
+  // client_id awaiting its grow-in reveal only — never set by `editCard`, which
+  // must not animate an existing card's height. →[K:deck-editor-focus-claim]
   const pending_grow_client_id = ref<string | null>(null)
 
-  // The mounted editor list registers its `scrollToCard` here so `editCard`
-  // can reach it without a template-ref chain through the mode-stack's
-  // dynamic `<component :is>` panes (see list.vue).
+  // Registered by the mounted editor list so `editCard` can scroll to a card
+  // without a template-ref chain through mode-stack's dynamic pane.
   const list_scroller = shallowRef<{ scrollToCard: (client_id: string) => void } | null>(null)
 
-  // Backstop, not the mechanism: entering edit mode forces the deck's own order,
-  // so the editor is normally always reorderable. The gap it closes is mobile,
-  // where the dock keeps page settings reachable mid-edit — change the sort
-  // there, widen to desktop, and drag would otherwise come back over a list
-  // whose rendered neighbours aren't rank neighbours.
+  // False only on mobile mid-edit, where the dock keeps the sort control
+  // reachable — drag would otherwise run over rendered neighbours that aren't
+  // rank neighbours.
   const can_reorder = computed(() => toValue(opts.shell.sort_by) === 'default')
 
   const card_attributes = computed<DeckCardAttributes>(() => ({
@@ -107,23 +80,13 @@ export function useCardListController(opts: Options) {
 
   /**
    * The single create seam every "add card" intent funnels through — desktop
-   * toolbar, per-row append / prepend, the editor's empty-state CTA, and the
-   * mobile dock editor. Guards the plan cap, stages the temp via `insert`,
-   * optionally records it as the autofocus + grow-in target, then fires its
-   * INSERT in the background so the card is a real, saved card before a single
-   * key is pressed. No-op past the cap.
+   * toolbar, per-row append / prepend, the empty-state CTA, the mobile dock
+   * editor. Stages the temp via `insert`, optionally marks it as the focus
+   * target, then fires its INSERT in the background. No-op past the plan cap.
    *
-   * The focus target is assigned in the same synchronous block as `insert()`,
-   * after the sole `await` (the cap guard): the list insert queues Vue's render,
-   * which flushes before any later microtask, so assigning
-   * `pending_focus_client_id` after a *further* `await` would lose the race —
-   * the row would mount and claim focus before the target is set.
-   *
-   * @param insert - Virtual-list insert to run once the guard passes; returns
-   *   the staged temp's `client_id`.
-   * @param focus - Whether the new row should autofocus and grow in. Off for the
-   *   mobile dock editor, which opens its own focused surface over the staged
-   *   card and would fight the desktop row's autofocus.
+   * @param focus - Off for the mobile dock editor, which opens its own
+   *   focused surface over the staged card and would fight the row's own
+   *   autofocus.
    * @returns The staged `client_id`, or `undefined` when the cap vetoes staging.
    */
   async function stageCard(insert: () => string, focus = false): Promise<string | undefined> {
@@ -131,6 +94,8 @@ export function useCardListController(opts: Options) {
 
     const client_id = insert()
 
+    // Assign in the same tick as insert — the row mounts before any later
+    // microtask. →[K:deck-focus-microtask-ordering]
     if (focus) {
       pending_focus_client_id.value = client_id
       pending_grow_client_id.value = client_id
@@ -178,50 +143,30 @@ export function useCardListController(opts: Options) {
   /**
    * The editor's "new card" intent: enter edit mode, play the add chime, then
    * stage a fresh card at the top for immediate typing. Shared by the toolbar
-   * button and the empty-state CTA so the mode-switch + chime + autofocus flow
-   * lives in one place.
-   *
-   * With cards already on screen the mode-stack is mounted, so we await its
-   * edit-pane slide before staging — the new card's focus + scroll-into-view
-   * then read final positions, not a mid-animation transform. On an empty deck
-   * the mode-stack isn't mounted (the view shows the empty state), so nothing
-   * reports the transition settled and awaiting would hang forever; the stack
-   * mounts fresh in edit mode the instant the staged card flips the view out of
-   * its empty state, so we just set the mode and stage synchronously.
-   *
-   * The add chime plays alone: the new row's autofocus is programmatic, which
-   * list-item-card's onFocusIn detects and stays silent for, so the card's own
-   * focus `slide_up` never fires to collide with it.
+   * button and the empty-state CTA.
    */
   async function newCard() {
     const stack_mounted = list.all_cards.value.length > 0
     const entered = opts.shell.setMode('edit')
 
+    // Only await the edit-pane slide when it's mounted to slide — an empty
+    // deck has no mode-stack yet, and awaiting would hang forever.
     if (stack_mounted) await entered
 
+    // The new row's autofocus is programmatic and stays silent, so the chime
+    // plays alone.
     emitSfx('snappy_button_2')
     addCardAtTop()
   }
 
-  /**
-   * One-shot autofocus claim: returns true exactly once, for the card whose
-   * `client_id` was last staged through the create seam (`addFocusedCard`). The
-   * matching row calls this on mount and focuses its editor; every other card
-   * gets false.
-   */
+  /** One-shot autofocus claim, true exactly once for the pending client_id. →[K:deck-editor-focus-claim] */
   function claimFocus(client_id: string): boolean {
     if (pending_focus_client_id.value !== client_id) return false
     pending_focus_client_id.value = null
     return true
   }
 
-  /**
-   * One-shot grow-in claim: returns true exactly once, for the freshly-added
-   * card whose `client_id` was staged through the create seam (`addFocusedCard`).
-   * The matching row calls this on mount and plays its reveal. `editCard` never
-   * sets this target, so navigating to an existing card focuses it without the
-   * grow-in.
-   */
+  /** One-shot grow-in claim, true exactly once for the pending client_id. →[K:deck-editor-focus-claim] */
   function claimGrow(client_id: string): boolean {
     if (pending_grow_client_id.value !== client_id) return false
     pending_grow_client_id.value = null
@@ -233,34 +178,23 @@ export function useCardListController(opts: Options) {
     list_scroller.value = scroller
   }
 
-  /**
-   * The grid dropdown's "Edit" intent: switch to edit mode, then scroll the
-   * chosen card into view. The scroll waits on the mode transition settling —
-   * mode-stack owns the window scroll + pane transforms while it slides, so
-   * scrolling earlier lands at the wrong offset. `scrollToCard` pulls the row
-   * into the virtualizer's window even when it starts outside the current range,
-   * and `pending_focus_client_id` lands the editor focus on it — without the
-   * grow-in reveal, which stays reserved for freshly-added cards (`claimGrow`).
-   */
+  /** The grid dropdown's "Edit" intent: switch to edit mode, then scroll the chosen card into view. */
   async function editCard(card_id: number) {
     const entry = list.all_cards.value.find((c) => c.id === card_id)
     if (!entry) return
 
+    // No grow-in — that stays reserved for freshly-added cards (`claimGrow`).
     pending_focus_client_id.value = entry.client_id
+
+    // mode-stack owns the window scroll + pane transforms while sliding, so
+    // scroll only once the transition settles.
     await opts.shell.setMode('edit')
     list_scroller.value?.scrollToCard(entry.client_id)
   }
 
   /**
-   * Reposition a persisted card within the deck by drag index. `from`/`to` are
-   * indices into `list.all_cards`. Mints a key between the drop slot's two
-   * persisted neighbours and fires the mutation, which optimistically re-keys
-   * and re-sorts the cache synchronously (so the dropped row settles without a
-   * refetch) and reconciles on settle. Failures roll back in the mutation, so
-   * the reorder visibly snaps back — a toast explains why.
-   *
-   * No-op when the dragged row is a temp: it has no key yet, and nothing to
-   * persist until its first save.
+   * Reposition a persisted card within the deck by drag index, `from`/`to`
+   * indexing `list.all_cards`. No-op on a temp row — it has no key yet.
    */
   function reorderCard(from: number, to: number) {
     const cards = list.all_cards.value
@@ -307,18 +241,12 @@ export function useCardListController(opts: Options) {
 
   /**
    * Insert the staged temp at its rendered position and promote it on success.
+   * The key is minted here, not at stage time, so it reflects the temp's
+   * neighbours as of the actual save.
    *
-   * The key is minted here, not when the card was staged, so it reflects
-   * whatever the temp's neighbours are at the moment it's actually saved.
-   *
-   * `guardAddCards` already vetoes staging past the plan cap, but that check
-   * runs when the temp is added — a stale `card_count` or a concurrent edit on
-   * another device can still let a write reach the cap trigger and be rejected
-   * here. `handleLimitError` re-surfaces the upgrade alert for that case and the
-   * entry is left staged for the caller to keep or roll back. Any other
-   * rejection propagates.
-   *
-   * @returns `false` when the cap rejected the write, `true` on success.
+   * @returns `false` when a race let the write reach the plan cap after
+   *   `guardAddCards` already passed it — `handleLimitError` re-surfaces the
+   *   upgrade alert and the entry is left staged. Any other rejection propagates.
    */
   async function insertTemp(
     temp_id: number,
@@ -345,11 +273,9 @@ export function useCardListController(opts: Options) {
    * Fire the eager INSERT for a just-staged card, queued behind any insert
    * already in flight so successive creates mint their keys in render order.
    *
-   * Failures are swallowed: this insert only ever carries an empty card, so
-   * nothing the user typed can be lost. The entry simply stays a temp and the
-   * next edit re-inserts it — no error toast for a save the user never asked
-   * for. A cap rejection is the exception: the deck genuinely can't hold the
-   * card, so the row comes back out of the list.
+   * Failures are swallowed — the staged card is still empty, so nothing the
+   * user typed is lost and the next edit re-inserts it. A cap rejection is
+   * the exception: the row comes back out of the list.
    */
   function insertStaged(client_id: string) {
     const entry = list.findEntryByClientId(client_id)
@@ -372,10 +298,9 @@ export function useCardListController(opts: Options) {
   /**
    * Route a resolved edit to INSERT or UPDATE.
    *
-   * @param staged - The entry the card had before any in-flight eager insert
-   *   resolved, or `undefined` for an already-persisted card. Re-read here by
-   *   client_id: the insert may have promoted it (so this is an UPDATE) or, at
-   *   the cap, rolled it out of the list entirely (so there's nothing to save).
+   * @param staged - The card's entry before any in-flight eager insert
+   *   resolved, re-read by client_id since that insert may have promoted it
+   *   or, at the cap, rolled it out of the list.
    */
   function persistEdit(id: number, staged: CardEntry | undefined, values: Partial<Card>) {
     const entry = staged && list.findEntryByClientId(staged.client_id)

--- a/src/views/deck/composables/view-shell.ts
+++ b/src/views/deck/composables/view-shell.ts
@@ -15,23 +15,16 @@ export const deckViewShellKey = Symbol('deckViewShell') as InjectionKey<DeckView
 
 /**
  * UI shell of the deck view: which mode (pane) is active and how the grid
- * renders. Deliberately free of card-data concerns so panes that only switch
- * modes don't have to depend on the whole card-list controller.
+ * renders. Free of card-data concerns so panes that only switch modes don't
+ * depend on the whole card-list controller.
  *
- * Mode changes all funnel through here — `setMode` / `toggleMode` / `exitMode`
- * are the single seam for cross-cutting concerns like unsaved-changes guards.
- * The pane/chrome each mode maps to lives in `deck/modes.ts`.
- *
- * @example
- * const shell = useDeckViewShell()
- * provide(deckViewShellKey, shell)
+ * `setMode` / `toggleMode` / `exitMode` are the single seam every mode change
+ * funnels through. The pane/chrome each mode maps to lives in `deck/modes.ts`.
  */
 export function useDeckViewShell() {
   const mode = ref<CardEditorMode>('view')
 
-  // First-time default: mobile packs the densest grid (`base`); larger viewports
-  // keep the roomier `md`. Read once at init — `useLocalRef` ignores this default
-  // whenever a stored choice exists, so an explicit prior pick is preserved.
+  // First-time default only — `useLocalRef` ignores it once a choice is stored.
   const is_mobile = useMatchMedia('w<md').value
   const grid_size = useLocalRef<CardGridSize>('deck-grid-size', is_mobile ? 'base' : 'md')
   const grid_face = useLocalRef<Exclude<CardSide, 'cover'>>('deck-grid-face', 'front')
@@ -53,11 +46,8 @@ export function useDeckViewShell() {
 
   /**
    * Switch the deck view to `new_mode`, resolving once that pane's enter
-   * transition has finished animating — the mode-stack calls `notifyModeSettled`
-   * from the GSAP completion. Resolves immediately when already in `new_mode`.
-   * `mode` still flips synchronously; only the returned promise is deferred, so
-   * callers that ignore it are unaffected. Plays the shared mode-switch chime
-   * (`ui.select`) on every real switch, so call sites don't each wire their own.
+   * transition finishes (`notifyModeSettled`, from the mode-stack's GSAP
+   * completion). `mode` flips synchronously; only the promise is deferred.
    */
   function setMode(new_mode: CardEditorMode): Promise<void> {
     if (mode.value === new_mode) return Promise.resolve()

--- a/src/views/deck/composables/virtual-list.ts
+++ b/src/views/deck/composables/virtual-list.ts
@@ -18,36 +18,15 @@ export type CardEntry = {
 
 let next_temp_id = 0
 
-/**
- * Mint a unique negative integer to fill the `Card.id` slot for a temp card.
- *
- * The id is purely a placeholder — branching logic uses `entry.real_id`,
- * never the sign of the id. The negative range is just a convenient
- * "definitely not a real bigserial id" sentinel for diagnostics.
- */
+/** Mint a placeholder id for a temp card — diagnostics only, branching reads `entry.real_id`. */
 function tempPlaceholderId(): number {
   return --next_temp_id
 }
 
 /**
  * Merged read model for the deck-editor card list: persisted cards from the
- * Pinia Colada infinite query, interleaved with client-side temp cards that
- * the user is mid-creating.
- *
- * Every rendered card carries a stable `client_id` used as the v-for key.
- * client_ids survive the temp → persisted transition (seeded on promote,
- * reused when the persisted refetch arrives), so the text-editor stays
- * mounted across the handoff and the user does not lose focus.
- *
- * @param cards_query - The infinite query for the deck's persisted cards.
- * @param deck_id     - Reactive deck id, used when constructing new temp cards.
- *
- * @example
- * const list = useVirtualCardList(cards_query, deck_id)
- * for (const card of list.all_cards.value) {
- *   // card.client_id — stable v-for key
- *   // card.id        — placeholder (negative) until promoted, then real
- * }
+ * infinite query, interleaved with client-side temp cards mid-creation.
+ * →[K:deck-temp-card-handoff]
  */
 export function useVirtualCardList(
   cards_query: CardsQuery,
@@ -55,10 +34,8 @@ export function useVirtualCardList(
 ) {
   const temp_entries = ref<CardEntry[]>([])
 
-  // Persistent client_id for each persisted card so v-for keys stay stable
-  // across refetches. Seeded on promote so a temp's client_id carries over to
-  // its eventual persisted ingest — the only thing keeping the text-editor
-  // mounted across the temp→persisted transition.
+  // Stable client_id per persisted real id, so v-for keys survive a refetch.
+  // →[K:deck-temp-card-handoff]
   const client_id_by_real_id = new Map<number, string>()
 
   /**
@@ -97,9 +74,8 @@ export function useVirtualCardList(
     return set
   })
 
-  // Temps still in flight: not yet promoted, OR promoted but the persisted
-  // refetch hasn't arrived. Once it has, the persisted copy renders in the
-  // temp's place — same client_id, no remount.
+  // Temps not yet promoted, or promoted but the persisted refetch hasn't
+  // landed yet. →[K:deck-temp-card-handoff]
   const live_temps = computed<CardEntry[]>(() =>
     temp_entries.value.filter((e) => e.real_id === null || !persisted_id_set.value.has(e.real_id))
   )
@@ -114,13 +90,8 @@ export function useVirtualCardList(
 
   /**
    * Return a new card list with `entry` inserted at the position implied by
-   * its anchor. Pure — does not mutate `cards`.
-   *
-   * 1. No anchor                          → append to the tail.
-   * 2. Anchor not in the loaded pages     → append to the tail (fallback —
-   *    the user added a card next to one that lives on an unloaded page).
-   * 3. Anchor found                       → insert before or after it,
-   *    according to `entry.side`.
+   * its anchor. Pure — does not mutate `cards`. Falls back to the tail when
+   * there's no anchor, or the anchor lives on a page not yet loaded.
    */
   function withTempInserted(cards: CardWithClientId[], entry: CardEntry): CardWithClientId[] {
     const wrapped: CardWithClientId = { ...entry.card, client_id: entry.client_id }
@@ -187,11 +158,7 @@ export function useVirtualCardList(
 
   /**
    * Build the empty Card record that backs a freshly-staged temp entry.
-   *
-   * No rank: the key is minted against live neighbours at insert time, not at
-   * stage time, so a temp that sits around while the list moves under it still
-   * lands where the user dropped it. An absent rank is also what marks an entry
-   * as un-persisted when neighbours are resolved.
+   * No rank — an absent rank is also what marks an entry as un-persisted.
    */
   function buildEmptyCard(): Card {
     return {
@@ -203,15 +170,10 @@ export function useVirtualCardList(
   }
 
   /**
-   * Stage a new temp card. Resolves an anchor + side from the args (or falls
-   * back to the tail of the persisted list) so the card appears in the right
-   * place in `all_cards` immediately, before any insert RPC has fired.
+   * Stage a new temp card, placed in `all_cards` immediately — before any
+   * insert RPC has fired.
    *
-   * @param left_card_id  - If given, the new card is placed `after` this id.
-   * @param right_card_id - If given (and `left_card_id` is not), the new card
-   *                        is placed `before` this id.
-   * @returns The stable `client_id` of the staged card, so the caller can later
-   *          target it (e.g. to autofocus its editor once it mounts).
+   * @returns The stable `client_id` of the staged card.
    */
   function addCard(left_card_id?: number, right_card_id?: number): string {
     const { anchor_id, side } = resolveAnchor(left_card_id, right_card_id)
@@ -239,11 +201,8 @@ export function useVirtualCardList(
   }
 
   /**
-   * Stage a new temp card at the very top of the deck. Anchors `before` the
-   * first *persisted* card — a real id the insert RPC can resolve, where a
-   * still-unsaved temp's placeholder id can't — and `unshift`s the entry so it
-   * renders above any temps already stacked at the top (repeated "add at top"
-   * clicks each land newest-first). Appends with no anchor on an empty deck.
+   * Stage a new temp card at the very top of the deck, anchored before the
+   * first persisted card so repeated clicks land newest-first.
    *
    * @returns The stable `client_id` of the staged card.
    */
@@ -264,12 +223,8 @@ export function useVirtualCardList(
 
   /**
    * The persisted keys either side of a staged card's slot in the rendered
-   * list, ready to mint its own key from.
-   *
-   * Read at insert time rather than at stage time, and against the rendered
-   * list rather than the entry's anchor — so a run of temps stacked in the same
-   * gap each resolve past one another to real neighbours, in the order the user
-   * sees them.
+   * list. Read against the rendered list, not the entry's anchor, so a run
+   * of temps stacked in the same gap resolve past one another in order.
    */
   function neighbourRanksFor(client_id: string): RankNeighbours {
     const cards = all_cards.value
@@ -290,22 +245,17 @@ export function useVirtualCardList(
   }
 
   /**
-   * Look up the entry with `client_id`. Unlike `findEntryByCardId` the key
-   * survives promotion, so a caller holding one across an in-flight insert can
-   * re-read the entry afterwards — or find it gone, if the insert rolled back.
+   * Look up the entry with `client_id`. Unlike `findEntryByCardId`, the key
+   * survives promotion, so a caller can re-read the entry after an in-flight
+   * insert resolves.
    */
   function findEntryByClientId(client_id: string): CardEntry | undefined {
     return temp_entries.value.find((e) => e.client_id === client_id)
   }
 
   /**
-   * Merge `values` into an entry's own card record.
-   *
-   * An eagerly-created card is promoted in place and never refetched, so the
-   * deck's cached pages don't hold it and `saveCard`'s optimistic patch can't
-   * reach it. Without this its card would stay the empty record it was staged
-   * with — a stale merge base that the mobile editor's one-side-at-a-time saves
-   * would use to clobber the other side.
+   * Merge `values` into an entry's own card record — a promoted temp is never
+   * refetched, so `saveCard`'s optimistic patch can't reach it here.
    */
   function patchTemp(client_id: string, values: Partial<Card>) {
     const entry = findEntryByClientId(client_id)
@@ -336,34 +286,12 @@ export function useVirtualCardList(
   }
 
   /**
-   * Apply the result of a successful INSERT to a staged temp entry. Called
-   * by the mutation layer after `insert_card_at` returns, before the deck
-   * refetch lands.
+   * Syncs a local temp card to the real id the insert returned.
    *
-   * Three things happen:
+   * The row keeps its identity through the swap, so it doesn't remount and
+   * the user can carry on typing in it. →[K:deck-temp-card-handoff]
    *
-   * 1. **Entry stops being a temp.** `real_id` is no longer null, so the
-   *    next save on this card routes to UPDATE instead of INSERT. The card's
-   *    `id` and `rank` are also filled in, and the just-saved text is applied
-   *    so the entry mirrors server state.
-   *
-   * 2. **Client_id is registered against the real id.** When the cache
-   *    refetch eventually returns the same row, `wrapPersisted` will look up
-   *    `client_id_by_real_id.get(real_id)` and find this entry's client_id,
-   *    so the persisted copy inherits the same v-for key.
-   *
-   * 3. **The handoff stays seamless.** Same v-for key across the
-   *    temp → persisted swap means Vue reuses the same DOM nodes — no
-   *    remount, no focus loss while the user keeps typing.
-   *
-   * No-op if no entry matches `temp_id`.
-   *
-   * @param temp_id   - The id the temp had before this INSERT (the negative
-   *                    placeholder originally minted by `addCard`).
-   * @param real_id   - The real id the insert returned.
-   * @param real_rank - The key the card was written with.
-   * @param values    - The text values that were just persisted, applied so
-   *                    the entry's card mirrors what the server now holds.
+   * @param temp_id - The negative placeholder id the temp was minted with.
    */
   function promoteTemp(temp_id: number, real_id: number, real_rank: string, values: Partial<Card>) {
     const entry = findEntryByCardId(temp_id)

--- a/src/views/deck/deck-settings/index.vue
+++ b/src/views/deck/deck-settings/index.vue
@@ -156,12 +156,8 @@ watch(active_page, (page) => {
   if (page === null) editor.active_side.value = 'cover'
 })
 
-// The preview and aside unmount at the phone boundary and remount in their
-// untucked poses on the way back, dropping the imperative tuck styling — so
-// whenever they (re)appear, snap the chrome to the pose the displayed tab
-// demands. This also covers first mount: a sheet opened straight onto a
-// full-bleed tab starts with the chrome already gone rather than animating it
-// away in front of the user.
+// The preview and aside remount in their untucked pose past the phone
+// boundary, dropping the imperative tuck styling — snap it back on (re)appear.
 watch([preview_el, aside_el], ([preview]) => {
   if (preview) chrome.snap(is_full_bleed.value)
 })

--- a/src/views/deck/deck-settings/tab-review-pacing/index.vue
+++ b/src/views/deck/deck-settings/tab-review-pacing/index.vue
@@ -10,15 +10,10 @@ import { pacingFieldsKey, usePacingFields } from './use-pacing-fields'
 import { presetActionsKey, usePresetActions } from './use-preset-actions'
 import DeckSaveButton from '../deck-save-button.vue'
 
-// This page is full-bleed, so `--deck-settings-padding` is 0 and the header row
-// would sit flush against the scrolling container's edge — clipping the preset
-// chip's 2px hover outline, which paints outside its border box. `pt-0.5` is
-// just enough room for it.
-//
-// The scheduling panel's `bgx-*` texture brings `isolation: isolate` with it
-// (its -1 pseudo-element needs the stacking context), which traps the steps
-// dropdowns' popovers inside the panel. `z-10` lifts that whole context above
-// the save button below it, which would otherwise paint over an open menu.
+// `pt-0.5` below leaves room for the preset chip's hover outline, clipped
+// otherwise by the full-bleed page's zero padding.
+// `z-10` on the scheduling panel lifts its `bgx-*` stacking context above the
+// save button, which would otherwise paint over an open steps dropdown.
 const editor = inject(deckEditorKey)!
 
 const pacing = usePacingFields(editor.deck!, editor.draft)

--- a/src/views/deck/deck-settings/tab-review-pacing/scheduling-section.vue
+++ b/src/views/deck/deck-settings/tab-review-pacing/scheduling-section.vue
@@ -15,12 +15,8 @@ import {
 
 const { t } = useI18n()
 
-// This section paints its own brown-200/stone-700 panel (class set by the
-// parent, data-depth co-located there) that LIFTS OFF the depth-1 window, so it
-// is one elevation up — depth 2. Declaring it makes the spinbox and select-menu
-// wells inside resolve `below` at depth 2 (brown-300 / grey-800), a step darker
-// than the panel so they read as recessed, instead of the window's depth-1
-// `below` which sits lighter than the panel and reads wrong.
+// This panel lifts one elevation off the depth-1 window, so its wells resolve
+// `below` a step darker than the panel instead of the window's lighter one.
 provideDepth(2)
 
 const {

--- a/src/views/deck/deck-settings/tab-review-pacing/use-pacing-fields.ts
+++ b/src/views/deck/deck-settings/tab-review-pacing/use-pacing-fields.ts
@@ -113,10 +113,8 @@ export function usePacingFields(deck: Deck, draft: DeckDraft): PacingFields {
   // it's the preset relationship being reported, not any one field's state.
   const override_count = computed(() => Object.keys(draft.pacing_overrides).length)
 
-  // Every pacing field as the deck currently displays it — the same ladder the
-  // individual controls read through, collected into one preset-shaped payload.
-  // Fork and push both promote exactly this, so what the user sees is what the
-  // preset gets.
+  // Every field as it's currently displayed, collected into one preset-shaped
+  // payload — fork and push both promote exactly this.
   const resolved_pacing = computed<ReviewPacingValues>(() => {
     const values = {} as Record<PlainFieldKey | CapFieldKey, unknown>
 

--- a/src/views/deck/deck-settings/tab-review-pacing/use-preset-actions.ts
+++ b/src/views/deck/deck-settings/tab-review-pacing/use-preset-actions.ts
@@ -31,18 +31,9 @@ export type PresetActions = {
 export const presetActionsKey: InjectionKey<PresetActions> = Symbol('preset-actions')
 
 /**
- * Preset lifecycle actions for the Review Pacing tab — fork, push, rename, delete.
- *
- * Pull is deck-local and already lives on the fields themselves (per-field reset
- * + reset-all). Push is global: it rewrites the preset every following deck reads
- * from, so it's all-or-nothing and confirmed, never per-field.
- *
- * Preset writes hit the server immediately, so any deck-side bookkeeping they
- * imply is flushed with them — through `persistPacing`, which writes only the
- * pacing sidecar. Everything else on the draft still lands on Save as usual.
- *
- * @example
- * provide(presetActionsKey, usePresetActions(pacing, editor))
+ * Preset lifecycle actions for the Review Pacing tab — fork, push, rename,
+ * delete. Push is global and confirmed, never per-field, since it rewrites
+ * the preset every following deck reads from.
  */
 export function usePresetActions(pacing: PacingFields, editor: DeckEditor): PresetActions {
   const { draft, rebase } = editor

--- a/src/views/deck/deck-settings/window-chrome.ts
+++ b/src/views/deck/deck-settings/window-chrome.ts
@@ -13,16 +13,8 @@ export type WindowChrome = ReturnType<typeof useWindowChrome>
  * Drives a tab window's surrounding chrome — the pinned card preview and the
  * form aside — in and out together, so a tab can claim the whole content area.
  *
- * `is_tucked` flips at the preview's edge-on midpoint rather than when the
- * animation starts, so the caller can restack the card behind the content page
- * on the one frame where it can't be seen.
- *
- * @param preview - the positioned wrapper around the pinned card, not the card itself
- * @param aside - the aside element sharing the content row with the tab outlet
- *
- * @example
- * const chrome = useWindowChrome(preview_el, aside_el)
- * await chrome.tuck()
+ * `is_tucked` flips at the preview's edge-on midpoint, not when the animation
+ * starts, so the caller can restack the card on the one frame it can't be seen.
  */
 export function useWindowChrome(
   preview: Readonly<Ref<HTMLElement | null | undefined>>,

--- a/src/views/deck/mobile-editor/use-mobile-card-editor.ts
+++ b/src/views/deck/mobile-editor/use-mobile-card-editor.ts
@@ -16,17 +16,11 @@ type CardSide = 'front' | 'back'
 export type ImageControls = { openPicker: () => void; onRemove: () => void }
 
 /**
- * Drives the deck view's focused single-card editor — the mobile-only surface
- * that lives in the app dock and lets the user edit one face at a time, flip
- * between sides, and cycle prev/next through the whole deck.
+ * Drives the deck view's focused single-card editor — the mobile-only
+ * surface in the app dock that edits one face at a time and cycles prev/next.
  *
- * Holds no card data of its own: the cursor is a `client_id` into the editor
- * controller's `all_cards`, so it stays valid across the temp→persisted
- * promotion (the client_id is stable) and the current card re-derives live as
- * the list changes. Saving and image upload funnel back through the same
- * controller the desktop list editor uses, so there's a single persistence path.
- *
- * @param controller - The deck's card-list controller (provided via cardEditorKey).
+ * Holds no card data of its own: the cursor is a `client_id` into the
+ * controller's `all_cards`, so it stays valid across the temp→persisted swap.
  */
 export function useMobileCardEditor(controller: CardListController) {
   const cards = controller.list.all_cards
@@ -73,14 +67,7 @@ export function useMobileCardEditor(controller: CardListController) {
     close_modal?.()
   }
 
-  /**
-   * The mobile "new card" intent: stage a fresh temp card through the shared
-   * controller (gated on the plan cap, same as the desktop toolbar) and open
-   * the mobile editor focused on it. Shared by the empty-state CTA and the
-   * dock's new-card button at phone width, so staging + opening stays in one
-   * place. No-op when the cap blocks staging — `addCard` already surfaced the
-   * upgrade alert.
-   */
+  /** The mobile "new card" intent: stage through the shared controller, then open focused on it. */
   async function openNewCard() {
     const client_id = await controller.addCard()
     if (!client_id) return
@@ -101,8 +88,7 @@ export function useMobileCardEditor(controller: CardListController) {
     emitSfx(side.value === 'back' ? 'transition_up' : 'transition_down')
   }
 
-  // Stepping always lands on the front so each card opens the same way; the
-  // editor remounts on the client_id change, re-seeding the uncontrolled face.
+  // Always lands on the front, so each card opens the same way.
   function step(delta: number) {
     const next = cards.value[index.value + delta]
     if (!next) return
@@ -119,9 +105,7 @@ export function useMobileCardEditor(controller: CardListController) {
     step(1)
   }
 
-  // One side at a time, saved sequentially, so the cached card (kept current by
-  // saveCard's optimistic patch) is a safe merge base — no need to send both
-  // sides the way the dual-editor list row does.
+  // One side at a time — unlike the dual-editor list row, never both.
   function update(edited_side: CardSide, text: string) {
     const card = current.value
     if (!card) return
@@ -129,9 +113,7 @@ export function useMobileCardEditor(controller: CardListController) {
     return controller.updateCard(card.id!, { [`${edited_side}_text`]: text })
   }
 
-  // After a move/delete removes the current card, land on whatever now sits at
-  // its old slot (or the new last card); close once the deck is empty. No-op
-  // when the card is still there — the user dismissed the confirm/move modal.
+  // Lands on whatever now sits at the removed card's old slot; closes once the deck is empty.
   function reconcileCursor(prev_index: number) {
     if (current.value) return
     if (!cards.value.length) return close()

--- a/src/views/deck/mode-stack.vue
+++ b/src/views/deck/mode-stack.vue
@@ -24,10 +24,10 @@ const { sticky_header = null } = defineProps<ModeStackProps>()
 const shell = inject(deckViewShellKey)!
 
 const stack = useTemplateRef<HTMLElement>('stack')
-// Panes currently mid-slide, keyed by element. A Set (not a counter) so an
-// interrupted transition can't unbalance it: delete is idempotent, and the next
-// add/delete cycle reconciles a missed terminal hook.
+// A Set, not a counter — delete is idempotent, so an interrupted transition can't unbalance it.
 const sliding_panes = ref(new Set<Element>())
+// Holds the clip from mode-switch until the entering pane's transition starts
+// — a lazy overlay pane can take a beat to load, and without this the stack collapses in that gap.
 const switch_pending = ref(false)
 const clip_min_height = ref(0)
 
@@ -79,22 +79,15 @@ function onOverlayAfterLeave(el: Element) {
   sliding_panes.value.delete(el)
 }
 
-// A rapid mode flip can yank an entering/leaving pane before its slide
-// finishes; Vue fires the *-cancelled hook instead of *-after. Stop the tween
-// and drop the pane from the in-flight set so `is_transitioning` can't latch on
-// forever — which would strand the clip min-height and leave the page scrolled
-// past its content.
+// On a rapid mode flip Vue fires *-cancelled instead of *-after — drop the
+// pane from the in-flight set so `is_transitioning` can't latch on forever.
 function onOverlayCancelled(el: Element) {
   cancelOverlayAnimation(el)
   sliding_panes.value.delete(el)
 }
 
 // Sync flush: the DOM still shows the outgoing mode, so the capture reads the
-// scroll and rects the user is actually looking at. The scroll jump is never
-// seen — the transition hooks re-offset both panes before the next paint.
-// `switch_pending` holds the clip from this moment until the entering pane's
-// transition starts: a lazy overlay pane can take a beat to load on first
-// entry, and without the held min-height the stack collapses in that gap.
+// scroll and rects the user is actually looking at.
 watch(
   shell.mode,
   () => {

--- a/src/views/deck/mode-toolbar/page-settings.vue
+++ b/src/views/deck/mode-toolbar/page-settings.vue
@@ -20,18 +20,12 @@ const { t } = useI18n()
 const { is_page_settings_open, openPageSettings, closePageSettings } = inject(deckViewShellKey)!
 const is_mobile = useMatchMedia('w<md')
 
-// The popover teleports out of the deck view, so its content can't inherit the
-// page's depth. Declare depth 1 explicitly (matching the data-depth stamped on
-// the panel) so the sorting dropdown inside resolves `element` against this
-// floating panel rather than the root page's depth 0 — otherwise it paints
-// element@0 (brown-300), the same colour as the panel, and vanishes.
+// The popover teleports out of the deck view, so its content can't inherit
+// the page's depth — declare it explicitly, matching the panel's data-depth.
 provideDepth(1)
 
-// Below md the mode-toolbar (and this popover) is only CSS-hidden, not
-// unmounted — the mobile footer's own panel drives `is_page_settings_open`
-// there instead. Gating `open` on `!is_mobile` keeps this popover's
-// outside-click listener from ever attaching on mobile, which would otherwise
-// treat every tap inside the footer panel as a click outside and close it.
+// Gated so this popover's outside-click listener never attaches on mobile,
+// where the footer's own panel drives `is_page_settings_open` instead.
 const desktop_open = computed(() => is_page_settings_open.value && !is_mobile.value)
 
 function toggle() {


### PR DESCRIPTION
[TARO-339](https://app.notion.com/p/3b60953c224c81899836df4c779fdd00)

> Stacked on #522.

## Summary

- **915 → 569 comment lines** in `src/views/deck/`. Biggest cuts: `list-controller.ts` 179 → 99, `virtual-list.ts` 162 → 90.
- The three essays the ticket named became real entries in a new `corpus/decks/card-editor.md`: `[K:deck-focus-microtask-ordering]`, `[K:deck-temp-card-handoff]`, `[K:deck-editor-focus-claim]`.
- The survivor one-liner stayed inline exactly as the ticket asked — "assign in the same tick as insert, the row mounts before any later microtask" — with the walkthrough cited rather than kept.

## Closes a dangling citation

`[K:deck-temp-card-handoff]` is one of the three slugs #520's signed-off comment examples already cite. It's declared here with that exact spelling and cited from `virtual-list.ts` at four sites, so that example resolves once this lands.