### PR TITLE
TARO-340: Comment sweep — remaining views and router

### DIFF
--- a/.claude/rules/safari-gotchas.md
+++ b/.claude/rules/safari-gotchas.md
@@ -25,6 +25,11 @@ Then in CSS: `@media (...) { [data-mobile-below-width="md"] { … } }`. Browser 
 
 Memoizing the class function to return the same string reference does **not** help — Vue still patches class on every re-render the moment any tracked dep (matchMedia, etc.) fires. The fix is to remove the reactive binding entirely from the scrolling element, not to make it cheaper.
 
+## Sticky elements lag during scroll
+
+A `position: sticky` bar lags behind scroll in iOS standalone (home-screen) mode unless pinned to
+its own compositor layer with `transform: translateZ(0)`.
+
 ## Audio
 
 **A seek set on load is silently dropped.** iOS ignores `audio.currentTime` when there's no user gesture and the media isn't seekable yet — the element stays at 0 while a JS `current_time` ref optimistically jumps ahead, so playback starts from the beginning with the UI stranded. Defer the seek to a pending value applied **inside `play()`**, i.e. within the tap gesture; a manual seek clears the pending value.

--- a/corpus/study/study.md
+++ b/corpus/study/study.md
@@ -82,6 +82,12 @@ So the summary at the end isn't the save — by the time you get there, every
 review it lists is already recorded. The end-of-session step only refreshes the
 deck counts so the dashboard reflects your work.
 
+Underneath, each card in the pile carries its own save state, separate from
+whether you got it right: **unreviewed** (not yet rated, or re-served because
+its last save never confirmed), **pending** (rated and advanced past, save in
+flight), **saved** (confirmed durable), or **failed** (given up on, dropped from
+the summary). [K:study-review-durability]
+
 > [!WATCH]
 > Because reviews go one at a time as you rate, closing the tab mid-run loses no
 > _grades_ that have already been confirmed. What's lost is the in-tab progress

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -14,24 +14,29 @@ const Dashboard = () => import('@/views/dashboard/index.vue')
 const DeckView = () => import('@/views/deck/deck-view.vue')
 const LessonView = () => import('@/views/audio-reader/lesson/index.vue')
 
-// Each screen declares which checkpoint policies apply; the single beforeEach
-// below reads this rather than hardcoding exceptions per route.
 declare module 'vue-router' {
+  /**
+   * Per-route checkpoint policies the single `beforeEach` below reads,
+   * instead of hardcoding exceptions per route.
+   */
   interface RouteMeta {
-    // Signed-in-only: a signed-out visitor is bounced to sign-in.
+    /** Signed-in-only: a signed-out visitor is bounced to sign-in. */
     requiresAuth?: boolean
-    // Marketing/auth surface: a signed-in visitor is sent into the app.
+    /** Marketing/auth surface: a signed-in visitor is sent into the app. */
     guestOnly?: boolean
-    // Gated screen: the named useCan capability must be true to enter.
+    /** Gated screen: the named `useCan` capability must be true to enter. */
     capability?: 'useAudioReader'
   }
 }
 
