### PR TITLE
TARO-342: Comment sweep — components

### DIFF
--- a/corpus/architecture/dialog-card-scroll.md
+++ b/corpus/architecture/dialog-card-scroll.md
@@ -1,0 +1,58 @@
+---
+id: dialog-card
+domain: architecture
+status: current
+hazard: true
+related: [layout-kit]
+updated: 2026-08-08
+---
+
+# Dialog-card layout
+
+How `layout-kit/dialog-card` owns its scrolling body, its toolbar row, and its
+content-grid padding, so call sites stop hand-rolling the same things slightly
+differently each time.
+
+## The scrolling body
+
+`dialog-card-body.vue` is opt-in: wrap the default slot in it only when the body
+can overflow. Once wrapped, two things follow from where it sits:
+
+- **Bottom padding collapses when a `#toolbar` is present.** `--dialog-body-pb`
+  comes from the card and drops to 0 once the card has a toolbar row, since that
+  row then owns the space above the bottom edge instead. The fallback keeps a
+  body rendered outside a `dialog-card` sane.
+- **The scroll-bar hangs in the card's own horizontal padding** (`-right-8`
+  against a `--dialog-px` of 1.5–2rem), so the body has to sit in the content
+  column rather than break out of it — moving the body out from under the card's
+  padding orphans the scroll-bar's positioning.
+
+> [!HAZARD] [K:dialog-card-overflow-bleed] **`overflow_bleed` widens the clip boundary without moving the slotted content.**
+> `overflow-y-auto` clips the x-axis too, so corner-overhang content (an
+> absolutely positioned menu or tick sitting a few px outside a grid cell) gets
+> cut off. `overflow_bleed` adds matching padding plus a negative margin on the
+> scrolling content div — the clip boundary widens into the surrounding
+> `--dialog-px` gutter while the slotted content's own visible position doesn't
+> move. It's horizontal only: the top edge isn't clipped, and bleeding it too
+> could collide with a header.
+
+## The toolbar slot isn't reactive to read from a computed
+
+> [!HAZARD] [K:dialog-card-toolbar-slot-reactivity] **`slots.toolbar` doesn't trigger reactivity — read it from a plain function called in the template, never a `computed`.**
+> A `computed` wrapping `slots.toolbar` caches the first answer and never
+> notices a `v-if`'d toolbar appearing or disappearing later. `gridRowsClass()`
+> and `bodyPaddingStyle()` on `dialog-card/index.vue` are plain functions called
+> straight from the template so they re-run every render instead.
+
+## Grid padding is a literal class, not an arbitrary-value reference
+
+> [!HAZARD] [K:dialog-card-content-grid-padding] **`--content-grid-padding` is set as an inline style, not a `content-grid-px-(--dialog-px)` class.**
+> Tailwind's arbitrary-value matcher never generates a rule for a class
+> referencing a bare custom property like that — the class silently no-ops, and
+> the padding falls back to the content-grid default of 0, so every direct
+> child renders flush against the card's edge. Setting the var directly in
+> `:style` sidesteps the matcher entirely.
+
+## Related
+
+[[layout-kit]]

--- a/corpus/cards/cards.md
+++ b/corpus/cards/cards.md
@@ -117,6 +117,18 @@ selection.
 Deriving the mode from "is anything selected" would yank the UI away the instant
 you unticked the last card.
 
+## A focusing tap can blur itself
+
+> [!HAZARD] [K:text-editor-ghost-click-guard] **Focusing the card text editor on tap can re-target the tap's own synthetic mouse events.**
+> Focusing an element on `pointerdown` can trigger the browser's native
+> "scroll the focused input above the keyboard" behaviour, shifting the layout
+> mid-tap. The tap's synthesized compatibility events (`mousedown`, `mouseup`,
+> `click`) are then hit-tested at dispatch time — after that shift — so they
+> land on whatever now sits under the finger instead of the original target,
+> and the stray `mousedown` blurs the editor before `click` ever fires. The
+> text editor swallows the whole synthetic sequence for a short window after a
+> focusing tap rather than letting it re-target.
+
 ## What this isn't
 
 - **Not the study schedule.** When a card is next due and how well it's known is

--- a/corpus/theming/theming.md
+++ b/corpus/theming/theming.md
@@ -81,6 +81,17 @@ _danger_, an informational one for _info_. Each meaning points at a real
 palette today, but the call site only ever says the meaning — so the color
 behind _danger_ can change without touching a single button.
 
+## Palette identity is opt-in [K:theming-palette-identity]
+
+A palette lands on an element as a plain HTML attribute, `data-palette`. Attributes don't inherit —
+only CSS properties do — so a component only carries a palette's colors when `data-palette` sits on
+that component's own root, never because an ancestor happens to carry one.
+
+That's deliberate. A neutral component nested inside a colored region stays neutral unless it
+explicitly opts in, so a palette can never leak into everything nested under it by accident. Giving a
+component the palette is always a conscious act at that component, not a side effect of its position
+in the tree.
+
 ## Textured backgrounds
 
 Some surfaces carry a faint pattern — stripes, clouds, a dot grid — laid over

--- a/src/components/billing/checkout-modal/use-checkout.ts
+++ b/src/components/billing/checkout-modal/use-checkout.ts
@@ -19,12 +19,8 @@ function wait(ms: number) {
 }
 
 /**
- * Owns the checkout modal's Stripe Elements session and open/close chimes.
- * Collapses every loading/error/success signal into a single `status`, so
- * the UI branches on one value instead of combining several booleans.
- * `onSubmit` confirms the payment, waits for the member's plan to sync, then
- * flashes a success message and auto-closes reporting the upgrade. Closing
- * via backdrop/esc is suppressed while a submission is in flight.
+ * Owns the checkout modal's Stripe Elements session, open/close chimes, and a single
+ * `status` collapsing every loading/error/success signal the UI branches on.
  */
 export function useCheckout(close: (response?: CheckoutResponse) => void) {
   const { t } = useI18n()
@@ -63,10 +59,8 @@ export function useCheckout(close: (response?: CheckoutResponse) => void) {
     close()
   })
 
