### PR TITLE
TARO-341: Comment sweep — api and stores

### DIFF
--- a/corpus/sessions/_map.md
+++ b/corpus/sessions/_map.md
@@ -1,0 +1,6 @@
+# sessions
+
+Being signed in — what the browser holds, and what it keeps believing after the
+server has changed its mind.
+
+- [[sessions]] — a token the browser holds for an hour; the server can end a session without the browser noticing ⚠️

--- a/corpus/sessions/sessions.md
+++ b/corpus/sessions/sessions.md
@@ -1,0 +1,133 @@
+---
+id: sessions
+domain: sessions
+status: current
+hazard: true
+related: [members, permissions]
+updated: 2026-08-08
+---
+
+# Sessions
+
+Being signed in. What the browser is actually holding, how the app finds out who
+you are on a cold load, and how you prove it's still you before something
+sensitive changes hands.
+
+Signing in hands the browser a **token**. It sits in the browser's own storage,
+it says who you are, and it carries an expiry — one hour.
+
+The token is the whole answer. When the app reads or writes data, the database
+checks the token's signature and its expiry and nothing else. It does not ask the
+sign-in service whether that account still exists, or whether someone revoked the
+session ten seconds ago. It can't afford to — that check would ride on every
+single request.
+
+So there are two separate ideas of "signed in", and they can disagree:
+
+- **The server's** — is there a live session on record for this account?
+- **The browser's** — is there an unexpired token in storage?
+
+Everything below follows from the gap between them.
+
+> [!HAZARD] [K:deleted-account-token-outlives-deletion] **Ending a session on the server does not sign the browser out. The token in the browser keeps working until it expires on its own.**
+> Deleting an account revokes every session for it. That has no effect on the
+> token already sitting in this browser: it stays signature-valid for its full
+> hour, the app hands it back from storage without ever asking the server, and
+> the database accepts it. So the screen still says you're signed in, and reads
+> and writes for a deleted account keep succeeding — for up to an hour after the
+> account is gone. Only a call that goes through the sign-in service itself
+> notices. The one thing that actually ends it is clearing the token out of local
+> storage, which makes that cleanup a security step rather than tidying up.
+> [What has to happen instead ↓](#ending-a-session-means-clearing-the-browsers-copy)
+
+> [!HAZARD] [K:oauth-popup-loses-its-opener] **The Google sign-in popup comes back as a stranger. It cannot be recognised by the window it came from.**
+> Google's consent screen sends a header that permanently moves the popup into a
+> separate group of browser windows. The link back to the window that opened it
+> is cut for good, and the name the popup was opened under doesn't survive
+> either — not even once the popup navigates back onto our own site. Anything
+> handed to the popup through the window itself is therefore gone by the time it
+> matters. The tempting repair is to carry the state in the address the popup
+> comes back to, and that address is exactly the one field that must not be
+> caller-controlled: an open redirect. What does survive is local storage, which
+> isn't scoped to that window group.
+> [How the popup is recognised instead ↓](#the-popup-is-recognised-through-storage-not-the-window)
+
+## Ending a session means clearing the browser's copy
+
+Two paths end a session, and they end it differently.
+
+**Signing out** asks the server to end the session and clears the local token.
+Both halves happen, so both ideas of "signed in" go false together.
+
+**An account deletion** has already ended the session server-side by the time the
+app finds out. There is nothing left to revoke, so the teardown is purely local:
+drop the stored token, clear the cached data, close what's open. Skip the token
+and the account looks alive for the rest of the hour.
+
+The app also watches for the sign-in library giving up on the session by itself —
+a background token renewal refused because the session was revoked on another
+device. That's the stale-tab case, and it's caught by listening rather than by
+waiting for the next request to fail.
+
+## The popup is recognised through storage, not the window
+
+Sign-in with Google opens a popup, unless the device is a phone — there it's a
+full-page redirect instead, because a popup on a phone is worse than useless.
+
+Before the popup opens, the app writes a flag into local storage. When the popup
+lands back on our own site, the callback page reads that flag and knows to close
+itself rather than navigate to the dashboard. The flag is cleared unconditionally
+on the way in, so one abandoned popup can't misfire on a later sign-in.
+
+The address the popup returns to is fixed by the app and is deliberately not
+something a caller can pass in.
+
+## Proving it's still you
+
+Before something sensitive changes — a password, account access — the app makes
+you prove your identity again. Which proof you get depends on whether you have a
+password at all.
+
+> [!WATCH] [K:password-identity-not-client-derivable] Whether an account can sign
+> in with a password is **not** readable from the signed-in session, and the
+> field that looks like the answer isn't one. A password set on a Google-origin
+> account never shows up in the session's list of sign-in methods. The database
+> has to be asked.
+
+Someone with a password re-enters it. Someone without one — a Google-only
+account — gets a one-time code emailed to them, and using that code signs them in
+again. In both cases the proof is a real sign-in, not a flag.
+
+> [!WATCH] [K:reauth-nonce-does-not-gate] The purpose-built "reauthenticate"
+> call in the auth library reads like the right tool and gates nothing here. The
+> code it issues is only checked when a specific server setting is on **and** the
+> session is over 24 hours old — otherwise a deliberately wrong code still lets
+> the change through (verified against a local auth server). A hijacked tab is
+> recent by definition, so that path would never challenge the one attacker it
+> exists to stop.
+
+Both proofs work by signing you in again, which means they leave nothing behind
+on the session for a later step to inspect. Whoever calls the sensitive operation
+is responsible for having done the proof first; the operation itself cannot check.
+
+Changing a password ends every **other** session for the account, so anyone who
+already had access loses it.
+
+## Finding out who you are on a cold load
+
+On a fresh page load the app resolves identity once and every navigation shares
+that single answer, rather than each one asking again. The answer is thrown away
+whenever sign-in state changes, so the next navigation asks fresh.
+
+> [!WATCH] [K:session-restore-retry-storm] Reading the stored session triggers a
+> silent token renewal when it has expired, and the auth library treats a dead
+> connection as retryable — it will back off and retry for up to 30 seconds
+> before admitting failure. Anything waiting on identity waits that long too, so
+> the read is raced against a short timeout.
+
+## What this isn't
+
+This topic is about **being** signed in — the token, its lifetime, and proving
+identity again. What a signed-in person is then _allowed_ to do is
+[[permissions]]. Who they are as an account — profile, plan, deletion grace
+window — is [[members]].

--- a/src/api/billing/db/index.ts
+++ b/src/api/billing/db/index.ts
@@ -41,9 +41,8 @@ async function manage<T>(body: ManagePayload): Promise<T> {
   return data
 }
 
-// Normalized subscription view returned by the edge function — flat domain
-// fields, no raw Stripe shapes. `null` for free members. Money is in minor
-// units and `currentPeriodEnd` is a UNIX second; the FE formats both.
+// Money is in the currency's smallest unit and the date is a UNIX second —
+// both are formatted for display elsewhere.
 export type SubscriptionView = {
   priceCents: number | null
   currency: string | null
@@ -91,10 +90,8 @@ export function changePlan(planId: string) {
   return manage<{ subscription: StripeSubscription }>({ action: 'change-plan', planId })
 }
 
-// An immediate cancellation also refunds the unused part of the period, so the
-// response carries what Stripe actually gave back. `refunded: false` is a normal
-// outcome, not an error — a trial or a $0 invoice has nothing unused to return.
-// Absent entirely for `atPeriodEnd`, where every paid day gets used.
+// `refunded: false` is a normal outcome, not a failure — a trial has nothing
+// unused to give back.
 export type ProratedRefundOutcome =
   | { refunded: true; amountCents: number; currency: string; creditNoteId: string }
   | { refunded: false; reason: string }

--- a/src/api/billing/mutations/use-cancel-subscription-mutation.ts
+++ b/src/api/billing/mutations/use-cancel-subscription-mutation.ts
@@ -2,11 +2,8 @@ import { useMutation, useQueryCache } from '@pinia/colada'
 import { cancelSubscription } from '../db'
 
 /**
- * Cancels the caller's subscription. Pass `atPeriodEnd: true` for a soft
- * cancel (plan stays active until the current period ends, user can still
- * call resume); `false` cancels immediately.
- *
- * Invalidates all billing queries and the member profile.
+ * Cancels the member's plan. `atPeriodEnd: true` lets it run to the end of what
+ * they've paid for and can still be called off; `false` ends it on the spot.
  */
 export function useCancelSubscriptionMutation() {
   const queryCache = useQueryCache()

--- a/src/api/billing/mutations/use-change-plan-mutation.ts
+++ b/src/api/billing/mutations/use-change-plan-mutation.ts
@@ -2,12 +2,8 @@ import { useMutation, useQueryCache } from '@pinia/colada'
 import { changePlan } from '../db'
 
 /**
- * Switches the caller's active subscription to a new plan. Prorates
- * immediately (`proration_behavior: 'always_invoice'`) so the diff is
- * charged or credited on the spot — the user sees the cost change reflect
- * in their next invoice rather than at the period boundary.
- *
- * Invalidates all billing queries and the member profile (plan label).
+ * Moves the member onto a different plan. The difference is charged or credited
+ * straight away, not held over to the end of the period.
  */
 export function useChangePlanMutation() {
   const queryCache = useQueryCache()

--- a/src/api/billing/mutations/use-create-setup-intent-mutation.ts
+++ b/src/api/billing/mutations/use-create-setup-intent-mutation.ts
@@ -2,12 +2,8 @@ import { useMutation, useQueryCache } from '@pinia/colada'
 import { createSetupIntent } from '../db'
 
 /**
- * Requests a Stripe Checkout Session (setup mode) and returns its
- * `clientSecret` so the client can mount a Payment Element and confirm it
- * to attach a new card to the customer without an immediate charge.
- * Used by the change-card modal.
- *
- * Invalidates the payment-methods list so the newly attached card appears.
+ * Opens a card-entry form for saving a new card. Nothing is charged — this only
+ * puts a card on file.
  */
 export function useCreateSetupIntentMutation() {
   const queryCache = useQueryCache()

--- a/src/api/billing/mutations/use-create-subscription-mutation.ts
+++ b/src/api/billing/mutations/use-create-subscription-mutation.ts
@@ -2,10 +2,8 @@ import { useMutation } from '@pinia/colada'
 import { createSubscription, type CreateSubscriptionArgs } from '../db'
 
 /**
- * Creates a Stripe Checkout Session (subscription mode) for the caller's
- * selected plan and returns its `clientSecret`. The client mounts a Payment
- * Element against that secret and confirms it to activate the subscription.
- * Used by the initial checkout flow, not plan changes.
+ * Opens the payment form for a first subscription. Confirming it starts the
+ * plan. Moving between plans is a different call.
  */
 export function useCreateSubscriptionMutation() {
   return useMutation({

--- a/src/api/billing/mutations/use-detach-payment-method-mutation.ts
+++ b/src/api/billing/mutations/use-detach-payment-method-mutation.ts
@@ -2,11 +2,8 @@ import { useMutation, useQueryCache } from '@pinia/colada'
 import { detachPaymentMethod } from '../db'
 
 /**
- * Removes a saved payment method from the caller's Stripe customer. Detach
- * is non-destructive for past charges — it only prevents future billing
- * against this card.
- *
- * Invalidates the payment-methods list.
+ * Forgets a saved card. Charges already made against it are untouched — this
+ * only stops future ones.
  */
 export function useDetachPaymentMethodMutation() {
   const queryCache = useQueryCache()

--- a/src/api/billing/mutations/use-resume-subscription-mutation.ts
+++ b/src/api/billing/mutations/use-resume-subscription-mutation.ts
@@ -2,11 +2,8 @@ import { useMutation, useQueryCache } from '@pinia/colada'
 import { resumeSubscription } from '../db'
 
 /**
- * Un-sets `cancel_at_period_end` on a previously soft-cancelled
- * subscription — the plan continues as if the cancel never happened.
- * Only meaningful while the sub is still in its final active period.
- *
- * Invalidates all billing queries and the member profile.
+ * Calls off a cancellation, so the plan carries on as if it never happened.
+ * Only possible while the plan is still running out its final period.
  */
 export function useResumeSubscriptionMutation() {
   const queryCache = useQueryCache()

--- a/src/api/billing/mutations/use-set-default-payment-method-mutation.ts
+++ b/src/api/billing/mutations/use-set-default-payment-method-mutation.ts
@@ -1,13 +1,7 @@
 import { useMutation, useQueryCache } from '@pinia/colada'
 import { setDefaultPaymentMethod } from '../db'
 
-/**
- * Updates the Stripe customer's default payment method. The new default is
- * used for the next recurring invoice charge.
- *
- * Invalidates the payment-methods list (to re-badge) and the subscription
- * query (its `default_payment_method` field reflects the new choice).
- */
+/** Picks which saved card gets charged from the next bill onwards. */
 export function useSetDefaultPaymentMethodMutation() {
   const queryCache = useQueryCache()
   return useMutation({

--- a/src/api/billing/queries/use-invoices-query.ts
+++ b/src/api/billing/queries/use-invoices-query.ts
@@ -1,11 +1,7 @@
 import { useQuery } from '@pinia/colada'
 import { listInvoices } from '../db'
 
-/**
- * Lists recent invoices for the caller's Stripe customer — used in the
- * billing history section. Each row links out to the Stripe-hosted invoice
- * URL (and PDF) for full detail and receipts.
- */
+/** The member's recent bills. Each one links out to its full invoice and receipt. */
 export function useInvoicesQuery(limit = 20) {
   return useQuery({
     key: () => ['billing', 'invoices', limit],

--- a/src/api/billing/queries/use-payment-methods-query.ts
+++ b/src/api/billing/queries/use-payment-methods-query.ts
@@ -1,11 +1,7 @@
 import { useQuery } from '@pinia/colada'
 import { listPaymentMethods } from '../db'
 
-/**
- * Lists all card payment methods attached to the caller's Stripe customer,
- * plus the id of the current default (used to badge the row and hide the
- * "make default" action on it).
- */
+/** The member's saved cards, and which of them is the one that gets charged. */
 export function usePaymentMethodsQuery() {
   return useQuery({
     key: ['billing', 'payment-methods'],

--- a/src/api/billing/queries/use-subscription-query.ts
+++ b/src/api/billing/queries/use-subscription-query.ts
@@ -2,12 +2,8 @@ import { useQuery } from '@pinia/colada'
 import { getSubscription } from '../db'
 
 /**
- * Fetches the caller's current Stripe subscription (plan, status, renewal
- * date, default payment method) along with the upcoming invoice preview.
- * Returns `{ subscription: null, upcoming: null }` for free-plan members
- * with no Stripe record.
- *
- * Invalidated by any `['billing', ...]` mutation.
+ * The member's plan and what they'll be charged next. Both come back `null`
+ * for someone on the free plan, who has never been billed.
  */
 export function useSubscriptionQuery() {
   return useQuery({

--- a/src/api/billing/stripe.d.ts
+++ b/src/api/billing/stripe.d.ts
@@ -1,5 +1,4 @@
-// Minimal Stripe shapes — the frontend only reads the fields the UI needs.
-// Shipping the full `@stripe/stripe` SDK types would add ~1MB of dead weight.
+// Only the fields the screen reads. The full vendor types weigh about 1 MB.
 
 export type StripePrice = {
   id: string

--- a/src/api/cards/db/bulk-insert.ts
+++ b/src/api/cards/db/bulk-insert.ts
@@ -14,12 +14,10 @@ export type BulkInsertCardsParams = {
 }
 
 /**
- * Append a batch of cards to a deck, in the order given.
+ * Adds a batch of cards to the end of a deck, in the order given.
  *
- * The `bulk_insert_cards_in_deck` RPC this replaces existed to hand out ranks;
- * with keys minted up front it's a plain multi-row insert. The cap trigger on
- * `cards` sees the whole batch as one statement, so a batch that would overshoot
- * is rejected as a unit rather than filling up to the cap and stopping.
+ * A batch that would take the deck over its card limit is refused whole — it
+ * never fills up to the limit and stops part-way.
  */
 export async function bulkInsertCardsInDeck({
   deck_id,

--- a/src/api/cards/db/cards-by-ids.ts
+++ b/src/api/cards/db/cards-by-ids.ts
@@ -2,9 +2,8 @@ import { supabase } from '@/supabase-client'
 import logger from '@/utils/logger'
 
 /**
- * Fetches cards by explicit id, ignoring due-ness. Used to rebuild a session's
- * locked queue on refresh-resume without pulling in newly-due cards the way
- * the due-cards RPC would.
+ * Named cards, whether or not they're due. A resumed session rebuilds the pile
+ * it had, not the pile it would get today.
  */
 export async function fetchCardsByIds(card_ids: number[]): Promise<Card[]> {
   if (!card_ids.length) return []

--- a/src/api/cards/db/get-cards-in-deck.ts
+++ b/src/api/cards/db/get-cards-in-deck.ts
@@ -18,11 +18,8 @@ export type CardsPage = {
 /**
  * One page of a deck's cards, plus a peek at the row after it.
  *
- * The peek is what makes the page boundary safe to write against: a card
- * dropped below the last loaded row needs the key of the row *after* it to sit
- * between the two. Without it that card would resolve "no next neighbour" and
- * be sent to the end of the entire deck. It doubles as the has-more signal, so
- * paging no longer has to infer it from a short page.
+ * The peek is what makes the bottom of a page safe to drop a card onto —
+ * without it, a card dropped there is sent to the end of the whole deck.
  */
 export async function fetchCardsInDeck({
   deck_id,

--- a/src/api/cards/db/insert.ts
+++ b/src/api/cards/db/insert.ts
@@ -5,14 +5,10 @@ import { fetchDeckTailRank } from './tail-rank'
 
 export type InsertCardParams = {
   deck_id: number
-  // Position key, from `@/utils/card/rank`. Omit to add the card at the end of
-  // the deck — for callers with no list on screen to resolve neighbours from
-  // (e.g. the term popover, adding to a deck picked from a dropdown).
+  // Where in the deck it goes. Omit when there's no list on screen to place it against.
   rank?: string
   front_text: string
   back_text: string
-  // Optional free-text note that rides along with the card (e.g. the term
-  // popover's contextual explanation). Omitted for most adds.
   note?: string | null
 }
 
@@ -25,12 +21,10 @@ async function lastPositionIn(deck_id: number): Promise<string> {
 }
 
 /**
- * Create a card at an already-decided position, or at the end of the deck.
+ * Creates a card at an already-decided position, or at the end of the deck.
  *
- * A plain insert rather than an RPC: with the rank resolved on the client there
- * is nothing left for the server to compute. `member_id` is filled by the
- * `set_member_id` trigger, and the per-deck cap by the trigger on `cards`, which
- * rejects an over-cap insert with `PT402`.
+ * Owner and the per-deck card limit are both the database's to enforce; going
+ * over the limit comes back as `PT402`.
  */
 export async function insertCard(params: InsertCardParams): Promise<{ id: number; rank: string }> {
   const rank = params.rank ?? (await lastPositionIn(params.deck_id))

--- a/src/api/cards/db/member-card-index.ts
+++ b/src/api/cards/db/member-card-index.ts
@@ -2,8 +2,7 @@ import { supabase } from '@/supabase-client'
 import { useMemberStore } from '@/stores/member'
 import logger from '@/utils/logger'
 
-// One distinct card front + the decks that hold it. The matcher normalizes
-// `term` at build time, so this stays the raw value the RPC returns.
+// `term` stays exactly as stored — the matcher does its own normalising.
 export type CardIndexEntry = {
   term: string
   deck_ids: number[]
@@ -24,9 +23,8 @@ export async function fetchMemberCardIndex(): Promise<CardIndexEntry[]> {
   return entries
 }
 
-// Payload instrumentation: the fetch-all index is only viable while the
-// response stays small. Log term count + serialized size so we can spot when a
-// power user crosses the line and we need server-side per-lesson matching.
+// Fetching every term at once only works while the answer stays small — this is
+// the early warning that someone's collection has outgrown it.
 function trackIndexPayload(entries: CardIndexEntry[]) {
   const bytes = new Blob([JSON.stringify(entries)]).size
   logger.info(`[card-index] ${entries.length} terms, ${(bytes / 1024).toFixed(1)} KiB`)

--- a/src/api/cards/db/move-to-deck.ts
+++ b/src/api/cards/db/move-to-deck.ts
@@ -5,31 +5,25 @@ import { fetchDeckTailRank } from './tail-rank'
 
 export type MoveCardsToDeckArgs =
   | { target_deck_id: number; card_ids: number[] }
-  // `count` is how many cards the whole-deck move covers — the same number the
-  // move modal shows. Only an upper bound is needed (see below), so the
-  // caller's own tally serves; there's nothing to ask the server for.
+  // The caller's own tally is enough — only an upper bound is needed, see below.
   | { target_deck_id: number; source_deck_id: number; except_ids: number[]; count: number }
 
 /**
- * How many keys to mint.
+ * How many positions to mint.
  *
- * An upper bound, not an exact count: the RPC pairs keys with the cards it
- * resolves and ignores any spare, so overshooting costs nothing. Undershooting
- * doesn't work — a card would be left without a key — and that's what the RPC
- * rejects outright.
+ * An upper bound, not an exact count: spares are ignored, but a shortfall would
+ * leave a card with nowhere to go and is rejected outright.
  */
 function countKeysNeeded(args: MoveCardsToDeckArgs): number {
   return 'card_ids' in args ? args.card_ids.length : args.count
 }
 
 /**
- * Move cards into another deck, appended after whatever is already there and
- * keeping their relative order.
+ * Moves cards into another deck, after whatever is already there and keeping
+ * their order.
  *
- * Split of labour: the client mints a run of keys sitting after the target
- * deck's last card, and the RPC decides which cards get them. Resolving that set
- * here instead would mean paging every id out past `max_rows` only to send it
- * straight back.
+ * Here decides *where* they land; the server decides *which* cards move.
+ * Working out that set here would mean paging every id out only to send it back.
  */
 export async function moveCardsToDeck(args: MoveCardsToDeckArgs): Promise<void> {
   const key_count = countKeysNeeded(args)

--- a/src/api/cards/db/move.ts
+++ b/src/api/cards/db/move.ts
@@ -3,13 +3,12 @@ import logger from '@/utils/logger'
 
 export type MoveCardParams = {
   card_id: number
-  // Position key for the card's new slot, from `@/utils/card/rank`.
   rank: string
 }
 
 /**
- * Reposition a card within its deck. Writing the new key *is* the move — no
- * anchor to resolve, no neighbours to shift, no rebalance to trigger.
+ * Moves a card within its deck. Writing its new position *is* the move — no
+ * neighbours shift, and nothing is renumbered.
  */
 export async function moveCard({ card_id, rank }: MoveCardParams): Promise<void> {
   const { error } = await supabase.from('cards').update({ rank }).eq('id', card_id)

--- a/src/api/cards/db/session-bootstrap.ts
+++ b/src/api/cards/db/session-bootstrap.ts
@@ -3,10 +3,8 @@ import logger from '@/utils/logger'
 import { localDayStart } from '@/utils/date'
 
 /**
- * Single-request study-session bootstrap: the resolved decks plus the merged,
- * server-capped study queue for all of them, in the given deck order. Replaces
- * the old fan-out of one get_study_session_cards call per deck — the RPC embeds
- * each card's review row and each deck's resolved pacing/appearance itself.
+ * Everything a study session opens with, in one request: the decks themselves
+ * plus their cards merged into a single pile, already capped for the day.
  */
 export async function fetchSessionBootstrap(deck_ids: number[]): Promise<SessionBootstrap> {
   const { data, error } = await supabase.rpc('get_session_decks_and_cards', {

--- a/src/api/cards/db/tail-rank.ts
+++ b/src/api/cards/db/tail-rank.ts
@@ -2,11 +2,10 @@ import { supabase } from '@/supabase-client'
 import logger from '@/utils/logger'
 
 /**
- * The highest rank in a deck, or `null` when it's empty.
+ * The position of a deck's last card, or `null` when it has none.
  *
- * Any write that appends to a deck the caller doesn't have loaded needs this —
- * the client computes keys from neighbours, and "append" means the neighbour is
- * whatever currently sits last.
+ * Needed to add to the end of a deck the caller hasn't loaded — a new position
+ * is worked out from its neighbours, and here that neighbour is whatever is last.
  */
 export async function fetchDeckTailRank(deck_id: number): Promise<string | null> {
   const { data, error } = await supabase

--- a/src/api/cards/db/update.ts
+++ b/src/api/cards/db/update.ts
@@ -8,11 +8,8 @@ import { buildCardPayload } from '@/utils/card/payload'
 import { type CardBase } from '@type/card'
 
 /**
- * Upserts a card with `values` merged over the current state. Leaves `card`
- * untouched — optimistic apply and rollback are the caller's concern.
- * Caller-side debouncing lives in the `useSaveCardMutation` wrapper, and the
- * no-change short-circuit lives in the composable that calls it (both must
- * happen before any optimistic mutation is applied to `card`).
+ * Saves a card with `values` written over it, leaving `card` itself untouched —
+ * showing the change early, and undoing it, are the caller's job.
  */
 export async function saveCard(card: Card, values: Partial<Card>): Promise<void> {
   if (!card.id) return
@@ -64,19 +61,11 @@ export async function setCardImage(card_id: number, file: File, side: 'front' | 
 
   const bucket = 'member-images'
   const slot = `card_${side}` as const
-  // Content-addressed path: hashing the bytes means the same image reused
-  // across cards (or as a deck bg) collapses to one storage object. member_id
-  // stays the first segment — it scopes dedup per-member and satisfies the
-  // storage RLS foldername check. Which card/side uses the image lives in
-  // `media` (card_id + slot), not in the path.
+  // Named after the bytes, so one picture used on ten cards is stored once. The
+  // owner has to stay the first segment for storage's own access check.
   const path = `${member_id}/${await hashFile(file)}.${file.type.split('/')[1]}`
 
-  // Upload first so we don't soft-delete the previous image (via the DB
-  // trigger on insertMedia) until the new file is actually in storage.
-  // Failure mode: upload fails → nothing changed.
-  //                insertMedia fails → storage file is orphaned, reaped by
-  //                cleanup-media cron.
-  // `cause` tags which step failed so the UI can tell the two apart.
+  // Upload before recording it, so the old picture isn't dropped until the new one lands.
   try {
     await uploadImage(bucket, path, file)
   } catch {

--- a/src/api/cards/mutations/_invalidate.ts
+++ b/src/api/cards/mutations/_invalidate.ts
@@ -2,15 +2,10 @@ import type { useQueryCache } from '@pinia/colada'
 
 type QueryCache = ReturnType<typeof useQueryCache>
 
-// A write flags every affected deck's data as out of date, but only
-// re-downloads the deck on screen. `refetch_inactive: true` re-downloads the
-// off-screen ones too, so a deck you're not looking at (after moving cards out
-// of it) is already right when you open it, rather than showing the old list
-// for a beat first.
 type InvalidateOptions = {
+  // Reload decks you aren't looking at as well, so one you open next is already right.
   refetch_inactive?: boolean
-  // Set false when the write's row is already correct on screen, so only the
-  // deck's counts need re-reading and the card list can be left alone.
+  // False when the row on screen is already correct and only the counts moved.
   card_pages?: boolean
 }
 
@@ -31,18 +26,13 @@ export function invalidateDeck(
   if (card_pages) queryCache.invalidateQueries({ key: ['cards', deck_id] })
 }
 
-// `exact` on the deck list: keys match by prefix, so a bare `['decks']` also
-// catches `['decks', 'count']` — how many decks the member owns, which adding
-// or removing a *card* can never change. Without it every card write re-counts
-// the member's decks for nothing.
+// `exact` keeps this off the deck *count*, which no card write can ever change.
 export function invalidateAllCardCounts(queryCache: QueryCache) {
   queryCache.invalidateQueries({ key: ['cards', 'count'] })
   queryCache.invalidateQueries({ key: ['decks'], exact: true })
 }
 
-// The member-wide card index (front text → decks) drifts whenever a card is
-// created, deleted, has its front edited, or moves decks. Marks the query stale;
-// it only refetches while a lesson is actually mounted.
+// Marks the index stale. It only reloads while a lesson is open to use it.
 export function invalidateCardIndex(queryCache: QueryCache) {
   queryCache.invalidateQueries({ key: ['cards', 'index'] })
 }

--- a/src/api/cards/mutations/insert.ts
+++ b/src/api/cards/mutations/insert.ts
@@ -9,19 +9,14 @@ export function useInsertCardMutation() {
   return useMutation({
     mutation: (params: InsertCardParams) => insertCard(params),
     onSettled: (_data, _error, params) => {
-      // A blank card carries nothing the deck's card pages don't already show:
-      // the editor staged the row and `promoteTemp` fills in the id and rank the
-      // insert returned, and an empty card can't be flagged a duplicate. Only
-      // the deck's own counts moved, so skip re-reading the whole page. An
-      // insert that does carry text (the audio-reader panel, a re-insert after a
-      // failed eager save) has no such row on screen and still refetches.
+      // A blank card is already on screen exactly as the server stores it, so only
+      // the counts moved. An insert carrying text has no such row and still reloads.
       const blank = !params.front_text && !params.back_text
 
       invalidateDeck(queryCache, params.deck_id, { card_pages: !blank })
       invalidateAllCardCounts(queryCache)
 
-      // The index maps front text → decks, so a card inserted without one adds
-      // nothing to it.
+      // The index is keyed by front text, so a card without one adds nothing to it.
       if (params.front_text) invalidateCardIndex(queryCache)
     }
   })

--- a/src/api/cards/mutations/move-to-deck.ts
+++ b/src/api/cards/mutations/move-to-deck.ts
@@ -2,9 +2,7 @@ import { useMutation, useQueryCache } from '@pinia/colada'
 import { moveCardsToDeck, type MoveCardsToDeckArgs } from '../db'
 import { invalidateAllCardCounts, invalidateCardIndex, invalidateDeck } from './_invalidate'
 
-// Mutation vars mirror the RPC's two modes (explicit vs select-all) and add
-// `source_deck_ids` to the explicit variant so the hook can invalidate
-// source decks without the caller doing any cache work.
+// `source_deck_ids` rides along so the caller never has to touch the cache itself.
 export type MoveCardsToDeckVars =
   | { target_deck_id: number; card_ids: number[]; source_deck_ids: number[] }
   | { target_deck_id: number; source_deck_id: number; except_ids: number[]; count: number }
@@ -30,9 +28,7 @@ export function useMoveCardsToDeckMutation() {
   return useMutation({
     mutation: (vars: MoveCardsToDeckVars) => moveCardsToDeck(toDbArgs(vars)),
     onSettled: (_data, _error, vars) => {
-      // refetch_inactive: user may be on neither source nor target deck after
-      // a cross-deck move. Without it, the previously-viewed target deck
-      // would render stale cached pages on re-entry.
+      // A move can leave you looking at neither deck, so reload both off-screen too.
       sourceDeckIds(vars).forEach((id) =>
         invalidateDeck(queryCache, id, { refetch_inactive: true })
       )

--- a/src/api/cards/mutations/move.ts
+++ b/src/api/cards/mutations/move.ts
@@ -12,7 +12,7 @@ export type UseMoveCardMutationParams = MoveCardParams & {
 
 type ReorderContext = { pages: CardsPage[]; pageParams: unknown[] } | undefined
 
-/** Deck order: rank ascending, id breaking ties — the server's ORDER BY. */
+/** The order a deck reads in, matching the server's exactly. */
 function byRank(a: Card, b: Card): number {
   if (a.rank === b.rank) return (a.id ?? 0) - (b.id ?? 0)
   return (a.rank ?? '') < (b.rank ?? '') ? -1 : 1
@@ -30,16 +30,11 @@ function refillPages(pages: CardsPage[], flat: Card[]): CardsPage[] {
 }
 
 /**
- * Apply the card's new key to the deck's cached pages and re-sort, in place of
- * waiting for the refetch. Keeps the rendered order in lockstep with the drop so
- * the row doesn't snap back between drop and the server round-trip.
+ * Settles a dropped card into its new place immediately, so the row doesn't
+ * snap back while the server catches up. Returns the order to undo back to.
  *
- * Re-sorting rather than splicing to the drop index means the cache lands
- * exactly where the server will: the key alone decides the position, and plain
- * string comparison here matches the column's C collation there.
- *
- * Returns the pre-move snapshot for rollback, or `undefined` when the deck
- * isn't cached (nothing to reorder).
+ * Re-sorted rather than spliced to the drop index, so it lands exactly where
+ * the server will put it.
  */
 function reorderCardInDeckCache(
   queryCache: QueryCache,
@@ -64,13 +59,7 @@ function reorderCardInDeckCache(
   return snapshot
 }
 
-/**
- * Reposition a single card within its deck.
- *
- * `onMutate` optimistically re-keys and re-sorts the cached pages synchronously,
- * so the drag-reorder UI can settle the dropped row immediately. `onError`
- * restores the pre-move snapshot; `onSettled` invalidates the deck to reconcile.
- */
+/** Moves a single card to a new place in its deck. */
 export function useMoveCardMutation() {
   const queryCache = useQueryCache()
   return useMutation({

--- a/src/api/cards/mutations/save.ts
+++ b/src/api/cards/mutations/save.ts
@@ -11,10 +11,8 @@ type SaveCardVars = {
 }
 
 /**
- * Optimistically merge `values` into the matching card across ALL of the deck's
- * cached views (default sort, any active filter, any active sort). Uses a key
- * prefix so the patch lands regardless of which sort_by / query is currently
- * active in the cache.
+ * Writes an edit straight into the card wherever it's already been loaded —
+ * every sort and every search the member has looked at, not just the one on screen.
  */
 function patchCardInDeckCache(queryCache: QueryCache, card: Card, values: Partial<Card>) {
   if (card.deck_id === undefined || card.id === undefined) return
@@ -32,14 +30,10 @@ function patchCardInDeckCache(queryCache: QueryCache, card: Card, values: Partia
 }
 
 /**
- * Debounce is keyed by card id so concurrent edits to different cards don't
- * supersede each other. Superseded calls resolve with undefined.
+ * Saves an edited card, one save per card no matter how fast the typing.
  *
- * `onMutate` optimistically patches the cached card synchronously (before the
- * debounce fires) so view mode and the next save's merge base reflect the edit
- * immediately. This is a local cache write, not a refetch — it can't fight the
- * component-owned editor state the way a self-triggered `invalidate` would.
- * Bulk ops (delete, move, deck change) still invalidate explicitly.
+ * The edit lands in the loaded copy straight away rather than being re-fetched,
+ * so it can't fight the editor the member is still typing in.
  */
 export function useSaveCardMutation() {
   const queryCache = useQueryCache()

--- a/src/api/cards/queries/cards-by-ids.ts
+++ b/src/api/cards/queries/cards-by-ids.ts
@@ -3,8 +3,8 @@ import { toValue, type MaybeRefOrGetter } from 'vue'
 import { fetchCardsByIds } from '../db'
 
 /**
- * Fetches cards by explicit id, bypassing the due-cards filter — used to
- * restore a study session's locked queue after a refresh.
+ * Named cards, whether or not they're due — how a study session picks its pile
+ * back up after a reload.
  */
 export function useCardsByIdsQuery(card_ids: MaybeRefOrGetter<number[]>) {
   return useQuery({

--- a/src/api/cards/queries/cards-page.ts
+++ b/src/api/cards/queries/cards-page.ts
@@ -5,9 +5,8 @@ import { fetchCardsInDeck } from '../db'
 export const CARDS_PAGE_SIZE = 50
 
 /**
- * Cache key for the deck's paginated cards query. Includes sort_by and query
- * so Pinia Colada gives separate cache entries per active filter state, and
- * mutations can target the default view by passing the `'default'`/`''` pair.
+ * Names one deck's card list. Sort and search are part of the name, so each
+ * combination is kept separately — pass `'default'` and `''` for the plain list.
  */
 export function cardsInDeckQueryKey(
   deck_id: number | undefined,
@@ -36,8 +35,7 @@ export function useCardsInDeckInfiniteQuery(
         offset: pageParam as number,
         limit: page_size
       }),
-    // Each page peeks one row past its own window, so "is there more?" is a
-    // fact rather than an inference from a short page.
+    // Each page looks one row further than it shows, so "is there more" is known, not guessed.
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.next_rank === null) return null
       return allPages.reduce((sum, page) => sum + page.cards.length, 0)

--- a/src/api/cards/queries/member-card-index.ts
+++ b/src/api/cards/queries/member-card-index.ts
@@ -3,8 +3,7 @@ import { fetchMemberCardIndex } from '../db'
 
 export type { CardIndexEntry } from '../db'
 
-// Member-wide index of every distinct card front + its decks. Fetched once and
-// reused across every lesson in the session; invalidated by card mutations.
+/** Every term the member has a card for, and which decks hold it. */
 export function useMemberCardIndexQuery() {
   return useQuery({
     key: () => ['cards', 'index'],

--- a/src/api/cards/queries/session-bootstrap.ts
+++ b/src/api/cards/queries/session-bootstrap.ts
@@ -3,16 +3,14 @@ import { toValue, type MaybeRefOrGetter } from 'vue'
 import { fetchSessionBootstrap } from '../db'
 
 /**
- * Server-built study-session bootstrap merged across the given decks, in deck
- * order. Returns the resolved decks + the merged study queue in one round-trip;
- * caps + new/review partition stay per deck on the backend.
+ * Everything a study session opens with — the decks, and their cards merged
+ * into one pile — in a single request.
  */
 export function useSessionBootstrapQuery(deck_ids: MaybeRefOrGetter<number[]>) {
   return useQuery({
     key: () => ['cards', 'session-bootstrap', toValue(deck_ids)],
     query: () => fetchSessionBootstrap(toValue(deck_ids)),
-    // Driven manually via refetch() by the session bootstrap (which must await
-    // server truth, never seed from cache) — auto-fetch would double the call.
+    // Asked for by hand: a session must open on the server's answer, never a stored one.
     enabled: () => false
   })
 }

--- a/src/api/decks/mutations/delete.ts
+++ b/src/api/decks/mutations/delete.ts
@@ -7,9 +7,7 @@ export function useDeleteDeckMutation() {
     mutation: (id: number) => deleteDeck(id),
     onSettled: (_data, error, id) => {
       queryCache.invalidateQueries({ key: ['decks'] })
-      // On success the row is gone — drop the cached entry without refetch
-      // (a refetch would 404). On error the row still exists; leave its
-      // cache alone.
+      // Forget it rather than reload it — there's nothing left there to ask for.
       if (!error) queryCache.invalidateQueries({ key: ['deck', id] }, false)
     }
   })

--- a/src/api/decks/mutations/move.ts
+++ b/src/api/decks/mutations/move.ts
@@ -13,15 +13,11 @@ function interpolateRank(before: number | undefined, after: number | undefined):
 }
 
 /**
- * Optimistically move `deck_id` to sit `side` of `anchor_id` within the
- * cached deck list, in place of waiting for the refetch. Returns the pre-move
- * snapshot for rollback, or `undefined` when the list isn't cached.
+ * Settles a dragged deck beside its anchor immediately, so it doesn't snap
+ * back while the server catches up. Returns the order to undo back to.
  *
- * The dashboard displays decks sorted by `rank`, but the cache array itself
- * isn't in rank order (the fetching RPC has no `ORDER BY rank`) — so instead
- * of splicing the raw array, find `anchor_id`'s neighbour in a rank-sorted
- * view and patch only the moved deck's `rank`. The render-order sort then
- * places it correctly on its own.
+ * Only the moved deck's position is rewritten — the loaded list isn't held in
+ * display order, so moving it within that array would place it wrongly.
  */
 function reorderDeckCache(
   queryCache: QueryCache,
@@ -46,14 +42,7 @@ function reorderDeckCache(
   return snapshot
 }
 
-/**
- * Reposition a single deck within the dashboard, relative to an anchor deck.
- *
- * `onMutate` optimistically reorders the cached list synchronously, so the
- * drag-reorder UI can settle the dropped card immediately. `onError` restores
- * the pre-move snapshot; `onSettled` invalidates to reconcile with the
- * server-authoritative ranks.
- */
+/** Moves a single deck on the dashboard, to either side of another one. */
 export function useMoveDeckMutation() {
   const queryCache = useQueryCache()
   return useMutation({

--- a/src/api/decks/queries/count.ts
+++ b/src/api/decks/queries/count.ts
@@ -1,12 +1,8 @@
 import { useQuery } from '@pinia/colada'
 import { fetchMemberDeckCount } from '../db'
 
-// `useCan()` instantiates this query, and `useCan()` is mounted per card face
-// editor — so the default 5s staleTime made every newly rendered card row
-// refetch the member's deck count. The count only moves when a deck is created,
-// deleted or moved, and all three invalidate `['decks']` (a prefix match that
-// catches this key), so explicit invalidation carries the freshness. This is
-// just the backstop for a case that misses.
+// Long, because this is asked once per card row on screen. Creating, deleting or
+// moving a deck already reloads it — this is only the backstop.
 const STALE_TIME = 1000 * 60 * 5
 
 export function useMemberDeckCountQuery() {

--- a/src/api/feedback/db/index.ts
+++ b/src/api/feedback/db/index.ts
@@ -1,9 +1,8 @@
 import { supabase } from '@/supabase-client'
 import logger from '@/utils/logger'
 
-// The community board only ever shows public items — RLS also lets moderators/admins
-// read internal ones (for the future admin dashboard), so this filter is required
-// on top of RLS, not redundant with it.
+// A moderator is allowed to read unpublished posts, so the board has to ask for
+// published ones itself rather than assume it can only see those.
 export async function fetchFeedbackItems(): Promise<FeedbackItem[]> {
   const { data, error } = await supabase
     .rpc('feedback_items_with_votes')

--- a/src/api/feedback/mutations/toggle-vote.ts
+++ b/src/api/feedback/mutations/toggle-vote.ts
@@ -5,9 +5,8 @@ type QueryCache = ReturnType<typeof useQueryCache>
 type VoteSnapshot = FeedbackItem[] | undefined
 
 /**
- * Optimistically flips `voted_by_me` and adjusts `vote_count` for the given
- * item, in place of waiting for the refetch. Returns the pre-toggle
- * snapshot for rollback, or `undefined` when the list isn't cached.
+ * Flips the vote and its tally on the loaded post straight away, so the heart
+ * responds under the finger. Returns the state to undo back to.
  */
 function toggleVoteInCache(queryCache: QueryCache, feedback_id: number): VoteSnapshot {
   const snapshot = queryCache.getQueryData(['feedback-items']) as VoteSnapshot
@@ -29,12 +28,7 @@ function toggleVoteInCache(queryCache: QueryCache, feedback_id: number): VoteSna
   return snapshot
 }
 
-/**
- * Toggle the current member's vote on a feedback item. `onMutate`
- * optimistically flips the cached vote so the heart responds immediately;
- * `onError` restores the pre-toggle snapshot; `onSettled` invalidates to
- * reconcile with the server-authoritative count.
- */
+/** Adds or takes back the member's vote on a post. */
 export function useToggleFeedbackVoteMutation() {
   const queryCache = useQueryCache()
   return useMutation({

--- a/src/api/lessons/db/ai.ts
+++ b/src/api/lessons/db/ai.ts
@@ -20,15 +20,12 @@ export type StartLessonArgs = {
   title: string
   audio_path: string
   script: TranscriptScript
-  // Ordered transcription slices for a long upload. Empty/omitted for a short
-  // file — the server then transcribes audio_path as a single chunk.
+  // Slices of a long upload, in order. Omitted for a short file, which goes whole.
   chunks?: LessonChunk[]
 }
 
-// The edge functions return a JSON body `{ code }` on failure (e.g.
-// 'output_truncated', 'file_too_large'). supabase-js surfaces non-2xx as a
-// FunctionsHttpError carrying the Response on `.context`; this re-throws a typed
-// error so the FE can switch on the code rather than parse a raw message.
+// Carries the server's own name for what went wrong, so the screen can react to
+// it rather than pick a message apart.
 export class EdgeFunctionError extends Error {
   constructor(public code: string) {
     super(code)
@@ -68,17 +65,17 @@ export function translateTerm(args: TranslateTermArgs): Promise<TranslationResul
   return invokeEdge<TranslationResult>('translate-term', args)
 }
 
-// Kick off async transcription: the edge function creates the lesson row in a
-// `processing` state and returns it immediately (202) while a background worker
-// fills the transcript. The FE polls the row for the result.
+/**
+ * Starts transcribing an upload. Comes back with the lesson right away, still
+ * empty — the transcript arrives later, and the screen watches for it.
+ */
 export function startLessonTranscription(args: StartLessonArgs): Promise<Lesson> {
   return invokeEdge<{ lesson: Lesson }>('transcribe-lesson', { action: 'start', ...args }).then(
     (data) => data.lesson
   )
 }
 
-// Re-run transcription for a lesson that previously failed. The audio is still in
-// storage, so this just resets the row to `processing` and restarts the worker.
+/** Transcribes a failed lesson again. The audio is still stored, so nothing is re-uploaded. */
 export function retryLessonTranscription(lesson_id: number): Promise<Lesson> {
   return invokeEdge<{ lesson: Lesson }>('transcribe-lesson', {
     action: 'retry',

--- a/src/api/lessons/db/audio.ts
+++ b/src/api/lessons/db/audio.ts
@@ -4,15 +4,12 @@ import logger from '@/utils/logger'
 
 const BUCKET = 'audio-lessons'
 
-// The bucket is private, so playback uses a short-lived signed URL rather than a
-// public URL (contrast with member-images). One hour is generous for a single
-// listening session; the reader re-mints if it expires.
+// Lesson audio is private, so playing it needs a temporary address. An hour
+// covers a listening session; the reader asks again if it runs out.
 export const SIGNED_URL_TTL_SECONDS = 60 * 60
 
-// Supabase Storage routes through Cloudflare, which rejects single request bodies
-// over 100 MB. Audio playback files for long books can far exceed that, so all
-// uploads use TUS (resumable, chunked) rather than the standard POST endpoint.
-// 6 MiB is the Supabase-recommended TUS chunk size.
+// Uploads go up in pieces — a single request tops out at 100 MB, and an
+// audiobook is far bigger than that.
 const TUS_CHUNK_BYTES = 6 * 1024 * 1024
 
 export async function uploadLessonAudio(path: string, file: File | Blob): Promise<void> {
@@ -56,8 +53,7 @@ export async function uploadLessonAudio(path: string, file: File | Blob): Promis
   })
 }
 
-// Remove several objects at once (best-effort orphan cleanup when a start fails
-// after some chunks already uploaded). A single remove call takes all paths.
+/** Deletes several audio files at once, for cleaning up after a failed upload. */
 export async function deleteLessonAudioPaths(paths: string[]): Promise<void> {
   if (paths.length === 0) return
   const { error } = await supabase.storage.from(BUCKET).remove(paths)

--- a/src/api/lessons/db/collections.ts
+++ b/src/api/lessons/db/collections.ts
@@ -33,8 +33,7 @@ export async function fetchLessonCollection(id: number): Promise<LessonCollectio
 }
 
 export async function createLessonCollection(title: string): Promise<LessonCollection> {
-  // member_id is stamped by the set_member_id trigger, so the client only sends
-  // the title.
+  // Ownership is stamped by the database, never sent from here.
   const { data, error } = await supabase
     .from('lesson_collections')
     .insert({ title })
@@ -49,14 +48,12 @@ export async function createLessonCollection(title: string): Promise<LessonColle
   return data as LessonCollection
 }
 
+/** Bookmarks where the member got to — which chapter, and how far into it. */
 export async function setCollectionProgress(
   collection_id: number,
   lesson_id: number,
   position_seconds = 0
 ): Promise<void> {
-  // Bookmark the chapter the member is on plus the audio offset within it. The
-  // owner-update RLS policy already scopes this to the caller's own collection,
-  // so no RPC is needed.
   const { error } = await supabase
     .from('lesson_collections')
     .update({ last_lesson_id: lesson_id, last_position_seconds: position_seconds })
@@ -68,10 +65,8 @@ export async function setCollectionProgress(
   }
 }
 
+/** Deletes a collection. Its chapters and their audio go with it, on their own. */
 export async function deleteLessonCollection(id: number): Promise<void> {
-  // FK is ON DELETE CASCADE, so removing the collection removes its lessons,
-  // and each lesson-delete trigger soft-deletes its audio media row for the
-  // cleanup cron — no client-side storage delete needed.
   const { error } = await supabase.from('lesson_collections').delete().eq('id', id)
 
   if (error) {

--- a/src/api/lessons/db/lessons.ts
+++ b/src/api/lessons/db/lessons.ts
@@ -28,9 +28,7 @@ export async function fetchLesson(id: number): Promise<Lesson> {
 }
 
 export async function deleteLesson(id: number): Promise<void> {
-  // Plain row delete. The lesson-delete trigger soft-deletes the audio media row,
-  // and the cleanup-media cron reaps the storage object — no client-side
-  // storage delete needed (and none possible for the member-cascade path anyway).
+  // The audio file is cleaned up on its own schedule — nothing to delete here.
   const { error } = await supabase.from('lessons').delete().eq('id', id)
 
   if (error) {

--- a/src/api/lessons/index.ts
+++ b/src/api/lessons/index.ts
@@ -1,7 +1,5 @@
 export * from './queries'
 export * from './mutations'
 
-// Types + the typed error the popover catches — re-exported so components import
-// them from the barrel rather than reaching into db/.
 export { EdgeFunctionError } from './db'
 export type { TranslationResult } from './db'

--- a/src/api/lessons/mutations/create.ts
+++ b/src/api/lessons/mutations/create.ts
@@ -5,35 +5,25 @@ import type { ChunkProgress } from '@/composables/audio-reader/audio-chunker'
 import { uploadLessonAudio, deleteLessonAudioPaths } from '../db/audio'
 import { startLessonTranscription } from '../db/ai'
 
-// Progress surfaced to the upload modal: the chunker's own stages plus the upload
-// stage this mutation owns. `ratio` is 0–1 where a stage can report one.
 export type LessonUploadStage = ChunkProgress['stage'] | 'uploading'
+// `ratio` is 0–1, on the stages that can report one.
 export type LessonUploadProgress = { stage: LessonUploadStage; ratio?: number }
 
 export type StartLessonVars = {
-  // The collection the new lesson is uploaded into.
   collection_id: number
   title: string
   file: File
-  // Which Chinese script to convert the transcript to (Whisper tends to emit
-  // Traditional). 'original' leaves Whisper's output untouched.
+  // Which Chinese script the transcript is converted to. 'original' converts nothing.
   script?: TranscriptScript
-  // Surfaces transcode/slice/upload progress for the modal's progress bar.
   onProgress?: (progress: LessonUploadProgress) => void
 }
 
 /**
- * Preprocess the audio into two encodes — a CBR playback copy (byte-accurate
- * seeking) and a compact 16 kHz mono master sliced into overlapping transcription
- * chunks — upload both, and kick off async transcription. Returns as soon as the
- * `processing` lesson row exists — a background worker transcribes chunk-by-chunk
- * and the collection view polls the row. Slicing client-side is what lets an
- * arbitrary-length file be transcribed.
+ * Turns a recording into a chapter: prepares the audio, uploads it, and sets
+ * transcription going. Returns once the chapter exists, still being transcribed.
  *
- * Playback and transcription use DIFFERENT assets: `audio_path` is the CBR
- * playback copy (a VBR source seeks too coarsely and desyncs the highlight after a
- * skip, and the 16 kHz encode is unlistenable), while every entry in the chunk
- * manifest points at the compact encode Whisper wants.
+ * Two different versions of the audio go up — one to listen to, one to
+ * transcribe. Neither works in the other's place.
  */
 export function useStartLessonMutation() {
   const queryCache = useQueryCache()
@@ -46,14 +36,12 @@ export function useStartLessonMutation() {
       script,
       onProgress
     }: StartLessonVars): Promise<Lesson> => {
-      // Lazy-load the chunker so ffmpeg.wasm (a heavy bundle) only enters the app
-      // on an actual upload, not on every page that touches the lessons API.
+      // Loaded here so the audio toolkit, which is large, downloads only on an upload.
       const { chunkAudio } = await import('@/composables/audio-reader/audio-chunker')
       const { playback, full, ext, chunks } = await chunkAudio(file, onProgress)
 
-      // Transcription sources: the overlapping slices for a long file, or the whole
-      // compact MP3 as a single chunk for a short one. Never the original — it may
-      // be stereo/hi-fi and blow Whisper's 25 MiB per-call cap.
+      // Slices for a long recording, the whole compact copy for a short one — never
+      // the original, which can be too large to transcribe in one go.
       const sources = chunks.length ? chunks : [{ blob: full, offset: 0 }]
 
       const base = `${useMemberStore().id}/${uid()}`
@@ -61,7 +49,6 @@ export function useStartLessonMutation() {
       const uploaded: string[] = []
 
       try {
-        // Playback copy first — the CBR transcode that seeks accurately.
         onProgress?.({ stage: 'uploading', ratio: 0 })
         await uploadLessonAudio(audio_path, playback)
         uploaded.push(audio_path)
@@ -83,15 +70,13 @@ export function useStartLessonMutation() {
           chunks: manifest
         })
       } catch (error) {
-        // Failed before the lesson row (and its media row) exist, so every object
-        // uploaded so far is an orphan the cleanup cron won't reap — remove them.
+        // Nothing yet records these files, so nothing will ever clean them up but this.
         await deleteLessonAudioPaths(uploaded).catch(() => {})
         throw error
       }
     },
     onSettled: (_data, _error, { collection_id }) => {
-      // The lesson list is keyed by collection; the collection's lesson_count
-      // (read from the counts view) also changed.
+      // The collection's chapter list and its chapter count both moved.
       queryCache.invalidateQueries({ key: ['lessons', collection_id] })
       queryCache.invalidateQueries({ key: ['lesson-collections'] })
     }

--- a/src/api/lessons/mutations/delete-collection.ts
+++ b/src/api/lessons/mutations/delete-collection.ts
@@ -8,8 +8,7 @@ export function useDeleteLessonCollectionMutation() {
     mutation: (id: number) => deleteLessonCollection(id),
     onSettled: (_data, error, id) => {
       queryCache.invalidateQueries({ key: ['lesson-collections'] })
-      // On success the collection (and its lessons, via cascade) are gone — drop
-      // the cached detail + lesson-list entries without a refetch that would 404.
+      // Forget them rather than reload them — the collection and its chapters are gone.
       if (!error) {
         queryCache.invalidateQueries({ key: ['lesson-collection', id] }, false)
         queryCache.invalidateQueries({ key: ['lessons', id] }, false)

--- a/src/api/lessons/mutations/delete.ts
+++ b/src/api/lessons/mutations/delete.ts
@@ -3,7 +3,7 @@ import { deleteLesson } from '../db'
 
 export type DeleteLessonVars = {
   id: number
-  // The owning collection, so we invalidate the right lesson list + its count.
+  // Carried so the caller never has to reload the collection itself.
   collection_id: number
 }
 
@@ -14,10 +14,8 @@ export function useDeleteLessonMutation() {
     mutation: ({ id }: DeleteLessonVars) => deleteLesson(id),
     onSettled: (_data, error, { id, collection_id }) => {
       queryCache.invalidateQueries({ key: ['lessons', collection_id] })
-      // The collection's lesson_count (counts view) dropped by one.
       queryCache.invalidateQueries({ key: ['lesson-collections'] })
-      // On success the row is gone — drop the cached entry without a refetch
-      // (which would 404). On error the row still exists; leave its cache alone.
+      // Forget it rather than reload it — there's nothing left there to ask for.
       if (!error) queryCache.invalidateQueries({ key: ['lesson', id] }, false)
     }
   })

--- a/src/api/lessons/mutations/retry.ts
+++ b/src/api/lessons/mutations/retry.ts
@@ -3,16 +3,11 @@ import { retryLessonTranscription } from '../db/ai'
 
 export type RetryLessonVars = {
   id: number
-  // The collection the lesson lives in — carried so onSettled can invalidate its
-  // list without the caller owning invalidation.
+  // Carried so the caller never has to reload the collection itself.
   collection_id: number
 }
 
-/**
- * Re-run transcription for a lesson that failed. The audio is still in storage,
- * so this resets the row to `processing` and restarts the background worker; the
- * collection view's poll picks up the result.
- */
+/** Transcribes a failed chapter again. The audio is still stored, so nothing is re-uploaded. */
 export function useRetryLessonMutation() {
   const queryCache = useQueryCache()
 

--- a/src/api/lessons/mutations/translate-term.ts
+++ b/src/api/lessons/mutations/translate-term.ts
@@ -1,9 +1,7 @@
 import { useMutation } from '@pinia/colada'
 import { translateTerm, type TranslateTermArgs } from '../db'
 
-// A one-shot action, not cached server state — wrapped in useMutation only for
-// the built-in isLoading / error / data refs the popover needs. No onSettled
-// invalidation because there's nothing in the cache to touch.
+// A one-off ask, not stored data — a mutation purely for its loading and error state.
 export function useTranslateTermMutation() {
   return useMutation({
     mutation: (args: TranslateTermArgs) => translateTerm(args)

--- a/src/api/lessons/mutations/update-progress.ts
+++ b/src/api/lessons/mutations/update-progress.ts
@@ -3,18 +3,16 @@ import { setCollectionProgress } from '../db'
 
 export type SetCollectionProgressVars = {
   collection_id: number
-  // The chapter the member is on — becomes the collection's bookmark.
   lesson_id: number
-  // Audio offset (seconds) within that chapter; defaults to the chapter start.
+  // Seconds into that chapter. Defaults to its start.
   position_seconds?: number
 }
 
 /**
- * Persist the member's resume point — which chapter they're on plus the audio
- * offset within it. Fires on reader open (offset 0) and then throttled during
- * playback, so onSettled patches the collection caches in place rather than
- * invalidating: a refetch on every playback tick would be wasteful and could
- * re-trigger the reader's restore.
+ * Saves where the member got to, so they can pick the book back up.
+ *
+ * Runs over and over while they listen, so it writes the new position straight
+ * into what's loaded — re-reading it each time could jerk them back.
  */
 export function useSetCollectionProgressMutation() {
   const queryCache = useQueryCache()

--- a/src/api/lessons/queries/audio-url.ts
+++ b/src/api/lessons/queries/audio-url.ts
@@ -2,18 +2,11 @@ import { useQuery } from '@pinia/colada'
 import { toValue, type MaybeRefOrGetter } from 'vue'
 import { getLessonAudioSignedUrl, SIGNED_URL_TTL_SECONDS } from '../db'
 
-// This URL feeds the `<audio>` src directly, and every re-mint returns a *new*
-// signed token — so any refetch swaps the src, which resets playback to 0 and
-// drops the transcript cursor. Pinia Colada's defaults would do exactly that: it
-// refetches stale queries on window focus and network reconnect, so pocketing the
-// phone (tab hidden) and reopening it would restart the audio. Hold the same URL
-// for the whole session instead — the token is valid an hour, well past a single
-// listen — and leave re-minting to a fresh path or an explicit refresh().
+// A full hour, because asking again hands back a different address, and swapping
+// the address mid-listen restarts the audio from the beginning.
 const STALE_TIME_MS = SIGNED_URL_TTL_SECONDS * 1000
 
-// Signed URLs expire (1h TTL), so this is cached server state keyed by path.
-// The reader re-runs it on a fresh path; refresh() re-mints if a URL goes stale
-// mid-session.
+/** A playable address for a lesson's audio, good for an hour. */
 export function useLessonAudioUrlQuery(path: MaybeRefOrGetter<string | undefined>) {
   return useQuery({
     key: () => ['lesson-audio', toValue(path) ?? ''],

--- a/src/api/lessons/queries/resolve-entry.ts
+++ b/src/api/lessons/queries/resolve-entry.ts
@@ -2,15 +2,11 @@ import { useQueryCache } from '@pinia/colada'
 import { fetchLessonsByCollection } from '../db'
 
 /**
- * Resolve which chapter to open a collection at, book-style:
- *   - the bookmarked lesson if the collection has one (the `on delete set null`
- *     FK guarantees a set `last_lesson_id` still points at a live lesson, so no
- *     fetch is needed here);
- *   - otherwise the first chapter;
- *   - otherwise `null` — the collection is empty and has nothing to read.
+ * Which chapter a collection opens at — the bookmark, or the first chapter, or
+ * `null` when there is nothing in it.
  *
- * The lesson list is read through the same cache key the reader page uses
- * (`['lessons', id]`), so a warm cache skips the refetch.
+ * A bookmark always points at a chapter that still exists, so it needs no
+ * checking.
  */
 export async function resolveCollectionEntryLesson(
   collection: LessonCollection
@@ -22,8 +18,7 @@ export async function resolveCollectionEntryLesson(
     key: ['lessons', collection.id],
     query: () => fetchLessonsByCollection(collection.id)
   })
-  // refresh(), not fetch() — actually honors the "warm cache skips the
-  // refetch" behavior this function's docstring already promised.
+  // `refresh`, never `fetch` — `fetch` re-reads a list already loaded.
   const { data } = await cache.refresh(entry)
 
   return data?.[0]?.id ?? null

--- a/src/api/media/db/index.ts
+++ b/src/api/media/db/index.ts
@@ -25,7 +25,7 @@ export function getImageUrl(bucket: string, path: string): string {
   return supabase.storage.from(bucket).getPublicUrl(path).data.publicUrl
 }
 
-/** Public URL for a card-face image, which lives in the `member-images` bucket. */
+/** A displayable address for a picture on a card. */
 export function cardImageUrl(path: string): string {
   return getImageUrl('member-images', path)
 }
@@ -45,9 +45,8 @@ export async function insertMedia(params: Media): Promise<void> {
 }
 
 /**
- * Soft-delete the active cover-image media row for a deck. Mirrors
- * `deleteCardImage`: the storage object is left for the `cleanup-media` cron to
- * reap. No-op when the deck has no active cover image.
+ * Drops a deck's cover image, doing nothing when it has none. The file itself
+ * is cleaned up later, on its own schedule.
  */
 export async function deleteDeckCoverImage(deck_id: number): Promise<void> {
   const { error } = await supabase

--- a/src/api/members/db/index.ts
+++ b/src/api/members/db/index.ts
@@ -1,12 +1,9 @@
 import { supabase } from '@/supabase-client'
 import logger from '@/utils/logger'
 
-// Explicit column list, not `select('*')` — `members` also holds
-// stripe_customer_id/stripe_subscription_id, which are server-only
-// (webhook + edge functions via the service-role client) and have no
-// business shipping to the browser in the fetch response.
-// `delete_at` has to be here: it's what tells the app the account is pending
-// deletion, and without it the whole divert-to-pending flow silently no-ops.
+// Listed out rather than everything: the row also holds billing identifiers that
+// have no business reaching the browser. `delete_at` must stay — it is the only
+// thing telling the app an account is pending deletion.
 const MEMBER_COLUMNS =
   'id, display_name, description, created_at, email, avatar_url, role, plan, preferences, cover_config, delete_at, plans(deck_limit, cards_per_deck_limit)' as const
 
@@ -18,26 +15,20 @@ export async function fetchMemberById(id: string): Promise<Member | null> {
     .single()
 
   if (error) {
-    // PGRST116 = `.single()` found zero rows — RLS is filtering this id out,
-    // not a fetch failure. That's an expected "not visible" outcome, so it
-    // resolves to null rather than surfacing as an error.
+    // No rows means this account isn't visible to the caller, not that the read failed.
     if (error.code === 'PGRST116') return null
 
     logger.error(error.message)
     throw error
   }
 
-  // supabase-js can't infer the `plans` embed as a single object without
-  // generated Database types (it defaults nested relations to arrays) — it
-  // is one at runtime, since `plan` is a FK on this table.
+  // The plan comes back as one object; the client library can only guess a list.
   return data as unknown as Member
 }
 
 /**
- * Patches an existing member row. Every member row is auto-created by the
- * signup trigger, so this is always an update, never a real insert — a
- * `.upsert()` here would fail on any payload that omits a NOT NULL column
- * (Postgres validates the INSERT tuple before it resolves the conflict).
+ * Changes part of an existing member. Signup always creates the row, so this
+ * never has to make one — and can't, since a partial payload wouldn't be valid.
  */
 export async function upsertMember({ id, ...updates }: Member): Promise<void> {
   const { error } = await supabase.from('members').update(updates).eq('id', id)

--- a/src/api/members/queries/prefetch.ts
+++ b/src/api/members/queries/prefetch.ts
@@ -7,8 +7,7 @@ export function prefetchMemberById(id: string) {
     key: ['member', id],
     query: () => fetchMemberById(id)
   })
-  // refresh(), not fetch() — fetch() unconditionally aborts and restarts any
-  // in-flight request, which doubles this exact fetch when the member store's
-  // own reactive query (mounted at the app root) already started it.
+  // `refresh`, never `fetch` — `fetch` restarts a request already in flight, and
+  // the member store starts this exact one at app start.
   return cache.refresh(entry)
 }

--- a/src/api/review-pacing/db/index.ts
+++ b/src/api/review-pacing/db/index.ts
@@ -1,7 +1,7 @@
 import { supabase } from '@/supabase-client'
 import logger from '@/utils/logger'
 
-/** Every pacing field a preset carries, minus its identity — the shape a deck resolves down to. */
+/** Every dial a preset sets, without the preset itself — what a deck ends up with. */
 export type ReviewPacingValues = Pick<
   ReviewPacingPreset,
   | 'desired_retention'
@@ -15,7 +15,7 @@ export type ReviewPacingValues = Pick<
 
 export type NewReviewPacingPreset = ReviewPacingValues & Pick<ReviewPacingPreset, 'name'>
 
-/** Fetches the current member's preset library plus the one system preset — RLS scopes the rest. */
+/** The member's own presets, plus the built-in one everybody gets. */
 export async function fetchPresets(): Promise<ReviewPacingPreset[]> {
   const { data, error } = await supabase
     .from('review_pacing_presets')
@@ -65,7 +65,7 @@ export async function updatePreset({
   return data as ReviewPacingPreset
 }
 
-/** A deck's pacing sidecar row — which preset it follows, and what it pins locally. */
+/** Which preset a deck follows, and which dials it pins for itself. */
 export type DeckPacing = {
   deck_id: number
   review_pacing_preset_id: number | null
@@ -73,9 +73,8 @@ export type DeckPacing = {
 }
 
 /**
- * Writes just a deck's pacing sidecar. Narrower than `save_deck`, which rewrites
- * every editable deck column; this lets a preset action persist the deck half of
- * its own work without flushing the rest of an open draft.
+ * Saves a deck's pacing and nothing else, so a preset action can't flush the
+ * rest of an open, unsaved deck edit along with it.
  */
 export async function saveDeckPacing(pacing: DeckPacing): Promise<void> {
   const { error } = await supabase

--- a/src/api/review-pacing/index.ts
+++ b/src/api/review-pacing/index.ts
@@ -1,5 +1,4 @@
 export * from './queries'
 export * from './mutations'
 
-// Payload shapes only — `db/` itself stays internal to the domain.
 export type { NewReviewPacingPreset, ReviewPacingValues } from './db'

--- a/src/api/review-pacing/mutations/delete.ts
+++ b/src/api/review-pacing/mutations/delete.ts
@@ -6,8 +6,7 @@ export function useDeletePresetMutation() {
   return useMutation({
     mutation: (id: number) => deletePreset(id),
     onSettled: () => {
-      // Deleting a preset also reverts any deck that had it assigned (FK is
-      // ON DELETE SET NULL) — decks need a refetch too, not just the list.
+      // Every deck that was following the preset falls back to its own settings.
       queryCache.invalidateQueries({ key: ['review-pacing-presets'] })
       queryCache.invalidateQueries({ key: ['decks'] })
     }

--- a/src/api/review-pacing/mutations/save-deck-pacing.ts
+++ b/src/api/review-pacing/mutations/save-deck-pacing.ts
@@ -1,20 +1,19 @@
 import { useMutation, useQueryCache } from '@pinia/colada'
 import { saveDeckPacing, type DeckPacing } from '../db'
 
-/**
- * Persists one deck's pacing sidecar on its own. Preset actions write to the
- * server immediately, so the deck half of that work (a cleared override bag, a
- * re-pointed preset link) has to land immediately too — waiting for the modal's
- * Save would leave the two halves disagreeing until then.
- */
 // Trap: a pin is presence, not difference →[K:pin-is-presence-not-difference]
+/**
+ * Saves which preset a deck follows and what it pins, on its own.
+ *
+ * Preset actions save the moment they're taken, so the deck's half has to land
+ * with them — held back until Save, the two would disagree in between.
+ */
 export function useSaveDeckPacingMutation() {
   const queryCache = useQueryCache()
   return useMutation({
     mutation: (pacing: DeckPacing) => saveDeckPacing(pacing),
     onSettled: () => {
-      // The deck's pacing values are resolved server-side, so a changed link or
-      // override bag restates every one of them.
+      // A changed preset link restates every one of the deck's pacing values.
       queryCache.invalidateQueries({ key: ['decks'] })
     }
   })

--- a/src/api/review-pacing/mutations/upsert.ts
+++ b/src/api/review-pacing/mutations/upsert.ts
@@ -9,8 +9,7 @@ export function useUpsertPresetMutation() {
     mutation: ({ id, ...preset }: UpsertPresetVars) =>
       id ? updatePreset({ id, ...preset }) : createPreset(preset),
     onSettled: () => {
-      // Editing a preset re-paces every deck following it, so the decks' BE-resolved
-      // pacing values are stale too — not just the preset list.
+      // Editing a preset re-paces every deck following it, not just the preset list.
       queryCache.invalidateQueries({ key: ['review-pacing-presets'] })
       queryCache.invalidateQueries({ key: ['decks'] })
     }

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -17,9 +17,10 @@ export type LoginOutcome =
 
 export type OAuthProvider = 'google'
 
-// In dev, requests can come from a LAN hostname (e.g. testing on a phone) rather
-// than localhost — Supabase must redirect back to that same hostname, not the
-// prod URL baked into the env var.
+/**
+ * Where an auth email or consent screen sends the browser back to — the machine
+ * you're testing from in dev, the production URL everywhere else.
+ */
 function buildRedirectUrl(path: string, prodUrl: string): string {
   if (
     import.meta.env.DEV &&
@@ -39,13 +40,13 @@ const RESET_PASSWORD_REDIRECT_URL = buildRedirectUrl(
 
 const GET_SESSION_TIMEOUT_MS = 2000
 
-// getSession() triggers a background refresh_token request when the cached
-// session is expired. supabase-js wraps any network failure on that request
-// (e.g. connection refused) as retryable and retries with backoff for up to
-// 30s before surfacing an error — there's no way to special-case it sooner
-// from out here. Race it against a short timeout so a dead connection still
-// bails out fast instead of stalling anything awaiting it (e.g. the root
-// route's auth guard) for the full retry window.
+/**
+ * The session this browser is holding, or `null`.
+ *
+ * Raced against a 2s timeout: a dead connection makes the silent token renewal
+ * retry for far longer than anything waiting on identity can sit still for.
+ * →[K:session-restore-retry-storm]
+ */
 export async function getSession(): Promise<Session | null> {
   const { data, error } = await Promise.race([
     supabase.auth.getSession(),
@@ -61,9 +62,10 @@ export async function getSession(): Promise<Session | null> {
   return data?.session
 }
 
-// Unlike getSession(), this revalidates against the server rather than reading
-// the cached session — needed after linking/unlinking an identity, since that
-// doesn't rewrite the cached session's `identities` array.
+/**
+ * The account as the server currently sees it. Ask after linking or unlinking a
+ * sign-in method — the stored session keeps the old list.
+ */
 export async function getUser(): Promise<User | null> {
   const { data, error } = await supabase.auth.getUser()
 
@@ -74,10 +76,10 @@ export async function getUser(): Promise<User | null> {
   return data?.user
 }
 
-// Supabase's recovery link lands the browser back on the site with tokens in
-// the URL hash (implicit flow); the client auto-exchanges them and fires this
-// event once. Checking the URL first means a normal visit never pays for the
-// listener/await this needs.
+/**
+ * Whether this page load arrived from a password-reset link. Checked before
+ * anything else so an ordinary visit never pays for the wait that follows.
+ */
 export function isPasswordRecoveryUrl(): boolean {
   return (
     window.location.hash.includes('type=recovery') ||
@@ -87,10 +89,12 @@ export function isPasswordRecoveryUrl(): boolean {
 
 const PASSWORD_RECOVERY_TIMEOUT_MS = 8000
 
-// An expired or already-used recovery link still carries `type=recovery` but
-// Supabase never fires the event for it, so this can't just await forever —
-// it resolves false after a timeout and lets the caller fall back to a normal
-// page load instead of hanging with a dangling subscription.
+/**
+ * Whether the reset link's tokens were accepted, giving up after 8s.
+ *
+ * An expired or already-used link looks identical in the address bar and simply
+ * never arrives, so waiting on it forever would hang the page load.
+ */
 export function waitForPasswordRecovery(): Promise<boolean> {
   return new Promise((resolve) => {
     const { data: sub } = supabase.auth.onAuthStateChange((event) => {
@@ -111,9 +115,11 @@ export function waitForPasswordRecovery(): Promise<boolean> {
   })
 }
 
-// Fires when Supabase's client gives up on the session locally — a manual
-// sign-out, or its own background token refresh failing because the session
-// was revoked/expired elsewhere. Returns an unsubscribe function.
+/**
+ * Calls back when the auth library drops the session by itself — a sign-out
+ * here, or a renewal refused because the session was ended on another device.
+ * Returns an unsubscribe.
+ */
 export function onSignedOut(callback: () => void): () => void {
   const { data: sub } = supabase.auth.onAuthStateChange((event) => {
     if (event !== 'SIGNED_OUT') return
@@ -123,9 +129,10 @@ export function onSignedOut(callback: () => void): () => void {
   return () => sub.subscription.unsubscribe()
 }
 
-// A revoked/expired session doesn't always trigger onSignedOut before the
-// next API call — the request itself can come back 401/JWT-expired first.
-// This lets callers recognize that case and treat it the same way.
+/**
+ * Whether a request failed because the session is no longer good. An ended
+ * session usually surfaces here before `onSignedOut` gets to fire.
+ */
 export function isAuthError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false
 
@@ -139,8 +146,7 @@ export async function login(email: string, password: string): Promise<LoginOutco
 
     if (!error) return 'success'
 
-    // Supabase folds "no such user" into invalid_credentials to prevent account
-    // enumeration, so this single code covers both wrong-password and no-account.
+    // One code covers a wrong password and no such account — the server won't say which.
     if (error.code === 'invalid_credentials') return 'invalid-credentials'
     if (error.code === 'email_not_confirmed') return 'email-not-confirmed'
     if (error.status === 429) return 'rate-limited'
@@ -161,19 +167,10 @@ export async function logout(): Promise<void> {
   }
 }
 
+// Trap: an ended session's token keeps working until it is cleared →[K:deleted-account-token-outlives-deletion]
 /**
- * Drops the locally persisted session for the case where the server has already
- * revoked it (account deletion). Scoped to `local` because there is nothing left
- * to revoke globally.
- *
- * Not optional cleanup — leaving the token in storage is what makes a deleted
- * account look signed in. The JWT stays signature-valid for its full lifetime
- * (`jwt_expiry`, 1h), `getSession()` hands it back without ever asking the
- * server, and PostgREST accepts it, so every table read and RPC keeps working.
- * Only a call that resolves the JWT through GoTrue notices the session is gone.
- *
- * Logged and swallowed: this is teardown, there is nothing to retry, and
- * supabase-js clears its stored session even when the server rejects the call.
+ * Drops this browser's copy of the session, for when the server has already
+ * ended it. Logged and swallowed — teardown with nothing left to retry.
  */
 export async function signOutLocal(): Promise<void> {
   const { error } = await supabase.auth.signOut({ scope: 'local' })
@@ -184,12 +181,10 @@ export async function signOutLocal(): Promise<void> {
 }
 
 /**
- * Revokes every session for this account except the one making the call — the
- * caller stays signed in where they are.
+ * Ends every session for this account except this one.
  *
  * Logged and swallowed: it runs after a password change has already succeeded,
- * so failing it must not turn a completed change into a reported failure. The
- * new password is live either way.
+ * so a failure here must not report the completed change as failed.
  */
 export async function signOutOthers(): Promise<void> {
   const { error } = await supabase.auth.signOut({ scope: 'others' })
@@ -200,14 +195,11 @@ export async function signOutOthers(): Promise<void> {
 }
 
 /**
- * Requests account deletion: marks the account pending, cancels any
- * subscription with a prorated refund, and revokes every session.
+ * Requests account deletion — marks the account pending, refunds any
+ * subscription pro rata, ends every session — and resolves with the deadline.
  *
- * Resolves with the deletion deadline. Idempotent — calling it again returns the
- * original deadline rather than extending the grace window.
- *
- * The caller's session is dead once this resolves, so any teardown afterwards
- * must not depend on an authenticated request succeeding.
+ * Asking twice returns the original deadline rather than extending the grace
+ * window. Nothing afterwards can depend on an authenticated request succeeding.
  */
 export async function requestAccountDeletion(): Promise<string> {
   const { data, error } = await supabase.functions.invoke<{ deleteAt: string }>(
@@ -224,12 +216,11 @@ export async function requestAccountDeletion(): Promise<string> {
 }
 
 /**
- * Cancels a pending deletion within the grace window and restores access to the
- * member's data. Their previously-public decks become public again.
+ * Calls off a pending deletion, giving the member their data back and making
+ * their previously-public decks public again.
  *
- * Does NOT resurrect the cancelled subscription — re-subscribing is manual.
- * Throws if the account isn't pending, or if the deadline has already passed
- * (the purge job may be mid-sweep at that point).
+ * The cancelled subscription does not come back — re-subscribing is manual.
+ * Throws once the deadline has passed, when the purge may already be running.
  */
 export async function restoreAccount(): Promise<void> {
   const { error } = await supabase.rpc('restore_account')
@@ -266,10 +257,10 @@ export async function signupEmail(
 }
 
 /**
- * Whether `name` is free as a display name (case-insensitive), via the
- * `is_display_name_available` RPC. Fails open — a check failure returns `true`
- * so a flaky network never blocks signup; the unique constraint is the real
- * backstop.
+ * Whether a display name is still free, ignoring case.
+ *
+ * Fails open, so a flaky connection never blocks signup — the database's own
+ * uniqueness rule is what actually holds the line.
  */
 export async function isDisplayNameAvailable(name: string): Promise<boolean> {
   const { data, error } = await supabase.rpc('is_display_name_available', {
@@ -293,36 +284,34 @@ type StartOAuth = (options: {
   skipBrowserRedirect?: boolean
 }) => Promise<{ data: { url: string | null } | null; error: unknown }>
 
-// Google's consent screen sends Cross-Origin-Opener-Policy, which forces a
-// permanent browsing-context-group switch on the popup — window.opener is
-// severed for good, and window.name (tied to that same context) doesn't
-// survive the swap either, even once the popup navigates back to our own
-// origin. localStorage isn't scoped to the browsing-context group the way
-// those are, so a flag written right before window.open() is still readable
-// once the popup lands back on our site.
+// Trap: the consent screen severs the popup's link to the window that opened it →[K:oauth-popup-loses-its-opener]
 const OAUTH_POPUP_FLAG = 'oauth-popup-pending'
 
-// Cleared unconditionally up front so a flag left behind by an abandoned
-// popup (closed before completing auth) can't misfire on a later full-page
-// redirect flow.
 function clearOAuthPopupFlag(): void {
   window.localStorage.removeItem(OAUTH_POPUP_FLAG)
 }
 
-/** Callback view checks this to decide whether to close itself or navigate to the dashboard. */
+/**
+ * Whether this page load is the return leg of a sign-in popup. Reading it
+ * clears it.
+ */
 export function consumeOAuthPopupFlag(): boolean {
   const pending = window.localStorage.getItem(OAUTH_POPUP_FLAG) === '1'
   clearOAuthPopupFlag()
   return pending
 }
 
-// Sign-in resolves on the store's own 'SIGNED_IN' auth event; linking a new
-// identity to an already-signed-in user doesn't fire that event, so it resolves
-// once the popup/redirect tab closes instead.
+/**
+ * Runs a Google flow in a popup, or as a full-page redirect on a phone.
+ *
+ * Signing in finishes on the sign-in event. Adding a new sign-in method to an
+ * account fires no such event, so that variant waits for the popup to close.
+ */
 async function runOAuthFlow(
   start: StartOAuth,
   waitFor: 'signed-in' | 'popup-closed'
 ): Promise<void> {
+  // An abandoned popup leaves the flag behind, where it would misfire on the next attempt.
   clearOAuthPopupFlag()
 
   if (prefersFullRedirect()) {
@@ -390,11 +379,13 @@ async function runOAuthFlow(
 
 export type OAuthOutcome = 'success' | 'error'
 
-// The OAuth callback URL and popup transport are owned entirely by
-// runOAuthFlow — deliberately not caller-configurable. Letting a caller pass
-// `redirectTo` here once let a UI "land on /dashboard" intent override the
-// registered `/auth/callback` URL, which both broke popup self-close and is the
-// classic open-redirect footgun. `provider` is the only knob.
+/**
+ * Signs in with Google.
+ *
+ * `provider` is the only knob on purpose: a caller-supplied return address both
+ * breaks the popup's self-close and is the classic open-redirect footgun.
+ * →[K:oauth-popup-loses-its-opener]
+ */
 export async function signInOAuth(provider: OAuthProvider): Promise<OAuthOutcome> {
   try {
     await runOAuthFlow(
@@ -408,17 +399,14 @@ export async function signInOAuth(provider: OAuthProvider): Promise<OAuthOutcome
   }
 }
 
-/** Links a Google identity to the currently signed-in user. Requires `enable_manual_linking`. */
+/** Adds Google as a second way to sign in to the account already signed in here. */
 export async function linkGoogleIdentity(): Promise<void> {
   await runOAuthFlow(
     (opts) => supabase.auth.linkIdentity({ provider: 'google', options: opts }),
     'popup-closed'
   )
 
-  // The popup closing only means the linking tab is done — it doesn't guarantee
-  // this tab's client has picked up the new identity (no 'SIGNED_IN'-style event
-  // fires for linking). Force a resync so the caller sees it immediately instead
-  // of only after a page reload.
+  // The popup closing says the other tab finished, not that this one knows about it yet.
   const { error } = await supabase.auth.refreshSession()
   if (error) throw error
 }
@@ -454,15 +442,9 @@ export async function updateEmail(email: string): Promise<UpdateEmailOutcome> {
 /**
  * Whether this account can sign in with a password.
  *
- * Not derivable client-side. `user.identities` looks like the answer and isn't:
- * GoTrue creates the `email` identity at email signup and never when a password
- * is set, so a Google-origin account that sets one shows no email identity for
- * good. `app_metadata.providers` mirrors identities, same hole.
- *
- * Falls back to `false`, which routes the member to the emailed-code proof.
- * That's the safe direction — still a real re-proof of identity, just not the
- * one they'd expect — where `true` would offer a current-password field to
- * someone who has no password to type.
+ * Falls back to `false`, which routes the member to the emailed code — still a
+ * real proof, where `true` would offer a password field to someone who has
+ * none. →[K:password-identity-not-client-derivable]
  */
 export async function fetchHasPassword(): Promise<boolean> {
   try {
@@ -483,17 +465,11 @@ export async function fetchHasPassword(): Promise<boolean> {
 export type VerifyPasswordOutcome = 'success' | 'invalid-credentials' | 'error'
 
 /**
- * Re-proves identity for a member who signs in with a password, by signing in
- * again as them. Used as the gate in front of a password change.
+ * Re-proves identity for a member who has a password, by signing them in again.
  *
- * The email is read from the live session rather than taken as an argument —
- * that's the same-account guard. A caller can't hand in a different address and
- * have a successful sign-in to *someone else's* account read as proof, which
- * would also silently swap this tab onto that account.
- *
- * Succeeding replaces the current session with a fresh one for the same user.
- * Nothing in the app reacts to `SIGNED_IN`, so this is invisible to the rest of
- * the store.
+ * The address comes off the live session rather than an argument — that is the
+ * same-account guard, so a successful sign-in to someone *else's* account can
+ * never be handed back as proof.
  */
 export async function verifyPassword(password: string): Promise<VerifyPasswordOutcome> {
   try {
@@ -521,26 +497,14 @@ export async function verifyPassword(password: string): Promise<VerifyPasswordOu
 export type RequestReauthCodeOutcome = 'success' | 'rate-limited' | 'error'
 
 /**
- * Emails a one-time sign-in code to the signed-in account. Paired with
- * `verifyReauthCode` this is the re-proof of identity for members with no
- * password to re-enter (Google-only).
+ * Emails a one-time sign-in code — the identity re-proof for a member with no
+ * password to re-enter.
  *
- * Same-account by construction twice over: the email comes off the live session,
- * and `shouldCreateUser: false` means a stray address can't quietly mint a new
- * account instead.
- *
- * Deliberately not the OAuth popup: on phones the OAuth transport falls back to
- * a full-page redirect, which would abandon the half-filled password form. A
- * mailed code behaves identically on every device.
- *
- * Also deliberately not `reauthenticate()` + `updateUser({ nonce })`, which
- * reads like the purpose-built API but does not gate anything here. GoTrue only
- * validates that nonce when `secure_password_change` is on AND the session is
- * over 24h old; otherwise it ignores the value entirely (VERIFIED against local
- * GoTrue: a deliberately wrong nonce still changed the password). A hijacked
- * tab is by definition recent, so that path would never challenge the one
- * attacker it exists to stop. `verifyOtp` is a real sign-in and always
- * validates.
+ * Same-account twice over: the address comes off the live session, and a stray
+ * one can't quietly mint a new account instead. Deliberately not the sign-in
+ * popup, which becomes a full-page redirect on a phone and would abandon the
+ * half-filled form, and deliberately not the library's own reauthenticate call,
+ * which gates nothing here. →[K:reauth-nonce-does-not-gate]
  */
 export async function requestReauthCode(): Promise<RequestReauthCodeOutcome> {
   try {
@@ -571,11 +535,11 @@ export async function requestReauthCode(): Promise<RequestReauthCodeOutcome> {
 export type VerifyReauthCodeOutcome = 'success' | 'invalid-code' | 'error'
 
 /**
- * Consumes the emailed code, which signs the member in again — that fresh
- * sign-in *is* the proof of identity.
+ * Spends the emailed code, signing the member in again — that fresh sign-in
+ * *is* the proof.
  *
- * GoTrue answers a wrong code and an expired one with the same `otp_expired`,
- * deliberately, so both collapse into one outcome here.
+ * A wrong code and an expired one come back identical, deliberately, so both
+ * collapse into one outcome here.
  */
 export async function verifyReauthCode(code: string): Promise<VerifyReauthCodeOutcome> {
   try {
@@ -603,15 +567,10 @@ export async function verifyReauthCode(code: string): Promise<VerifyReauthCodeOu
 export type UpdatePasswordOutcome = 'success' | 'weak-password' | 'same-password' | 'error'
 
 /**
- * Sets a new password, then revokes every other session for the account.
+ * Sets a new password, then ends every other session for the account.
  *
- * The sign-out lives here rather than at the call sites so both flows that end
- * in a new password — the account-access change and the emailed reset — close
- * off anyone who already had access.
- *
- * Re-proving identity is the caller's job, ahead of this call (`verifyPassword`
- * or `verifyReauthCode`). It can't be enforced here: both proofs work by signing
- * in again, which leaves nothing on the session for this function to inspect.
+ * The sign-out lives here so both flows that end in a new password close off
+ * anyone who already had access. Re-proving identity is the caller's job.
  */
 export async function updatePassword(password: string): Promise<UpdatePasswordOutcome> {
   try {
@@ -635,9 +594,10 @@ export async function updatePassword(password: string): Promise<UpdatePasswordOu
 
 export type RequestPasswordResetOutcome = 'success' | 'error'
 
-// Supabase doesn't error for an unknown email (prevents account enumeration),
-// so unlike login/signup there's no keyed outcome map — only real backend
-// failures (rate limit, network) fall through to 'error'.
+/**
+ * Emails a reset link. An unknown address succeeds like any other — the server
+ * won't reveal whether an account exists, so only real failures reach 'error'.
+ */
 export async function requestPasswordReset(email: string): Promise<RequestPasswordResetOutcome> {
   try {
     const { error } = await supabase.auth.resetPasswordForEmail(email, {

--- a/src/stores/member.ts
+++ b/src/stores/member.ts
@@ -12,16 +12,11 @@ export const useMemberStore = defineStore('member', () => {
   const error = query.error
   const status = query.status
 
-  // `id` is sourced from the session (set synchronously once auth restores),
-  // not the member-profile query. Downstream api calls that scope queries by
-  // member_id read this field synchronously, so racing against a pending
-  // profile fetch would stringify `undefined` into the query and fail.
+  // From the session, which lands in one step — a profile still loading reads as nobody.
   const id = computed(() => session.user?.id)
   const display_name = computed(() => member.value?.display_name)
   const description = computed(() => member.value?.description)
-  // Sourced from the session, not the member-profile query — the `members`
-  // row's email is only set once at signup and goes stale after an email
-  // change, while the session always reflects the current auth email.
+  // From the session: the profile's copy is written once at signup and never updated.
   const email = computed(() => session.user?.email)
   const created_at = computed(() => member.value?.created_at)
   const avatar_url = computed(() => member.value?.avatar_url)
@@ -34,18 +29,14 @@ export const useMemberStore = defineStore('member', () => {
 
   const has_member = computed(() => Boolean(id.value))
 
-  // The account was deleted server-side while the JWT is still valid: auth
-  // says we're logged in, but the profile fetch succeeded with zero rows
-  // (`fetchMemberById` resolves PGRST116 to null rather than throwing, so
-  // `error` stays empty). Only trustworthy once the query has settled —
-  // `data` is null while pending too.
+  // Signed in, but the account behind it is gone. Only meaningful once the
+  // profile has finished loading — it reads as absent while still in flight.
+  // →[K:deleted-account-token-outlives-deletion]
   const profile_missing = computed(
     () => session.authenticated && status.value === 'success' && member.value == null
   )
 
-  // Deletion requested but not yet carried out. Distinct from profile_missing
-  // above, which is the *post*-purge case (the row is gone) — these are two
-  // different states and the pending one is recoverable.
+  // Deletion asked for but not yet carried out — still recoverable, unlike `profile_missing`.
   const pending_deletion = computed(() => Boolean(member.value?.delete_at))
   const delete_at = computed(() => member.value?.delete_at ?? null)
 

--- a/src/stores/notice-store.ts
+++ b/src/stores/notice-store.ts
@@ -9,8 +9,7 @@ export type NoticeVariant = 'toast' | 'panel'
 export type NoticeAction = {
   label: string
   onClick: () => void
-  // Also dismiss the notice (through the same path as the close button /
-  // auto-dismiss timer) after running onClick.
+  // Dismiss the notice once onClick has run.
   closesOnClick?: boolean
   sfx?: { press?: SoundKey }
 }
@@ -22,8 +21,7 @@ type NoticeOptions = {
   variant?: NoticeVariant
   actions?: NoticeAction[]
   onDismiss?: () => void
-  // Panel-only: dims the page behind the panel. Ignored by the toast variant.
-  // Defaults to true.
+  // Dims the page behind a panel; a toast ignores it. Defaults to true.
   backdrop?: boolean
   // Show the close (x) button. Defaults to true.
   closable?: boolean

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -66,11 +66,7 @@ export const useSessionStore = defineStore('sessionStore', () => {
   const loading_count = ref(0)
   let logging_out_intentionally = false
 
-  // Shared in-flight promise for the one identity resolution. The router
-  // checkpoint fires this on the first navigation and every later navigation
-  // awaits the same answer, so a cold load never pays for two round-trips or
-  // races two restores. Cleared on any auth transition (fresh sign-in, logout)
-  // so the next navigation re-resolves against the new session.
+  // Every navigation awaits this one answer, so a cold load never resolves identity twice.
   let resolved: Promise<boolean> | undefined
 
   const authenticated = computed(() => Boolean(user.value?.aud === 'authenticated'))
@@ -79,19 +75,15 @@ export const useSessionStore = defineStore('sessionStore', () => {
   const hasPasswordIdentity = computed(() => identities.value.some((i) => i.provider === 'email'))
   const hasGoogleIdentity = computed(() => identities.value.some((i) => i.provider === 'google'))
 
-  // Supabase's client can locally sign itself out (e.g. a background token
-  // refresh rejected because the session was revoked on another device)
-  // without any component ever calling logout(). This is the "stale tab"
-  // case: catch it here rather than only reacting to failed API calls.
+  // The stale tab: a session ended on another device, with nothing here having asked to log out.
   onSignedOut(() => {
     if (logging_out_intentionally) return
     forceLogout()
   })
 
   /**
-   * True if this page load is a password-recovery redirect, after awaiting the
-   * session exchange. False both for a normal load and for an expired/reused
-   * recovery link (the exchange times out rather than firing the event).
+   * Whether this page load came from a working password-reset link. An expired
+   * or already-used one reads as false, same as an ordinary visit.
    */
   async function checkPasswordRecovery(): Promise<boolean> {
     if (!isPasswordRecoveryUrl()) return false
@@ -118,17 +110,12 @@ export const useSessionStore = defineStore('sessionStore', () => {
     }
   }
 
-  /**
-   * The one identity resolution, memoized. Every navigation awaits this single
-   * shared promise instead of each restoring the session itself. Cleared by
-   * `clearResolved()` on any auth transition so the next call re-resolves.
-   */
+  /** Who is signed in, resolved once and shared by every navigation after it. */
   function ensureResolved(): Promise<boolean> {
     return (resolved ??= restoreSession())
   }
 
-  // Re-arm ensureResolved() so the next navigation reflects the current session
-  // rather than the memoized answer from before a sign-in or sign-out.
+  /** Forces the next navigation to work out who is signed in again. Call on any sign-in or sign-out. */
   function clearResolved(): void {
     resolved = undefined
   }
@@ -159,10 +146,10 @@ export const useSessionStore = defineStore('sessionStore', () => {
     if (isAuthError(error)) forceLogout()
   }
 
-  // Same end state as logout(), but skipped when already logged out (avoids
-  // reacting to its own signOut() call below) and explains why the session
-  // ended instead of silently redirecting. `reason` only picks the copy —
-  // every reason gets the same teardown + redirect.
+  /**
+   * Ends a session the member didn't ask to end, telling them why rather than
+   * bouncing them silently. `reason` picks the wording; the teardown is one.
+   */
   async function forceLogout(reason: ForceLogoutReason = 'expired'): Promise<void> {
     if (!authenticated.value) return
 
@@ -195,19 +182,16 @@ export const useSessionStore = defineStore('sessionStore', () => {
     return supaSignupEmail(email, password, opts)
   }
 
-  // Single funnel for a freshly established session: tear down the auth UI and
-  // land on the dashboard. Every successful sign-in path (OAuth here, email
-  // login/signup from their dialogs) routes through this, so no path can
-  // navigate without closing its modal — the gap that left the OAuth popup's
-  // parent modal open on top of the dashboard.
+  /**
+   * Settles the app into a just-signed-in state.
+   *
+   * Every sign-in path routes through here, so none of them can navigate
+   * without first closing the dialog it was started from.
+   */
   function onAuthenticated(): void {
-    // Re-arm identity resolution so the checkpoint on the next navigation sees
-    // the freshly established session, not the memoized signed-out answer from
-    // the welcome load.
     clearResolved()
     closeAllModals()
-    // Land on where the member was originally headed (captured as `?next=` when
-    // the checkpoint bounced them here), falling back to the dashboard.
+    // Wherever they were originally headed before being sent to sign in.
     router.push(consumeReturnDestination() ?? { name: 'dashboard' })
   }
 
@@ -266,25 +250,22 @@ export const useSessionStore = defineStore('sessionStore', () => {
   }
 
   /**
-   * Whether the account has a password has to be asked of the database — see
-   * `fetchHasPassword`. Refreshed wherever `user` is assigned, so the two never
-   * disagree, and after a password change, which flips it for Google-origin
-   * accounts setting one for the first time.
+   * Re-asks whether the account can sign in with a password. Run it wherever
+   * `user` is assigned, and after a password change.
+   * →[K:password-identity-not-client-derivable]
    */
   async function refreshHasPassword(): Promise<void> {
     has_password.value = await fetchHasPassword()
   }
 
-  // Single teardown funnel for both logout() and forceLogout(): clears auth
-  // identity, then fans out to every bit of state that would otherwise leak
-  // into the next session or the logged-out surface. The audio engine is left
-  // running — logged-out surfaces still need sound.
+  /**
+   * Clears everything that would otherwise leak into the next session or onto
+   * the logged-out screens. Sound keeps playing — the welcome screen needs it.
+   */
   function reset() {
     user.value = undefined
     has_password.value = false
 
-    // Re-arm resolution so a re-login after this teardown resolves fresh instead
-    // of returning the stale signed-in answer.
     clearResolved()
     closeAllModals()
     clearQueryCache()
@@ -292,14 +273,13 @@ export const useSessionStore = defineStore('sessionStore', () => {
     clearPersistedSession()
   }
 
+  // Trap: an ended session's token keeps working until it is cleared →[K:deleted-account-token-outlives-deletion]
   /**
-   * Teardown for a session the server has already revoked (account deletion).
-   * reset() alone isn't enough — it clears this store but leaves supabase-js
-   * holding the token, which then reads as a live session on the next visit.
+   * Tears down a session the server has already ended, token included.
    *
-   * Flagged as intentional for the same reason logout() is: dropping the stored
-   * session fires SIGNED_OUT, and forceLogout() reacting to it would stack a
-   * "your session expired" notice on top of the caller's own messaging.
+   * Flagged intentional for the reason `logout()` is: dropping the token
+   * announces a sign-out, which would otherwise stack a "session expired"
+   * notice on top of whatever the caller is already telling the member.
    */
   async function discardRevokedSession(): Promise<void> {
     logging_out_intentionally = true
@@ -312,8 +292,7 @@ export const useSessionStore = defineStore('sessionStore', () => {
     }
   }
 
-  /** Drop every entry from the Pinia Colada cache so stale data can't carry
-   * over into the next login (Colada has no wholesale clear, so remove each). */
+  /** Forgets every bit of fetched data, so none of it shows up under the next account. */
   function clearQueryCache() {
     queryCache.getEntries().forEach((entry) => queryCache.remove(entry))
   }
@@ -339,9 +318,6 @@ export const useSessionStore = defineStore('sessionStore', () => {
     ensureResolved,
     logout,
     forceLogout,
-    // Exposed for teardown after a server-side session revocation (account
-    // deletion), where the sessions are already gone and only local state —
-    // stored token, query cache, modals, phone — still needs clearing.
     discardRevokedSession,
     handleAuthError,
     signupEmail,

--- a/src/stores/shortcut-store.ts
+++ b/src/stores/shortcut-store.ts
@@ -49,9 +49,7 @@ function normalizeComboFromEvent(ev: KeyboardEvent): KeyCombo {
   if (ev.metaKey) mods.push('meta')
   if (ev.altKey) mods.push('alt')
   if (ev.shiftKey) mods.push('shift')
-  // Prefer a small set of names:
   const k = ev.key.toLowerCase()
-  // Map common names
   const key = k === 'escape' ? 'esc' : k === ' ' ? 'space' : k
   const parts = [...mods.sort(), key]
   return parts.join('+') as KeyCombo
@@ -159,11 +157,10 @@ export const useShortcutStore = defineStore('shortcutStore', () => {
   async function _handleKeyEvent(ev: KeyboardEvent) {
     const combo = normalizeComboFromEvent(ev)
 
-    // Walk stack from top to bottom
+    // Innermost scope first, so a dialog's key beats the page's behind it.
     for (let i = filtered_stack.value.length - 1; i >= 0; i--) {
       const scope = filtered_stack.value[i]
 
-      // find first matching, active shortcut within this scope
       for (const sc of scope.shortcuts.values()) {
         if (sc.combo !== combo) continue
 

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -15,10 +15,7 @@ export const useThemeStore = defineStore('theme', () => {
     return mode.value === 'dark'
   })
 
-  /* `is_dark` is the single source of truth for the resolved mode. It used to
-   * share the job with a module-scope matchMedia listener that wrote the DOM
-   * directly; the two could disagree, and consumers reading `is_dark`
-   * (getStripeAppearance) then rendered against the wrong mode. */
+  // The only place light-or-dark reaches the page. A second writer drifts from `is_dark`.
   watchEffect(() => {
     const resolved = is_dark.value ? 'dark' : 'light'
     document.documentElement.setAttribute('data-mode', resolved)


### PR DESCRIPTION
[TARO-341](https://app.notion.com/p/3b60953c224c819dae51ffb786dc4e8f)

> Stacked on #524.

## Summary

- **739 → 446 comment lines** across `src/api/` and `src/stores/`, 63 files, comments only.
- The two security traps the ticket called out are now in the knowledge layer instead of one file's docstrings, in a new `corpus/sessions/sessions.md`.

## The two traps

- **`[K:deleted-account-token-outlives-deletion]`** — ending a session on the server doesn't sign the browser out. The token stays signature-valid for its full hour (`jwt_expiry = 3600`, confirmed in `supabase/config.toml`), is handed back from storage without asking the server, and the database accepts it — so reads and writes for a deleted account keep succeeding until local storage is cleared.
- **`[K:oauth-popup-loses-its-opener]`** — Google's consent screen permanently moves the popup into a separate browsing-context group, severing `window.opener` and `window.name` for good, even after it returns to our own origin. Local storage isn't so scoped, so a flag written before `window.open()` survives. The tempting repair — carrying state in the return address — is the one field that must not be caller-controlled.

Both echoed where they bite and cited from the code they came from. Three further entries: `[K:password-identity-not-client-derivable]`, `[K:reauth-nonce-does-not-gate]`, `[K:session-restore-retry-storm]`.

Their `hazards.md` rows land in the assembly PR at the top of this stack, not here — six sweeps editing one index would have conflicted.