-// Resolves the member row before the capability check reads any field off it.
-// The store is a projection of a query App.vue starts reactively and nothing
-// awaits, so a direct URL hit can otherwise read an empty role mid-restore.
-// Colada dedupes, so this joins the in-flight fetch rather than issuing a
-// second one.
+/**
+ * Resolves the member row before the capability check reads any field off it.
+ *
+ * The store is a projection of a query App.vue starts reactively and nothing
+ * awaits, so a direct URL hit can otherwise read an empty role mid-restore.
+ * Colada dedupes, so this joins the in-flight fetch rather than issuing a
+ * second one.
+ */
 async function resolveMember() {
   const id = useSessionStore().user?.id
   if (id) await prefetchMemberById(id).catch(() => {})
@@ -41,9 +46,11 @@ async function resolveMember() {
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  // The app scrolls the page (not inner containers), so reset to the top on each
-  // navigation — including chapter-to-chapter param changes — and restore the
-  // saved position on back/forward.
+  /**
+   * The app scrolls the page, not inner containers, so reset to the top on
+   * each navigation — including chapter-to-chapter param changes — and
+   * restore the saved position on back/forward.
+   */
   scrollBehavior(_to, _from, savedPosition) {
     return savedPosition ?? { top: 0 }
   },
@@ -100,29 +107,26 @@ const router = createRouter({
   ]
 })
 
-// The single auth checkpoint every navigation passes through. Reads each route's
-// declared policies and runs them in a fixed order — auth, then guestOnly, then
-// capability — with the first failure winning. Identity resolves once via the
-// session store's memoized ensureResolved(); only the capability branch pays for
-// the member row.
+/**
+ * The single auth checkpoint every navigation passes through — each route's
+ * declared policies run in turn, first failure wins. Identity resolves once
+ * via the session store's memoized `ensureResolved()`; only the capability
+ * check pays for the member row.
+ */
 router.beforeEach(async (to) => {
   const session = useSessionStore()
 
-  // 1. auth — a signed-in-only screen reached while signed out sends the visitor
-  //    to sign-in, carrying where they were headed so it survives the round trip.
+  // Signed-in-only screen reached while signed out: bounce to sign-in, carrying where they were headed so it survives the round trip.
   if (to.meta.requiresAuth && !(await session.ensureResolved())) {
     return { name: 'welcome', query: { next: to.fullPath } }
   }
 
-  // 2. guestOnly — a marketing/auth page reloaded while signed in jumps to the
-  //    app. Skipped on a password-recovery link (whose redirect lands on
-  //    /welcome) so the reset dialog there stays reachable.
+  // Marketing/auth page reloaded while signed in: jump to the app — skipped on a password-recovery link so the reset dialog on /welcome stays reachable.
   if (to.meta.guestOnly && !isPasswordRecoveryUrl() && (await session.ensureResolved())) {
     return { name: 'dashboard' }
   }
 
-  // 3. capability — a gated screen checks the member is allowed in, once the row
-  //    has resolved. Reuses the single admin rule in useCan; no second copy.
+  // Gated screen: resolve the member row, then defer to useCan's single admin rule.
   if (to.meta.capability) {
     await resolveMember()
     if (!useCan()[to.meta.capability].value) return { name: 'dashboard' }

--- a/src/views/app-shell/authenticated.vue
+++ b/src/views/app-shell/authenticated.vue
@@ -15,16 +15,20 @@ const member = useMemberStore()
 
 useResumeStudySession()
 
-// The skeleton overlay masks the real route while it's mid-transition, and also
-// for the whole time a member is pending-deletion — so their account/profile
-// never paints behind the restore dialog. Same visual state as a cold load.
+/**
+ * Masks the real route while it's mid-transition, and also for the whole
+ * time a member is pending-deletion — so their account/profile never paints
+ * behind the restore dialog. Same visual state as a cold load.
+ */
 const show_skeleton = computed(() => show_skeleton_overlay.value || member.pending_deletion)
 
-// A suspended (pending-deletion) member is admitted to the shell and sees the
-// route skeleton — the checkpoint no longer diverts them to welcome. The
-// restore dialog opens over that skeleton once the member row confirms the
-// pending state. `immediate` so a cold load on an already-suspended member
-// still fires when the row resolves.
+/**
+ * A suspended (pending-deletion) member is admitted to the shell and sees
+ * the route skeleton — the checkpoint no longer diverts them to welcome.
+ * The restore dialog opens over that skeleton once the member row confirms
+ * the pending state. `immediate` so a cold load on an already-suspended
+ * member still fires when the row resolves.
+ */
 watch(
   () => member.pending_deletion,
   (pending) => {

--- a/src/views/app-shell/nav-bar/back-button.vue
+++ b/src/views/app-shell/nav-bar/back-button.vue
@@ -10,10 +10,12 @@ const is_mobile = useMatchMedia('w<sm')
 
 const visible = computed(() => router.currentRoute.value.name !== 'dashboard')
 
-// A fresh page load (direct URL, refresh) has no router-tracked entry to go
-// back to — the router's history.state.back is null in that case — so
-// `router.go(-1)` would just re-land on this same route instead of actually
-// navigating back.
+/**
+ * A fresh page load (direct URL, refresh) has no router-tracked entry to go
+ * back to — `router.options.history.state.back` is null in that case — so
+ * `router.go(-1)` would just re-land on this same route instead of actually
+ * navigating back.
+ */
 function onBack() {
   if (router.options.history.state.back) router.go(-1)
   else router.push({ name: 'dashboard' })

--- a/src/views/app-shell/nav-bar/index.vue
+++ b/src/views/app-shell/nav-bar/index.vue
@@ -14,8 +14,6 @@ onMounted(() => {
 </script>
 
 <template>
-  <!-- translateZ(0) pins this sticky bar to its own compositor layer; without it,
-       iOS standalone lags it during scroll. -->
   <nav
     data-testid="nav-bar-container"
     ref="nav-bar"

--- a/src/views/auth/callback.vue
+++ b/src/views/auth/callback.vue
@@ -10,16 +10,13 @@ const router = useRouter()
 onMounted(async () => {
   await supabase.auth.getSession()
 
-  // Popup flow: the opener tab owns the navigation (and consumes the return
-  // destination), so this tab just closes itself.
+  // Popup flow: the opener tab owns the navigation, so this tab just closes itself.
   if (consumeOAuthPopupFlag()) {
     window.close()
     return
   }
 
-  // Full-page redirect flow: this tab landed back here after the OAuth round
-  // trip. Land on the originally-intended destination (stashed in
-  // sessionStorage before the redirect), falling back to the dashboard.
+  // Redirect flow: land on the destination stashed before the OAuth round trip, falling back to the dashboard.
   router.push(consumeReturnDestination() ?? { name: 'dashboard' })
 })
 </script>

--- a/src/views/dashboard/actions-panel/shell.vue
+++ b/src/views/dashboard/actions-panel/shell.vue
@@ -7,9 +7,7 @@ type DashboardActionsPanelShellProps = {
 
 const { body_class = '' } = defineProps<DashboardActionsPanelShellProps>()
 
-// The body is a raised surface (its own bg), so it declares depth 1 — a
-// recessed element inside it (the options-panel well) then resolves relative to
-// this surface rather than falling through to the depth-0 page.
+// The body is a raised surface, so nested recessed elements resolve against it, not the depth-0 page.
 provideDepth(1)
 
 defineSlots<{

--- a/src/views/dashboard/audio-reader-section.vue
+++ b/src/views/dashboard/audio-reader-section.vue
@@ -27,8 +27,7 @@ function onEdit(collection: LessonCollectionWithCount) {
 }
 
 async function onCreate() {
-  // A fresh collection has no chapters yet, so drop straight into its edit modal
-  // to upload the first lesson.
+  // A fresh collection has no chapters yet — drop straight into its edit modal.
   const collection = await create_modal.open().response
   if (collection) edit_modal.open(collection.id)
 }

--- a/src/views/dashboard/composables/deck-options-menu.ts
+++ b/src/views/dashboard/composables/deck-options-menu.ts
@@ -9,8 +9,8 @@ import type { DropdownOption } from '@/components/ui-kit/dropdown-button/index.v
 export type DeckOptionsMenu = ReturnType<typeof useDeckOptionsMenu>
 
 type DeckOptionsMenuConfig = {
-  // Enter the dashboard's rearrange (editing) mode. Owned by the dashboard
-  // view; the grid forwards it up so this composable never touches that state.
+  /** Enter the dashboard's rearrange (editing) mode, owned by the dashboard
+   *  view — the grid only forwards it up, never touches that state itself. */
   onRearrange: () => void
 }
 
@@ -19,10 +19,6 @@ type DeckOptionsMenuConfig = {
  * card's gear dropdown and the mobile long-press popover so the two entry points
  * never drift. Options are deck-agnostic; the acting deck is passed to
  * `onSelect`, which lets a single popover instance serve every card.
- *
- * @example
- * const { options, onSelect } = useDeckOptionsMenu({ onRearrange: () => emit('rearrange') })
- * // <dropdown-menu :options="options" @select="onSelect($event, deck)" />
  */
 export function useDeckOptionsMenu({ onRearrange }: DeckOptionsMenuConfig) {
   const { t } = useI18n()

--- a/src/views/dashboard/deck-grid/index.vue
+++ b/src/views/dashboard/deck-grid/index.vue
@@ -28,8 +28,10 @@ const is_md = useMatchMedia('w>=md')
 const deck_actions = useDeckActions()
 
 const creating_deck = ref(false)
-// Drives the reorder-grid geometry (cell width per breakpoint); the cards
-// themselves are fluid and just fill the positioned cells.
+/**
+ * Drives the reorder-grid geometry (cell width per breakpoint); the cards
+ * themselves are fluid and just fill the positioned cells.
+ */
 const size = computed(() => (is_md.value ? 'sm' : 'xs'))
 const container_el = useTemplateRef<HTMLElement>('container_el')
 
@@ -40,18 +42,23 @@ const reorder = useDeckGridReorder(
   size
 )
 
-// Locked-deck ids during downgrade grace, recomputed from local rank so a
-// reorder across the 10th position updates the dim/lock optimistically.
+/**
+ * Locked-deck ids during downgrade grace, recomputed from local rank so a
+ * reorder across the 10th position updates the dim/lock optimistically.
+ */
 const { lockedIds } = useDeckGrace(() => decks)
 
-// Animate a slot reflow only when the deck count itself changes (delete/create)
-// — a drag-drop reorder already has its own lift/drop settle animation, and
-// transitioning the resting position too would fight it (the dropped card
-// would visibly slide from its pre-persist slot to its post-persist one).
+/**
+ * Animate a slot reflow only when the deck count itself changes
+ * (delete/create) — a drag-drop reorder already has its own lift/drop settle
+ * animation, and transitioning the resting position too would fight it (the
+ * dropped card would visibly slide from its pre-persist slot to its
+ * post-persist one).
+ */
 const REFLOW_TRANSITION_DURATION = 200
 const reflowing = ref(false)
 let reflow_timeout = 0
-// The first firing is the initial query resolving, not a real reflow — skip it.
+// The first firing is the initial query resolving, not a real reflow.
 let deck_count_initialized = false
 
 watch(
@@ -70,10 +77,7 @@ watch(
   }
 )
 
-// TransitionGroup's `appear` never fires here: this route renders inside a
-// <Suspense> (authenticated.vue), and Vue skips transition hooks for elements
-// mounted within an unresolved suspense boundary — even one that resolves
-// synchronously. Play the reveal once by hand instead.
+// TransitionGroup's `appear` never fires inside authenticated.vue's unresolved <Suspense> — play the reveal once by hand instead.
 onMounted(() => {
   if (!container_el.value) return
 

--- a/src/views/dashboard/deck-grid/item.vue
+++ b/src/views/dashboard/deck-grid/item.vue
@@ -10,11 +10,11 @@ import { usePressHold } from '@/composables/ui/press-hold'
 
 type DeckGridItemProps = {
   deck: Deck
-  // the grid is in drag-to-reorder mode: the card is a drag handle, not tappable
+  /** The grid is in drag-to-reorder mode: the card is a drag handle, not tappable. */
   rearranging?: boolean
-  // this card is the one currently being dragged — opts out of the idle jiggle
+  /** This card is the one currently being dragged — opts out of the idle jiggle. */
   dragging?: boolean
-  // downgrade-grace lock (rank-recomputed by the grid) — dims + lock-badges the deck
+  /** Downgrade-grace lock, rank-recomputed by the grid — dims and lock-badges the deck. */
   locked?: boolean
 }
 
@@ -41,9 +41,11 @@ function onPress() {
   emit('press')
 }
 
-// A touch hold opens the corner options menu; a plain tap still flows through
-// the click path to `press`. In rearrange mode the grid owns pointerdown (drag
-// pickup), and mouse holds stay inert — desktop opens the menu from the button.
+/**
+ * A touch hold opens the corner options menu; a plain tap still flows through
+ * the click path to `press`. In rearrange mode the grid owns pointerdown (drag
+ * pickup), and mouse holds stay inert — desktop opens the menu from the button.
+ */
 function onPointerdown(event: PointerEvent) {
   if (rearranging || event.pointerType === 'mouse') return
   options_hold.arm(event, () => dropdown.value?.show())
@@ -69,10 +71,7 @@ function onOptionSelect(option: DropdownOption) {
     >
       <template #corner-action>
         <DeckGridDeleteButton v-if="rearranging" :deck="deck" @pointerdown.stop />
-        <!-- dropdown-button drops on* attrs in trigger-only mode (inheritAttrs:
-             false + attr partitioning), so .stop must live on a wrapper or the
-             gear's events reach ui-tappable (navigate) and the hold recognizer -->
-        <div v-else @pointerdown.stop @click.stop>
+        <div v-else data-testid="deck-grid-item__options-stop" @pointerdown.stop @click.stop>
           <ui-dropdown-button
             ref="dropdown"
             data-testid="dashboard__deck-options-button"

--- a/src/views/dashboard/deck-grid/skeleton.vue
+++ b/src/views/dashboard/deck-grid/skeleton.vue
@@ -10,7 +10,7 @@ type DeckGridSkeletonProps = {
 
 const { count = 12 } = defineProps<DeckGridSkeletonProps>()
 
-// Mirrors the real grid's per-breakpoint cell width (use-deck-grid CELL_WIDTH).
+// Mirrors the real grid's per-breakpoint cell width (use-deck-grid.ts cardWidthPx).
 const is_md = useMatchMedia('w>=md')
 const card_width = computed(() => (is_md.value ? 'w-(--card-w-sm)' : 'w-(--card-w-xs)'))
 </script>

--- a/src/views/dashboard/deck-grid/use-deck-grid-reorder.ts
+++ b/src/views/dashboard/deck-grid/use-deck-grid-reorder.ts
@@ -17,8 +17,10 @@ import { usePressHold } from '@/composables/ui/press-hold'
 import { resolveReorderAnchor } from '@/utils/reorder'
 import { useDeckGrid, type DeckGridCellSize } from './use-deck-grid'
 
-// Touch picks a card up on a press-and-hold (like iOS), so a plain swipe still
-// scrolls the page; a small finger move within the window aborts the hold.
+/**
+ * Touch picks a card up on a press-and-hold (like iOS), so a plain swipe still
+ * scrolls the page; a small finger move within the window aborts the hold.
+ */
 const HOLD_MS = 200
 const HOLD_TOLERANCE = 8
 
@@ -42,10 +44,12 @@ export function useDeckGridReorder(
   const press_hold = usePressHold({ duration: HOLD_MS, tolerance: HOLD_TOLERANCE })
 
   const container_width = ref(0)
-  // container_width starts at 0, so columns/row_count fall back to a single
-  // tall column for one frame — gate the rendered height on this so a refresh
-  // never briefly renders (and lays out scroll restoration against) a page
-  // several times its real height.
+  /**
+   * `container_width` starts at 0, so columns/row_count fall back to a single
+   * tall column for one frame — gate the rendered height on this so a refresh
+   * never briefly renders (and lays out scroll restoration against) a page
+   * several times its real height.
+   */
   const measured = computed(() => container_width.value > 0)
 
   const { cell_width, gap_x, columns, row_count, row_pitch, itemPosition } = useDeckGrid(

--- a/src/views/dashboard/deck-grid/use-deck-grid-reorder.ts
+++ b/src/views/dashboard/deck-grid/use-deck-grid-reorder.ts
@@ -113,16 +113,18 @@ export function useDeckGridReorder(
    */
   let lifted_card: HTMLElement | null = null
 
+  /**
+   * Lift/drop must animate the innermost, transform-free element — the outer
+   * item carries the reactive `itemPosition` translate, and the middle
+   * wrapper carries the reactive drag-offset translate. GSAP caches whichever
+   * transform is on the element it tweens and rewrites the whole thing on
+   * drop, stomping either one (same reason `popDeckIn`/`popDeckOut` target
+   * the innermost child, not the position-carrying wrapper).
+   */
   function beginDrag(index: number, event: PointerEvent) {
     reorder.start(index, event)
     if (reorder.dragging_index.value === null) return
 
-    // Lift/drop must animate the innermost, transform-free element — the
-    // outer item carries the reactive itemPosition translate, and the middle
-    // wrapper carries the reactive drag-offset translate. GSAP caches
-    // whichever transform is on the element it tweens and rewrites the whole
-    // thing on drop, stomping either one (same reason popDeckIn/popDeckOut
-    // target the innermost child, not the position-carrying wrapper).
     const item = (event.target as HTMLElement).closest<HTMLElement>(
       '[data-testid="deck-grid__item"]'
     )
@@ -157,8 +159,7 @@ export function useDeckGridReorder(
     press_hold.cancel()
   })
 
-  // Settle the lifted card back to rest the moment the drag ends (the engine
-  // clears dragging_index on the window pointerup).
+  // Settle the lifted card the moment the engine clears dragging_index.
   watch(
     () => reorder.dragging_index.value,
     (current, previous) => {

--- a/src/views/dashboard/deck-grid/use-deck-grid-reorder.ts
+++ b/src/views/dashboard/deck-grid/use-deck-grid-reorder.ts
@@ -93,10 +93,12 @@ export function useDeckGridReorder(
     return `translate(${offset.x}px, ${offset.y}px)`
   }
 
-  // Idle iOS-style jiggle: vary phase and tempo per card off its index so the
-  // grid shimmers organically instead of beating in unison. Lighter rotation
-  // than the deck-view card grid — the dashboard shows more cards at once, so
-  // the default amplitude reads as too busy.
+  /**
+   * Idle iOS-style jiggle: varies phase and tempo per card off its index so
+   * the grid shimmers organically instead of beating in unison. Lighter
+   * rotation than the deck-view card grid — the dashboard shows more cards at
+   * once, so the default amplitude reads as too busy.
+   */
   function jiggleStyle(index: number) {
     return {
       '--jiggle-delay': `${-(index % 11) * 47}ms`,
@@ -105,8 +107,10 @@ export function useDeckGridReorder(
     }
   }
 
-  // The card lifted on pickup, held so the matching drop can settle it back —
-  // the drop fires from a window pointerup, not a DOM event on the card.
+  /**
+   * The card lifted on pickup, held so the matching drop can settle it back —
+   * the drop fires from a window pointerup, not a DOM event on the card.
+   */
   let lifted_card: HTMLElement | null = null
 
   function beginDrag(index: number, event: PointerEvent) {

--- a/src/views/dashboard/deck-grid/use-deck-grid.ts
+++ b/src/views/dashboard/deck-grid/use-deck-grid.ts
@@ -3,8 +3,10 @@ import { cardWidthPx } from '@/utils/card/widths'
 
 export type DeckGridCellSize = 'sm' | 'xs'
 
-// Cell width comes from the shared --card-w-* tokens (the fluid card fills the
-// cell); CELL_ASPECT mirrors --aspect-card.
+/**
+ * Cell width comes from the shared --card-w-* tokens (the fluid card fills
+ * the cell); `CELL_ASPECT` mirrors --aspect-card.
+ */
 const CELL_ASPECT = 8 / 7
 const GAP_X = 12 // gap-x-3
 const GAP_Y = 32 // gap-y-8

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -31,8 +31,11 @@ const can = useCan()
 const { data: decks_data, error: decks_error } = useMemberDecksQuery()
 const sort_by = useLocalRef<SortOption>('dashboard-deck-sort', 'custom')
 const editing_decks = ref(false)
-// Edit mode always shows rank order — reorder curation only makes sense against
-// the ranking it edits. Grace on its own does not override the chosen sort.
+/**
+ * Edit mode always shows rank order — reorder curation only makes sense
+ * against the ranking it edits. Grace on its own does not override the
+ * chosen sort.
+ */
 const effective_sort = computed(() => (editing_decks.value ? 'custom' : sort_by.value))
 const decks = computed(() => {
   return [...(decks_data.value ?? [])].sort(DECK_SORT_COMPARATORS[effective_sort.value])

--- a/src/views/dashboard/review-inbox/use-tick-sfx.ts
+++ b/src/views/dashboard/review-inbox/use-tick-sfx.ts
@@ -2,8 +2,10 @@ import { onBeforeUnmount, watch, type Ref } from 'vue'
 import { emitSfx } from '@/sfx/bus'
 import { useMatchMedia } from '@/composables/ui/media-query'
 
-// Matches the "+4" gap fudge use-scroll.ts uses for its own page-size math,
-// so both stay in lockstep with the actual card pitch.
+/**
+ * Matches the "+4" gap fudge use-scroll.ts uses for its own page-size math,
+ * so both stay in lockstep with the actual card pitch.
+ */
 function cardPitch(el: HTMLElement) {
   const card_width = (el.firstElementChild as HTMLElement | null)?.offsetWidth ?? el.clientWidth
   return card_width + 4
@@ -29,8 +31,7 @@ export function useReviewInboxTickSfx(items_el: Ref<HTMLElement | null>) {
       const el = attached_el
       if (!el) return
 
-      // Elastic overscroll (iOS rubber-banding) briefly pushes scrollLeft past
-      // the real [0, max] range — clamp it so bounce doesn't count as a crossing.
+      // Clamp scrollLeft — iOS rubber-banding overscroll pushes it past [0, max].
       const max_scroll_left = el.scrollWidth - el.clientWidth
       const scroll_left = Math.min(Math.max(el.scrollLeft, 0), max_scroll_left)
 

--- a/src/views/settings/account-access/account-access-content.vue
+++ b/src/views/settings/account-access/account-access-content.vue
@@ -21,7 +21,7 @@ const session = useSessionStore()
 
 const page = defineModel<AccountAccessContentPage>('page', { default: 'menu' })
 
-// Standalone tab context has no modal to close — fall back to returning to the menu.
+/** Closes via the modal when embedded; falls back to the account-access menu in the standalone tab context. */
 function onSuccessClose() {
   if (props.close) props.close()
   else page.value = 'menu'

--- a/src/views/settings/account-access/use-google-actions.ts
+++ b/src/views/settings/account-access/use-google-actions.ts
@@ -48,10 +48,7 @@ export function useGoogleActions() {
 
   return {
     loading,
-    // Wrapped in computed() rather than passed as the store's plain unwrapped
-    // boolean — a bare `session.hasGoogleIdentity` here is only read once, at
-    // composable-call time, and never updates again once copied into this
-    // returned object.
+    // computed(), not a bare boolean — an unwrapped read here would freeze at composable-call time and never update again.
     hasGoogleIdentity: computed(() => session.hasGoogleIdentity),
     hasPasswordIdentity: computed(() => session.hasPasswordIdentity),
     onConnect,

--- a/src/views/settings/account-access/use-password-actions.ts
+++ b/src/views/settings/account-access/use-password-actions.ts
@@ -196,9 +196,7 @@ export function usePasswordActions() {
   watch(current_password, () => clearOnInput('current_password'))
   watch(code, () => clearOnInput('code'))
 
-  // Plain object of refs, not reactive() — a consumer destructuring this
-  // (`const { password } = usePasswordActions()`) needs the actual Ref object
-  // to stay reactive; reactive() would unwrap it to a frozen snapshot value.
+  // Returns plain refs, not reactive() — reactive() would unwrap them, so a caller destructuring this loses reactivity.
   return {
     password,
     confirm_password,

--- a/src/views/settings/index.vue
+++ b/src/views/settings/index.vue
@@ -55,8 +55,7 @@ const active_page_ref = useTemplateRef<{ onChromeBack?: () => boolean }>('active
 const layout_mode = computed<WindowLayout>(() => pager.value?.layout_mode ?? 'phone')
 provide(settingsCloseKey, close)
 
-// account-access is reachable via the aside's edit button (tablet/desktop) or the
-// phone-only index entry — it never appears as a sidebar page-bar icon itself.
+// account-access is reachable only via the aside's edit button or the phone-only index entry, never as a sidebar page-bar icon.
 const pages = computed<Page[]>(() =>
   (Object.keys(PAGE_META) as PageValue[]).map((value) => ({
     value,
@@ -85,8 +84,7 @@ const groups = computed<PagedWindowGroup[]>(() => [
 
 const header_title = computed(() => t('settings.header.title'))
 
-// Open/close sfx live on the modal itself so every callsite (phone launcher,
-// dashboard edit button) sounds identically. Mirrors the deck-settings modal.
+// Open/close sfx live here, not per-callsite, so every launcher sounds identical — mirrors the deck-settings modal.
 onMounted(() => emitSfx('snappy_button_3'))
 onBeforeUnmount(() => emitSfx('pop_up_close'))
 

--- a/src/views/settings/tab-app/audio-section.vue
+++ b/src/views/settings/tab-app/audio-section.vue
@@ -13,8 +13,7 @@ const editor = inject(memberEditorKey)!
 
 onBeforeUnmount(() => audio_player.resetSettings())
 
-// Only the sliders live-preview; the mute toggle is excluded, so previewing
-// always treats audio as unmuted (mute is applied on save via App.vue).
+// Only the sliders live-preview — mute is excluded, so the preview always plays unmuted; mute itself applies on save via App.vue.
 watch(
   () => [
     editor.draft.preferences.audio.interface_sounds,

--- a/src/views/settings/tab-subscription/plan-section.vue
+++ b/src/views/settings/tab-subscription/plan-section.vue
@@ -23,9 +23,7 @@ const member_store = useMemberStore()
 
 const { subscription, cost, status, description } = useSubscriptionLabels(subscriptionQuery)
 
-// Free vs paid is known instantly from client state; the Stripe payload (cost,
-// renewal, actions) is what we wait on — so it drives the skeleton, not the
-// free/paid identity of the pill.
+// Only the Stripe payload (cost, renewal, actions) drives the skeleton — the free/paid identity is already known from client state.
 const is_paid = computed(() => member_store.plan === 'paid')
 const loading = computed(() => is_paid.value && subscriptionQuery.isLoading.value)
 const errored = computed(() => is_paid.value && !!subscriptionQuery.error.value)

--- a/src/views/settings/tab-subscription/use-change-cc.ts
+++ b/src/views/settings/tab-subscription/use-change-cc.ts
@@ -31,8 +31,7 @@ export function useChangeCard(close: (response?: ChangeCardResponse) => void) {
   onBeforeUnmount(() => emitSfx('pop_up_close'))
 
   async function onSubmit() {
-    // A failed outcome is intentionally left unhandled here — Stripe's own
-    // Payment Element renders the decline/validation message inline.
+    // A failed outcome is left unhandled here — Stripe's own Payment Element renders the decline/validation message inline.
     const outcome = await confirm()
     if (outcome.status !== 'success') return
 

--- a/src/views/study-session/composables/card-actions.ts
+++ b/src/views/study-session/composables/card-actions.ts
@@ -15,13 +15,6 @@ type UseActiveCardActionsOptions = {
  * another deck. Reuses the card domain's shared prompts (`useCardPrompts`) and
  * write seam (`useCardMutations`), then calls `onRemoved` so the session queue
  * drops the card and advances.
- *
- * @example
- * const { onDelete, onMove } = useActiveCardActions({
- *   active_card,
- *   deck_id: () => deck.id,
- *   onRemoved: dropCard
- * })
  */
 export function useActiveCardActions({
   active_card,

--- a/src/views/study-session/composables/session-controller.ts
+++ b/src/views/study-session/composables/session-controller.ts
@@ -157,8 +157,7 @@ function useStudySessionController({ deck_ids, onClosed }: UseStudySessionContro
     persisted_session.value = {
       deck_ids,
       card_ids: engine.cards.value.map((c) => c.id),
-      // Only durably-saved reviews are persisted, so a card whose save never
-      // confirmed is re-served as unreviewed on resume rather than rebuilt done.
+      // Only durably-saved reviews persist — an unconfirmed save is re-served as unreviewed on resume.
       results: engine.durableResults(),
       completed: engine.state.value === 'summary'
     }
@@ -194,9 +193,7 @@ function useStudySessionController({ deck_ids, onClosed }: UseStudySessionContro
     engine.reviewCard(grade)
   }
 
-  // The session ends the moment the engine reaches `summary` (last card reviewed
-  // or stop button) — flush every deck's queued reviews. Shell derives its own
-  // view from `state`, so there's no onFinished callback to relay results.
+  // The session ends once `state` reaches `summary` — flush every deck's queued reviews.
   watch(
     () => engine.state.value,
     (state) => {

--- a/src/views/study-session/composables/session-engine.ts
+++ b/src/views/study-session/composables/session-engine.ts
@@ -8,17 +8,7 @@ import type { SaveReviewVars } from '@/api/reviews'
 
 export type StudyCard = Card & { state: ReviewState }
 
-/**
- * A card's durability lifecycle within a session (orthogonal to its pass/fail
- * grade, which lives in the review result):
- * - `unreviewed` — not yet rated, or re-served on resume because its save
- *   never confirmed.
- * - `pending` — rated and advanced past optimistically; its `save_review` is
- *   in flight and it is not yet durable.
- * - `saved` — its `save_review` confirmed; the review is durable.
- * - `failed` — its save was ultimately given up; not counted as reviewed and
- *   excluded from the summary.
- */
+/** A card's save state, separate from whether the user got it right. →[K:study-review-durability] */
 type ReviewState = 'unreviewed' | 'pending' | 'saved' | 'failed'
 
 /**
@@ -66,10 +56,9 @@ type SessionEngineDeps = {
  * `deck_id`, which it hands to the injected `schedulerFor` / `startingSideFor` —
  * so a merged multi-deck queue schedules each card against its own deck's pacing.
  *
- * It also coordinates the durable-save lifecycle (pending/saved/failed, in-flight
- * tracking, the summary hold); the retry mechanics themselves live in
- * `review-saver.ts`. If that coordination grows further, lift it into its own
- * seam rather than letting this core keep swelling.
+ * It also coordinates the durable-save lifecycle — in-flight tracking, the
+ * summary hold — while the retry mechanics live in `review-saver.ts`.
+ * →[K:study-review-durability]
  */
 export function useSessionEngine({
   schedulerFor,
@@ -82,8 +71,7 @@ export function useSessionEngine({
 
   const saver = useReviewSaver()
 
-  // In-flight background saves, kept so the summary can wait on them when the
-  // last card is reviewed. A save removes itself once it settles.
+  /** In-flight background saves the summary waits on; each removes itself once it settles. */
   const _in_flight = new Set<Promise<void>>()
 
   const state = ref<SessionState>('loading')
@@ -94,17 +82,15 @@ export function useSessionEngine({
   const active_card = shallowRef<StudyCard | undefined>(undefined)
   const results = shallowRef<CardReviewResult[]>([])
 
-  // A `random` deck rolls each card's side once, the first time it's asked for,
-  // and remembers it for the rest of the session. Without the memo the roll
-  // would land differently on every read — and the preview card's intro flip
-  // (played before the engine advances) would disagree with the side the card
-  // actually opens on.
+  /**
+   * Memoized per card so a `random` deck's rolled side stays stable — otherwise
+   * the preview card's intro flip could disagree with the side it opens on.
+   */
   const _rolled_sides = new Map<number, 'front' | 'back'>()
 
   const cards = computed(() => _cards_in_deck.value)
 
-  // A card counts as reviewed once it's rated (pending) and stays counted once
-  // saved; a save that ultimately fails drops back out (it's re-served later).
+  /** Counts `pending` through `saved`; a `failed` save drops back out and is re-served later. */
   const reviewed_count = computed(
     () => cards.value.filter((c) => c.state === 'pending' || c.state === 'saved').length
   )
@@ -118,8 +104,7 @@ export function useSessionEngine({
     cards.value.slice(current_index.value + 1).find((c) => c.state === 'unreviewed')
   )
 
-  // The cover is showing whenever we're not actively studying or done — that
-  // includes the loading window, where the cover card rises in.
+  /** True through the loading window too, so the cover card is already up when it arrives. */
   const is_cover = computed(() => state.value === 'loading' || state.value === 'cover')
 
   const active_starting_side = computed<'front' | 'back'>(() =>
@@ -313,9 +298,6 @@ export function useSessionEngine({
       return
     }
 
-    // Compute scheduling at the moment the user rates, against this card's own
-    // deck scheduler. next() is the single-grade repeat() — item.card.due is
-    // calculated from now.
     const review = card.review ?? (createEmptyCard(new Date()) as Review)
     const item = schedulerFor(card.deck_id).next(review, new Date(), grade)
 
@@ -331,8 +313,7 @@ export function useSessionEngine({
       })
     }
 
-    // The card advances instantly and is only `pending` — it becomes durably
-    // reviewed once its background save confirms, or `failed` if it never does.
+    // Advances instantly as `pending` — durable only once the background save confirms.
     card.review = item.card
     card.state = 'pending'
 

--- a/src/views/study-session/composables/summary-card-actions.ts
+++ b/src/views/study-session/composables/summary-card-actions.ts
@@ -46,9 +46,7 @@ export function useSummaryCardActions({ onRemoved }: UseSummaryCardActionsOption
     const source_deck_ids = [
       ...new Set(target.map((card) => card.deck_id).filter((id): id is number => id !== undefined))
     ]
-    // A single-deck selection disables that deck in the picker, same as the
-    // active-card mover; a mixed-deck selection has no "current" deck to
-    // disable.
+    // A mixed-deck selection has no single "current" deck to disable in the picker.
     const current_deck_id = source_deck_ids.length === 1 ? source_deck_ids[0] : undefined
 
     async function move(target_deck_id: number) {

--- a/src/views/study-session/composables/summary-selection.ts
+++ b/src/views/study-session/composables/summary-selection.ts
@@ -33,9 +33,11 @@ export function useSummarySelection({
   dropCard,
   closeCategory
 }: UseSummarySelectionOptions) {
-  // The cards on the currently open category page, resolved from the same
-  // session card list the category page itself reads — so a delete/move that
-  // drops a card here disappears there too, no separate refetch.
+  /**
+   * The cards on the currently open category page, resolved from the same
+   * session card list the page itself reads — so a delete/move here disappears
+   * there too, no separate refetch.
+   */
   const category_cards = computed<StudyCard[]>(() => {
     const cat = category.value
     if (!cat) return []
@@ -100,15 +102,13 @@ export function useSummarySelection({
     if (card) await moveCards([card])
   }
 
-  // Selection only makes sense on a category page — leaving one (including
-  // the auto-close below) drops back to the calm, read-only summary.
+  // Leaving a category page drops back to the calm, read-only summary.
   watch(category, () => {
     selection.exitSelection()
     edit.stop()
   })
 
-  // The last card leaving a category (deleted, or moved to another deck) has
-  // nothing left to show — fall back to the summary landing.
+  // The last card leaving a category has nothing left to show — fall back to the summary.
   watch(category_cards, (list) => {
     if (category.value && list.length === 0) closeCategory()
   })

--- a/src/views/study-session/deck-resolution.ts
+++ b/src/views/study-session/deck-resolution.ts
@@ -44,8 +44,7 @@ type ResolvedDeck = {
   shuffle: boolean
 }
 
-// Used until a card's deck lands (or for a card whose deck somehow isn't in the
-// session). The cover gates on loading, so this never schedules a real review.
+/** Used until a card's deck lands; the cover gates on loading, so this never schedules a real review. */
 const FALLBACK_FSRS = new FSRS(generatorParameters({ enable_fuzz: true }))
 
 const DeckResolutionKey: InjectionKey<DeckResolution> = Symbol('study-session.deck-resolution')

--- a/src/views/study-session/index.vue
+++ b/src/views/study-session/index.vue
@@ -63,7 +63,7 @@ const nav_mode = computed<'close' | 'stop' | 'back'>(() => {
   return 'stop'
 })
 
-// The textured backdrop reads as busy behind the settings form, so drop it there.
+/** The textured backdrop reads as busy behind the settings form, so drop it there. */
 const bgx_class = computed(() =>
   active_page.value === 'settings'
     ? ''

--- a/src/views/study-session/index.vue
+++ b/src/views/study-session/index.vue
@@ -81,8 +81,7 @@ const title = computed(() => {
     : t('study-session.multiple-decks-title')
 })
 
-// The Select/Done header action and the bulk bar only make sense on an open
-// category page, and hide while its editor sub-state is showing.
+/** Only on an open category page, and hidden while its editor sub-state is showing. */
 const show_summary_select_button = computed(
   () => current_page.value === 'summary-category' && !summary_editing_card.value
 )
@@ -100,8 +99,7 @@ function onClosed() {
 }
 
 function onPaneEnterStart() {
-  // Every swap gets a light click, distinct per direction; only the summary's
-  // first arrival gets the session-complete jingle.
+  // Only the summary's first arrival gets the session-complete jingle; every other swap gets a light click.
   const enter_sfx = {
     settings: 'snappy_button_3',
     studying: 'snappy_button_2',

--- a/src/views/study-session/session-header-nav-button.vue
+++ b/src/views/study-session/session-header-nav-button.vue
@@ -2,9 +2,8 @@
 import UiButton from '@/components/ui-kit/button.vue'
 import { useI18n } from 'vue-i18n'
 
-// The leading (header-start) nav action. Its shape is session-state-driven; the
-// parent decides the mode and routes the single `press`. `minimize` will join
-// here when the session gains a minimized state.
+// The leading (header-start) nav action — the parent picks the mode, this only
+// routes `press`. `minimize` will extend `NavMode` once sessions can minimize.
 type NavMode = 'close' | 'stop' | 'back'
 
 type SessionHeaderNavButtonProps = {

--- a/src/views/study-session/session-header-nav-button.vue
+++ b/src/views/study-session/session-header-nav-button.vue
@@ -2,8 +2,7 @@
 import UiButton from '@/components/ui-kit/button.vue'
 import { useI18n } from 'vue-i18n'
 
-// The leading (header-start) nav action — the parent picks the mode, this only
-// routes `press`. `minimize` will extend `NavMode` once sessions can minimize.
+/** The leading nav action — the parent picks the mode, this only routes `press`. */
 type NavMode = 'close' | 'stop' | 'back'
 
 type SessionHeaderNavButtonProps = {

--- a/src/views/study-session/session-settings/index.vue
+++ b/src/views/study-session/session-settings/index.vue
@@ -26,7 +26,7 @@ const {
 const is_coarse = useMatchMedia('coarse')
 const is_mobile = useMatchMedia('w<sm')
 
-// Ratings mode is a boolean pref; the option group speaks string values.
+/** Ratings mode is a boolean pref; the option group speaks string values. */
 const ratings_mode = computed<RatingsMode>({
   get: () => (show_all_ratings.value ? 'advanced' : 'simple'),
   set: (value) => (show_all_ratings.value = value === 'advanced')

--- a/src/views/study-session/session-studying/card/card-stage.vue
+++ b/src/views/study-session/session-studying/card/card-stage.vue
@@ -44,8 +44,7 @@ const { current_cover } = useCoverCarousel(
 
 const preview_appearance = computed(() => resolution.appearanceFor(next_card.value?.deck_id))
 
-// While loading nothing renders in the stage — the cover card rises in (via the
-// transition) once data lands. No separate skeleton: it's just the cover card.
+/** No separate loading skeleton — while loading, nothing renders and the cover card rises in once data lands. */
 const card_view = computed<'loading' | 'edit' | 'read'>(() => {
   if (loading.value) return 'loading'
   if (editing.value) return 'edit'
@@ -61,9 +60,7 @@ function onDragRating(grade: Grade | null) {
   primed_grade.value = grade
 }
 
-// Only the cover card rises in (the modal-open intro). Subsequent cards mount
-// on their starting side, so their enter is a no-op; the before-enter runs
-// before Vue paints the element, which is what keeps the rise flash-free.
+/** Only the cover card rises in; subsequent cards mount on their starting side, so their enter is a no-op. */
 let cover_tween: gsap.core.Tween | undefined
 
 function onCardBeforeEnter(el: Element) {

--- a/src/views/study-session/session-studying/card/card-stage.vue
+++ b/src/views/study-session/session-studying/card/card-stage.vue
@@ -75,9 +75,11 @@ function onCardEnter(el: Element, done: () => void) {
   cover_tween = coverCardEnter(el as HTMLElement, done)
 }
 
-// A leave fires when a card is replaced mid-rise; a modal close instead tears
-// the subtree down with no leave hook — so kill the rise tween on unmount too,
-// or a spam close leaves it running (stray slide_up + work on a detached node).
+/**
+ * A leave fires when a card is replaced mid-rise; a modal close instead tears
+ * the subtree down with no leave hook — so kill the rise tween on unmount too,
+ * or a spam close leaves it running (stray slide_up + work on a detached node).
+ */
 function onCardLeave(_el: Element, done: () => void) {
   cover_tween?.kill()
   done()

--- a/src/views/study-session/session-studying/card/study-card.vue
+++ b/src/views/study-session/session-studying/card/study-card.vue
@@ -20,8 +20,7 @@ defineExpose({ rate, el: () => card_ref.value?.$el as HTMLElement | undefined })
 type StudyCardProps = {
   card?: Card
   side: CardSide
-  // Projected next-review labels per grade ("Study again in 1 day"), frozen
-  // per active card upstream so they don't drift mid-drag.
+  /** Projected next-review label per grade, frozen per active card upstream so it doesn't drift mid-drag. */
   rating_labels?: Record<Grade, string>
   show_all_ratings?: boolean
   cover_override?: DeckCover
@@ -55,11 +54,11 @@ const drag_rating = ref<Grade>(Rating.Good)
 const primed_grade = ref<Grade | null>(null)
 
 const is_dragging = ref(false)
-// Guards against rapid key/click spam re-triggering an action (and replaying
-// its sfx) mid-animation. For a flip it covers only the outgoing face's
-// rotate-out (cleared on `flip-out-complete`) so the card is re-flippable the
-// instant the new face shows; for a fling it stays true until this card
-// unmounts on advance.
+/**
+ * Guards against key/click spam re-triggering an action mid-animation. A flip
+ * clears it on `flip-out-complete`; a fling leaves it set until this card
+ * unmounts on advance.
+ */
 const is_animating = ref(false)
 
 const { register } = useGestures()

--- a/src/views/study-session/session-studying/card/study-card.vue
+++ b/src/views/study-session/session-studying/card/study-card.vue
@@ -138,10 +138,7 @@ function flingCard(
 
   emitSfx(grade === Rating.Again ? 'music_plink_locancel' : 'music_plink_ok')
 
-  // Leave is_animating true: after `reviewed` the parent plays the incoming
-  // card's intro flip before advancing. This instance stays mounted (and so
-  // its shortcuts stay live) through that window, so the flag keeps spam from
-  // re-flinging until the next card is keyed in fresh.
+  // Leave is_animating true — this instance stays mounted through the parent's next-card intro flip, and the flag guards it from a spam re-fling.
   const onTransitionEnd = () => {
     el.removeEventListener('transitionend', onTransitionEnd)
     card_offset.value = 0
@@ -201,9 +198,7 @@ function endDrag(el: HTMLElement, { dx, dy }: { dx: number; dy: number }) {
   if (is_animating.value) return
 
   if (isTap(dx, dy)) {
-    // A tap that ends a drag-selection of the card's text shouldn't also flip.
-    // A plain tap collapses the selection on mousedown, so this only catches
-    // the release of a real selection.
+    // Skip the flip only for a real surviving selection — a plain tap already collapsed it on mousedown.
     const sel = window.getSelection()
     if (sel && !sel.isCollapsed) return
 
@@ -223,10 +218,12 @@ function isTap(dx: number, dy: number) {
   return Math.abs(dx) < FLIP_THRESHOLD && Math.abs(dy) < FLIP_THRESHOLD
 }
 
-// Spamming the flip racks up the browser's click counter, whose double/triple
-// clicks word- and line-select the card content. Suppress the default selection
-// on those multi-clicks only — a single click (and a deliberate click-drag to
-// select) keeps `detail === 1`, so manual selection still works.
+/**
+ * Spamming the flip racks up the browser's click counter, whose double/triple
+ * clicks word- and line-select the card content. Suppresses the default
+ * selection on those multi-clicks only — a single click (and a deliberate
+ * click-drag to select) keeps `detail === 1`, so manual selection still works.
+ */
 function onCardMouseDown(e: MouseEvent) {
   if (e.detail > 1) e.preventDefault()
 }

--- a/src/views/study-session/session-studying/card/study-card.vue
+++ b/src/views/study-session/session-studying/card/study-card.vue
@@ -162,7 +162,7 @@ function handleDrag(el: HTMLElement, dx: number, dy: number) {
   updateDragRating(dx, dy)
 }
 
-/** Updates drag_rating from vertical position and emits primed_grade when the zone or rating changes. */
+/** Derives the vertical-drag rating and emits it only when the swipe zone or the rating actually changes. */
 function updateDragRating(dx: number, dy: number) {
   if (show_all_ratings && dx > SWIPE_DISTANCE_THRESHOLD) {
     const new_rating = toDragRating(dy)

--- a/src/views/study-session/session-studying/rating-buttons/advanced.vue
+++ b/src/views/study-session/session-studying/rating-buttons/advanced.vue
@@ -22,8 +22,7 @@ const is_mobile = useMatchMedia('w<md')
 
 const { show_button_preview, rating_times } = useInjectedStudySessionController()
 
-// Preview replaces every button's icon/word with its projected interval; falls
-// back to icons if the frozen times aren't ready (e.g. before the first card).
+/** Replaces every button's icon/word with its projected interval; falls back to icons until times are frozen. */
 const preview_on = computed(
   () => show_button_preview.value && !!rating_times.value.bare[Rating.Good]
 )

--- a/src/views/study-session/session-summary/aggregate.ts
+++ b/src/views/study-session/session-summary/aggregate.ts
@@ -1,19 +1,5 @@
 import type { CardReviewResult } from '@/views/study-session/composables/session-engine'
 
-/**
- * Pure FSRS-aware aggregation for the post-session summary. Buckets the raw
- * per-card results captured during a session into the categories the summary
- * lists. No reactivity, no i18n — just data in, data out.
- *
- * Maturity bands bucket cards by their scheduled interval (the real mastery
- * signal), not by FSRS state, which is a weak proxy for how well something is
- * known. A card "levels up" when its review pushes it across a band boundary
- * and "levels down" when a failure drops it back below one.
- *
- * Each bucket keeps the results themselves, not a count — the summary opens a
- * page per category listing its cards, and counts are just `.length`.
- */
-
 export type MaturityBand = 'forming' | 'familiar' | 'strong' | 'mastered'
 
 /** The categories the summary lists, in display order. */
@@ -36,6 +22,19 @@ function levelFor(interval_days: number): number {
   return BAND_ORDER.indexOf('mastered')
 }
 
+/**
+ * Pure FSRS-aware aggregation for the post-session summary — no reactivity, no
+ * i18n, just data in, data out.
+ *
+ * Buckets each result into the categories the summary lists. Maturity bands
+ * come from a card's scheduled interval (the real mastery signal), not FSRS
+ * state, which is a weak proxy for how well something is known — a card
+ * "levels up" crossing a band boundary upward, "levels down" dropping back
+ * across one on a failure.
+ *
+ * Each bucket keeps the results themselves, not a count — the summary opens a
+ * page per category listing its cards, and counts are just `.length`.
+ */
 export function aggregateSession(
   results: CardReviewResult[],
   thresholdFor: (deck_id?: number) => number

--- a/src/views/study-session/session-summary/aggregate.ts
+++ b/src/views/study-session/session-summary/aggregate.ts
@@ -12,7 +12,7 @@ export type SummaryData = {
   incorrect: CardReviewResult[]
 }
 
-// Ordered weakest → strongest; the index is the comparable "level".
+/** Ordered weakest → strongest; the index is the comparable "level". */
 const BAND_ORDER: MaturityBand[] = ['forming', 'familiar', 'strong', 'mastered']
 
 function levelFor(interval_days: number): number {

--- a/src/views/study-session/session-summary/category-page/category-section.vue
+++ b/src/views/study-session/session-summary/category-page/category-section.vue
@@ -13,13 +13,14 @@ type CategorySectionProps = {
 
 const { name, cards, heading } = defineProps<CategorySectionProps>()
 
-// Same geometry as the deck's card grid at its smallest size, sourced rather
-// than copied so the two can't drift.
+/** Same geometry as the deck's card grid at its smallest size, sourced rather than copied so the two can't drift. */
 const { cell_width, gap, grid_classes } = useCardGrid('base')
 
-// `auto-fit` rather than the composable's `auto-fill`: empty tracks collapse, so
-// `justify-center` can center the cards as a block instead of leaving dead space
-// on the right. Rows still fill left-to-right from a shared left edge.
+/**
+ * `auto-fit`, not the composable's `auto-fill`: empty tracks collapse, so
+ * `justify-center` centers the cards as a block instead of leaving dead space
+ * on the right — rows still fill left-to-right from a shared left edge.
+ */
 const grid_style = computed<CSSProperties>(() => ({
   gap: `${gap.value}px`,
   gridTemplateColumns: `repeat(auto-fit, ${cell_width.value}px)`

--- a/src/views/study-session/session-summary/category-page/index.vue
+++ b/src/views/study-session/session-summary/category-page/index.vue
@@ -29,12 +29,10 @@ const { cards, summary_editing_card, onSummaryEditUpdate, stopSummaryEdit } =
 
 const summary = computed(() => aggregateSession(results, thresholdFor))
 
-// The session queue holds the full card for everything reviewed, so a category's
-// results resolve to real cards without a refetch.
+/** The session queue holds the full card for everything reviewed, so results resolve without a refetch. */
 const cards_by_id = computed(() => new Map(cards.value.map((card) => [card.id, card])))
 
-// `correct` is the one category with two sections — its own cards plus the ones
-// that failed; every other category is a single unlabelled list.
+/** `correct` is the one category with two sections, its own cards plus the failed ones; the rest are one unlabelled list. */
 const sections = computed<Section[]>(() => {
   if (category !== 'correct') {
     return [{ name: category, cards: resolve(summary.value.groups[category]) }]

--- a/src/views/study-session/session-summary/category-page/summary-card.vue
+++ b/src/views/study-session/session-summary/category-page/summary-card.vue
@@ -55,7 +55,7 @@ function onMenuSelect(option: DropdownOption) {
   }
 }
 
-// A touch hold opens the corner more-menu; desktop hovers it into view instead.
+/** A touch hold opens the corner more-menu; desktop hovers it into view instead. */
 function onPointerdown(event: PointerEvent) {
   if (is_selecting.value || event.pointerType === 'mouse') return
   options_hold.arm(event, () => dropdown.value?.show())

--- a/src/views/study-session/session-summary/stats-panel.vue
+++ b/src/views/study-session/session-summary/stats-panel.vue
@@ -30,8 +30,7 @@ const entries = computed<OptionsPanelEntry[]>(() =>
   )
 )
 
-// `correct` carries the whole session's score, so it reads as a fraction rather
-// than a bare count like the other rows.
+/** `correct` carries the whole session's score, so it reads as a fraction rather than a bare count like the other rows. */
 function labelFor(key: SummaryCategory) {
   const count = summary.groups[key].length
 

--- a/src/views/study-session/session-summary/stats-panel.vue
+++ b/src/views/study-session/session-summary/stats-panel.vue
@@ -6,7 +6,7 @@ import type { SummaryCategory, SummaryData } from './aggregate'
 
 type StatsPanelProps = { summary: SummaryData }
 
-// Display order; `correct` leads because it's the headline stat.
+/** Display order; `correct` leads because it's the headline stat. */
 const CATEGORIES: { key: SummaryCategory; icon: string }[] = [
   { key: 'correct', icon: 'card-deck' },
   { key: 'new', icon: 'card-add' },
@@ -23,7 +23,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-// Empty categories drop out, except `correct` — a zero there is the point.
+/** Empty categories drop out, except `correct` — a zero there is the point. */
 const entries = computed<OptionsPanelEntry[]>(() =>
   CATEGORIES.filter(({ key }) => key === 'correct' || summary.groups[key].length > 0).map(
     ({ key, icon }) => ({ value: key, icon, label: labelFor(key) })

--- a/src/views/study-session/session-summary/summary-select-button.vue
+++ b/src/views/study-session/session-summary/summary-select-button.vue
@@ -2,8 +2,7 @@
 import UiButton from '@/components/ui-kit/button.vue'
 import { useI18n } from 'vue-i18n'
 
-// The header-end action on a summary category page — mirrors
-// `session-header-nav-button.vue`'s leading action, but toggles multi-select.
+/** The header-end action on a category page — mirrors the header's leading action, but toggles multi-select. */
 type SummarySelectButtonProps = {
   is_selecting?: boolean
 }

--- a/src/views/study-session/session-summary/summary-select-button.vue
+++ b/src/views/study-session/session-summary/summary-select-button.vue
@@ -2,9 +2,8 @@
 import UiButton from '@/components/ui-kit/button.vue'
 import { useI18n } from 'vue-i18n'
 
-// The header-end action on a summary category page — session-state-driven
-// like `session-header-nav-button.vue`'s leading action, just for entering /
-// leaving multi-select instead of navigation.
+// The header-end action on a summary category page — mirrors
+// `session-header-nav-button.vue`'s leading action, but toggles multi-select.
 type SummarySelectButtonProps = {
   is_selecting?: boolean
 }

--- a/src/views/welcome/index.vue
+++ b/src/views/welcome/index.vue
@@ -21,10 +21,7 @@ const roadmap = useTemplateRef('roadmap')
 
 provideWelcomeLayout()
 
-// The checkpoint has already sent a signed-in visitor into the app, so a mount
-// here means a signed-out sign-in surface. Two things to settle: open the reset
-// dialog for a recovery link, and stash any `?next=` destination so it survives
-// the sign-in (including the full-page OAuth redirect).
+// A recovery mount returns early — captureReturnDestination only runs for a normal signed-out visit.
 onMounted(async () => {
   if (await session.checkPasswordRecovery()) {
     resetPasswordModal.open()

--- a/src/views/welcome/login/dialog.vue
+++ b/src/views/welcome/login/dialog.vue
@@ -14,8 +14,7 @@ const auth = useLoginActions()
 async function onSubmit() {
   const result = await auth.submit()
 
-  // 'invalid' shows inline field errors; 'error' shows the backend message
-  // above the submit button — both keep the dialog open.
+  // Stay open on 'invalid'/'error' so the field or backend message can render — only 'success' closes.
   if (result !== 'success') return
 
   session.onAuthenticated()

--- a/src/views/welcome/section-features/feature-card.vue
+++ b/src/views/welcome/section-features/feature-card.vue
@@ -33,9 +33,11 @@ const size = computed<FeatureCardTier>(() => {
   return width.value === 'tablet' ? 'xl' : 'sm'
 })
 
-// Card width + icon/heading/description scale with the tier — xl (tablet)
-// reads biggest since the card itself is largest there, lg (desktop) and sm
-// (mobile) step down from it.
+/**
+ * Card width and its icon/heading/description sizes, keyed by tier. `xl`
+ * (tablet) reads biggest since the card itself is largest there; `lg`
+ * (desktop) and `sm` (mobile) step down from it.
+ */
 const CARD_WIDTH: Record<FeatureCardTier, string> = {
   xl: 'w-(--card-w-full)',
   lg: 'w-(--card-w-md)',

--- a/src/views/welcome/section-features/index.vue
+++ b/src/views/welcome/section-features/index.vue
@@ -94,10 +94,12 @@ function setSide(index: number, side: CardSide) {
   sides.value[index] = side
 }
 
-// Pair each ScrollTrigger's controlled card indices with the element whose scroll
-// position gates them: desktop flips the whole row off the <ul>; tablet and
-// mobile flip each grid row off its leading <li>, so both cards in a row flip
-// together.
+/**
+ * Pairs each ScrollTrigger's controlled card indices with the element whose
+ * scroll position gates them: desktop flips the whole row off the `<ul>`;
+ * tablet and mobile flip each grid row off its leading `<li>`, so both cards
+ * in a row flip together.
+ */
 function revealGroups(): { trigger: Element; indices: number[] }[] {
   if (!row.value) return []
   if (width.value === 'desktop') return [{ trigger: row.value, indices: features.map((_, i) => i) }]

--- a/src/views/welcome/section-features/index.vue
+++ b/src/views/welcome/section-features/index.vue
@@ -67,18 +67,20 @@ const features: Feature[] = [
   }
 ]
 
-// Tablet and mobile render the cards as a 2-column grid; desktop as one row.
+/** Column count of the tablet/mobile card grid; desktop renders one row instead. */
 const GRID_COLUMNS = 2
 
-// Every card starts on its cover and flips to front when its trigger fires.
+/** Which face each card shows — starts on its cover and flips to front when its trigger fires. */
 const sides = ref<CardSide[]>(features.map(() => 'cover'))
 
 const row = useTemplateRef<HTMLElement>('row')
 
 let teardowns: (() => void)[] = []
 
-// Desktop: single justified row that scroll-flips. Tablet and mobile: a 2×2
-// grid so each row of two flips together on its own trigger.
+/**
+ * Desktop: single justified row that scroll-flips. Tablet and mobile: a 2×2
+ * grid so each row of two flips together on its own trigger.
+ */
 const row_layout = computed(() => {
   if (width.value === 'desktop') return 'flex flex-wrap items-stretch justify-center gap-2'
   return 'grid grid-cols-[auto_auto] justify-center gap-2'

--- a/src/views/welcome/section-header.vue
+++ b/src/views/welcome/section-header.vue
@@ -2,9 +2,8 @@
 type SectionHeaderProps = {
   heading: string
   subtitle?: string
-  // Set when the header sits on an accent-filled section (e.g. pricing): text
-  // reads as on-accent and the rule as accent-muted. Otherwise the header sits
-  // on a neutral surface and reads as ink.
+  // True when this header sits on an accent-coloured section, so the text and
+  // rule switch to colours that read against it.
   onAccent?: boolean
 }
 

--- a/src/views/welcome/section-roadmap/index.vue
+++ b/src/views/welcome/section-roadmap/index.vue
@@ -12,8 +12,7 @@ type RoadmapItem = {
 
 const { t } = useI18n()
 
-// The panel band is a fixed brown-200 surface on the depth-0 page; declare
-// depth 1 so the options-panel well inside reads `below` against it.
+// Depth 1 so the options-panel well inside reads `below` against this band's fixed brown-200 surface.
 provideDepth(1)
 
 const items: RoadmapItem[] = [

--- a/src/views/welcome/signup/form.vue
+++ b/src/views/welcome/signup/form.vue
@@ -32,9 +32,6 @@ const { t } = useI18n()
       >
         {{ t('signup-dialog.google-button') }}
       </ui-button>
-      <!-- <ui-button size="lg" theme="brown" class="w-full!" @press="submitOAuth('apple')">
-        {{ t('signup-dialog.apple') }}
-      </ui-button> -->
     </div>
 
     <ui-divider :label="t('signup-dialog.divider-or')" />

--- a/src/views/welcome/signup/index.vue
+++ b/src/views/welcome/signup/index.vue
@@ -25,7 +25,7 @@ async function onSubmit() {
     return
   }
 
-  // 'invalid' shows inline field errors; only a genuine request failure alerts.
+  // Only 'error' alerts — 'invalid' already shows inline field errors.
   if (result === 'error') {
     alert.warn({
       title: t('signup-dialog.alert.error-title'),

--- a/src/views/welcome/welcome-layout.ts
+++ b/src/views/welcome/welcome-layout.ts
@@ -1,15 +1,19 @@
 import { computed, inject, provide, type ComputedRef, type InjectionKey } from 'vue'
 import { useMatchMedia } from '@/composables/ui/media-query'
 
-// Width drives the responsive layout across the welcome page on two boundaries:
-// `desktop` at/above `xl`, `tablet` between `sm` and `xl`, `mobile` below `sm`.
-// `desktop` starts at `xl` so the four-card feature row only unwraps once it
-// actually fits. Consumers that only split desktop vs not compare against
-// `'desktop'`.
+/**
+ * The welcome page's responsive width tier, split at two boundaries: `desktop`
+ * at/above `xl`, `tablet` between `sm` and `xl`, `mobile` below `sm`. `desktop`
+ * starts at `xl` so the four-card feature row only unwraps once it actually
+ * fits — a consumer that only cares desktop vs not compares against `'desktop'`.
+ */
 export type WelcomeWidth = 'mobile' | 'tablet' | 'desktop'
 
-// Height is orthogonal to width — right now it only governs vertical chrome
-// (splash-nav visibility + which actions variant shows). `medium` is reserved.
+/**
+ * The welcome page's responsive height tier, orthogonal to width — it only
+ * governs vertical chrome (splash-nav visibility, which actions variant shows).
+ * `medium` is reserved.
+ */
 export type WelcomeHeight = 'short' | 'medium' | 'tall'
 
 export const welcomeWidthKey: InjectionKey<ComputedRef<WelcomeWidth>> = Symbol('welcome-width')


### PR DESCRIPTION
[TARO-340](https://app.notion.com/p/3b60953c224c81c8b3b9ccc57bcfe4ae)

> Stacked on #523.

## Summary

- **~800 → 721 comment lines** across `src/views/` (minus `deck/` and `audio-reader/`) plus `src/router/`.
- The session engine's prose spelling out a four-state durability lifecycle above a four-member union that already carried it is gone — the depth is now `[K:study-review-durability]` in `corpus/study/study.md`, written as an extension of TARO-335's "Reviews save as you go" section rather than a contradiction of it.

## Closes a dangling citation

`[K:study-review-durability]` is the second of the three slugs #520's signed-off examples cite. Both citation sites in `session-engine.ts` resolve.

## Two facts moved rather than deleted

- A `<template>` comment explaining an iOS Safari `translateZ(0)` compositor-layer fix. Template comments are banned outright, so the fact moved into `.claude/rules/safari-gotchas.md`.
- A `<template>` comment about `ui-kit/dropdown-button` in `trigger-only` mode dropping `on*` attrs — the reason a `@pointerdown.stop` guard must sit on a wrapper `div`. Replaced in the markup by a `data-testid`.

## For you

The ticket said the session engine's closing architectural note belongs on the board, not in source. Removed and quoted here rather than filed: *"If that coordination grows further, lift it into its own seam rather than letting this core keep swelling."*