-  // The member row flips to the paid plan only once the Stripe webhook syncs
-  // it — that can lag a few seconds behind `confirm()` resolving. Poll rather
-  // than trusting the first refetch, so we don't show success against stale
-  // free-plan data.
+  // Polls instead of trusting the first refetch — the member row flips to `paid`
+  // only once the Stripe webhook syncs, which can lag a few seconds behind `confirm()`.
   async function waitForUpgradeSync() {
     for (let attempt = 0; attempt < SYNC_MAX_ATTEMPTS; attempt++) {
       const { data } = await memberQuery.refetch()
@@ -82,8 +76,7 @@ export function useCheckout(close: (response?: CheckoutResponse) => void) {
     is_confirming.value = true
     await waitForUpgradeSync()
     queryCache.invalidateQueries({ key: ['billing'] })
-    // Resubscribing clears the downgrade grace, so the deck list's is_locked
-    // flags flip off — refetch it (the sync above already waited for paid).
+    // Resubscribing clears the downgrade grace, so the deck list's is_locked flags flip off.
     queryCache.invalidateQueries({ key: ['decks'] })
     is_confirming.value = false
     is_success.value = true

--- a/src/components/card-actions/move-cards-modal.vue
+++ b/src/components/card-actions/move-cards-modal.vue
@@ -19,8 +19,7 @@ export type MoveCardsModalResponse = {
 
 type MoveCardsModalProps = {
   cards: Card[]
-  // Omitted for a selection spanning several decks — there's no single
-  // "current" deck to disable, so none of them are.
+  // Omitted for a multi-deck selection, since no single deck is "current" to disable.
   current_deck_id?: number
   count?: number
   move: (deck_id: number) => Promise<void>
@@ -43,8 +42,7 @@ const title = computed(() => {
   return t('move-cards-modal.title', { count: effective_count })
 })
 
-// Authoritative moving count (unlike the title's display-only effective_count,
-// which zeroes out for a single blank placeholder card).
+/** The real count of cards being moved — the title's count may read 0 for a blank placeholder card. */
 const moving_count = computed(() => count ?? cards.length)
 
 const target_deck = computed(() => decks.value?.find((deck) => deck.id === selected_deck_id.value))

--- a/src/components/card/card-cover.vue
+++ b/src/components/card/card-cover.vue
@@ -9,13 +9,11 @@ const { cover } = defineProps<{
 }>()
 
 const img_el = useTemplateRef<HTMLImageElement>('img')
-// image_path (public URL or staged objectURL) makes a custom image fill the
-// cover; palette/pattern/icon stay configured but never render behind it.
+/** True once this cover has a custom image — palette/pattern/icon stay configured but stop rendering behind it. */
 const has_image = computed(() => !!cover?.image_path)
 const { decoded, onLoad } = useImageReveal(() => cover?.image_path, img_el)
 
-// While decoding, show the shared SKELETON_COVER so loading matches the app
-// skeleton; once decoded, drop chrome (null) for the full-bleed image.
+/** Chrome bindings for the cover; null once the image decodes, so the picture goes full-bleed with no chrome underneath. */
 const bindings = computed(() => {
   if (decoded.value) return null
   return coverBindings(has_image.value ? SKELETON_COVER : cover, { border: false })
@@ -75,12 +73,8 @@ const bindings = computed(() => {
   color: var(--color-on-element);
 }
 
-/* A DECODED image cover has no chrome band — the picture goes edge-to-edge,
-   clipped to the face radius. Applied only once decoded; while the image loads
-   the cover renders the neutral bordered skeleton chrome instead (see the
-   `bindings` computed), so the loading state matches the common card skeleton.
-   The element fill sits under the picture, continuous with that skeleton's
-   element-coloured border, so the hand-off reads as the pattern fading out. */
+/* Applied only once the image decodes; before that the neutral skeleton chrome
+   renders instead — see the `bindings` computed above. */
 .card-cover--image {
   overflow: hidden;
   border: none;
@@ -91,9 +85,8 @@ const bindings = computed(() => {
   border-radius: inherit;
 }
 
-/* Tiny cards shrink the pattern tile via --card-pattern-scale (set by the
-   card's container-query chrome variants) so it still reads at ~43px. The
-   inline --bgx-size from coverBindings stays the single source of tile size. */
+/* Tiny cards shrink the pattern tile via --card-pattern-scale; the inline
+   --bgx-size from coverBindings stays the single source of tile size. */
 .card-cover.pattern-mask::before {
   -webkit-mask-size: calc(var(--bgx-size) * var(--card-pattern-scale, 1));
   mask-size: calc(var(--bgx-size) * var(--card-pattern-scale, 1));

--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -15,9 +15,7 @@ const { image, text, attributes } = defineProps<CardFaceProps>()
 
 const layout = computed(() => attributes?.image_layout ?? CARD_ATTRIBUTES_DEFAULTS.image_layout)
 
-// Font size is fluid off the card width (cqi, see the text-region rule); the
-// per-deck text_size level (1–10) only picks the multiplier. Both the default
-// editor and any slotted editor inherit it via the cascade.
+/** Multiplier applied to the fluid, width-based font size; both the default and any slotted editor inherit it via the CSS cascade. */
 const text_scale = computed(() => cardTextScale(attributes?.text_size))
 </script>
 
@@ -88,21 +86,18 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
   outline: 2px solid var(--color-red-500);
 }
 
-/* ----- Region placement by image layout ----------------------------------- */
-/* DOM order is image-region then text-region; layout reorders / repositions. */
-
-/* above: image on top, text below */
+/* DOM order is always image-region then text-region; layout reorders/repositions
+   below rather than changing markup order. */
 .card-face[data-layout='above'] {
   flex-direction: column;
 }
 
-/* below: image on the bottom, text above */
 .card-face[data-layout='below'] {
   flex-direction: column-reverse;
 }
 
 /* No overflow:hidden here — the editor's remove button pokes out of the corner
-   and must not be clipped. The image itself rounds via border-radius instead. */
+   and must not be clipped; the image itself rounds via border-radius instead. */
 .card-face__image-region {
   position: relative;
   flex: 1 1 auto;
@@ -115,23 +110,20 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
   border-radius: inherit;
 }
 
-/* Clip the text to the region box so long content can't spill past the card
-   edges. Only the text is clipped — image-region controls (remove button, etc.)
-   intentionally poke out and stay unclipped above. */
+/* Clips text so long content can't spill past the card edges; image-region
+   controls (remove button, etc.) intentionally stay unclipped above. */
 .card-face__text-region {
   flex: 0 0 auto;
   min-height: 0;
 
   overflow: hidden;
 
-  /* 9.554cqi * level multiplier reproduces the historical level table exactly
-     at --card-w-full (level 4 = 30px at 314px); tiny cards floor at 4px. */
+  /* 9.554cqi * text-scale reproduces the old level table (level 4 = 30px @314px); floors at 4px for tiny cards. */
   font-size: max(4px, calc(9.554cqi * var(--card-text-scale, 1)));
 }
 
-/* In above/below, the image shrinks as the text grows — but never below half
-   the face. Past that the text region is capped at half and its overflow clips
-   (see overflow: hidden above). */
+/* Image can shrink as text grows, but never below half the face; the text
+   region caps at the other half and clips past that. */
 .card-face[data-image='true']:not([data-layout='behind']) .card-face__image-region {
   min-height: 50%;
 }
@@ -140,7 +132,6 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
   max-height: 50%;
 }
 
-/* behind: image fills the face, text floats on top of it */
 .card-face[data-layout='behind'] .card-face__image-region {
   position: absolute;
   inset: 0;
@@ -155,7 +146,6 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
   flex: 1 1 auto;
 }
 
-/* ----- No image: text fills the face -------------------------------------- */
 .card-face[data-image='false'] .card-face__image-region {
   display: none;
 }
@@ -164,10 +154,8 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
   flex: 1 1 auto;
 }
 
-/* ----- Full-bleed: a behind-layout image with no text fills the face ------- */
-/* Only behind goes edge-to-edge. Above/below keep their padded image region in
-   both modes: in view the image fills the padded face (see below), in edit the
-   empty text region stays clickable so text can be typed back in. */
+/* Only `behind` goes edge-to-edge; above/below keep their padded image region
+   in both view and edit modes. */
 .card-face[data-image='true'][data-text='false'][data-layout='behind'] {
   padding: 0;
   gap: 0;
@@ -181,24 +169,21 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
   border-radius: var(--face-radius);
 }
 
-/* View only: drop the empty text region so nothing covers the image. In edit it
-   stays (filling the face) so a click anywhere off the image controls focuses
-   the editor to type — the corners dropzone backdrop is click-through. */
+/* View only — edit mode keeps the empty text region so a click off the image
+   still focuses the editor to type. */
 .card-face[data-mode='view'][data-image='true'][data-text='false'][data-layout='behind']
   .card-face__text-region {
   display: none;
 }
 
-/* Over a full-bleed image the placeholder would just clutter the picture — the
-   text cursor already signals you can click to type. The text editor reads
-   this var instead of us reaching into its internals. */
+/* Text editor reads this var itself — don't reach into its internals to hide
+   the placeholder over a full-bleed image. */
 .card-face[data-mode='edit'][data-image='true'][data-text='false'][data-layout='behind'] {
   --text-editor-placeholder-display: none;
 }
 
-/* View, above/below, no text: drop the empty text region so the gap below the
-   image collapses and the padded image fills the face symmetrically. (In edit
-   the region is kept so it stays clickable.) */
+/* Drops the empty text region in view so the image fills the face
+   symmetrically; edit keeps it so it stays clickable. */
 .card-face[data-mode='view'][data-image='true'][data-text='false']:is(
     [data-layout='above'],
     [data-layout='below']
@@ -207,10 +192,8 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
   display: none;
 }
 
-/* ----- Editor: hovering an image reveals a replaceable dropzone frame ------ */
-/* The image keeps its padded region in above/below (with or without text), so
-   the dashed frame sits just outside it. Behind layout uses floating corner
-   controls over the text instead, so it's excluded here. */
+/* Frames the padded image region with a dashed drop affordance; `behind`
+   layout uses floating corner controls instead and is excluded here. */
 .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
   .card-face__image-region {
   outline: 3px dashed transparent;
@@ -240,11 +223,8 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
   outline-color: var(--color-blue-650);
 }
 
-/* ----- Editor: dragging a replacement over a behind-layout image ----------- */
-/* Behind images are full-bleed with floating corner controls, so there's no
-   padded region to frame. While a file is dragged over it, pull the image in to
-   gain padding and frame the whole face with the dashed drop affordance — the
-   same cue the padded layouts show. */
+/* Behind images have no padded region to frame; while dragging, pull the image
+   in and frame the whole face with the same dashed affordance instead. */
 .card-face[data-mode='edit'][data-layout='behind'][data-image='true'] .card-face__image-region {
   transition:
     inset 0.15s ease,

--- a/src/components/card/cover-image-layer.vue
+++ b/src/components/card/cover-image-layer.vue
@@ -7,8 +7,7 @@ import { type CoverImage } from '@/composables/deck/cover-image'
 
 type CoverImageLayerProps = {
   cover_image: CoverImage
-  // The card root element — the layer listens for drag events across the whole
-  // cover face, not just its own overlays.
+  /** Card root element — drag events are listened for across the whole cover face, not just this layer's own overlays. */
   root: HTMLElement | null
 }
 
@@ -18,8 +17,7 @@ const { t } = useI18n()
 
 onBeforeUnmount(() => detachRootListeners(root))
 
-// The drop target is the whole cover face, so listen on the card root the card
-// hands us rather than on this layer's own overlays.
+/** Listens on the card root, since the drop target is the whole cover face rather than this layer's own overlays. */
 function attachRootListeners(el: HTMLElement | null) {
   if (!el) return
   el.addEventListener('dragenter', cover_image.onDragEnter)
@@ -47,7 +45,6 @@ watch(
 </script>
 
 <template>
-  <!-- @click.stop: openPicker()'s synthetic click must not bubble to the preview's cycleSide -->
   <input
     :ref="cover_image.file_input"
     type="file"
@@ -104,7 +101,6 @@ watch(
     </ui-button>
   </template>
 
-  <!-- Dragging a file / a validation error: a full-face prompt over the cover. -->
   <face-overlay
     v-if="cover_image.dragging.value || cover_image.error_message.value"
     variant="full"

--- a/src/components/card/face-editor.vue
+++ b/src/components/card/face-editor.vue
@@ -1,26 +1,20 @@
 <script setup lang="ts">
-// imports
 import { computed, useTemplateRef } from 'vue'
 import Card from '@/components/card/index.vue'
 import TextEditor from '@/components/card/text-editor.vue'
 
-// types
 type CardSide = 'front' | 'back'
 
 type FaceEditorProps = {
   card?: Card
   side: CardSide
-  // Deck-level attribute bag; hosts editing a bare face (no full card, e.g. the
-  // audio-reader field) pass per-face `attributes` instead.
+  /** Deck-level attribute bag; hosts editing a bare face (no full card, e.g. the audio-reader field) pass per-face `attributes` instead. */
   card_attributes?: DeckCardAttributes
   attributes?: CardAttributes
-  // Text override for hosts whose editor state lives outside the card; falls
-  // back to the card's own side text.
+  /** Override for hosts whose editor state lives outside the card; falls back to the card's own side text. */
   text?: string
   placeholder: string
-  // Stable identity for the editor remount key. Defaults to the card id, but a
-  // host cycling through temp cards passes the client_id so a temp→real id
-  // promotion mid-typing doesn't remount the editor and drop the caret.
+  /** Editor remount key. Defaults to the card id; a host cycling through temp cards passes the client_id so a temp→real id promotion mid-typing doesn't drop the caret. */
   card_key?: string | number
   input_testid?: string
   with_images?: boolean
@@ -28,7 +22,6 @@ type FaceEditorProps = {
   error?: boolean
 }
 
-// defines
 const {
   card,
   side,
@@ -47,23 +40,19 @@ const emit = defineEmits<{
   (e: 'update', side: CardSide, text: string): void
 }>()
 
-// composables
 const card_ref = useTemplateRef('card')
 const editor_ref = useTemplateRef('editor')
 
-// computed
 const face_text = computed(() => text ?? (side === 'front' ? card?.front_text : card?.back_text))
 const face_attributes = computed(() => attributes ?? card_attributes?.[side])
 const resolved_card_attributes = computed<DeckCardAttributes>(
   () => card_attributes ?? { front: attributes ?? {}, back: attributes ?? {} }
 )
 
-// The text-editor is uncontrolled, so it only seeds `content` on mount — keying
-// it by card + side remounts it whenever either changes (flip, prev/next).
+/** Remounts the uncontrolled text-editor whenever card or side changes, since it only seeds `content` on mount. */
 const editor_key = computed(() => `${card_key ?? card?.id}-${side}`)
 
-// Surface the card's image-layer controls so a host (the mobile editor's menu)
-// can drive add/remove for the current face. Null when there's no image layer.
+/** Card's image-layer controls, for a host (the mobile editor's menu) to drive add/remove for the current face; null when there's no image layer. */
 defineExpose({
   uploader: computed(() => card_ref.value?.image_controls ?? null),
   focus: () => editor_ref.value?.focus()

--- a/src/components/card/face-image-layer.vue
+++ b/src/components/card/face-image-layer.vue
@@ -19,8 +19,7 @@ type FaceImageLayerProps = {
   card: Card
   side: 'front' | 'back'
   attributes?: CardAttributes
-  // The card root element — the layer listens for drag/hover on the whole card
-  // and the upload composable dismisses lingering errors on outside clicks.
+  /** Card root element — drag/hover is listened for across the whole card, and the upload composable dismisses lingering errors on outside clicks. */
   root: HTMLElement | null
   disabled?: boolean
 }
@@ -60,24 +59,18 @@ const {
   rootEl: () => root ?? undefined
 })
 
-// Touch can't hover, so the hover-reveal add button is unreachable — and its
-// invisible hit area would otherwise swallow taps meant for the editor. Coarse
-// pointers add/replace images through the card menu instead.
+/** True on touch, where hover can't reveal the add button — coarse pointers add/replace images through the card menu instead. */
 const is_coarse = useMatchMedia('coarse')
 
 const layout = computed(() => attributes?.image_layout ?? CARD_ATTRIBUTES_DEFAULTS.image_layout)
-// Behind keeps the image full-bleed under the text, so its controls float in the
-// corners; above/below give the image its own region to scope the dropzone to.
+/** 'corners' floats controls over a full-bleed behind image; 'region' scopes the dropzone to the image's own area for above/below layouts. */
 const dropzone_mode = computed(() => (layout.value === 'behind' ? 'corners' : 'region'))
 const image_url = computed(() => (image_path.value ? cardImageUrl(image_path.value) : undefined))
-// The card fills its face's image slot with the region dropzone when this says
-// so. Doubles as the hover scope: in region mode the image is only part of the
-// card, so hover comes from the dropzone's enter/leave instead of card-wide.
+/** Also the hover scope switch — in region mode hover comes from the dropzone's enter/leave instead of card-wide. */
 const region_dropzone = computed(
   () => has_image.value && !disabled && dropzone_mode.value === 'region'
 )
-// Behind/full-bleed plays the hover chime card-wide; region scopes it to the
-// image region (see onRegionPointerEnter), so the card stays silent there.
+/** Hover chime for behind/full-bleed layouts; region layout scopes its own chime instead (see onRegionPointerEnter). */
 const card_sfx = computed<SfxOptions | undefined>(() =>
   has_image.value && dropzone_mode.value === 'corners' ? { hover: 'tap_05' } : undefined
 )
@@ -96,7 +89,7 @@ const error_message = computed(() => {
 
 onBeforeUnmount(() => detachRootListeners(root))
 
-// Skip card-wide hover in region mode — the dropzone reports image-region hover.
+/** Skips card-wide hover in region mode — the dropzone reports image-region hover instead. */
 function onRootPointerEnter() {
   if (!region_dropzone.value) onPointerEnter()
 }
@@ -105,8 +98,7 @@ function onRootPointerLeave() {
   if (!region_dropzone.value) onPointerLeave()
 }
 
-// Region mode scopes the hover chime to the image region; behind/full-bleed play
-// it card-wide via the sfx the card reads off this layer.
+/** Scopes the hover chime to the image region; behind/full-bleed play it card-wide instead, via `card_sfx`. */
 function onRegionPointerEnter() {
   emitSfx('tap_05')
   onPointerEnter()
@@ -117,8 +109,7 @@ function onAddClick() {
   openPicker()
 }
 
-// The drop target and hover surface is the whole card, not just this layer's
-// own overlays — listen on the card root the card hands us.
+/** Listens on the card root — the drop target and hover surface is the whole card, not just this layer's own overlays. */
 function attachRootListeners(el: HTMLElement | null) {
   if (!el) return
   el.addEventListener('dragenter', onDragEnter)

--- a/src/components/card/face-overlay.vue
+++ b/src/components/card/face-overlay.vue
@@ -4,8 +4,7 @@ import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 
 type FaceOverlayProps = {
-  // full: fills the whole face (empty-face drop target); inset: scrim over the
-  // image region (or the whole face in corners mode), revealed via `active`.
+  /** `full` fills the whole face (empty-face drop target); `inset` scrims the image region (or whole face in corners mode), revealed via `active`. */
   variant: 'full' | 'inset'
   error?: string
   heading?: string

--- a/src/components/card/image-dropzone.vue
+++ b/src/components/card/image-dropzone.vue
@@ -10,8 +10,7 @@ type ImageDropzoneProps = {
   active?: boolean
   disabled?: boolean
   error?: string
-  // Corner-button tooltips — no default: each caller passes its own wording so
-  // this control stays copy-agnostic (the card passes the card variant).
+  /** Corner-button tooltips — no default, so each caller passes its own wording and this control stays copy-agnostic. */
   remove_label?: string
   replace_label?: string
 }
@@ -34,10 +33,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-// Behind/full-bleed images reach the card edges with a large corner radius, so
-// controls sit inset at the face padding to clear the rounded corner (matching
-// the text inset). Region images are inset already, so the remove button pokes
-// out past the image corner.
+/** Corners mode insets controls to face padding to clear the large corner radius; region mode's image is already inset, so the button pokes out past its corner. */
 const remove_position = computed(() =>
   mode === 'corners' ? 'top-(--face-padding) right-(--face-padding)' : '-top-2 -right-2'
 )

--- a/src/components/card/index.vue
+++ b/src/components/card/index.vue
@@ -21,11 +21,9 @@ type CardProps = Partial<CardBase> & {
   sfx?: SfxOptions
   error?: boolean
   shimmer?: boolean
-  // Edit mode only: mount the image-edit layer (dropzone / picker / overlays)
-  // for the active face.
+  /** Edit mode only — mounts the image-edit layer (dropzone / picker / overlays) for the active face. */
   image_editing?: boolean
-  // Cover side only: mount the cover-image edit layer. Driven by the settings
-  // design preview, which supplies the shared `cover_image` staging interface.
+  /** Cover side only — mounts the cover-image edit layer, driven by the settings design preview's `cover_image` staging interface. */
   cover_editing?: boolean
   cover_image?: CoverImage
   disabled?: boolean
@@ -74,11 +72,10 @@ const editing_images = computed(
 const editing_cover = computed(() => cover_editing && !!cover_image && side === 'cover')
 const active_face = computed<'front' | 'back'>(() => (side === 'back' ? 'back' : 'front'))
 
-// The persisted-card slice the image layer's upload seam needs; temp cards
-// (id <= 0) keep the layer mounted but upload-gated.
+/** Persisted-card slice the image layer's upload seam needs; temp cards (id <= 0) keep the layer mounted but upload-gated. */
 const upload_card = computed(() => ({ id: id ?? 0, deck_id, front_image_path, back_image_path }))
 
-// Host editors (e.g. the mobile editor's menu) drive add/remove through this.
+/** Host editors (e.g. the mobile editor's menu) drive add/remove through this. */
 const image_controls = computed(() => {
   const layer = image_layer.value
   return layer ? { openPicker: layer.openPicker, onRemove: layer.onRemove } : null
@@ -217,14 +214,8 @@ function onLeave(el: Element, done: () => void) {
 </template>
 
 <style>
-/* The card is width-fluid: it fills its parent and everything inside scales
-   off the resolved width via container-query (cqi) units. The container is the
-   card root itself, so the geometry vars below live on its direct children —
-   cqi units on the container element would resolve against an ancestor.
-
-   The base rule sits in the components layer so width utilities on the card
-   (`w-[260px]`, `w-(--card-w-full)`) can override the fluid 100% default —
-   unlayered SFC CSS would always beat Tailwind's layered utilities. */
+/* In `components` layer so per-card width utilities can override the fluid
+   default — unlayered CSS always beats Tailwind's layered utilities. */
 @layer components {
   .card-container {
     container-type: inline-size;
@@ -242,17 +233,14 @@ function onLeave(el: Element, done: () => void) {
   }
 }
 
-/* Fluid geometry, calibrated so a card at --card-w-full (314px) reproduces the
-   historical full-size padding (20px); radius is deliberately rounder than the
-   historical 58px. Floors keep tiny covers from collapsing to sharp corners /
-   zero padding and keep the cover icon legible. */
+/* Calibrated so --card-w-full (314px) reproduces the historical 20px padding;
+   floors keep tiny covers from collapsing to sharp corners / illegible icons. */
 .card-container > * {
   --face-radius: clamp(14px, 22cqi, 70px);
   --face-padding: clamp(2px, 6.369cqi, 42px);
   --face-image-padding: calc(var(--face-padding) / 2);
 
-  /* Chrome (border band, cover icon, pattern tile) is two-variant, not fluid:
-     the full band here, and a deliberately chunky tiny variant below. */
+  /* Chrome (border, icon, pattern) is two-variant — full band here, chunky tiny variant below. */
   --face-border-width: 16px;
   --cover-icon-size: clamp(42px, 33%, 200px);
   --card-pattern-scale: 1;

--- a/src/components/card/text-editor.vue
+++ b/src/components/card/text-editor.vue
@@ -19,27 +19,18 @@ const emit = defineEmits<{
 const text_editor = useTemplateRef<HTMLDivElement>('text-editor')
 const has_content = ref(Boolean(content?.trim()))
 
-// Font size is owned by the parent card-face and inherited via the cascade —
-// see its fluid text-region rule. This surface only renders text and alignment.
-// Horizontal alignment lives on the editable (text-align); vertical lives on the
-// filling container (flex justify) so the editable can be content-height and
-// keep an empty caret centered instead of pinned to the top.
+/** Horizontal alignment lives on the editable (text-align); vertical lives on the filling container (flex justify), so an empty caret stays centered instead of pinned to the top. */
 const horizontal_alignment = computed(() => attributes?.horizontal_alignment ?? 'center')
 const vertical_alignment = computed(() => attributes?.vertical_alignment ?? 'center')
 
-// The editable surface is uncontrolled: seed it from `content` once, then let
-// the browser own the DOM. We never re-sync from the prop afterwards — `content`
-// in edit mode is only the user's own input echoed back, and re-writing it would
-// snap the caret to the start. Read-only mode renders `content` via Vue instead.
+/** Seeds the editable from `content` once; never re-synced afterward — content in edit mode is only the user's own input echoed back, and re-writing it would snap the caret to the start. */
 onMounted(() => {
   if (!text_editor.value) return
   text_editor.value.textContent = content ?? ''
 })
 
 function on_input(event: Event) {
-  // innerText tacks a trailing newline onto block content, so a cleared editor
-  // reads as "\n" not "". Collapse whitespace-only content to empty so the
-  // placeholder (and the card's data-text layout) react on the last deletion.
+  // innerText tacks a trailing newline onto cleared content ("\n" not "") — collapse whitespace-only text to empty.
   const raw = (event.target as HTMLElement).innerText ?? ''
   const text = raw.trim() ? raw : ''
   has_content.value = text.length > 0
@@ -50,11 +41,7 @@ function focus() {
   text_editor.value?.focus()
 }
 
-// The editable is only as tall as its content (so its empty caret stays
-// centered), so a click in the surrounding container won't land on it. Forward
-// those clicks: focus the editable and drop the caret at the end. Clicks on the
-// editable itself fall through to native caret placement. Uses `pointerdown` so
-// it fires for touch too — `mousedown` only arrives (late) after a tap on mobile.
+/** Forwards a click in the surrounding container (the editable is only content-height) to focus the editor and drop the caret at the end; clicks on the editable itself fall through to native placement. */
 function onContainerPointerDown(event: PointerEvent) {
   const editor = text_editor.value
   if (disabled || !editor || event.target === editor) return
@@ -73,15 +60,7 @@ function onContainerPointerDown(event: PointerEvent) {
   armGhostClickGuard()
 }
 
-// Focusing the editor here can trigger the browser's native "scroll the
-// focused input above the keyboard" behavior, shifting the layout mid-tap.
-// The tap's synthesized compatibility mouse events (`mousedown`, `mouseup`,
-// `click`) then get hit-tested at dispatch time — after that shift — instead
-// of against the original touch target, so they land on whatever now sits
-// under the finger (e.g. a button below the card). The `mousedown` in that
-// sequence is the real problem: its default action blurs the editor we just
-// focused, before `click` ever gets a say. Swallow the whole ghost sequence,
-// wherever it lands, within a short window after this gesture.
+/** Swallows the tap's synthetic mouse events after a focusing gesture, so the browser's scroll-into-view can't re-target them onto whatever now sits under the finger. →[K:text-editor-ghost-click-guard] */
 const GHOST_EVENT_WINDOW_MS = 500
 const GHOST_EVENT_TYPES = ['mousedown', 'mouseup', 'click'] as const
 let ghost_event_timer: ReturnType<typeof setTimeout> | undefined
@@ -154,9 +133,8 @@ defineExpose({ focus })
 </template>
 
 <style>
-/* The container fills the region and vertically positions the editable, which
-   sizes to its content — so an empty editor's caret centers with the text
-   instead of pinning to the top. */
+/* Vertically positions the editable, which sizes to its content, so an empty
+   editor's caret centers with the text instead of pinning to the top. */
 .text-editor-container {
   width: 100%;
   height: 100%;
@@ -164,9 +142,8 @@ defineExpose({ focus })
   flex-direction: column;
 }
 
-/* When editable, the whole filling container reads as a text target (clicks
-   anywhere focus the editor via onContainerPointerDown), not just the
-   content-height editable line. */
+/* Whole filling container reads as a text target when editable (clicks
+   anywhere focus via onContainerPointerDown), not just the content-height line. */
 .text-editor-container:has([contenteditable='plaintext-only']) {
   cursor: text;
 }
@@ -178,7 +155,6 @@ defineExpose({ focus })
   overflow-wrap: break-word;
 }
 
-/* Horizontal alignment — on the editable */
 .text-editor--h-left {
   text-align: left;
 }
@@ -191,7 +167,6 @@ defineExpose({ focus })
   text-align: right;
 }
 
-/* Vertical alignment — on the container */
 .text-editor--v-top {
   justify-content: flex-start;
 }
@@ -204,19 +179,16 @@ defineExpose({ focus })
   justify-content: flex-end;
 }
 
-/* Mirror the editor's alignment so the hint sits where typed text will land.
-   Horizontal maps to the main axis (justify-content + text-align), vertical to
-   the cross axis (align-items). */
+/* Mirrors the editor's alignment so the hint sits where typed text will land —
+   horizontal maps to justify-content + text-align, vertical to align-items. */
 .text-editor__placeholder {
   position: absolute;
   inset: 0;
-  /* Hosts (card-face, the card's loading scrim) hide the placeholder by
-     setting this var instead of selecting into our internals. */
+  /* Hosts (card-face, the loading scrim) hide this by setting the var, not by selecting into our internals. */
   display: var(--text-editor-placeholder-display, flex);
   pointer-events: none;
   color: var(--color-brown-300);
-  /* Match the editor so the hint's line box fits a content-height region
-     (otherwise the glyphs overflow it and clip). */
+  /* Matches the editor so the hint's line box fits a content-height region without clipping. */
   line-height: 1.2;
 }
 

--- a/src/components/deck/deck-design-preview.vue
+++ b/src/components/deck/deck-design-preview.vue
@@ -10,8 +10,7 @@ type DeckPreviewProps = {
   side: CardSide
   front_text?: string
   back_text?: string
-  // When set, the cover face becomes an image drop/pick target driven by this
-  // shared staging interface (settings design preview only).
+  // Turns the cover face into an image drop/pick target for the settings design preview.
   cover_editing?: boolean
   cover_image?: CoverImage
 }

--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -10,17 +10,16 @@ import { useI18n } from 'vue-i18n'
 type DeckThumbnailProps = {
   deck?: Deck
   hide_title?: boolean
-  // skip the hover-to-reveal fade — corner action stays visible unconditionally
+  // Skips the hover-to-reveal fade — the corner action stays visible unconditionally.
   corner_action_always_visible?: boolean
-  // grid is in drag-to-reorder mode: the card is a drag handle, not tappable
+  // True while the grid is in drag-to-reorder mode — the card is a drag handle, not tappable.
   rearranging?: boolean
-  // this is the card currently being picked up — show a lift shadow
+  // True for the card currently being picked up — shows a lift shadow.
   dragging?: boolean
-  // hold the hover/press look open (e.g. while the card's options menu is up)
+  // Holds the hover/press look open, e.g. while the card's options menu is up.
   active?: boolean
-  // downgrade-grace lock override. Defaults to the deck's own `is_locked`;
-  // the dashboard grid passes a rank-recomputed value so a reorder across the
-  // 10th position updates the dim/lock optimistically, without a backend round-trip.
+  // Overrides the deck's own `is_locked`, so a caller can dim/lock a card optimistically
+  // ahead of a backend round-trip (e.g. after a reorder crosses the 10th position).
   locked?: boolean
   sfx?: SfxOptions
 }
@@ -31,9 +30,8 @@ const {
   rearranging = false,
   dragging = false,
   active = false,
-  // Explicit `undefined` default: opt out of Vue's absent-Boolean-to-`false`
-  // coercion so the `deck?.is_locked` fallback below can still fire when a
-  // caller (the deck header) omits `locked` entirely.
+  // Explicit `undefined` opts out of Vue's absent-Boolean-to-`false` coercion, so the
+  // `deck?.is_locked` fallback below still fires when a caller omits `locked` entirely.
   locked = undefined,
   sfx
 } = defineProps<DeckThumbnailProps>()

--- a/src/components/layout-kit/app-window/index.vue
+++ b/src/components/layout-kit/app-window/index.vue
@@ -39,9 +39,7 @@ const {
 
 const { t } = useI18n()
 
-// The window is a raised surface: one step above whatever it opened over. The
-// body paints that surface; the sidebar is the recess beside it, so it reads
-// --color-below off the very same depth.
+/** A raised surface, one step above whatever it opened over; the sidebar recess beside it reads --color-below off this same depth. */
 const ambient_depth = useAmbientDepth()
 const depth = provideDepth(() => nextDepth(ambient_depth.value))
 
@@ -61,8 +59,7 @@ const header_border_class = computed(() => WINDOW_HEADER_BORDER_CLASS[header_bor
 const header_fill_class = computed(() => WINDOW_HEADER_FILL_CLASS[header_border])
 const close_label_text = computed(() => close_label ?? t('app-window.close-label'))
 
-// The default header owns the close button. A custom `header` slot replaces the
-// header entirely, so the caller owns its own close affordance there.
+/** Default header owns the close button; a custom `header` slot replaces the header entirely, so the caller owns its own close affordance there. */
 const show_builtin_close = computed(() => show_close_button && !slots.header)
 
 const header_bindings = computed(() =>

--- a/src/components/layout-kit/app-window/surface.ts
+++ b/src/components/layout-kit/app-window/surface.ts
@@ -6,11 +6,7 @@ export const WINDOW_HEADER_BORDER_CLASS: Record<WindowHeaderBorder, string> = {
   none: ''
 }
 
-// Paints back the strip the header's border mask cuts away, on a layer above
-// the overlay, so a lowered overlay is occluded along the shaped edge rather
-// than the header's straight box bottom. `none` needs no fill — its bottom edge
-// already is the box. `cloud` has no complement utility yet; a cloud-bordered
-// window that lowers its overlay will clip on a straight line until it does.
+/** Paints back the strip the header's shaped-border mask cuts away, so a lowered overlay occludes along the shaped edge. `cloud` has no fill utility yet — clips on a straight line until one's added. */
 export const WINDOW_HEADER_FILL_CLASS: Record<WindowHeaderBorder, string> = {
   wave: 'wave-bottom-fill-[50px]',
   cloud: '',

--- a/src/components/layout-kit/crossfade-resize.vue
+++ b/src/components/layout-kit/crossfade-resize.vue
@@ -7,9 +7,7 @@ import {
 } from '@/utils/animations/crossfade-resize'
 
 type CrossfadeResizeProps = {
-  // Snaps the wrapper's height instead of tweening it — set false only for
-  // panes with heavy DOM (a long transcript); see the perf note in
-  // `crossfadeResizeEnter`.
+  /** Snaps the wrapper's height instead of tweening it; set false only for panes with heavy DOM (a long transcript) — see the perf note in `crossfadeResizeEnter`. */
   animateHeight?: boolean
 }
 
@@ -22,9 +20,7 @@ const emit = defineEmits<{
 
 const wrapper = useTemplateRef<HTMLElement>('wrapper')
 
-// Stays full-bleed (no padding) so slotted children own their inset via the
-// parent's padding var — outlines/shadows then sit clear of the overflow clip
-// the swap applies mid-tween.
+// Stays full-bleed so slotted children's own inset keeps outlines/shadows clear of the overflow clip mid-tween.
 function onBeforeLeave() {
   emit('swap-start')
   if (wrapper.value) crossfadeResizeBeforeLeave(wrapper.value)()

--- a/src/components/layout-kit/dialog-card/dialog-card-body.vue
+++ b/src/components/layout-kit/dialog-card/dialog-card-body.vue
@@ -3,32 +3,12 @@ import { computed, useTemplateRef } from 'vue'
 import UiScrollBar from '@/components/ui-kit/scroll-bar.vue'
 import { useDialogCardViewport } from './dialog-card-viewport'
 
-/**
- * The dialog-card's scrolling region. Opt-in: wrap the default slot in it when
- * the body can overflow, and it owns the overflow, the bottom padding, and the
- * custom scroll-bar's placement — the three things every scrolling call site
- * used to hand-roll slightly differently.
- *
- * `--dialog-body-pb` comes from the card and collapses to 0 when the card has a
- * `#toolbar`, since the toolbar row then owns the space above the bottom edge.
- * The fallback keeps a body rendered outside a dialog-card sane.
- *
- * The scroll-bar hangs in the card's own horizontal padding (`-right-6` against
- * a `--dialog-px` of 1.5–2rem), so the body has to sit in the content column
- * rather than break out of it.
- */
+/** The dialog-card's opt-in scrolling region — owns the overflow, bottom padding, and custom scroll-bar placement. →[K:dialog-card-overflow-bleed] */
 
 type DialogCardBodyProps = {
-  // Selector or element for an inner scroller (an options-panel's content, say)
-  // when the overflow lives deeper than this wrapper. Omitted, the body scrolls.
+  /** Selector or element for an inner scroller (an options-panel's content, say) when the overflow lives deeper than this wrapper; omitted, the body scrolls. */
   scroll_target?: string | HTMLElement
-  // Opt-in horizontal bleed for corner-overhang content (e.g. an absolutely
-  // positioned menu/tick sitting a few px outside a grid cell). `overflow-y-auto`
-  // clips the x-axis too, so without this the overhang gets cut off. Adds
-  // matching padding + negative margin on the scrolling content div, widening
-  // its clip boundary into the surrounding `--dialog-px` gutter while the
-  // slotted content's own visible position doesn't move. Horizontal only — the
-  // top edge isn't clipped, and bleeding it too could collide with a header.
+  /** Opt-in horizontal bleed for corner-overhang content that `overflow-y-auto` would otherwise clip. →[K:dialog-card-overflow-bleed] */
   overflow_bleed?: boolean
 }
 

--- a/src/components/layout-kit/dialog-card/dialog-card-pager.vue
+++ b/src/components/layout-kit/dialog-card/dialog-card-pager.vue
@@ -3,7 +3,7 @@ import { sessionPaneEnter, sessionPaneLeave } from '@/utils/animations/session-p
 
 export type DialogCardPagerProps = {
   mode?: 'in-out' | 'out-in'
-  // Skip the entering pane's pre-enter delay (snappy reversible navigation).
+  /** Skips the entering pane's pre-enter delay, for snappy reversible navigation. */
   instant?: boolean
 }
 

--- a/src/components/layout-kit/dialog-card/index.vue
+++ b/src/components/layout-kit/dialog-card/index.vue
@@ -45,15 +45,9 @@ export type DialogCardProps = {
   dialog_px?: string
   content_max_width?: string
   content_breakout_max_width?: string
-  // Takes the header out of flow (absolutely pinned to the top) so the body
-  // fills the card's full height and any centering inside it is relative to
-  // that full height, not the space left over after the header. The header
-  // then visually floats over the top of the body instead of pushing it down.
+  /** Pins the header out of flow at the top so the body fills the card's full height, and the header floats over it instead of pushing it down. */
   float_header?: boolean
-  // Background utility classes. A dedicated prop rather than a `class`
-  // override so a caller's value replaces the default outright instead of
-  // both landing in the same Tailwind layer, where two conflicting bg-*
-  // utilities race unpredictably.
+  /** Dedicated prop rather than a `class` override, so a caller's value replaces the default outright instead of two conflicting bg-* utilities racing in the same Tailwind layer. */
   bg_class?: string
 }
 
@@ -82,26 +76,18 @@ const slots = defineSlots<{
   'header-start'(): any
   'header-end'(): any
   default(props: { viewport: DialogCardViewport }): any
-  // Pinned bottom row, outside the body's flow — action bars that must stay put
-  // while the body scrolls.
+  /** Pinned bottom row, outside the body's flow — action bars that must stay put while the body scrolls. */
   toolbar?(): any
 }>()
 
 const { t } = useI18n()
 
-// A dialog card always floats over the surface that opened it.
+/** Always floats over the surface that opened it. */
 const ambient_depth = useAmbientDepth()
 const depth = provideDepth(() => nextDepth(ambient_depth.value))
 
 const viewport = provideDialogCardViewport(full_bleed_at ?? SIZE_FULL_BLEED_AT[size])
-/**
- * Both of these read `slots.toolbar`, which is NOT reactive — wrapping either in
- * a `computed` would cache the first answer and never see a `v-if`'d toolbar
- * appear. Called from the template instead, so they re-run every render.
- *
- * Each branch spells its class out in full: Tailwind only generates an
- * arbitrary-value class it can find verbatim in the source.
- */
+/** Called from the template, not a `computed` — `slots.toolbar` isn't reactive. →[K:dialog-card-toolbar-slot-reactivity] */
 function gridRowsClass() {
   if (float_header) {
     return slots.toolbar ? 'grid-rows-[minmax(0,1fr)_auto]' : 'grid-rows-[minmax(0,1fr)]'
@@ -110,26 +96,15 @@ function gridRowsClass() {
   return slots.toolbar ? 'grid-rows-[auto_minmax(0,1fr)_auto]' : 'grid-rows-[auto_minmax(0,1fr)]'
 }
 
-/**
- * Bottom padding the body should leave itself. With a toolbar the toolbar row
- * owns that space, so the body takes none. Published as a variable rather than
- * injected state for the same non-reactivity reason.
- */
+/** With a toolbar, the toolbar row owns the bottom space and the body takes none. →[K:dialog-card-toolbar-slot-reactivity] */
 function bodyPaddingStyle() {
   return { '--dialog-body-pb': slots.toolbar ? '0px' : 'var(--dialog-px)' }
 }
 
-// `--content-grid-padding` is set here directly rather than via a
-// `content-grid-px-(--dialog-px)` class: Tailwind's arbitrary-value matcher
-// for that utility never actually generates a rule for a bare custom-property
-// reference, so the class silently no-ops and the padding stays at the
-// content-grid default of 0 — every direct child then renders flush against
-// the card's edge instead of inset by --dialog-px.
-//
-// --content-grid-max-width is capped to 100% on mobile so the content column
-// always resolves to `100% - padding*2` instead of the (larger, desktop-sized)
-// fixed max-width — otherwise a phone narrower than the size's max-width but
-// still wider than `100% - padding*2` renders content flush against the edge.
+/** Set directly rather than via a Tailwind arbitrary-value class. →[K:dialog-card-content-grid-padding] */
+// --content-grid-max-width caps to 100% on mobile so the content column always
+// resolves to `100% - padding*2`, rather than a fixed desktop-sized max-width
+// that could still be narrower than the phone's viewport.
 const card_style = computed(() => ({
   ...(dialog_px && { '--dialog-px': dialog_px }),
   '--content-grid-padding': 'var(--dialog-px)',

--- a/src/components/layout-kit/dialog-card/index.vue
+++ b/src/components/layout-kit/dialog-card/index.vue
@@ -101,10 +101,13 @@ function bodyPaddingStyle() {
   return { '--dialog-body-pb': slots.toolbar ? '0px' : 'var(--dialog-px)' }
 }
 
-/** Set directly rather than via a Tailwind arbitrary-value class. →[K:dialog-card-content-grid-padding] */
-// --content-grid-max-width caps to 100% on mobile so the content column always
-// resolves to `100% - padding*2`, rather than a fixed desktop-sized max-width
-// that could still be narrower than the phone's viewport.
+/**
+ * `--content-grid-padding` is set directly rather than via a Tailwind
+ * arbitrary-value class. →[K:dialog-card-content-grid-padding]
+ *
+ * `--content-grid-max-width` caps to 100% on mobile so the content column
+ * resolves to `100% - padding*2`, not a fixed desktop-sized max-width.
+ */
 const card_style = computed(() => ({
   ...(dialog_px && { '--dialog-px': dialog_px }),
   '--content-grid-padding': 'var(--dialog-px)',

--- a/src/components/layout-kit/field-row.vue
+++ b/src/components/layout-kit/field-row.vue
@@ -5,8 +5,7 @@ import UiIcon from '@/components/ui-kit/icon.vue'
 type FieldRowProps = {
   label: string
   tooltip?: string
-  // Stack the label above the control below `md` — for wide controls that don't
-  // fit beside the label on narrow screens.
+  /** Stacks the label above the control below `md`, for wide controls that don't fit beside the label on narrow screens. */
   stack?: boolean
 }
 

--- a/src/components/layout-kit/paged-window/directory-page.vue
+++ b/src/components/layout-kit/paged-window/directory-page.vue
@@ -27,8 +27,7 @@ const emit = defineEmits<{
 
 const layout_mode = inject(windowLayoutKey)
 
-// On phone the scroll container carries no padding, so the directory page owns
-// its own inset; on tablet/desktop the container already pads with `--window-px`.
+/** Phone owns its own inset, since the scroll container carries no padding there; tablet/desktop's container already pads with `--window-px`. */
 const padding_class = computed(() =>
   layout_mode?.value === 'phone' ? 'px-(--window-px) pb-(--window-px)' : ''
 )

--- a/src/components/layout-kit/paged-window/index.vue
+++ b/src/components/layout-kit/paged-window/index.vue
@@ -17,8 +17,7 @@ export type Page = {
   value: string
   icon?: string
   danger?: boolean
-  // Whether this page appears as a sidebar entry on desktop. Defaults to true;
-  // set false for pages only reachable via the directory or an aside affordance.
+  /** Whether this page appears as a sidebar entry on desktop; defaults to true, set false for pages only reachable via the directory or an aside affordance. */
   sidebar?: boolean
 }
 
@@ -42,9 +41,7 @@ export type PagedWindowProps = PagedWindowFrameProps & {
   hover_sfx?: SoundKey | SoundKey[] | ''
   select_sfx?: SoundKey | ''
   reselect_sfx?: SoundKey | ''
-  // Stretch the page column to the full content height instead of sizing it to
-  // its content, so a page can pin its own footer to the bottom. Off by
-  // default — pages sit at the top and end where their content does.
+  /** Stretches the page column to the full content height instead of sizing to its content, so a page can pin its own footer to the bottom. Off by default. */
   stretch_page?: boolean
 }
 
@@ -116,9 +113,7 @@ const directory_groups = computed<DirectoryPageGroup[]>(() =>
   }))
 )
 
-// Window's own close button shows on phone/tablet (no sidebar), where it doubles
-// as a back affordance once a page is open. Desktop navigates via the sidebar,
-// which carries its own close button.
+/** Shows on phone/tablet (no sidebar), doubling as a back affordance once a page is open; desktop navigates via the sidebar's own close button instead. */
 const window_close_button = computed(
   () => (!has_pages.value || !has_sidebar.value) && show_close_button
 )

--- a/src/components/layout-kit/paged-window/layout.ts
+++ b/src/components/layout-kit/paged-window/layout.ts
@@ -17,9 +17,6 @@ type WindowLayoutOptions = {
  *
  * `desktop` requires `desktop_query` to be set and matched; otherwise the window
  * only ever toggles between `phone` and `tablet`.
- *
- * @example
- * const { layout_mode, window_px } = useWindowLayout({ desktop_query: 'w>=lg & fine' })
  */
 export function useWindowLayout(opts?: WindowLayoutOptions) {
   const phone_query = opts?.phone_query ?? 'w<md'

--- a/src/components/layout-kit/paged-window/page-transition.ts
+++ b/src/components/layout-kit/paged-window/page-transition.ts
@@ -4,8 +4,7 @@ import { tabSlideEnter, tabSlideLeave } from '@/utils/animations/tab-slide'
 import type { WindowLayout } from './layout'
 
 type PageTransitionOptions = {
-  // Runs in the empty gap between the leaving and entering page — the one frame
-  // with no page mounted, so any reflow it triggers can't shift live content.
+  /** Runs in the empty gap between the leaving and entering page — the one frame with no page mounted, so any reflow it triggers can't shift live content. */
   between?: () => void | Promise<void>
 }
 

--- a/src/components/member/member-card.vue
+++ b/src/components/member/member-card.vue
@@ -28,10 +28,8 @@ const created_on = computed(() => formatShortDate(createdAt, locale.value))
 
 const body_bindings = computed(() => memberCoverBindings(cover))
 
-// The card's own chrome is a fixed brown-200 panel (not a depth-ramp surface),
-// but it IS a surface its children sit on — declare depth 1 so a neutral element
-// on it (the avatar-edit button) resolves to the lighter brown-50 pop rather
-// than the depth-0 brown-300 it would fall through to.
+// The card's fixed panel isn't itself depth-ramped, but children on it (the avatar-edit
+// button) still need to resolve to brown-50, not the depth-0 brown-300 they'd fall through to.
 provideDepth(1)
 </script>
 

--- a/src/components/mobile-dock/mobile-dock-host.vue
+++ b/src/components/mobile-dock/mobile-dock-host.vue
@@ -19,17 +19,17 @@ const bar = useTemplateRef<HTMLElement>('bar')
 const content_wrapper = useTemplateRef<HTMLElement>('content_wrapper')
 const content = useTemplateRef<HTMLElement>('content')
 
-// Publish the dock's live height to :root so any view can pad its content clear
-// of the bar. 0 while hidden (keyboard open, or the current route's breakpoint
-// doesn't match) so layouts collapse the gap.
+/**
+ * Publishes the dock's live height to `--mobile-dock-height` on `:root`, so any view can
+ * pad content clear of the bar. Reports 0 while the dock is hidden, collapsing the gap.
+ */
 function publishHeight() {
   const visible = is_mobile.value && !is_keyboard_open.value
   const height = visible ? (content.value?.offsetHeight ?? 0) : 0
   document.documentElement.style.setProperty('--mobile-dock-height', `${height}px`)
 }
 
-// Tweens content_wrapper across route swaps (a fixed footer with tiny, cheap
-// content — real height tween is safe here, unlike the transcript case).
+// Tiny, cheap footer content — a real height tween is safe here, unlike the transcript case.
 useAnimatedHeight(
   content_wrapper,
   content,

--- a/src/components/mobile-dock/use-mobile-dock.ts
+++ b/src/components/mobile-dock/use-mobile-dock.ts
@@ -1,25 +1,14 @@
 import { ref } from 'vue'
 import type { BreakpointKey } from '@/composables/ui/media-query'
 
-// A single dock exists app-wide. The host (`mobile-dock-host`) renders the fixed
-// chrome and registers its element here. Module-level (like the modal stack)
-// because there's one shared instance and the host/fill are siblings in the tree
-// — provide/inject can't bridge them.
+// Module-level, not provide/inject — the host and its `<mobile-dock>` fill are
+// siblings in the tree, so there's no ancestor to provide from.
 const el = ref<HTMLElement | null>(null)
 
-// The breakpoint below which the host shows itself — set by whichever
-// `<mobile-dock>` fill is currently mounted, so each route can pick its own
-// (deck-view's actions fit down to `md`, dashboard's don't shrink that far).
+// Set by whichever `<mobile-dock>` fill is currently mounted, so each route picks its own.
 const breakpoint = ref<BreakpointKey>('xl')
 
-/**
- * Shared state for the mobile dock — the fixed bottom bar that routes project
- * content into via `<mobile-dock>`.
- *
- * @returns `el` — the host's `<footer>` element, for routes that need to measure
- *   it (e.g. lifting scrolled content clear of the bar); `breakpoint` — the
- *   current fill's visibility threshold, read by the host to decide when to show.
- */
+/** Shared state for the mobile dock — the fixed bottom bar `<mobile-dock>` routes content into. */
 export function useMobileDock() {
   return { el, breakpoint }
 }

--- a/src/components/taro-phone/index.vue
+++ b/src/components/taro-phone/index.vue
@@ -43,10 +43,10 @@ function closePhone() {
   document.removeEventListener('pointerdown', onPageClick)
 }
 
-// Listens on pointerdown (not click) so outside-detection runs before any
-// click handler in the interaction — e.g. a modal's own close button — has a
-// chance to mutate modal_stack/is_open first, which would otherwise race
-// against this check.
+/**
+ * Closes the phone on an outside click. Listens on pointerdown, not click, so this runs
+ * before an in-flight click handler (e.g. a modal's own close button) can race it.
+ */
 function onPageClick(e: Event) {
   if (!store.is_open) return
 

--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -301,20 +301,10 @@ function onClick(e: MouseEvent) {
   --btn-outline-color: transparent;
 }
 
-/* ─── CHROME / IDENTITY SEAM ─────────────────────────────────────────────
- *
- * The base variant rules above read the identity role (--color-accent). A plain
- * button resolves it to the default accent; a button carrying `[data-palette]`
- * has already had --color-accent set on ITSELF by palettes.gen.css, so the
- * base rule resolves to THIS button's palette. `data-palette` is a plain HTML
- * attribute — attributes don't inherit — so a plain button nested in a
- * `data-palette="green"` region does NOT pick it up: identity is opt-in,
- * attribute-on-self, leak-proof by construction, with no extra selector needed.
- *
- * NEUTRAL — `.ui-kit-btn--neutral`. Solid defaults to accent because a solid
- * button is an action; the raised NEUTRAL button opts in explicitly and paints
- * the `element` chrome role. Ghost/outline are transparent chrome already, so
- * neutral only swaps their text/outline off accent onto ink. */
+/* A button only takes on a palette's colours if `data-palette` is on the button
+   itself. Attributes don't inherit, so a plain button sitting inside a coloured
+   region stays neutral — deliberately, so palettes can't leak into everything
+   nested under them. →[K:theming-palette-identity] */
 
 .ui-kit-btn--neutral.ui-kit-btn--solid {
   --btn-bg-color: var(--color-element);

--- a/src/components/ui-kit/dropdown-button/caret.vue
+++ b/src/components/ui-kit/dropdown-button/caret.vue
@@ -11,9 +11,8 @@ type DropdownCaretProps = {
   icon?: string
   size?: NonNullable<ButtonProps['size']>
   disabled?: boolean
-  // Chrome vs identity: a neutral caret rings itself in the `element` role;
-  // otherwise it reads `--color-accent`, which it inherits from the identity
-  // button it sits inside (that button carries the `data-palette`).
+  // A neutral caret rings itself in the `element` role; otherwise it reads
+  // `--color-accent`, inherited from the identity button it sits inside.
   neutral?: boolean
 }
 
@@ -41,12 +40,8 @@ const TRIGGER_PADDING: Record<NonNullable<ButtonProps['size']>, string> = {
 }
 const trigger_padding = computed(() => TRIGGER_PADDING[size])
 
-// A NEUTRAL caret is the two-tone companion of its button: it fills
-// --color-element-soft (a subtle adjacent neutral, brown-200 in light) at the
-// button's own ambient depth, so the pair reads as button + companion caret with
-// no ring. An IDENTITY caret has no such companion role, so it keeps the stepped
-// surface + accent pixel-seam: it sits one surface above (data-depth) and rings
-// itself in --color-accent, inherited from the identity button it sits in.
+// Only an identity caret uses this — it sits one depth surface above its
+// button to carry the stepped accent ring; a neutral caret ignores depth.
 const depth = computed(() => nextDepth(ambient_depth.value))
 
 function onEnter(el: Element, done: () => void) {

--- a/src/components/ui-kit/dropdown-button/index.vue
+++ b/src/components/ui-kit/dropdown-button/index.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
-// Only one dropdown menu may be open at a time, app-wide. Outside-click close
-// usually enforces this on its own, but a long-press open swallows the release
-// click (see press-hold.ts), so the previous menu would survive — the seam
-// closes it explicitly instead.
+/**
+ * The one dropdown allowed open app-wide — opening a new one closes this.
+ * Needed because a long-press open swallows the release click, so outside-click
+ * close never fires for it.
+ */
 let close_open_menu: (() => void) | null = null
 
 export type { DropdownOption } from './types'
@@ -39,13 +40,12 @@ type DropdownButtonProps = Pick<
   openOnTrigger?: boolean
   hideTrigger?: boolean
   shadow?: boolean
-  // Render only the trigger button — no primary action label alongside it.
+  // Renders only the trigger button, with no primary-action label beside it.
   triggerOnly?: boolean
-  // Disable only the primary action — the caret trigger stays live so the menu
-  // can still be opened (e.g. "already added, but add to another deck").
+  // Disables the primary action only — the caret stays live so the menu can
+  // still be opened.
   primaryDisabled?: boolean
-  // Disable the whole control — primary action AND the caret trigger, so the
-  // menu can't be opened either.
+  // Disables the primary action and the caret, so the menu can't open either.
   disabled?: boolean
 }
 
@@ -60,9 +60,8 @@ const {
   iconLeft,
   iconRight,
   sfx,
-  // Mirror ui-button's tap defaults: an absent Boolean prop casts to `false`,
-  // which would otherwise forward `:play-on-tap="false"` and suppress the
-  // button's own quiet-tap default. Keep in sync with button.vue.
+  // Mirrors button.vue's default — an absent Boolean prop casts to `false` and
+  // would otherwise suppress the button's own quiet-tap default.
   playOnTap = true,
   tapAnimate = false,
   position = 'bottom-start',
@@ -83,8 +82,7 @@ const emit = defineEmits<{
 
 const slots = defineSlots<{
   default(): unknown
-  // Raw dropdown body — replaces the options menu when provided. Receives
-  // `close` so the panel can dismiss the dropdown itself.
+  // Raw dropdown body, replacing the options menu; `close` lets it dismiss itself.
   panel(props: { close: () => void }): unknown
 }>()
 
@@ -93,43 +91,32 @@ const ambient_depth = useAmbientDepth()
 
 const popover_open = ref(false)
 
-// A dropdown trigger is CHROME by default — most are settings/overflow/option
-// menus, not accent actions. An accent dropdown opts in by passing a
-// `data-palette`, which routes onto the trigger button (and, via inheritance,
-// its caret) so the `[data-palette]` seam repaints it. Absent that, the trigger
-// button + caret render the `element` chrome roles (`neutral`).
+// Neutral (chrome) by default; opts into a palette only via `data-palette` on
+// this component. →[K:theming-palette-identity]
 const identity_palette = computed(() => attrs['data-palette'] as string | undefined)
 const is_neutral = computed(() => !identity_palette.value)
 
-// Callers reach these through a template ref: `open` to mirror the menu state
-// (e.g. keeping a card's active look while its menu is up), `show` to open the
-// menu from a gesture that isn't a trigger press (e.g. a long-press on the card).
+// `open` lets a caller mirror the menu state; `show` opens it from a gesture
+// that isn't a trigger press (e.g. a long-press on the card).
 defineExpose({ open: popover_open, show })
 
-// Class/layout attrs ride the popover container, while event handlers — the
-// consumer's primary @click — land on the inner button so they fire only from
-// the label region. Nothing is injected here: the container inherits the
-// ambient depth and identity like any other element.
+// Class/layout attrs ride the popover container; event handlers land on the
+// inner button instead, so they fire only from the label region.
 const popover_attrs = computed(() =>
   filter_attrs((key) => !key.startsWith('on') && key !== 'data-palette')
 )
-// `onClick` is handled through `onButtonClick` instead of forwarded, so the inner
-// button never receives both it and the trigger handler as a merged array — which
-// its play-on-tap intercept can't invoke (it expects a single onClick function).
+// `onClick` goes through `onButtonClick` instead, so the inner button never
+// receives it merged with the trigger handler as an array.
 const button_attrs = computed(() =>
   filter_attrs((key) => key.startsWith('on') && key !== 'onClick')
 )
 
-// The caret is the only way to open the menu unless the whole button is the
-// trigger, so it can only be hidden when `openOnTrigger` also makes the label
-// region open the popover.
+// Hideable only when `openOnTrigger` gives the label region its own way to
+// open the menu — otherwise the caret is the only trigger.
 const show_trigger = computed(() => !hideTrigger || !openOnTrigger)
 
-// The menu paints --color-element at the trigger's own ambient depth, so while
-// open the TRANSPARENT variants (ghost, outline) fill with that same element and
-// the trigger + menu read as one continuous surface. A SOLID button already fills
-// element, so it needs nothing. Neither shifts depth — the menu matches the
-// button's depth, not a stepped one.
+// Ghost/outline variants get an explicit fill while open, matching the menu's
+// background, so the two read as one surface; solid already fills.
 const trigger_style = computed(() => {
   if (variant === 'solid' || !popover_open.value) return undefined
   return { '--btn-bg-color': 'var(--color-element)', '--btn-text-color': 'var(--color-on-element)' }

--- a/src/components/ui-kit/icon.vue
+++ b/src/components/ui-kit/icon.vue
@@ -6,9 +6,7 @@ const { src } = defineProps<{
   src: string
 }>()
 
-// All icons are currently eager (bundled into the main chunk).
-// To make a subset lazy, replace the eager glob with an explicit file list
-// and let the rest fall through to the lazy glob below.
+/** Every icon, bundled eagerly. To make a subset lazy, list it explicitly and let the rest fall through to `lazyIcons` below. */
 const eagerIcons: Record<string, Component> = import.meta.glob('../../assets/icons/*.svg', {
   eager: true,
   import: 'default'

--- a/src/components/ui-kit/input.vue
+++ b/src/components/ui-kit/input.vue
@@ -76,9 +76,8 @@ const value = defineModel<string>('value')
   color: var(--color-ink);
 }
 
-/* The field is a WELL — one step below whatever surface it sits on. It used to
-   fake `data-theme="brown-100"` to get a neutral fill, which overwrote the real
-   identity for everything inside it. */
+/* One step below whatever surface it sits on — a real depth well, not the old
+   `data-theme="brown-100"` fake that overwrote the real identity underneath. */
 .ui-kit-input {
   background-color: var(--color-below);
   border-radius: var(--radius-4);

--- a/src/components/ui-kit/modal/mode-config.ts
+++ b/src/components/ui-kit/modal/mode-config.ts
@@ -21,11 +21,8 @@ export const MODAL_MODE_CONFIG: Record<ModalMode, ModeConfig> = {
     leave: (el, _, done) => slideDownFadeOut(el, done)
   },
 
-  // The `mobile-modal:` Tailwind variant (defined in
-  // `src/styles/custom-variants.css`) activates these utilities when the
-  // viewport drops below the modal's threshold (data-mobile-below-width/height
-  // are stamped by ui-kit/modal/index.vue). Keeping the class string static on
-  // the Vue side avoids touch-disrupting setAttribute calls during scroll on iOS Safari.
+  // Static string, not a computed class — a reactive one triggers Safari's
+  // touch-disrupting setAttribute mid-scroll.
   'mobile-sheet': {
     containerClass:
       'items-center mobile-modal:flex-col mobile-modal:overflow-y-auto mobile-modal:overscroll-y-contain mobile-modal:justify-start mobile-modal:pt-4 mobile-modal:pointer-events-auto',

--- a/src/components/ui-kit/popover.vue
+++ b/src/components/ui-kit/popover.vue
@@ -104,10 +104,8 @@ onUnmounted(() => {
 
 const side = computed(() => placement.value.split('-')[0] as 'top' | 'right' | 'bottom' | 'left')
 
-// Teleporting to <body> severs DOM inheritance, so the panel would fall back to
-// the root's depth and identity. Snapshot the trigger's RESOLVED values and
-// restate them on the teleported node. Only when teleported — the in-place path
-// inherits correctly on its own, and restating there would pin a stale value.
+// Teleporting to <body> severs DOM inheritance, so restate the trigger's
+// resolved depth/palette on the teleported node; the in-place path inherits them.
 const inherited_context = computed(() => {
   if (!teleport || !open) return {}
 
@@ -226,10 +224,8 @@ watch(
   display: block;
 }
 
-/* Applied per-piece (arrow here, the slotted panel applies its own) rather
-   than on `.ui-kit-popover` itself — a `filter` on that shared box creates a
-   rendering layer clipped to its own bounds, cutting off the arrow, which is
-   deliberately positioned to poke out past that edge. */
+/* Kept off `.ui-kit-popover` itself — a `filter` there would clip the arrow,
+   which deliberately pokes out past the box's edge. */
 .ui-kit-popover--shadow .ui-kit-popover__arrow-default {
   filter: drop-shadow(var(--drop-shadow-sm));
 }

--- a/src/components/ui-kit/scroll-bar.vue
+++ b/src/components/ui-kit/scroll-bar.vue
@@ -4,8 +4,7 @@ import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue'
 type UiScrollBarProps = {
   target?: string | HTMLElement
   // Viewport width above which the bar can show on a fine pointer. Page-level
-  // scroll-bars stay 'md' (avoid a custom bar on a narrow desktop window);
-  // container-local ones can drop to 'sm' to match their own mobile breakpoint.
+  // bars stay 'md'; container-local ones can drop to 'sm'.
   minWidth?: 'sm' | 'md'
 }
 
@@ -40,7 +39,6 @@ const thumbStyle = computed(() => ({
 onMounted(attach)
 onUnmounted(detach)
 
-/** SETUP */
 function attach() {
   scrollTarget = resolveTarget(target)
 
@@ -85,7 +83,6 @@ function detach() {
   scrollTarget = null
 }
 
-/** SCROLLBAR LOGIC */
 function scheduleUpdate() {
   if (animationFrame) return
 
@@ -141,7 +138,6 @@ function setScrollFromThumb(offsetPx: number) {
   scrollTarget.scrollTop = maxThumbTravel > 0 ? (clamped / maxThumbTravel) * maxScroll : 0
 }
 
-/** EVENT HANDLERS */
 function onThumbPointerDown(e: PointerEvent) {
   dragging.value = true
   dragStartY = e.clientY
@@ -175,7 +171,6 @@ function onTrackPointerDown(e: PointerEvent) {
   scheduleUpdate()
 }
 
-/** HELPER FUNCTIONS */
 function resolveTarget(target?: string | HTMLElement): HTMLElement | null {
   if (!target) return null
   if (typeof target !== 'string') return target

--- a/src/components/ui-kit/tag-button.vue
+++ b/src/components/ui-kit/tag-button.vue
@@ -59,11 +59,8 @@ const padding = computed(() => {
 </template>
 
 <style>
-/* Same chrome/identity seam as ui-tag: `element` chrome by default, identity
-   opt-in via a self `[data-palette]`. The seam vars sit on the SHELL (the
-   component root that fall-through attrs land on) so the hover drop-shadow
-   silhouette can read them and the inner button + bgx sweep inherit them.
-   Self-selectors, so no ancestor leak. */
+/* Element chrome by default; `[data-palette]` on the shell opts into the accent,
+   so the hover silhouette and bgx sweep inherit it too. →[K:theming-palette-identity] */
 .ui-tag-button-shell {
   --tagbtn-bg: var(--color-element);
   --tagbtn-fg: var(--color-on-element);

--- a/src/components/ui-kit/tag.vue
+++ b/src/components/ui-kit/tag.vue
@@ -71,12 +71,8 @@ const mask = computed(() => {
 </template>
 
 <style>
-/* Raised neutral chip. Chrome (`element`) by default; identity is opt-in and
-   attribute-on-self via `[data-palette]`. Both are self-selectors, so an
-   ancestor palette can't leak in: the base rule never reads --color-accent, and
-   the identity rule only matches when the attribute sits on THIS element
-   (attributes don't inherit), at which point --color-accent resolves to this
-   tag's own palette. */
+/* Raised neutral chip by default; only takes on a palette's colours when
+   `data-palette` sits on the tag itself. →[K:theming-palette-identity] */
 .ui-kit-tag {
   --tag-bg: var(--color-element);
   --tag-fg: var(--color-on-element);

--- a/src/components/ui-kit/textarea.vue
+++ b/src/components/ui-kit/textarea.vue
@@ -89,9 +89,8 @@ function onInput() {
   color: var(--color-ink);
 }
 
-/* The field is a WELL — one step below whatever surface it sits on. It used to
-   fake `data-theme="brown-100"` to get a neutral fill, which overwrote the real
-   identity for everything inside it. */
+/* One step below whatever surface it sits on — a real depth well, not the old
+   `data-theme="brown-100"` fake that overwrote the real identity underneath. */
 .ui-kit-textarea {
   background-color: var(--color-below);
   border-radius: var(--radius-4);

--- a/src/components/ui-kit/tooltip.vue
+++ b/src/components/ui-kit/tooltip.vue
@@ -3,10 +3,8 @@ import { computed, ref, useTemplateRef, watch, onBeforeUnmount } from 'vue'
 import { useFloating, flip, autoUpdate, offset, type Placement } from '@floating-ui/vue'
 import { useMatchMedia } from '@/composables/ui/media-query'
 
-// A tooltip is context-independent overlay chrome by design: it deliberately
-// contrasts with whatever it floats over, in both modes, so it inherits
-// nothing. `data-depth="overlay"` is exactly that — off the depth ramp, fixed
-// per mode (src/styles/depth.css).
+// Tooltips are context-independent overlay chrome — `data-depth="overlay"`
+// keeps them off the depth ramp entirely, fixed per mode (src/styles/depth.css).
 const {
   text,
   position = 'top',
@@ -35,10 +33,8 @@ const popoverRef = useTemplateRef<HTMLElement>('ui-tooltip')
 const is_active = ref(false)
 const is_coarse_pointer = useMatchMedia('coarse')
 
-// gates both DOM mount (v-if) and autoUpdate — keeps unused tooltips out of
-// the DOM entirely so switching modes doesn't pay the cost of mounting N
-// teleported popovers up front. Coarse pointers (touch) never show tooltips —
-// there's no hover to trigger them intentionally, only a tap-driven focus.
+// Gates both DOM mount and autoUpdate, so unused tooltips stay out of the DOM.
+// Coarse pointers never show one — there's no hover, only a tap-driven focus.
 const should_show = computed(
   () => !suppress && !is_coarse_pointer.value && (visible || is_active.value)
 )

--- a/src/components/ui-kit/wobble-box.vue
+++ b/src/components/ui-kit/wobble-box.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-// imports
 import { useId } from 'vue'
 import { useMatchMedia } from '@/composables/ui/media-query'
 
-// defines
 const { seed = 7 } = defineProps<{
   /** Turbulence seed — vary it to give reused instances a different wobble. */
   seed?: number
@@ -11,14 +9,12 @@ const { seed = 7 } = defineProps<{
 
 defineSlots<{ default: () => unknown }>()
 
-// composables + state
 // Filter ids must be unique per instance, or multiple boxes on one page
 // reference the same <filter> and the later ones render unfiltered.
 const filter_id = useId()
 
-// The SVG displacement filter exhausts iOS Safari's GPU filter buffer and
-// crashes the tab. On coarse pointers we drop the filter entirely and let the
-// uneven border-radius carry the hand-drawn blob shape on its own.
+// iOS Safari's GPU filter buffer crashes the tab on this displacement filter;
+// coarse pointers drop it and rely on the uneven border-radius instead.
 const is_coarse = useMatchMedia('coarse')
 </script>
 
@@ -38,9 +34,6 @@ const is_coarse = useMatchMedia('coarse')
           result="noise"
         />
         <feDisplacementMap in="SourceGraphic" in2="noise" scale="14" result="displaced" />
-        <!-- Blur smears the jagged displaced edge into a soft gradient, then the
-             colour-matrix steepens alpha (×11, −4.5 offset) to snap it back crisp —
-             leaving only a thin feathered band that reads as anti-aliasing. -->
         <feGaussianBlur in="displaced" stdDeviation="4" result="blurred" />
         <feColorMatrix
           in="blurred"
@@ -58,17 +51,15 @@ const is_coarse = useMatchMedia('coarse')
 </template>
 
 <style scoped>
-/* The background lives on a pseudo-element so the displacement filter wobbles
- * only the panel's edges — slotted content above it stays crisp. Uneven corner
- * radii plus the SVG turbulence give a soft, hand-drawn, mis-shapen look. */
+/* Lives on a pseudo-element so the filter wobbles only the panel's edges,
+ * leaving slotted content above it crisp. */
 .wobble-box::before {
   content: '';
   position: absolute;
   z-index: 0;
 
-  /* Supersample: render the panel at 2x, run the displacement filter, then
-   * scale back to 0.5x so the browser smooths the downscale and anti-aliases
-   * the wavy edge. Geometry below is doubled to compensate for the 0.5 scale. */
+  /* Supersamples at 2x then scales to 0.5x so the browser anti-aliases the
+   * wavy edge; geometry below is doubled to compensate. */
   left: 50%;
   top: 50%;
   width: 200%;


### PR DESCRIPTION
[TARO-342](https://app.notion.com/p/3b60953c224c8119accefc7b7568a741)

> Stacked on #525.

## Summary

- ~555 comment lines across ~90 files in `src/components/` brought to the spec. No comment remains in any `<template>`, no `@example` blocks, no section banners.
- The theming doctrine that lived inside one button's stylesheet is now `[K:theming-palette-identity]` in `corpus/theming/theming.md`, cited from four components.

## Closes the last dangling citation

`[K:theming-palette-identity]` is the third of the three slugs #520's signed-off examples cite — and `ui-kit/button.vue` carries your signed-off "good" comment verbatim. With this, all three of #520's example citations resolve.

## Other entries

`[K:text-editor-ghost-click-guard]` (the tap-refocus/ghost-click hazard in `card/text-editor.vue`), plus `[K:dialog-card-overflow-bleed]`, `[K:dialog-card-toolbar-slot-reactivity]` and `[K:dialog-card-content-grid-padding]` in a new `corpus/architecture/dialog-card-scroll.md`.

## Two hazards surfaced but not filed

Neither has a slug yet, so neither is in the register — flagging rather than losing them:

- A `filter`/`drop-shadow` on a shared parent creates a rendering layer clipped to that box's own bounds, cutting off any child positioned to overflow it. Must be applied per-piece, never on the shared ancestor. Seen twice: `popover.vue`'s arrow shadow, `tag-button.vue`'s hover silhouette.
- SVG `feDisplacementMap`/`feTurbulence` exhausts iOS Safari's GPU filter buffer and crashes the tab; needs a coarse-pointer gate with a non-filtered fallback. Seen in `wobble-box.vue`.