### PR TITLE
TARO-343: Comment sweep — utils and sfx

### DIFF
--- a/corpus/architecture/layering.md
+++ b/corpus/architecture/layering.md
@@ -1,0 +1,64 @@
+---
+id: layering
+domain: architecture
+status: current
+hazard: true
+related: [responsive]
+updated: 2026-08-08
+---
+
+# Layering
+
+Why a menu sometimes opens _underneath_ the thing it belongs to — and why the
+cause is almost never the code that drew the menu.
+
+Anything that floats above the page — a dropdown, a tooltip, a popover — is
+positioned against the window rather than against its parent. That works right
+up until some ancestor quietly changes the rules and makes itself the thing the
+floating element is measured against instead. From then on it is trapped: it
+can be clipped by that ancestor's edges, and it stacks with that ancestor
+rather than above the page.
+
+Nothing in the app asks for that. It is a side effect of animating.
+
+> [!HAZARD] [K:settled-transform-traps-overlays] **An animation that has finished still changes layout — the browser cares that a transform exists, not that it does nothing.**
+> Animation libraries leave their final values on the element as inline styles.
+> A finished move settles on "shift by zero"; a finished pop settles on "scale
+> by one"; a finished dim settles on "full brightness, no blur". Every one of
+> those is visually invisible and every one of them still counts, because the
+> browser's test is whether the property is set at all, not whether the value
+> does anything. So the moment a panel finishes animating, floating things
+> inside it get captured — and the bug surfaces later, somewhere else, in a
+> menu that worked fine before anyone touched the animation.
+> The cure is to clear the property when the animation lands, handing the
+> resting state back to the stylesheet.
+
+## Clear on the way in, not on the way out
+
+Only the animations that _finish visible_ need clearing. A pane that has
+animated out is being held off-screen by exactly the value you would be
+tempted to strip, so removing it snaps the pane back into view.
+
+The same asymmetry explains a subtler case. When one panel dims because
+another opened on top, the dimming has to be cleared when it is undone —
+otherwise a small alert opening and closing over a panel is enough to leave
+that panel permanently capturing its own dropdowns, long after the alert is
+gone.
+
+## Animate the child, not the positioned parent
+
+Where an element already carries a position of its own — a card sitting in a
+grid that places it — animating that same element makes two things fight over
+one property, and the composition is wrong in a way that looks like drift
+rather than a bug: scaling a parent scales its offset too, so the card slides
+as it grows.
+
+The fix is to animate one level in. The outer element keeps its placement, the
+inner one takes the animation, and neither has to know about the other.
+
+## What this isn't
+
+Not stacking order. Deciding which of two overlapping panels wins is a separate
+question with a separate answer; this topic is only about an element being
+captured into the wrong coordinate space in the first place, where stacking
+order no longer helps because the two things are no longer being compared.

--- a/corpus/architecture/responsive.md
+++ b/corpus/architecture/responsive.md
@@ -1,0 +1,74 @@
+---
+id: responsive
+domain: architecture
+status: current
+hazard: false
+related: [theming]
+updated: 2026-08-08
+---
+
+# Responsive conditions
+
+How the app asks "is this a small screen?" — and the short vocabulary every
+screen uses to ask it.
+
+A layout rarely wants to know the exact pixel width. It wants to know one thing
+about the situation: is there room for the sidebar, is this a touch device, is
+the window too short for the tall variant. Those questions are written as tiny
+token queries — `w>=lg & fine`, `w<md | h<sm` — rather than as full CSS media
+queries spelled out at every call site.
+
+## The vocabulary [K:media-query-token-language]
+
+An **atom** is one condition. There are four kinds:
+
+| Atom              | Asks                                    |
+| ----------------- | --------------------------------------- |
+| `w>=md` / `w<md`  | width at or above / below a breakpoint  |
+| `h>=lg` / `h<sm`  | height at or above / below a breakpoint |
+| `fine` / `coarse` | pointer — a mouse, or a finger          |
+| `dark` / `light`  | the system's colour-scheme preference   |
+
+Breakpoint names are the shared set: `sm`, `msm`, `md`, `mlg`, `lg`, `mxl`,
+`xl`, `2xl`. Their actual widths are read from the stylesheet, so a token query
+and a CSS rule can never disagree about where `md` starts.
+
+A **combinator** joins atoms: `&` means every atom must hold, `|` means any one
+of them. A query uses one or the other, never both — mixing them throws rather
+than guessing at precedence.
+
+> [!RULE]
+> A `<` atom is legal only under `|`, never under `&`.
+> "Too small" reads naturally as _any_ maximum exceeded — `w<md | h<sm`. Under
+> `&` it can't be expressed at all without negating the whole conjunction and
+> flipping every other atom with it, so a `<` atom under `&` throws on sight.
+> `>=` atoms are the mirror image and read naturally under `&`: big enough
+> means _every_ minimum met.
+
+## The answer is shared and permanent
+
+Asking the same question twice gets the same answer object back — one live
+listener per distinct query, kept for the life of the page and never torn down.
+Nothing is bound to a component, so a query can be read from anywhere: setup,
+render, an animation hook.
+
+That permanence is deliberate. Responsive conditions are page-wide facts, and
+two independent listeners for "is this a phone" is how a sidebar ends up
+visible while the column beside it has already fallen back to its narrow
+layout.
+
+> [!WATCH]
+> On iPhone the very first reading can be wrong. The viewport is still settling
+> — zoom and safe-area negotiation — at the instant a fresh page's first script
+> runs, so the answer is re-checked once after the first paint and corrected if
+> it drifted.
+
+## What this isn't
+
+Not theming. Whether the screen is dark is available here as an atom, but the
+dark-mode switch that actually recolours the app is [[theming]]'s, and it is
+driven by the member's saved choice rather than by the system preference alone.
+
+Not a general expression language. There are no parentheses, no nesting, and no
+negation — a condition too complicated to write as a flat list of atoms is a
+sign the layout wants splitting, not that the vocabulary wants extending.

--- a/corpus/sfx/sound.md
+++ b/corpus/sfx/sound.md
@@ -1,0 +1,83 @@
+---
+id: sound
+domain: sfx
+status: current
+hazard: true
+related: []
+updated: 2026-08-08
+---
+
+# Sound
+
+The taps, chimes, and clicks the interface makes — and why they go silent on a
+phone when nothing looks wrong.
+
+Every sound is a short clip, decoded once at startup and fired down a single
+audio channel the browser hands out. The channel is not always open. A browser
+keeps it shut until the person has actually touched the page, and a phone shuts
+it again whenever the screen locks or another app takes the foreground.
+
+So the interesting part of sound here isn't the playing. It's the reopening.
+
+> [!HAZARD] [K:ios-audio-interruption] **On iPhone the audio channel doesn't merely pause — it lands in a broken state that asking it to resume cannot fix.**
+> Locking the screen, taking a call, or switching apps drops the channel into a
+> state WebKit invented and no other browser has: _interrupted_. It looks
+> recoverable and isn't. The standard "carry on" call can hang forever without
+> ever reporting that it failed, so code waiting on the answer waits for good.
+> Two further edges make it worse. Only a **completed** touch counts as
+> reactivating — the finger lifting, never the finger landing — so listening for
+> the press instead of the release buys nothing at all. And asking to resume
+> before the person has touched anything is exactly what autoplay blocking
+> exists to reject; the browser refuses and logs a scolding of its own.
+> The only cure is to throw the channel away and build a fresh one inside the
+> gesture. [How the app recovers ↓](#reopening-the-channel)
+
+## Reopening the channel
+
+The app never assumes the channel survived anything. It watches for every
+signal that the page has come back — the tab becoming visible, the window
+regaining focus, the page being restored from the browser's back-forward
+cache, the channel itself announcing a state change — and treats all of them
+the same way: assume audio is dead, and get ready for the next touch.
+
+That readiness is the actual repair. A listener waits for the next completed
+gesture anywhere on the page, and when it fires, the old channel is discarded
+and a new one built on the spot, inside that gesture. The decoded clips are not
+tied to a channel, so nothing has to be downloaded again.
+
+Two smaller precautions ride along:
+
+- The listener runs on the way **down** the page rather than on the way back
+  up, so a control that stops the event from travelling further can't swallow
+  the one gesture that would have restored sound.
+- If the repair doesn't confirm shortly after the touch, it arms itself again.
+  Otherwise a single unlucky tap — one where heavy work elsewhere starved the
+  confirmation — would leave the app mute for the rest of the visit.
+
+> [!WATCH]
+> Coming back from the background, the channel can report itself as perfectly
+> healthy while the hardware is dead. Its own account of its state is not
+> evidence, so the return-from-background path rebuilds regardless of what the
+> channel claims.
+
+## Volume is three settings, not one
+
+Sounds are grouped into buses — interface, hover, and so on — and each bus has
+its own level that the member controls. A clip's designed loudness is scaled by
+its bus's setting, so turning hover sounds down doesn't touch anything else.
+
+The settings exist twice over: a committed baseline that came from the member's
+saved preferences, and a working copy. Dragging a volume slider moves the
+working copy so the previewed sounds play at the new level immediately; leaving
+without saving restores the baseline.
+
+## What this isn't
+
+Not lesson audio. A recorded lesson is a normal streamed audio element with its
+own seeking and playback position — a different mechanism with different
+constraints, sharing nothing with the effects channel described here.
+
+Not music. There is no continuous background track, which is why the app is
+careful to avoid touching the audio channel for a clip that would play at zero
+volume anyway: doing so steals audio focus from whatever the person is actually
+listening to and pauses it.

--- a/src/sfx/bus.ts
+++ b/src/sfx/bus.ts
@@ -17,11 +17,11 @@ export function emitSfx(keys: SoundKey | SoundKey[], opts: PlayOptions = {}): Pr
 }
 
 /**
- * Plays a sound effect, unless it's a spurious hover. Skips when touch is the
- * primary input, or when the pointer hasn't moved since the last click — i.e.
- * the UI shifted under a stationary cursor (a panel opened where the mouse was),
- * firing a `pointerenter` that isn't a real hover and would collide with the
- * click's own sound. A genuine hover is always preceded by pointer movement.
+ * Plays a hover sound, unless the hover isn't real.
+ *
+ * Silent on touch, and silent when the pointer hasn't moved since the last
+ * click — that means the UI moved under a still cursor rather than the person
+ * moving onto something, and the sound would collide with the click's own.
  *
  * @returns A promise that resolves when the sound has finished playing.
  */

--- a/src/sfx/config.ts
+++ b/src/sfx/config.ts
@@ -3,16 +3,13 @@ export type Bus = 'interface' | 'hover'
 export type SoundDef = {
   ext?: string
   default_volume?: number
-  // The volume bus a sound answers to when the caller doesn't override it.
-  // Only set for sounds that are intrinsically one bus regardless of trigger
-  // (the type_0x chatter is always 'hover'). Everything else defaults to
-  // 'interface'.
+  // Set this only for a sound that is one bus whatever triggers it — the
+  // typing chatter is always 'hover'. Anything else takes 'interface'.
   defaultBus?: Bus
 }
 
-// Flat registry — one entry per audio file, one decoded buffer. A sound's
-// identity is its file; its volume bus is resolved at emit time (see player.ts),
-// not baked into a namespace.
+// One entry per audio file — keep the list flat. A sound's identity is its
+// file, and its bus is resolved when it's emitted, not by where it sits here.
 export const SOUNDS = {
   bell_ping_high_pitched: {},
   card_drop: { default_volume: 0.3 },

--- a/src/sfx/engine.ts
+++ b/src/sfx/engine.ts
@@ -1,14 +1,9 @@
 /**
  * Web Audio engine for one-shot sound effects.
  *
- * Replaces Howler for SFX. We only ever used a sliver of Howler — load, one-shot
- * play, per-sound volume — and the part we leaned on, its AudioContext
- * lifecycle, is exactly what wedges on iOS: locking the phone or switching apps
- * drops the context into WebKit's non-standard 'interrupted' state, which
- * `resume()` often can't revive. Owning the context lets us close and rebuild it
- * on demand. AudioBuffers aren't bound to a context, so decoded sounds survive a
- * rebuild untouched — only the cheap one-shot BufferSourceNodes are recreated
- * per play.
+ * Owns the context outright so it can be closed and rebuilt on demand — the
+ * only cure for an interrupted one. →[K:ios-audio-interruption] Decoded buffers
+ * aren't bound to a context, so a rebuild costs no reloading.
  */
 
 type AudioContextCtor = new () => AudioContext
@@ -30,9 +25,8 @@ function resolveCtor(): AudioContextCtor | undefined {
   return win.AudioContext ?? win.webkitAudioContext
 }
 
-// The context fires statechange on every transition. 'running' fires the unlock
-// signal. Any non-running state resets the latch so the next 'running' transition
-// re-fires unlock_listeners — allowing queued sounds to retry after recovery.
+// Clearing the latch on every non-running state is what lets a later recovery
+// re-fire the unlock listeners and drain whatever queued up meanwhile.
 function notifyState(): void {
   if (ctx?.state === 'running') {
     markUnlocked()
@@ -42,22 +36,22 @@ function notifyState(): void {
   state_listeners.forEach((cb) => cb())
 }
 
-// Fires whenever the context transitions to 'running' — either via statechange
-// or the synchronous check in unlock() when a fresh context is born running.
-// notifyState() resets `unlocked` on every non-running transition, so this fires
-// again on each recovery, re-draining any queued sounds.
+// Call from both paths that can reach 'running': the statechange event, and
+// unlock()'s synchronous check for a fresh context born running.
 function markUnlocked(): void {
   if (unlocked) return
   unlocked = true
   unlock_listeners.forEach((cb) => cb())
 }
 
-// iOS Safari only opens audio output when a source is *started* inside the
-// unlocking gesture — resume() alone leaves it muted. A one-sample silent buffer
-// does the trick. Best-effort and fully guarded: priming must never break the
-// resume/unlock path (an earlier unguarded version rejected resume() and killed
-// audio on every platform). Synchronous (no await before start) so it stays
-// within the user gesture.
+/**
+ * Plays one silent sample to actually open audio output.
+ *
+ * Resuming alone leaves iOS muted — output opens only when a source starts
+ * inside the gesture. →[K:ios-audio-interruption] Keep it synchronous, and keep
+ * the try/catch: an unguarded version once rejected the resume and killed audio
+ * on every platform.
+ */
 function primeOutput(context: AudioContext): void {
   try {
     const source = context.createBufferSource()
@@ -90,9 +84,12 @@ async function decode(url: string): Promise<AudioBuffer> {
   return context.decodeAudioData(data)
 }
 
-// Resumes the context if needed, starts the buffer, and returns a promise that
-// settles when the sound ends. The fallback timer ensures settlement even when
-// the context suspends mid-play and onended never fires.
+/**
+ * Plays a decoded buffer once, resolving when it finishes.
+ *
+ * The fallback timer is load-bearing: a context that suspends mid-play never
+ * fires `onended`, so without it the promise would hang.
+ */
 async function play(buffer: AudioBuffer, volume: number): Promise<void> {
   const running = await resume()
   if (!running) return
@@ -125,8 +122,11 @@ async function play(buffer: AudioBuffer, volume: number): Promise<void> {
   })
 }
 
-// Wake a suspended context and report whether it ended up running. Used to gate
-// playback; the actual unlock/rebuild lives in unlock().
+/**
+ * Wakes a suspended context, reporting whether it actually ended up running.
+ *
+ * Gates playback only. Repairing a context that won't wake is `unlock`'s job.
+ */
 async function resume(): Promise<boolean> {
   const context = ensureContext()
   if (!context) return false
@@ -147,13 +147,15 @@ async function resume(): Promise<boolean> {
   return (context.state as AudioContextState) === 'running'
 }
 
-// Synchronous unlock for the user gesture. Everything here runs inside the
-// gesture's synchronous turn — iOS ignores audio work that happens after an await.
-//
-// `force` bypasses the running-state shortcut. iOS can report the context as
-// 'running' after an app-switch while the audio hardware is actually dead —
-// state alone isn't trustworthy on the way back from background, so
-// lifecycle.ts asks for a forced rebuild there regardless of what state claims.
+/**
+ * Reopens audio, from inside a user gesture.
+ *
+ * Never introduce an await before the rebuild — work after one falls outside
+ * the gesture and stops counting. →[K:ios-audio-interruption]
+ *
+ * @param force - Rebuild even when the context claims to be running, for
+ *   callers that know its own account of itself can't be trusted.
+ */
 function unlock(force = false): void {
   const current = ensureContext()
   if (!current) return
@@ -163,12 +165,8 @@ function unlock(force = false): void {
     return
   }
 
-  // A context created outside a user gesture is unrecoverable on iOS — its
-  // resume() promise never settles, and the same is true after an interruption.
-  // Rebuild synchronously inside this gesture so the new context is
-  // gesture-blessed. Buffers are context-agnostic, so nothing reloads.
-  // markUnlocked then fires via statechange once the fresh context reaches
-  // running (or immediately below if it is born running).
+  // Throw the old context away rather than trying to revive it — a context
+  // born outside a gesture can never be recovered. →[K:ios-audio-interruption]
   current.removeEventListener('statechange', notifyState)
   void current.close()
 

--- a/src/sfx/lifecycle.ts
+++ b/src/sfx/lifecycle.ts
@@ -1,13 +1,6 @@
 /**
- * Keeps the SFX AudioContext alive across page visibility, focus, and audio
- * interruptions.
- *
- * Mobile browsers suspend the context when the tab hides or the device locks;
- * iOS goes further and drops it into WebKit's non-standard 'interrupted' state
- * (device lock / app switch / a call), which a plain `resume()` often can't
- * revive. This module resumes on every wake signal, and arms a one-shot gesture
- * listener that hands off to `engine.unlock()` — which rebuilds the context
- * inside the gesture, the only reliable cure for 'interrupted'.
+ * Brings sound back after the tab hides, the device locks, or another app takes
+ * over. →[K:ios-audio-interruption]
  */
 import engine from '@/sfx/engine'
 import { trackPointerActivity } from '@/sfx/pointer-activity'
@@ -15,22 +8,21 @@ import { trackPointerActivity } from '@/sfx/pointer-activity'
 let installed = false
 let gesture_armed = false
 
-// iOS only treats a *completed* gesture as audio-activating — touchend / click,
-// never touchstart / pointerdown. Listening on pointerdown unlocks on an event
-// iOS ignores, so audio stays muted.
+// Never swap in a press event — only a completed gesture reactivates audio.
+// →[K:ios-audio-interruption]
 const GESTURE_EVENTS = ['touchend', 'click', 'keydown'] as const
 
-// How long to wait after a gesture-triggered unlock attempt before checking
-// whether it actually landed, and re-arming if not.
+// How long to leave an unlock attempt to land before re-arming for the next one.
 const UNLOCK_CHECK_MS = 300
 
-// Calling context.resume() before any user gesture has happened is exactly what
-// autoplay-blocking browsers reject — and Chrome logs a console warning about it
-// natively, even though we handle the rejection. Skip the speculative call
-// until a real gesture is on record; the gesture-armed listener still unlocks
-// on first tap regardless. Unsupported in Safari, where resume() before a
-// gesture was already unreliable — this only removes a call that wasn't doing
-// anything useful there either.
+/**
+ * Whether the user has interacted with this page at any point.
+ *
+ * Gate every speculative resume behind it — resuming before the first
+ * interaction is what autoplay blockers reject. →[K:ios-audio-interruption]
+ * Safari doesn't implement it, so this reads false there and the gesture
+ * listener does all the work.
+ */
 function hasUserActivation(): boolean {
   return (
     typeof navigator !== 'undefined' &&
@@ -40,15 +32,12 @@ function hasUserActivation(): boolean {
 }
 
 /**
- * Wires `visibilitychange`, `pageshow`, `focus`, and context `statechange`
- * listeners that resume the engine, plus a one-shot `touchend`/`click`/`keydown`
- * listener that unlocks (and, if needed, rebuilds) the context on the next
- * interaction. If that attempt doesn't land within `UNLOCK_CHECK_MS`, it
- * re-arms for the next gesture rather than leaving audio dead for the session.
+ * Starts watching for the page waking up, and repairs audio on the next tap.
  *
- * Returns a teardown function that removes every listener it registered.
- * Calling `installAudioLifecycle` while already installed is a no-op and returns
- * a no-op teardown — the original teardown remains the only way to uninstall.
+ * A second call while already installed does nothing and hands back a no-op —
+ * the teardown from the first call stays the only way to uninstall.
+ *
+ * @returns A teardown that removes every listener registered here.
  */
 export function installAudioLifecycle(): () => void {
   if (installed || typeof window === 'undefined') return () => {}
@@ -57,52 +46,40 @@ export function installAudioLifecycle(): () => void {
   let forced_unlock = false
   let was_hidden = false
 
-  // Arm the gesture retry up front whenever the context isn't running, then try
-  // an opportunistic resume. Crucially we do NOT gate arming on the resume
-  // result: a browser that blocks autoplay leaves `resume()` pending forever
-  // (it never resolves to tell us it failed), so awaiting it would mean the
-  // gesture listener — the only thing that actually unlocks audio — never gets
-  // armed. The resume is fire-and-forget; the gesture is what we rely on.
+  // Arm before resuming, and never await the resume — a blocked one stays
+  // pending forever, so the gesture listener would never get armed at all.
   const recover = () => {
     if (engine.state() === 'running') return
     armGestureRetry(false)
     if (hasUserActivation()) void engine.resume()
   }
 
-  // iOS can report the context as 'running' after an app-switch even though the
-  // audio hardware is actually dead — state can't be trusted on the way back
-  // from background. Skip the `state === 'running'` short-circuit entirely: arm
-  // the gesture retry unconditionally and force a full rebuild on the next tap.
+  // Force the rebuild here rather than checking state first — coming back from
+  // the background, the context lies about being healthy.
+  // →[K:ios-audio-interruption]
   const recoverFromBackground = () => {
     armGestureRetry(true)
     if (hasUserActivation()) void engine.resume()
   }
 
-  // Synchronous so the unlock's priming source + resume() fire inside the
-  // gesture — iOS ignores them otherwise. engine.unlock() owns the resume/rebuild
-  // dance; we just hand off the gesture.
+  // Keep this synchronous — an await here pushes the rebuild outside the
+  // gesture, where it no longer counts. →[K:ios-audio-interruption]
   const gestureRecover = () => {
     removeGestureListeners()
     gesture_armed = false
     engine.unlock(forced_unlock)
     forced_unlock = false
 
-    // This attempt's unlock is confirmed asynchronously, via the fresh
-    // context's `statechange` event — but heavy synchronous work sharing the
-    // same gesture (e.g. a modal mounting) can starve that transition
-    // entirely, so it may never fire at all. When that happens there's no
-    // event left to re-arm on, so nothing would ever retry and audio would
-    // stay dead for the rest of the session. Check back shortly and, if still
-    // locked, re-arm for the next gesture.
+    // Don't rely on the confirming `statechange` alone — heavy work sharing
+    // this gesture can starve it, leaving nothing to re-arm on and audio dead
+    // for the rest of the visit.
     setTimeout(() => {
       if (!engine.isUnlocked()) armGestureRetry(false)
     }, UNLOCK_CHECK_MS)
   }
 
-  // Capture phase, not bubble: handlers like the dropdown caret's `@click.stop`
-  // swallow propagation before the event reaches `window` in the bubble phase,
-  // so a bubble-phase listener would miss those gestures and leave audio locked.
-  // Capture runs window→target first, ahead of any descendant's stopPropagation.
+  // Keep these on the capture phase — a control that stops propagation would
+  // otherwise swallow the one tap that restores sound.
   const armGestureRetry = (force: boolean) => {
     if (force) forced_unlock = true
     if (gesture_armed) return
@@ -132,9 +109,8 @@ export function installAudioLifecycle(): () => void {
     }
   }
 
-  // `persisted` marks a bfcache restore — Safari can serve one after an
-  // app-switch instead of a fresh load, which is the same state-lie risk as
-  // the visibilitychange path above.
+  // Treat a restored page (`persisted`) as a background return — Safari serves
+  // one after an app-switch instead of a fresh load.
   const onPageShow = (e: PageTransitionEvent) => {
     if (e.persisted || was_hidden) {
       was_hidden = false
@@ -144,8 +120,8 @@ export function installAudioLifecycle(): () => void {
     }
   }
 
-  // statechange fires the moment iOS interrupts the context — a more direct
-  // signal than waiting for the page to become visible again.
+  // Catches an interruption the moment it happens, rather than waiting for the
+  // page to become visible again.
   const onStateChange = () => {
     if (engine.state() !== 'running') recover()
   }
@@ -156,8 +132,7 @@ export function installAudioLifecycle(): () => void {
   const offStateChange = engine.onStateChange(onStateChange)
   const offPointerActivity = trackPointerActivity()
 
-  // Arm now so the first user gesture unlocks the freshly-created (suspended)
-  // context, the same way Howler's global unlock handler used to.
+  // Arm now, so the very first tap of the visit unlocks the new context.
   recover()
 
   return () => {

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -5,8 +5,7 @@ import { BUS_DEFAULTS, SOUNDS, type Bus, type SoundDef, type SoundKey } from '@/
 export type PlayOptions = {
   volume?: number
   debounce?: number
-  // Override the bus this sound is routed through. Falls back to the sound's
-  // defaultBus, then 'interface'.
+  // Overrides the sound's own bus, which otherwise falls back to 'interface'.
   bus?: Bus
 }
 
@@ -16,10 +15,8 @@ type LoadedSound = {
   default_bus: Bus
 }
 
-// Audio files ship as separate hashed assets; setup() fetches and decodes them
-// at runtime. The glob captures URL strings only — no binary payload lands in
-// the JS bundle. setup() itself is invoked post-paint from App.vue so audio
-// download never blocks first paint.
+// Keep `query: '?url'` — it captures URL strings only, so no audio payload
+// lands in the JS bundle.
 const AUDIO_FILES = import.meta.glob('@/assets/audio/**/*.{wav,mp3,ogg}', {
   eager: true,
   query: '?url',
@@ -35,25 +32,24 @@ class AudioPlayer {
   loaded_sounds = new Map<SoundKey, LoadedSound>()
   initialized = false
   queued_sound: { key: SoundKey; options: PlayOptions } | undefined
-  // Resting setting per bus. setVolumeConfig (called from App.vue) overwrites
-  // this once member prefs load.
+  // The levels actually used to play. A preview can drift these off the
+  // baseline below, so never read them to decide what to save.
   volume_settings: Record<Bus, number> = { ...BUS_DEFAULTS }
-  // The committed baseline — what the server gave us (or defaults). previewVolumeConfig
-  // can drift volume_settings off this for live UI feedback; resetSettings restores it.
+  // The member's saved levels — what a discarded preview falls back to.
   committed_volume_settings: Record<Bus, number> = { ...BUS_DEFAULTS }
 
-  // Commit a new baseline and apply it (App.vue, on member-pref load/save).
+  // Commits a new baseline and applies it.
   setVolumeConfig = (settings: Record<Bus, number>) => {
     this.committed_volume_settings = { ...settings }
     this.volume_settings = { ...settings }
   }
 
-  // Apply settings live without committing — for previewing edits mid-drag.
+  // Applies settings without committing, so a slider drag can be heard live.
   previewVolumeConfig = (settings: Record<Bus, number>) => {
     this.volume_settings = { ...settings }
   }
 
-  // Discard any preview and fall back to the committed baseline.
+  // Discards any preview and falls back to the committed baseline.
   resetSettings = () => {
     this.volume_settings = { ...this.committed_volume_settings }
   }
@@ -105,18 +101,16 @@ class AudioPlayer {
     const sound = this.loaded_sounds.get(key)
     if (!sound) throw new Error(`Sound "${key}" not loaded.`)
 
-    // Bail before touching the context — resume() steals media-session focus
-    // and pauses background music even for a silent buffer.
+    // Bail before touching the context — waking it steals audio focus and
+    // pauses whatever the person is listening to, even at zero volume.
     const volume = options.volume ?? sound.base_volume * this._getVolumeMultiplier(sound, options)
     if (volume <= 0) return
 
     return engine.play(sound.buffer, volume)
   }
 
-  // Bus is resolved most-specific-first: explicit option, then the sound's own
-  // default, then 'interface' (baked into default_bus). 5 is the resting
-  // setting, so dividing by 5 yields a 1.0× multiplier at rest — sounds play at
-  // their designed volume unchanged.
+  // 5 is the resting setting, so the divisor keeps a rested bus at 1.0× and
+  // sounds play at exactly the volume they were designed at.
   private _getVolumeMultiplier(sound: LoadedSound, options: PlayOptions): number {
     const bus = options.bus ?? sound.default_bus
     return this.volume_settings[bus] / 5
@@ -144,5 +138,4 @@ class AudioPlayer {
   }
 }
 
-// Export instance as a singleton
 export default new AudioPlayer()

--- a/src/sfx/pointer-activity.ts
+++ b/src/sfx/pointer-activity.ts
@@ -1,13 +1,9 @@
 /**
- * Tracks coarse pointer activity so the hover gate can tell a real hover from a
- * spurious one. A hover that fires without the pointer having moved since the
- * last click means the UI shifted under a stationary cursor (a panel opened
- * where the mouse was) — a `pointerenter` that isn't a real hover. A genuine
- * hover is always preceded by pointer movement.
+ * Remembers when the pointer last moved and last pressed, so a hover sound can
+ * tell a real hover from the UI shifting under a still cursor.
  *
- * Until `trackPointerActivity()` is installed (from `installAudioLifecycle`)
- * the timestamps stay 0 and the gate reads "not stationary", so hovers play
- * normally — the safe default for SSR and for tests that import the bus alone.
+ * Uninstalled, this reports "moving", so hovers play normally — the safe
+ * default for tests importing the bus on its own.
  */
 let last_pointer_down = 0
 let last_pointer_move = 0

--- a/src/utils/animations/aside-retract.ts
+++ b/src/utils/animations/aside-retract.ts
@@ -4,14 +4,12 @@ const DURATION = 0.2
 const EASE = 'power2.inOut'
 
 /**
- * Slides the aside out past the right edge, where the sheet's overflow clips it.
+ * Slides the aside off the right edge and hands its column back.
  *
- * The track it occupies collapses instantly rather than over the tween — a
- * negative margin animated in step with the slide would reflow the sibling tab
- * content on every frame. An opposing `x` cancels the jump that instant
- * collapse would otherwise cause, so only the tween moves anything on screen.
- * Callers are expected to run this while the tab outlet is empty, so the
- * reflow itself is never seen.
+ * Run this while the tab beside it is empty. The column collapses in one step
+ * rather than over the slide — animating it would reflow the neighbouring
+ * content on every frame — and that step is only invisible if there's nothing
+ * there to jump.
  */
 export function retractAside(el: HTMLElement) {
   return new Promise<void>((resolve) => {
@@ -22,12 +20,7 @@ export function retractAside(el: HTMLElement) {
   })
 }
 
-/**
- * Reverse of {@link retractAside} — slides the aside back in, then hands its
- * track back. Restoring the margin shifts the aside left by exactly what
- * dropping the `x` offset shifts it right, so the final swap back into flow
- * costs no visible movement.
- */
+/** Reverse of {@link retractAside} — slides the aside back in and reclaims its column. */
 export function restoreAside(el: HTMLElement) {
   return new Promise<void>((resolve) => {
     gsap.to(el, {

--- a/src/utils/animations/card-slide.ts
+++ b/src/utils/animations/card-slide.ts
@@ -1,22 +1,19 @@
 import { gsap } from 'gsap'
 
 const DURATION = 0.25
-// Both panes share one easing/duration so they translate as a single rigid strip
-// — the incoming pane reads as pushing the outgoing one over.
+// Keep both panes on one easing and duration — any difference and they drift
+// apart instead of reading as one strip being pushed across.
 const EASE = 'power2.inOut'
 
 export type SlideDirection = 'forward' | 'back'
 
 /**
- * Horizontal push for swapping a card's whole face — the term translation and the
- * inline add-card panel. Wire the returned hooks on a single-child `<Transition>`
- * whose direct parent is `position: relative; overflow: hidden`.
+ * Swaps a card's whole face by pushing the new one in against the old.
  *
- * The entering pane stays in normal flow so it dictates the container's height
- * (and, in the footer, the height animation that follows it); the leaving pane
- * pins absolute and slides in lockstep, so the incoming pane pushes the outgoing
- * one off. `forward` pushes leftward (new pane from the right); `back` reverses
- * it (new pane from the left) so cancelling looks like the term card sliding back.
+ * Wire the hooks on a single-child `<Transition>` inside a `relative`,
+ * `overflow-hidden` parent. Use `back` for anything that undoes a `forward` —
+ * the reversed direction is what makes cancelling read as going back rather
+ * than as another step onward.
  */
 export function cardSlideEnter(direction: SlideDirection) {
   const from = direction === 'forward' ? 100 : -100

--- a/src/utils/animations/cover-carousel.ts
+++ b/src/utils/animations/cover-carousel.ts
@@ -5,18 +5,17 @@ const FLIP_DURATION = 0.5
 const FLIP_PERSPECTIVE = 800
 
 /**
- * One beat of the multi-deck cover carousel: holds the card flat, then flips it
- * a half-turn on its Y axis, swapping the displayed cover at the edge-on
- * midpoint via `onMidpoint`. Returns the timeline so the caller can chain the
- * next beat (onComplete) or kill it on stop.
+ * One beat of a deck cover cycling through the covers inside it — a pause,
+ * then a half-turn.
+ *
+ * @param onMidpoint - Swap the displayed cover here, the frame where the card
+ *   is edge-on and the change can't be seen.
  */
 export function cycleCoverCard(el: HTMLElement, onMidpoint: () => void): gsap.core.Timeline {
   const tl = gsap.timeline()
 
-  // Establish the perspective before any rotation. Without it the first
-  // rotateY renders as a flat horizontal squish (scaleX = cos θ) — the jank
-  // only the first flip shows, before GSAP has baked perspective into the
-  // element's inline transform.
+  // Set the perspective before any rotation, never alongside it — the very
+  // first flip renders as a flat squish otherwise.
   tl.set(el, { transformPerspective: FLIP_PERSPECTIVE })
   tl.to(el, { duration: HOLD_DURATION })
   tl.to(el, {

--- a/src/utils/animations/crossfade-resize.ts
+++ b/src/utils/animations/crossfade-resize.ts
@@ -3,8 +3,8 @@ import { gsap } from 'gsap'
 const HEIGHT_DURATION = 0.2
 const FADE_DURATION = 0.15
 
-// Pin a pane on top of its sibling so the two can crossfade in the same slot
-// without either dictating the wrapper's layout height.
+// Stacks a pane on its sibling so the two can crossfade in one slot without
+// either one dictating the wrapper's height.
 function pin(node: HTMLElement) {
   node.style.position = 'absolute'
   node.style.left = '0'
@@ -20,27 +20,11 @@ function unpin(node: HTMLElement) {
 }
 
 /**
- * Crossfade two arbitrary-height panes in the same slot while smoothly animating
- * their shared wrapper's height between the two sizes. Backs the layout-kit
- * `<crossfade-resize>` component; used for footer pane swaps (deck editor ⇄
- * actions, audio toolbar ⇄ term card).
+ * Freezes the wrapper's height before the outgoing pane leaves.
  *
- * Wire all three hooks on a single-child `<Transition>` (no `mode` — leave and
- * enter overlap) whose direct parent is `wrapper`. The wrapper must be
- * `relative` so the pinned panes stack. Because the footer is anchored at the
- * bottom of the viewport, growing the wrapper pushes its top edge upward.
- *
- * Overflow is clipped only for the duration of the tween — at rest the wrapper
- * lets content (e.g. the scrubber thumb that sits proud of its track) bleed past
- * its edges.
- *
- * Flow:
- * - before-leave: freeze the wrapper at its current height so it can't collapse
- *   when both panes pin absolute, and clip overflow for the tween.
- * - leave: pin the outgoing pane and fade it out.
- * - enter: pin the incoming pane, resize the wrapper to its natural height
- *   (snapped by default, tweened when `animate_height` is set — see below),
- *   fade it in, then release the wrapper back to `auto` and unclip.
+ * Wire all three hooks together, on a `<Transition>` with no `mode` so the two
+ * panes overlap, inside a `relative` wrapper. Alone, this one strands the
+ * wrapper at a fixed height — only the enter hook releases it.
  */
 export function crossfadeResizeBeforeLeave(wrapper: HTMLElement) {
   return () => {
@@ -55,10 +39,14 @@ export function crossfadeResizeLeave(el: Element, done: () => void) {
   gsap.to(node, { opacity: 0, duration: FADE_DURATION, ease: 'power1.out', onComplete: done })
 }
 
-// Panes with a lot of DOM (a long transcript) took 12+ forced layouts over
-// 200ms when `height` was tweened — snapping it in one frame (the default)
-// dodges that, with the opacity fade below covering the snap visually. Small,
-// cheap panes can afford the real tween instead via `animate_height`.
+/**
+ * Fades the incoming pane in, resizes the wrapper, and releases everything the
+ * other two hooks froze.
+ *
+ * @param animate_height - Tween the resize instead of snapping it. Only for
+ *   small panes: a long transcript cost 12+ forced layouts over 200ms, which
+ *   the default snap avoids and the fade hides.
+ */
 export function crossfadeResizeEnter(wrapper: HTMLElement, animate_height = false) {
   return (el: Element, done: () => void) => {
     const node = el as HTMLElement
@@ -85,8 +73,7 @@ export function crossfadeResizeEnter(wrapper: HTMLElement, animate_height = fals
       return
     }
 
-    // Tie both tweens to one timeline so cleanup (which releases the wrapper
-    // back to `auto` height) waits for whichever runs longer.
+    // One timeline, so the release waits for whichever tween runs longer.
     gsap
       .timeline({ onComplete: cleanup })
       .to(wrapper, { height: target, duration: HEIGHT_DURATION, ease: 'power2.out' }, 0)

--- a/src/utils/animations/deck-grid.ts
+++ b/src/utils/animations/deck-grid.ts
@@ -4,23 +4,16 @@ const POP_IN_DURATION = 0.2
 const POP_OUT_DURATION = 0.2
 
 const POP_IN_EVENT = 'deck-pop-in'
-// Safety net for waitForDeckPopIn callers in case the deck grid never mounts
-// or animates the deck in question (e.g. it's off-screen) — bounded so a
-// caller awaiting the signal can never hang indefinitely.
+// Bounds the wait — the deck may be off-screen, or the grid may never mount at
+// all, and neither should hang the caller.
 const POP_IN_SIGNAL_TIMEOUT = 1000
 
 /**
- * Reveal a freshly created deck thumbnail with a playful pop-in. Also
- * broadcasts a `deck-pop-in` event (read by `waitForDeckPopIn`) once the
- * animation completes, keyed off the element's `data-deck-id` attribute.
+ * Pops a newly created deck into the grid, and announces when it has landed so
+ * `waitForDeckPopIn` can resolve.
  *
- * Animates `el`'s first child, not `el` itself: `el` is the transition-group's
- * direct child and carries the deck grid's reactive resting-position
- * transform. GSAP's scale tween and this element's translate would otherwise
- * fight over the same `transform` property (and compose in the wrong
- * direction — scaling the *ancestor* of a translated element scales its
- * offset too). Same reason `liftListItem`/`dropListItem` target the deepest
- * card element instead of a positioned wrapper.
+ * Pass the grid cell — the pop is applied one level in, because the cell is
+ * already carrying its own placement. →[K:settled-transform-traps-overlays]
  */
 export function popDeckIn(el: Element, done: () => void) {
   const target = el.firstElementChild ?? el
@@ -47,10 +40,7 @@ export function popDeckIn(el: Element, done: () => void) {
   )
 }
 
-/**
- * Resolve once the given deck's grid pop-in animation finishes (or after a
- * short timeout if it never fires — the grid may not be mounted).
- */
+/** Resolves once a deck has finished popping in, or shortly after regardless. */
 export function waitForDeckPopIn(id: number): Promise<void> {
   return new Promise((resolve) => {
     const timeout = window.setTimeout(cleanup, POP_IN_SIGNAL_TIMEOUT)
@@ -70,7 +60,7 @@ export function waitForDeckPopIn(id: number): Promise<void> {
   })
 }
 
-/** Shrink a removed deck thumbnail away. Same first-child target as popDeckIn. */
+/** Shrinks a removed deck away. Takes the grid cell, same as `popDeckIn`. */
 export function popDeckOut(el: Element, done: () => void) {
   gsap.to(el.firstElementChild ?? el, {
     scale: 0.5,

--- a/src/utils/animations/deck-view/card-overlay.ts
+++ b/src/utils/animations/deck-view/card-overlay.ts
@@ -3,21 +3,16 @@ import { gsap } from 'gsap'
 const DURATION = 0.5
 const SCALE = 0.95
 
-/* ── Viewport context ──────────────────────────────────────────────────────── */
-
-// A mode switch animates in viewport space: the window scroll jumps to
-// `settle_y` (where the incoming pane rests) at the moment of the switch, and
-// every hook offsets its pane so nothing appears to move until the tweens run.
+// The page scroll jumps the instant the mode switches. Every hook below offsets
+// its pane by that jump, so nothing appears to move until the tweens run.
 export type ModeSwitchViewport = {
   from_y: number
   settle_y: number
   stack_top: number
 }
 
-// Must run before the DOM patches — rects and scroll still describe the
-// outgoing mode, i.e. what the user is actually looking at. `settle_y` keeps
-// the user's scroll when they're above the stack, otherwise lands the incoming
-// pane's top just below the sticky header.
+// Call before the DOM patches — afterwards the measurements describe the new
+// mode rather than what the user is still looking at.
 export function captureModeSwitch(
   stack: HTMLElement,
   sticky_header?: HTMLElement | null
@@ -30,30 +25,23 @@ export function captureModeSwitch(
   return { from_y, settle_y, stack_top }
 }
 
-// The shift that keeps an out-of-flow pane visually still across the
-// settle-scroll jump.
+// The shift that keeps an out-of-flow pane visually still across the jump.
 function scrollCompensation(vp: ModeSwitchViewport) {
   return vp.settle_y - vp.from_y
 }
 
-// Distance from the stack's top to the viewport's bottom edge once settled.
-// Doubles as the overlay's slide-in offset and as the stack's min-height
-// during the switch — the clip box must reach the screen bottom or a short
-// incoming grid clips the outgoing pane to its own height.
+// Also the stack's minimum height during the switch — the clip box has to reach
+// the bottom of the screen, or a short incoming grid crops the outgoing pane.
 export function distanceToViewportBottom(vp: ModeSwitchViewport) {
   return Math.max(0, vp.settle_y + window.innerHeight - vp.stack_top)
 }
 
-/* ── Grid pane: scales down + fades ───────────────────────────────────────── */
-
-// Anchor the scale to the top edge so it shrinks/grows downward only — a
-// centre origin drifts the top edge and reads as a vertical slide.
+// Keep the scale anchored to the top edge — from the centre, the top drifts and
+// the whole thing reads as a vertical slide.
 const ORIGIN = 'top center'
 
-// Entering grid stays in flow (it defines the settled height) and fades up
-// from a slightly shrunk state. The grid is kept mounted via v-show, so clear
-// the absolute positioning and compensation a prior leave left behind — it
-// must rejoin flow to define the page height again.
+// The grid is only hidden, never unmounted, so clear what a previous leave left
+// on it — it has to rejoin the flow to define the page height again.
 export function fadeScaleEnter(el: Element, done: () => void) {
   gsap.set(el, { clearProps: 'position,top,left,width,transform,overflow' })
   gsap.fromTo(
@@ -63,11 +51,8 @@ export function fadeScaleEnter(el: Element, done: () => void) {
   )
 }
 
-// Leaving grid drops out of flow (so the entering pane owns the height) and
-// shrinks + fades in place — compensated so the rows under the user's eyes
-// stay put through the scroll jump. Clip overflow while absolute: the grid's
-// `h-full` resolves against the stack's clip min-height, so its own
-// `overflow-y-auto` would otherwise flash a scrollbar and shift the content.
+// Keep the overflow clip — while absolute, the grid resolves its height against
+// the stack and would otherwise flash a scrollbar and shift its content.
 export function fadeScaleLeave(el: Element, vp: ModeSwitchViewport, done: () => void) {
   gsap.set(el, {
     position: 'absolute',
@@ -87,10 +72,8 @@ export function fadeScaleLeave(el: Element, vp: ModeSwitchViewport, done: () => 
   })
 }
 
-/* ── Overlay pane (editor / importer): slides up + down ───────────────────── */
-
-// Entering overlay stays in flow but starts with its top at the viewport's
-// bottom edge, layered above the grid, and rises into place.
+// Starts the editor with its top at the bottom of the screen, above the grid,
+// ready to rise into place.
 export function primeOverlayBelow(el: Element, vp: ModeSwitchViewport) {
   gsap.set(el, { position: 'relative', zIndex: 1, y: distanceToViewportBottom(vp) })
 }
@@ -104,24 +87,20 @@ export function slideOverlayUp(el: Element, done: () => void) {
   })
 }
 
-// Drop the entered overlay's inline overrides so it settles as a plain in-flow
-// block and the page — not the pane — owns the scroll.
+// Call once the rise finishes, or the page never takes the scroll back off the
+// pane.
 export function settleOverlay(el: Element) {
   gsap.set(el, { clearProps: 'position,zIndex,transform' })
 }
 
-// A mode flip can interrupt an in-flight slide. Kill the tween so its late
-// onComplete can't fire and its inline position/transform don't linger on a
-// reused element — the caller has already dropped the pane from its in-flight
-// set, this just stops GSAP from mutating it further.
+// Call when a mode flip interrupts a slide, so a late completion can't fire and
+// stale inline styles can't linger on a reused element.
 export function cancelOverlayAnimation(el: Element) {
   gsap.killTweensOf(el)
 }
 
-// Leaving overlay drops out of flow (so the entering grid owns the height) and
-// slides one screen down from wherever the user was looking. When the user was
-// scrolled into the pane, one screen of travel can't carry its top edge past
-// the viewport bottom — fade it out so it never unmounts mid-screen.
+// Fades when the user had scrolled into the pane — from there, one screen of
+// travel can't clear the bottom edge, and it would vanish mid-screen.
 export function slideOverlayDown(el: Element, vp: ModeSwitchViewport, done: () => void) {
   const from = scrollCompensation(vp)
 

--- a/src/utils/animations/flip.ts
+++ b/src/utils/animations/flip.ts
@@ -1,8 +1,6 @@
 import { gsap } from 'gsap'
 
-// The card flip (src/components/card/index.vue delegates here), generalised so
-// the rotation axis can be chosen: 'y' flips horizontally (the card), 'x'
-// vertically.
+// Turning a card over. `y` turns it left-to-right, `x` top-to-bottom.
 type FlipAxis = 'x' | 'y'
 
 const ROTATE = { x: 'rotateX', y: 'rotateY' } as const
@@ -17,8 +15,8 @@ export function flipEnter(el: Element, axis: FlipAxis, done: () => void) {
       scale: 1,
       duration: 0.2,
       ease: 'back.out(2)',
-      // The resting state is identity, so drop GSAP's inline transform on
-      // completion — otherwise it shadows CSS hover transforms (e.g. scale).
+      // Drop the inline transform once landed, or it shadows the card's CSS
+      // hover effects. →[K:settled-transform-traps-overlays]
       clearProps: 'transform',
       onComplete: done
     }

--- a/src/utils/animations/list-item.ts
+++ b/src/utils/animations/list-item.ts
@@ -3,12 +3,11 @@ import { gsap } from 'gsap'
 const ENTER_DURATION = 0.3
 
 /**
- * Reveal a freshly-added card row, growing it in from a collapsed top edge.
- * Driven imperatively (not a Vue Transition) because the editor list is
- * windowed: every row's slot is reserved up front, so a transition would fire
- * for rows scrolling into view too. The caller gates this to the one card it
- * just added, animating it within its reserved slot rather than reflowing the
- * list.
+ * Grows a newly added card row into view.
+ *
+ * Call it directly, on the one row that was just added — the editor list
+ * reserves every row's space up front, so a transition would fire this for
+ * rows merely scrolled past too.
  */
 export function expandListItemIn(el: HTMLElement) {
   gsap.from(el, {
@@ -24,11 +23,11 @@ export function expandListItemIn(el: HTMLElement) {
 const LIFT_SCALE = 1.03
 
 /**
- * Pickup pop for a reorder drag: a quick scale up with a little overshoot that
- * settles to a held, slightly-lifted scale (the row reads as "picked up" for
- * the whole drag). Pair with `dropListItem` on release. Animates `scale` only —
- * no clearProps — so it composes with the row's reactive drag transform
- * (translate) and the held scale persists until the drop.
+ * Lifts a row as it's picked up for a reorder drag, holding it raised until
+ * `dropListItem` puts it back.
+ *
+ * Deliberately leaves its scale behind — the row is still being dragged, and
+ * clearing it would both drop the lift and wipe the drag's own offset.
  */
 export function liftListItem(el: HTMLElement) {
   gsap

--- a/src/utils/animations/modal.ts
+++ b/src/utils/animations/modal.ts
@@ -2,13 +2,8 @@ import { gsap } from 'gsap'
 
 const ENTER_SETTLE_DELAY = 0.033
 
-/**
- * Enter tweens settle on an identity transform, which gsap leaves inline as
- * `transform: translate(0px, 0px)`. Visually a no-op, but any non-none
- * transform (or filter) makes the element a containing block for `position:
- * fixed` descendants — so a settled modal captures the popovers inside it and
- * its own `overflow` clips them. Hand the resting state back to CSS instead.
- */
+// Spread into every tween that settles visible, or the modal traps its own
+// popovers. →[K:settled-transform-traps-overlays]
 const CLEAR_TRANSFORM = { clearProps: 'transform' } as const
 
 export function slideUpFadeIn(el: Element, done: () => void) {
@@ -89,10 +84,10 @@ export function recedeModal(el: Element, is_pinned: boolean) {
 /**
  * Restores a modal to full prominence once the modal above it has closed.
  *
- * Clears the filter alongside the transform — a settled `brightness(1)
- * blur(0px)` is as much a containing block as a settled `translate(0, 0)`, so
- * leaving it behind re-traps this modal's popovers the moment a nested modal
- * (an alert, a prompt) has come and gone.
+ * Clear the filter here as well as the transform — a settled brightness traps
+ * popovers exactly like a settled transform does, so an alert opening and
+ * closing over this modal would otherwise break its dropdowns for good.
+ * →[K:settled-transform-traps-overlays]
  */
 export function restoreModal(el: Element, is_pinned: boolean) {
   gsap.to(el, {

--- a/src/utils/animations/preview-tuck.ts
+++ b/src/utils/animations/preview-tuck.ts
@@ -34,16 +34,15 @@ export function snapPinnedPreview(el: HTMLElement, tucked: boolean) {
 function flipToPose(el: HTMLElement, pose: PreviewPose, onEdgeOn: () => void) {
   const tl = gsap.timeline()
 
-  // Perspective has to be baked into the inline transform before the first
-  // rotate, or the opening frame renders as a flat scaleX squish instead of a
-  // turn — same first-flip jank the cover carousel works around.
+  // Set the perspective before the first rotate, never alongside it — the
+  // opening frame renders as a flat squish otherwise.
   tl.set(el, { transformPerspective: FLIP_PERSPECTIVE })
   tl.to(el, { rotateY: 90, duration: HALF_TURN_DURATION, ease: 'power2.in', onComplete: onEdgeOn })
   tl.set(el, { rotateY: -90 })
   tl.to(el, { rotateY: 0, duration: HALF_TURN_DURATION, ease: 'power2.out' })
 
-  // The travel runs across both halves rather than after them, so the card is
-  // already drifting away as it turns rather than turning then sliding.
+  // Keep the travel spanning both halves of the turn — split after it, the
+  // card reads as turning and then sliding, two moves instead of one.
   tl.to(el, { ...pose, duration: HALF_TURN_DURATION * 2, ease: 'power2.inOut' }, 0)
 
   return new Promise<void>((resolve) => {

--- a/src/utils/animations/reader-cursor.ts
+++ b/src/utils/animations/reader-cursor.ts
@@ -8,8 +8,8 @@ const FADE = 0.2
 
 type Edges = { left: number; right: number }
 
-// Per-element edge state so each move animates from where the highlight
-// actually is, and stale tweens get killed cleanly (they target this object).
+// Keyed per element so a move starts from where that highlight actually is,
+// and so an interrupted tween has something specific to be killed on.
 const edgesByEl = new WeakMap<HTMLElement, Edges>()
 
 function paint(el: HTMLElement, edges: Edges) {
@@ -18,10 +18,12 @@ function paint(el: HTMLElement, edges: Edges) {
 }
 
 /**
- * Glide a floating highlight `el` to cover `box` (coordinates relative to its
- * offset parent), moving both edges together. `duration` overrides the default
- * edge/vertical speed so the pointer-driven pill can answer the pointer quickly.
- * The first call drops the highlight onto the box with no animation.
+ * Glides the reading highlight onto a word, both edges moving together. The
+ * first call drops it into place instead, with no glide from nowhere.
+ *
+ * @param box - Where to land, relative to the highlight's offset parent.
+ * @param duration - Override the default speed. The pointer-driven pill runs
+ *   faster so it keeps up with the finger.
  */
 export function moveReaderCursor(
   el: HTMLElement,
@@ -59,9 +61,8 @@ export function moveReaderCursor(
 }
 
 /**
- * Fade the highlight out and forget its position, so the next
- * `moveReaderCursor` drops fresh onto the new word instead of sliding across
- * the page from a stale spot.
+ * Fades the highlight out and forgets where it was, so it reappears on the
+ * next word rather than streaking across the page to reach it.
  */
 export function hideReaderCursor(el: HTMLElement) {
   const edges = edgesByEl.get(el)

--- a/src/utils/animations/scrim-reveal.ts
+++ b/src/utils/animations/scrim-reveal.ts
@@ -4,30 +4,18 @@ const DURATION = 0.32
 const HIDDEN_SCALE = 0.94
 
 type PopScrimRevealOptions = {
-  // Also tween the fields' height, so the panel collapses to the scrim rather
-  // than holding the full height. For narrow layouts, where reserving space for
-  // hidden content costs more than the stable height is worth.
+  // Collapse the panel down to the cover instead of holding the fields' full
+  // height. For narrow layouts, where the reserved space costs more than the
+  // steady height is worth.
   collapse?: boolean
 }
 
 /**
- * Swaps a panel's scrim for the fields beneath it with a bubble pop — the
- * outgoing layer shrinks away while the incoming one overshoots back to full
- * size.
+ * Swaps a panel's cover for the fields beneath it with a bubble pop.
  *
- * The badge's own pill never moves — only its contents ride along with the
- * fields, so the notch in the panel's top edge is permanent and just empties
- * out while the fields are hidden.
- *
- * Both layers stay mounted and share a grid cell, so the panel is always as
- * tall as the taller one. Without `collapse` that's the fields whichever layer
- * is showing, which keeps the panel's height stable; with it the fields tween
- * to zero and the scrim sets the height instead.
- *
- * Inline height/overflow/transform are cleared once the tween lands so the
- * resting state is owned by the caller's classes — otherwise a collapse would
- * survive a resize into a layout that never collapses, and a settled transform
- * would keep trapping the revealed layer's popovers in its stacking context.
+ * Both layers stay mounted in one grid cell, so pass the badge's contents
+ * rather than the badge itself — the notch in the panel's top edge is permanent
+ * and only empties out.
  */
 export function popScrimReveal(
   scrim: HTMLElement,
@@ -54,12 +42,9 @@ export function popScrimReveal(
       scale: 1,
       duration: DURATION,
       ease: 'back.out(1.7)',
-      // A settled `scale: 1` is visually a no-op but not a layout one — any
-      // non-none transform makes the element a containing block for fixed
-      // descendants and a stacking context of its own, which traps the slotted
-      // fields' dropdown menus underneath later siblings. Drop it once landed;
-      // the outgoing layer keeps its inline transform, since that's what's
-      // holding it hidden.
+      // Drop the settled scale, or the fields' dropdowns get trapped. The
+      // outgoing layer keeps its transform — that's what's hiding it.
+      // →[K:settled-transform-traps-overlays]
       clearProps: 'transform'
     },
     DURATION * 0.35

--- a/src/utils/animations/session-intro.ts
+++ b/src/utils/animations/session-intro.ts
@@ -7,12 +7,11 @@ const COVER_DURATION = 0.1
 const COVER_DELAY = 0.15
 
 /**
- * Cover-card entrance, driven by a Vue `<transition>` so the hidden state lands
- * before the element is ever painted (no mount-time flash). Pair these as the
- * transition's `@before-enter` and `@enter` hooks.
+ * Raises the cover card into a session that's just opened.
  *
- * `beforeEnter` runs before Vue inserts the element — that's what makes it
- * flash-proof; `enter` rises it in after the modal's pop has settled.
+ * Wire as a transition's `@before-enter` and `@enter`, never imperatively on
+ * mount — hiding the card has to happen before it is ever painted, or it
+ * flashes at full size first.
  */
 export function coverCardBeforeEnter(el: HTMLElement) {
   gsap.set(el, { opacity: 0, y: COVER_RISE })

--- a/src/utils/animations/session-pane.ts
+++ b/src/utils/animations/session-pane.ts
@@ -5,22 +5,18 @@ const ENTER_DELAY = 0.15
 const LEAVE_DURATION = 0.1
 
 /**
- * Transition between the study-session phases (flashcard → summary). The
- * outgoing flashcard pane is already empty by the time the session completes
- * (the last card swiped out), so the summary simply pops in on top: the
- * leaving pane fades while the entering pane scales up and fades in.
+ * Pops the summary in over the finished flashcard pane.
  *
- * The modal is a fixed size and both panes fill it (`h-full`), so there's no
- * height to animate — just opacity and a scale.
+ * No height to animate — the session window is a fixed size and both panes
+ * fill it.
  */
 export function sessionPaneLeave(el: Element, done: () => void) {
   gsap.to(el, { opacity: 0, duration: LEAVE_DURATION, onComplete: done })
 }
 
 type SessionPaneEnterOptions = {
-  // Skip the pre-enter delay so the incoming pane appears immediately, for
-  // reversible in-session navigation (settings) rather than the terminal
-  // summary pop.
+  // No delay — this is for panes the member can go back from, like settings,
+  // where a beat of blank reads as a stutter rather than a flourish.
   instant?: boolean
   onStart?: () => void
 }

--- a/src/utils/animations/tab-height.ts
+++ b/src/utils/animations/tab-height.ts
@@ -4,16 +4,11 @@ const DURATION = 0.15
 const FADE_DURATION = 0.12
 
 /**
- * Vue Transition JS hooks that animate a wrapper's height between tab swaps.
+ * Resizes a panel smoothly as one tab replaces another.
  *
- * Pair `onLeave` + `onEnter` on a `<Transition mode="out-in">` whose direct
- * parent is the `wrapper` element. The wrapper must be `overflow-hidden` so
- * the height clip is clean.
- *
- * Flow:
- * - leave: capture the wrapper's current height, freeze it, fade content out.
- * - enter: measure the new content's `scrollHeight`, tween the wrapper from
- *   the frozen height to the new height, then release back to `auto`.
+ * Pair both hooks on a `<Transition mode="out-in">` inside an
+ * `overflow-hidden` wrapper — `onLeave` freezes the height and only `onEnter`
+ * releases it, so using either alone strands the panel at a fixed size.
  */
 export function tabHeightLeave(wrapper: HTMLElement) {
   return (el: Element, done: () => void) => {

--- a/src/utils/animations/tab-sheet.ts
+++ b/src/utils/animations/tab-sheet.ts
@@ -1,10 +1,8 @@
 import { gsap } from 'gsap'
 
 const ENTER_DURATION = 0.18
-// Tab body leave duration gates the lifetime of any overlay teleported by
-// the leaving tab — tab-sheet's mode="out-in" Transition keeps the leaving
-// pane mounted for exactly this window. Per-tab overlay leave animations
-// must complete in ≤ TAB_LEAVE_DURATION or they get cut off.
+// Also the deadline for anything a leaving tab put on screen elsewhere — the
+// pane stays mounted for exactly this long, and slower exits get cut off.
 export const TAB_LEAVE_DURATION = 0.22
 const OFFSET = 16
 
@@ -16,9 +14,8 @@ export function tabContentEnter(el: Element, done: () => void) {
     opacity: 1,
     duration: ENTER_DURATION,
     ease: 'expo.out',
-    // Strip the transform inline style on completion — a lingering transform
-    // creates a stacking context that traps z-indexed children (e.g. popovers)
-    // beneath later siblings.
+    // Strip the transform once landed, or the tab traps its own popovers.
+    // →[K:settled-transform-traps-overlays]
     clearProps: 'transform,opacity',
     onComplete: done
   })

--- a/src/utils/animations/tab-slide.ts
+++ b/src/utils/animations/tab-slide.ts
@@ -6,16 +6,14 @@ const LEAVE_DURATION = 0.15
 const SLIDE_X = 48
 
 /**
- * Directional slide for sheet/tablet tab transitions.
+ * Slides a tab in or out, the way drilling into a menu and backing out of it
+ * should feel on a narrow screen.
  *
- * Forward (index → tab): content fades out, new tab slides in from the right.
- * Back   (tab → index):  current tab slides out to the right, content fades in.
+ * Pass the same `direction` ref to both hooks — the enter hook needs the value
+ * as it was before the leave began, so a fresh ref reads the wrong way round.
  *
- * When `wrapper` is provided (sheet layout), the wrapper's height is also
- * animated so the modal resizes smoothly as tab content changes.
- *
- * Pass the same `direction` ref to both leave and enter so the enter hook
- * reads the direction that was set before the leave began.
+ * @param wrapper - Resize this alongside the slide. For the sheet layout,
+ *   where the panel itself has to grow and shrink with its content.
  */
 export function tabSlideLeave(direction: Ref<'forward' | 'back'>, wrapper?: HTMLElement) {
   return (el: Element, done: () => void) => {

--- a/src/utils/animations/transcript-scroll.ts
+++ b/src/utils/animations/transcript-scroll.ts
@@ -1,16 +1,15 @@
-// Where the active line rests in the scroll viewport (0 = top, 1 = bottom). A
-// little above centre keeps the upcoming lines visible while never letting the
-// current line jam against the top or bottom edge.
+// Where the active line rests down the screen. Keep it above centre so the
+// upcoming lines stay visible and the current one never jams against an edge.
 const ANCHOR_RATIO = 0.4
 
-// Deadzone boundaries for word-level scroll. Words inside this band don't
-// trigger a scroll; words outside snap to SCROLL_ANCHOR.
+// The band a word may sit in without triggering a scroll. Widen it and the
+// followed word drifts; narrow it and every word jitters the page.
 const DEADZONE_TOP = 0.15
 const DEADZONE_BOTTOM = 0.35
 const SCROLL_ANCHOR = 0.2
 
-// The transcript always scrolls the page itself — there's no bounded internal
-// column on any breakpoint.
+// The transcript scrolls the page itself — there's no bounded inner column on
+// any screen size.
 function metrics() {
   const doc = document.documentElement
   return {
@@ -25,19 +24,18 @@ function scrollTo(target: number, animate: boolean) {
 }
 
 /**
- * Stop any in-flight smooth scroll. Used when the member takes the scroll over
- * by hand, so the active-word follow lets go instead of fighting them. Issuing
- * a fresh `scrollTo` at the current position interrupts the browser's own
- * smooth-scroll animation immediately.
+ * Stops any scroll still in flight, so the follow lets go the moment the member
+ * takes over by hand rather than fighting them.
  */
 export function cancelScroll() {
   window.scrollTo({ top: window.scrollY, behavior: 'auto' })
 }
 
 /**
- * Lift `el` clear above `limit_bottom` (a viewport Y, e.g. a fixed footer's top
- * edge) by scrolling the page up just enough. No-op when `el` already sits
- * above the limit. Used to re-clear a selected word after the term footer grows.
+ * Scrolls just enough to lift an element clear of something covering the bottom
+ * of the screen — re-exposing a selected word after the footer grows over it.
+ *
+ * @param limit_bottom - Screen position of the covering edge.
  */
 export function scrollClearOf(el: HTMLElement, limit_bottom: number, animate = true) {
   const overshoot = el.getBoundingClientRect().bottom - limit_bottom
@@ -48,10 +46,7 @@ export function scrollClearOf(el: HTMLElement, limit_bottom: number, animate = t
   scrollTo(target, animate)
 }
 
-/**
- * Scroll the page so `el` rests ~40% down the viewport, clamped to the
- * scrollable range. Used to follow the active transcript line as audio plays.
- */
+/** Follows the line being spoken, parking it a little above centre. */
 export function scrollLineIntoView(el: HTMLElement, animate = true) {
   const el_rect = el.getBoundingClientRect()
   const { current, viewport, max } = metrics()
@@ -63,10 +58,9 @@ export function scrollLineIntoView(el: HTMLElement, animate = true) {
 }
 
 /**
- * Scroll the page only when `el` has drifted outside the deadzone band
- * (15%–35% of the viewport). When outside, snaps it to the top of the band.
- * No-ops when the word is already visible inside the band, so mid-sentence
- * words don't cause jitter.
+ * Follows the word being spoken, but only once it has drifted out of the band —
+ * so the page holds still through most of a sentence instead of nudging along
+ * under every word.
  */
 export function scrollWordIntoDeadzone(el: HTMLElement, animate = true) {
   const el_rect = el.getBoundingClientRect()

--- a/src/utils/animations/welcome/feature-reveal.ts
+++ b/src/utils/animations/welcome/feature-reveal.ts
@@ -6,23 +6,20 @@ gsap.registerPlugin(ScrollTrigger)
 // Delay between consecutive cards as the row reveals.
 const FEATURE_STAGGER = 0.12
 
-// Cards are active only while the row overlaps this vertical band of the viewport
-// (measured from the top). Outside it — above or below — they go inactive, giving
-// a deadzone at the top and bottom of the screen. The band is intentionally
-// taller above center so cards linger active a little longer when scrolling down.
+// The band of the screen a row has to reach to come alive. Deliberately
+// lopsided — cards stay awake a little longer on the way down.
 const BAND_TOP = '25%'
 const BAND_BOTTOM = '60%'
 
 /**
- * Drive a set of feature cards active/inactive in a staggered sequence as
- * `trigger` passes through the central band of the viewport: active on entry,
- * inactive on exit, in either scroll direction. `indices` are the card indices
- * this trigger controls (the whole row on desktop, one grid row on tablet, the
- * whole stack on mobile); they fire in array order. `setActive` is called per
- * card on a GSAP-scheduled timeline — the caller decides what "active" means
- * (flip cover→front, or reveal a stacked card).
+ * Wakes a group of welcome-page cards one after another as they scroll into
+ * the middle of the screen, and puts them back to sleep on the way out.
  *
- * Returns the ScrollTrigger so the caller can `kill()` it on unmount.
+ * @param indices - The cards this trigger owns, woken in the order given.
+ *   How the page is grouped varies by screen size.
+ * @param setActive - What waking means here: turning a card over, or
+ *   revealing one from a stack.
+ * @returns The trigger, which the caller must kill on unmount.
  */
 export function createFeatureReveal(
   trigger: Element,

--- a/src/utils/billing/stripe-theme.ts
+++ b/src/utils/billing/stripe-theme.ts
@@ -1,9 +1,6 @@
-// Shared Appearance config for the Stripe Payment Element — reused by the
-// initial checkout flow and the change-card modal so both share the same
-// colors, typography, and control styles as the rest of the app.
-//
-// Colors are resolved from Tailwind's :root CSS variables at call time so a
-// palette tweak propagates everywhere without another hand-edit here.
+// Makes the payment form look like the rest of the app. Colours are read from
+// the stylesheet when this runs, so never paste literal ones in — a palette
+// change would leave the card fields behind.
 
 import type { Appearance } from '@stripe/stripe-js'
 import { FONT_FAMILY, FONT_URL } from '@/styles/fonts'
@@ -22,9 +19,8 @@ function withAlpha(hex: string, percent: number): string {
 }
 
 /**
- * Builds the shared Payment Element appearance, in either light or dark
- * palette. `is_dark` should mirror the app's own `useThemeStore().is_dark`
- * so the Stripe form always matches the surrounding modal chrome.
+ * @param is_dark - Pass the app's own dark-mode flag, not the system
+ *   preference — the form has to match the panel it sits in.
  */
 export function getStripeAppearance(is_dark: boolean): Appearance {
   const danger = token(is_dark ? '--color-red-600' : '--color-red-500')
@@ -74,8 +70,8 @@ export function getStripeAppearance(is_dark: boolean): Appearance {
         borderColor: accent,
         backgroundColor: surface
       },
-      // Selected-tab label/icon default to a primary-tinted color that reads
-      // low-contrast against the surface — pin them back to the base text color.
+      // Pin these back to the base text colour — Stripe's own selected-tab
+      // tint is too faint to read against our surface.
       '.TabLabel--selected': {
         color: text
       },

--- a/src/utils/card-editor/selection-payload.ts
+++ b/src/utils/card-editor/selection-payload.ts
@@ -6,12 +6,10 @@ export type DeleteArgs = { except_ids: number[] } | { cards: Card[] }
 export type MoveArgs = { card_ids: number[] } | { source_deck_id: number; except_ids: number[] }
 
 /**
- * Loaded persisted cards covered by the current selection, with `review`
- * stripped so the result is safe to spread into write payloads.
+ * The saved cards the selection covers, of those scrolled into view.
  *
- * In select-all mode this is incomplete by design — only the loaded pages
- * are reflected. The select-all delete path uses `{ except_ids }` instead so
- * the FE never has to enumerate every card.
+ * Under "select all" that's a partial answer — only what's loaded — so never
+ * build a whole-deck operation from it.
  */
 export function loadedSelectedCards(
   selection: Pick<CardSelection, 'filterSelected'>,
@@ -23,15 +21,13 @@ export function loadedSelectedCards(
 }
 
 /**
- * Build a card-set payload by combining the current selection with an
- * optional additional card id:
+ * The selection, plus one more card when the action was aimed at a card
+ * outside it — right-clicking an unselected row while others are ticked.
  *
- * - `additional_card_id` undefined            → just the current selection.
- * - `additional_card_id` already in selection → just the current selection.
- * - `additional_card_id` new                  → selection plus that card.
+ * Leaves the selection itself alone.
  *
- * Strips `review` from the appended card so the result is safe to spread
- * into write payloads. Does not mutate selection state.
+ * @param additional_card_id - The aimed-at card. Already-selected or unknown
+ *   ids change nothing.
  */
 export function collectCards(
   selection: Pick<CardSelection, 'filterSelected' | 'isCardSelected'>,
@@ -51,11 +47,11 @@ export function collectCards(
 }
 
 /**
- * Resolve the args for the underlying delete mutation, deduced from the
- * current selection state. Returns `null` when there is nothing to delete.
+ * What to hand the delete, and how many cards it covers. `null` when nothing
+ * would be deleted.
  *
- * - select-all mode → `{ except_ids }` for deck-wide delete.
- * - otherwise       → `{ cards }` enumerated from selection + optional id.
+ * Under "select all" it describes the deck by what was *un*ticked, so deleting
+ * ten thousand cards never means listing ten thousand ids.
  */
 export function resolveDeleteArgs(
   selection: Pick<
@@ -79,17 +75,11 @@ export function resolveDeleteArgs(
 }
 
 /**
- * Resolve the args for the underlying move mutation. Returns `null` when
- * nothing is movable.
+ * What to hand the move, how many cards it covers, and a few of them to show
+ * in the confirmation. `null` when nothing would move.
  *
- * - select-all mode → `{ source_deck_id, except_ids }`; the BE moves every
- *   card in the source deck except the deselected ones, so the FE doesn't
- *   have to enumerate ids that aren't even loaded yet.
- * - otherwise       → `{ card_ids }` enumerated from selection + optional id.
- *
- * Also returns `preview_cards` — the loaded subset of the moving set, used
- * by the modal title for representative front/back display. In select-all
- * mode this is incomplete (only loaded pages); the BE works off the args.
+ * Same "select all" shape as the delete above. `preview_cards` is only ever
+ * for display — the count is the honest number, that list may be shorter.
  */
 export function resolveMoveArgs(
   selection: Pick<

--- a/src/utils/card/payload.ts
+++ b/src/utils/card/payload.ts
@@ -1,8 +1,7 @@
 import { type CardBase } from '@type/card'
 
-// Allow-list of upsert-safe columns. Keeps non-column fields (e.g. `review`,
-// which persists through its own RPC) and runtime-only state (e.g. study
-// session `preview`/`state`) from leaking into the upsert body.
+// An allow-list, not a convenience — a card carries fields that aren't columns
+// at all, and a study session hangs more on it that must never be saved.
 const CARD_UPSERT_COLUMNS = [
   'id',
   'deck_id',

--- a/src/utils/card/rank.ts
+++ b/src/utils/card/rank.ts
@@ -1,17 +1,10 @@
 import { generateKeyBetween, generateNKeysBetween } from 'fractional-indexing'
 
 /**
- * The single key generator for card ordering — nothing else in the app, and
- * nothing in Postgres, mints a rank.
+ * The single key generator for card ordering — mint a rank here, nowhere else.
  *
- * A rank is a base62 string ordered by plain byte comparison, so a card's
- * position is decided entirely by its two neighbours: no server round-trip to
- * compute it, no shared counter, and no rebalance pass when a gap runs out of
- * room. That's what lets an offline insert carry a real, mergeable position
- * instead of a placeholder.
- *
- * The column is `text COLLATE "C"` for the same reason — the database's default
- * en_US collation reorders case, and these keys are case-sensitive.
+ * A card's position comes only from its two neighbours, so an insert needs no
+ * round-trip and no rebalance. →[K:card-rank-byte-collation]
  */
 
 /** `null` on either side means "no neighbour": the head or tail of the deck. */

--- a/src/utils/card/text-scale.ts
+++ b/src/utils/card/text-scale.ts
@@ -1,17 +1,16 @@
 import { CARD_ATTRIBUTES_DEFAULTS } from '@/utils/deck/defaults'
 
-// Font px per text-size level (1–10) on the enshrined full-size card
-// (--card-w-full, 314px). Level 4 is the deck default and the calibration
-// anchor: every other level is expressed as a multiplier of its 30px.
+// Calibrated against a full-size card. Level 4 is the anchor every other level
+// is measured from, so changing it rescales all ten.
 const LEVEL_PX_AT_FULL = [16, 20, 24, 30, 36, 44, 52, 60, 70, 84]
 const FULL_BASE_PX = LEVEL_PX_AT_FULL[CARD_ATTRIBUTES_DEFAULTS.text_size - 1]
 
 export const DEFAULT_TEXT_LEVEL = CARD_ATTRIBUTES_DEFAULTS.text_size
 
 /**
- * Multiplier the card face applies to its fluid base font size for a deck's
- * text-size level. Out-of-range / fractional levels clamp and round the same
- * way the old per-size px table did.
+ * How much to scale a card's text for a deck's chosen size. A multiplier, not
+ * a pixel size — the card's own font size already varies with how big the card
+ * is being drawn.
  */
 export function cardTextScale(level?: number): number {
   const clamped = Math.min(

--- a/src/utils/card/widths.ts
+++ b/src/utils/card/widths.ts
@@ -1,9 +1,9 @@
 export type CardWidthToken = 'full' | 'md' | 'sm' | 'xs' | '2xs'
 
 /**
- * Resolve a `--card-w-<token>` width token to its px number. Single source of
- * truth for card widths lives in main.css; use this where layout math needs
- * the number (e.g. grid cell geometry) instead of mirroring the px value.
+ * Reads a card width from the stylesheet, for the layout maths that needs the
+ * number. Call this rather than copying the value — the stylesheet is where a
+ * card width is actually decided.
  */
 export function cardWidthPx(token: CardWidthToken): number {
   const root_styles = getComputedStyle(document.documentElement)

--- a/src/utils/cover/bindings.ts
+++ b/src/utils/cover/bindings.ts
@@ -43,8 +43,8 @@ function buildPatternStyle(
 
   return {
     '--bgx-image': `var(--bgx-${pattern})`,
-    // No --bgx-fill: the pattern-mask utility defaults it to --color-accent-pattern,
-    // which the cover's own data-palette resolves to that palette's texture tint.
+    // Don't set a fill here — leaving it unset is what lets the cover's own
+    // palette tint its texture.
     '--bgx-opacity-light': options.patternOpacity ?? token.opacity,
     '--bgx-opacity-dark': options.patternOpacityDark ?? options.patternOpacity ?? token.opacityDark,
     '--bgx-size': options.patternSize ?? token.size

--- a/src/utils/cover/patterns.ts
+++ b/src/utils/cover/patterns.ts
@@ -12,14 +12,11 @@ export type CoverPattern = {
 }
 
 /**
- * Single source of truth for cover background patterns. Each key has a matching
- * `--bgx-<key>` image var (src/styles/main.css `@theme static`) and an SVG in
- * `assets/backgrounds/`. `satisfies Record<DeckCoverPattern, …>` keeps this in
- * lockstep with the global union — adding a union member without an entry here
- * (or vice-versa) is a compile error.
+ * Every pattern a deck cover can wear.
  *
- * To add a pattern: drop the SVG, add a `--bgx-<key>` var, extend the
- * `DeckCoverPattern` union, and add one entry here.
+ * A new one needs four things in step: the SVG in `assets/backgrounds/`, a
+ * `--bgx-<key>` variable in `main.css`, a member of the `DeckCoverPattern`
+ * union, and an entry here. The type catches the last two, not the first two.
  */
 export const COVER_PATTERNS = {
   'diagonal-stripes': {

--- a/src/utils/cover/tokens.ts
+++ b/src/utils/cover/tokens.ts
@@ -25,11 +25,8 @@ export const SUPPORTED_ICONS: string[] = [
 
 export const BORDER_SIZE_PX = 16
 
-// The neutral cover every loading skeleton renders: a plain diagonal-stripes
-// pattern with no palette, so it resolves to the `element` (neutral) chrome.
-// Single source of truth — the deck/card grid skeletons and the custom-image
-// loading placeholder all read from here so a loading cover is pixel-identical
-// to the app's common card skeleton.
+// The cover a deck wears while it's still loading. Every skeleton reads this
+// one, so a loading deck looks the same wherever it appears.
 export const SKELETON_COVER: DeckCover = {
   pattern: 'diagonal-stripes'
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -3,9 +3,8 @@ export function isoNow(): string {
 }
 
 /**
- * ISO timestamp of the start of the caller's local day (00:00 in their
- * current timezone). Used to scope "today's" daily-cap counts on the
- * backend without baking a timezone assumption into SQL.
+ * Midnight this morning, where the member actually is. Send this with any
+ * "today" question rather than letting the server decide when today began.
  */
 export function localDayStart(): string {
   const now = new Date()
@@ -73,18 +72,15 @@ function toRelativeAtUnit(
 }
 
 /**
- * Formats a batch of dates that are displayed together (e.g. one per FSRS
- * rating). If any two would otherwise render identical text, every date in
- * the batch collapses to day-level granularity instead, so "1 week" / "1
- * week" / "9 days" becomes "8 days" / "8 days" / "9 days" — one clash bumps
- * the whole group, keeping their granularity consistent with each other.
+ * Formats dates shown side by side — the four rating buttons — so no two of
+ * them read the same.
  *
- * A date under a day away is exempted from the day-level bump — rounding it
- * to days would show "0 days" — and renders in hours instead, even while
- * its siblings stay at day granularity.
+ * When any two would collide, the whole group drops to days together, since
+ * "1 week / 1 week / 9 days" is worse than "8 days / 8 days / 9 days". Anything
+ * less than a day out stays in hours regardless, rather than showing "0 days".
  */
-// Largest-first, with the compact abbreviation each unit prints. Weeks are
-// deliberately omitted so a "6 day" interval reads "6d", never "1w".
+// Largest first. No week unit, deliberately — a six-day gap should read "6d"
+// rather than rounding up to "1w".
 const SHORT_UNITS: [number, string][] = [
   [31_536_000, 'y'],
   [2_592_000, 'mo'],
@@ -95,10 +91,9 @@ const SHORT_UNITS: [number, string][] = [
 ]
 
 /**
- * Compact absolute duration from now for tight UI (e.g. rating buttons):
- * magnitude only, no "in"/"ago" direction and no trailing period — "1min",
- * "1d", "2mo". Use `toRelative` instead for higher-fidelity prose. Rounds to
- * the nearest unit.
+ * How far off a date is, squeezed to fit a button — "1min", "1d", "2mo". Says
+ * nothing about direction, so only use it where past and future can't be
+ * confused. `toRelative` is the one that reads as prose.
  */
 export function toShortDuration(input: DateInput): string {
   const diffSeconds = Math.abs((toDate(input).getTime() - Date.now()) / 1000)

--- a/src/utils/deck/defaults.ts
+++ b/src/utils/deck/defaults.ts
@@ -1,8 +1,7 @@
 /**
- * Single source of truth for deck-shaped defaults: settings, study config,
- * card attributes, and the UI bounds the deck-settings forms apply on top.
- * Both the editor (when staging a fresh deck) and the runtime study-session
- * core (when filling missing fields on a loaded deck) read from here.
+ * What a deck's settings are when nobody has chosen. Read them here whether
+ * you're creating a deck or filling gaps in a loaded one — the two drifting
+ * apart is how a deck studies differently from how its settings screen reads.
  */
 
 import { randomCoverConfig } from '@/utils/cover'
@@ -28,9 +27,8 @@ export const CARD_ATTRIBUTES_DEFAULTS: Required<
 }
 
 /**
- * UI bounds for the daily-limit spinboxes in tab-review-pacing. Unbounded above
- * on purpose — decks grow, so a limit is allowed to exceed the current card
- * count. `null` on the model means "no cap" (the "all" pill is active).
+ * Bounds for the daily-limit steppers. Deliberately open-ended upward — decks
+ * grow, so a limit above today's card count is a reasonable thing to set.
  */
 export const DAILY_LIMIT_BOUNDS = {
   step: 5,
@@ -38,10 +36,7 @@ export const DAILY_LIMIT_BOUNDS = {
   min: 0
 } as const
 
-/**
- * Merge a `Partial<DeckConfig>` over `DECK_CONFIG_DEFAULTS`, ignoring keys
- * whose override value is `undefined` so they don't leak past the default.
- */
+/** Fills a deck's unset settings in from the defaults above. */
 export function withDeckConfigDefaults(partial?: Partial<DeckConfig>): Required<DeckConfig> {
   const out = { ...DECK_CONFIG_DEFAULTS }
   if (!partial) return out

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,12 +1,9 @@
 /**
- * SHA-256 hex digest of a file's raw bytes.
+ * A file's fingerprint, taken from its bytes alone — so the same picture used
+ * on ten cards is stored once, whatever it was named on the way in.
  *
- * Used to content-address uploads: identical bytes produce an identical hash,
- * so the same image reused across cards (or as a deck background) maps to a
- * single storage object instead of one copy per use.
- *
- * Reads bytes via FileReader rather than `file.arrayBuffer()` for environment
- * portability (jsdom's File predates `arrayBuffer`).
+ * Reads through `FileReader` rather than the shorter modern call, which the
+ * test environment's `File` doesn't have.
  */
 export async function hashFile(file: File): Promise<string> {
   const bytes = await readArrayBuffer(file)

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -63,7 +63,6 @@ class LoggerClass {
       }
     ]
 
-    // find the index of the level
     const index = Object.values(LogTypes).findIndex((l) => l === level)
 
     if (index <= this.logLevel) {
@@ -83,13 +82,8 @@ class LoggerClass {
         if (match?.[1]) {
           let url = match[1]
 
-          // Remove protocol + host
           url = url.replace(/^https?:\/\/[^/]+\/?/, '')
-
-          // Remove query params
           url = url.replace(/\?.*?(?=:)/, '')
-
-          // Remove webpack://customer-flows/.
           url = url.replace(/^webpack:\/\/customer-flows\/\./, '')
 
           return url

--- a/src/utils/member/defaults.ts
+++ b/src/utils/member/defaults.ts
@@ -1,7 +1,6 @@
 /**
- * Default values for member-editor staging + the settings UI. Both the
- * profile tab and the member-card preview pull initial values from here when
- * the underlying member record is missing a field.
+ * What a member's card looks like before they've chosen anything. Read here
+ * from both the settings form and its preview, so the two always agree.
  */
 
 export const MEMBER_SETTINGS_DEFAULTS = {

--- a/src/utils/member/preferences.ts
+++ b/src/utils/member/preferences.ts
@@ -4,8 +4,8 @@ export type ResolvedMemberPreferences = {
   accessibility: {
     left_hand: boolean
   }
-  // Persisted audio prefs — one slider per bus, named with the `_sounds` suffix
-  // the settings UI and DB use. `toBusVolumes` maps them onto the player's buses.
+  // One slider each, stored under the names the settings screen and the
+  // database use. `toBusVolumes` translates them for the player.
   audio: {
     muted: boolean
     interface_sounds: number
@@ -71,8 +71,9 @@ export function withMemberPreferencesDefaults(
 }
 
 /**
- * Map persisted `*_sounds` prefs onto the bus-keyed volumes the player consumes.
- * When `muted` is set, every bus resolves to 0 regardless of its slider value.
+ * Turns the member's saved sound settings into the volumes the player wants.
+ * Muted wins over every slider, so their individual levels survive being
+ * muted and come back as they were.
  */
 export function toBusVolumes(audio: ResolvedMemberPreferences['audio']): Record<Bus, number> {
   if (audio.muted) return { interface: 0, hover: 0 }

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,8 +1,8 @@
 /**
- * Deep-clone a plain data value (objects, arrays, primitives), reading through
- * Vue reactive proxies to produce a detached, non-reactive snapshot. Used to
- * capture a draft's base state so later mutations don't write back into it.
- * Plain-data only — no Dates, Maps, class instances, or cycles.
+ * Takes a detached snapshot of reactive data, for holding on to what a form
+ * looked like before the member started editing.
+ *
+ * Plain data only — Dates, Maps, class instances, and cycles do not survive.
  */
 export function deepClone<T>(value: T): T {
   if (typeof value !== 'object' || value === null) return value
@@ -16,10 +16,11 @@ export function deepClone<T>(value: T): T {
 }
 
 /**
- * Structural equality for plain data. Keys whose value is `undefined` are
- * ignored on both sides, so a merged-in default that leaves a field `undefined`
- * doesn't read as a change. Replaces the fragile key-order `JSON.stringify`
- * comparison the editors used for dirty-checking.
+ * Whether two plain values hold the same data, whatever order their keys are
+ * in. Use it for "has the member changed anything" checks.
+ *
+ * A missing key and an explicitly empty one count as equal, so filling in
+ * defaults doesn't make an untouched form look edited.
  */
 export function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true

--- a/src/utils/palette/registry.ts
+++ b/src/utils/palette/registry.ts
@@ -1,31 +1,13 @@
 /**
- * Single source of truth for the seven user-assignable palettes.
+ * The colours a member can pick from, each carrying its light and dark
+ * rendition so a caller names one palette rather than a pair.
  *
- * Each entry resolves BOTH renditions, so a caller passes one palette name
- * (`green`) instead of a `theme` + `theme_dark` pair. `satisfies` keeps this in
- * lockstep with the `PaletteName` union — adding a union member without an
- * entry here (or dropping a role from a rendition) is a compile error.
+ * Keep `accentMuted` one step lighter within the same hue — a muted step that
+ * borrows the neighbouring colour reads as the wrong palette entirely.
+ * `SUPPORTED_PALETTES` in `src/utils/cover/tokens.ts` must list the same set.
  *
- * The palette set mirrors `SUPPORTED_PALETTES` in src/utils/cover/tokens.ts,
- * which is the real palette set.
- *
- * `accent` / `onAccent` were lifted verbatim from each palette's original
- * `primary` / `on-primary` rendition in the retired theme layer.
- *
- * `accentMuted` is the adjacent lighter step of the same hue, normally the
- * palette's original `secondary`. Two of those secondaries left the hue family
- * and are corrected here:
- *
- *   yellow.dark   originally paired with orange-500 -> corrected to yellow-500
- *   orange.light  originally paired with yellow-500 -> corrected to orange-400
- *
- * `orange-400` was added to the @theme scale in main.css for that second case:
- * the family previously stopped at 500, so the muted step had nowhere in-hue to
- * go and borrowed yellow. The new step matches the 500 -> 400 lightness delta of
- * the other warm families (red, pink).
- *
- * After editing this file run `pnpm gen:palette-css` to regenerate
- * src/styles/palettes.gen.css.
+ * Run `pnpm gen:palette-css` after editing, or the generated stylesheet still
+ * carries the old values.
  */
 // Trap: the color set is closed; an out-of-set color renders bare →[K:closed-color-set-fails-bare]
 export const PALETTES = {
@@ -43,7 +25,6 @@ export const PALETTES = {
   },
   yellow: {
     light: { accent: 'yellow-500', accentMuted: 'yellow-400', onAccent: 'brown-700' },
-    // originally paired yellow-700 with orange-500; corrected to stay in-hue.
     dark: { accent: 'yellow-700', accentMuted: 'yellow-500', onAccent: 'brown-100' }
   },
   purple: {
@@ -61,9 +42,8 @@ export const PALETTES = {
 } satisfies Record<PaletteName, PaletteDefinition>
 
 /**
- * Meaning-first aliases. Call sites that mean "this is destructive" should say
- * `danger`, not `red` — the palette behind a meaning can change without
- * touching them.
+ * Names for what a colour means rather than what it is. Say `danger`, never
+ * `red`, so the colour behind a meaning can change in one place.
  */
 export const SEMANTIC_ALIASES = {
   brand: 'blue',

--- a/src/utils/reorder.ts
+++ b/src/utils/reorder.ts
@@ -1,15 +1,14 @@
 export type ReorderAnchor = { anchor_id: number; side: 'before' | 'after' }
 
 /**
- * Resolve a fractional-rank anchor for a drag-reorder. `without` is the
- * rendered list with the dragged row already removed; `to` is the array index
- * the dragged row should land at. Picks the nearest *persisted* neighbour to
- * anchor against — temps (negative placeholder ids) can't anchor a server move.
+ * Finds the saved row a dropped row should be placed against.
  *
- * Walks left from the drop slot for a row to land `after`; if none (dropping
- * at the very top, or only temps to the left) walks right for a row to land
- * `before`. Returns `null` when no persisted neighbour exists — e.g. the list
- * holds a single persisted row, so there is nothing to reorder against.
+ * Skips rows that haven't been saved yet — the server can't position anything
+ * relative to a card it doesn't know about. `null` when nothing saved sits on
+ * either side, which means there's nothing to reorder against at all.
+ *
+ * @param without - The list as rendered, with the dragged row taken out.
+ * @param to - Where in that list it was dropped.
  */
 export function resolveReorderAnchor(without: { id?: number }[], to: number): ReorderAnchor | null {
   for (let i = to - 1; i >= 0; i--) {

--- a/src/utils/review-pacing/defaults.ts
+++ b/src/utils/review-pacing/defaults.ts
@@ -1,16 +1,16 @@
 export type LearningStepsKey = '10m' | '1hr' | '1d' | '1m-10m' | '1m-10m-1d'
 export type RelearningStepsKey = '10m' | '1hr' | '1d' | '1m-10m'
 
-// ts-fsrs' own default maximum_interval (~100 years) — the "uncapped" value a
-// null/0 max_interval resolves to before it reaches the scheduler.
+// What "no ceiling" resolves to before it reaches the scheduler — roughly a
+// hundred years, which is the scheduler's own idea of unlimited.
 export const FSRS_MAX_INTERVAL = 36500
 
-// Mirrors the system preset's leech_threshold default — only a defensive
-// fallback for when a resolved deck value is somehow absent.
+// A fallback only. The system preset carries the real value; if you're reading
+// this one, something upstream failed to resolve.
 export const DEFAULT_LEECH_THRESHOLD = 8
 
-// Percentages. Below 70 the scheduler thrashes; above 97 intervals collapse to
-// near-daily, so FSRS itself treats the range outside these as unusable.
+// Don't widen these. Below 70 the scheduler thrashes; above 97 every card
+// comes back near-daily. The scheduler itself rejects the range outside.
 export const DESIRED_RETENTION_BOUNDS = { min: 70, max: 97, step: 1 } as const
 
 export const LEECH_THRESHOLD_BOUNDS = { min: 1, max: 99, step: 1 } as const

--- a/src/utils/tag-button/mask.ts
+++ b/src/utils/tag-button/mask.ts
@@ -14,12 +14,10 @@ export function outsetSideFor(notchSide: NotchSide): OutsetSide {
 }
 
 /**
- * Compute the CSS `mask` shorthand for `ui-kit/tag-button`. The mask composes
- * three layers (notch strip, outset strip, middle base rectangle) so a single
- * background color paints the full tag silhouette — concave notch on one side,
- * convex point on the other.
+ * Cuts a tag button into its luggage-label shape — a bite out of one end, a
+ * point on the other — so one flat colour paints the whole silhouette.
  *
- * Returned string is suitable for both `mask` and `-webkit-mask`.
+ * Set the result on both `mask` and `-webkit-mask`.
  */
 export function buildTagButtonMask(params: TagButtonMaskParams): string {
   const { notchSide, notchDepth: n, outsetDepth: o, apexRadius: k, cornerRadius: cr } = params

--- a/src/utils/tips/catalog.ts
+++ b/src/utils/tips/catalog.ts
@@ -7,10 +7,7 @@ export type Tip = {
   body_key: string
 }
 
-/**
- * Single source of truth for tip content. The dashboard rotates through these;
- * a future standalone tips app will browse/filter the same list by `category`.
- */
+/** The study tips the dashboard rotates through. */
 export const TIPS: Tip[] = [
   {
     id: 'sound',

--- a/src/utils/transcript-match.ts
+++ b/src/utils/transcript-match.ts
@@ -1,12 +1,10 @@
 import type { CardIndexEntry } from '@/api/cards'
 import { cleanTerm, type DisplayWord } from '@/utils/transcript'
 
-// A run of transcript words whose joined text matches a card front. `lo`/`hi`
-// are global word indices (the same space as WordRange), so a match drops
-// straight into the selection machinery. `deck_ids` are the decks already
-// holding this term, which drive the term panel's add-button state. `palette`
-// colours the highlight after the reader joins the owning deck's cover — the
-// matcher itself leaves it unset.
+// A stretch of the transcript that says one of the member's cards. `lo`/`hi`
+// share the numbering `WordRange` uses, so a match is a selection as it
+// stands. The matcher leaves `palette` unset — the reader fills it in from the
+// owning deck's cover.
 export type CardMatch = {
   lo: number
   hi: number
@@ -15,17 +13,17 @@ export type CardMatch = {
   palette?: PaletteName
 }
 
-// Normalized card front → the decks holding it. Built once per index, then
-// shared by the matcher, the per-word lookup, and term→deck queries.
+// Build this once and share it — the matcher, the per-word lookup, and the
+// term panel all read the same map.
 export type CardTermMap = Map<string, number[]>
 
-// No real card front spans more words than this, so the inner scan never grows a
-// candidate span unbounded — a safety cap on the worst case, not a content rule.
+// A ceiling on the scan, not a limit on what a card may say — no real card
+// front runs this long.
 const MAX_SPAN_WORDS = 16
 
 /**
- * Collapse the raw index to normalized-term → decks, merging case/punctuation
- * variants ("Cat" + "cat") into one entry so every consumer keys off one form.
+ * Folds the card index down to one entry per term, so "Cat" and "cat," are the
+ * same card as far as everything downstream is concerned.
  */
 export function buildCardTermMap(index: CardIndexEntry[]): CardTermMap {
   const map: CardTermMap = new Map()
@@ -46,13 +44,8 @@ export function decksForTerm(terms: CardTermMap, term: string): number[] {
 }
 
 /**
- * Find every card front that appears verbatim as a run of transcript words,
- * resolved leftmost-longest and non-overlapping. Word-spans and the map's keys
- * are normalized the same way (see `normalizeForMatch`) so casing and
- * surrounding punctuation never block a match.
- *
- * @example
- * const matches = matchCardsInWords(flatWords, buildCardTermMap(cardIndex))
+ * Finds every card front spoken in the transcript, preferring the longest
+ * phrase at each point and never overlapping two matches.
  */
 export function matchCardsInWords(words: DisplayWord[], terms: CardTermMap): CardMatch[] {
   if (terms.size === 0) return []
@@ -80,8 +73,8 @@ export function matchCardsInWords(words: DisplayWord[], terms: CardTermMap): Car
 }
 
 /**
- * Index matches by every word they cover, so a word component (or a tap handler)
- * can resolve "is this word in a match, and which one" in O(1).
+ * Indexes matches by each word they cover, so a tapped word can name its match
+ * without searching.
  */
 export function matchesByWord(matches: CardMatch[]): Map<number, CardMatch> {
   const map = new Map<number, CardMatch>()
@@ -92,9 +85,9 @@ export function matchesByWord(matches: CardMatch[]): Map<number, CardMatch> {
 }
 
 /**
- * Reduce a card front or a joined word-span to its comparable form: surrounding
- * punctuation stripped (matching `cleanTerm`), inner whitespace collapsed, and
- * case folded. Returns '' for punctuation-only input.
+ * Reduces a card front or a run of spoken words to the form the two are
+ * compared in. Both sides must come through here, or casing and stray
+ * punctuation block matches that should land. Punctuation alone yields `''`.
  */
 export function normalizeForMatch(text: string): string {
   return cleanTerm(text).replace(/\s+/g, ' ').toLowerCase()
@@ -110,9 +103,7 @@ function maxKeyLength(terms: CardTermMap): number {
   return max
 }
 
-// From word `start`, grow the span one word at a time and keep the longest span
-// whose normalized text is a known term. Stops once the span outgrows the
-// longest term (no longer one can match) or hits the span-word cap.
+// Grows the span a word at a time, keeping the longest that names a card.
 function longestMatchFrom(
   words: DisplayWord[],
   start: number,


### PR DESCRIPTION
[TARO-343](https://app.notion.com/p/3b60953c224c8123a520c2c38456355f)

> Stacked on #526.

## Summary

- **860 → 640 comment lines** across `src/utils/` (minus `transcript.ts`) and `src/sfx/`.
- **`[K:ios-audio-interruption]`** — a new `corpus/sfx/sound.md`: iOS drops the audio context into a non-standard interrupted state, only a completed gesture reactivates it, and resuming before user activation is what autoplay blockers reject. Echoed at 8 sites across `lifecycle.ts` and `engine.ts`, since it bites in both the recovery module and the engine's rebuild path.
- **`[K:settled-transform-traps-overlays]`** — the "a finished animation still creates a containing block" rationale was restated across four animation helpers. Extracted to `corpus/architecture/layering.md`, cited from six sites.
- **`[K:media-query-token-language]`** in `corpus/architecture/responsive.md` — the atoms, the breakpoint set, and the `<`-only-under-`|` legality rule.

## Side finding, not fixed here

`src/utils/logger.ts` strips a `webpack://customer-flows/.` prefix — dead code from a different codebase, since this project has no webpack. The comment restating it is gone; the code was left rather than widening this diff.

## Note

The "no comment in the repo references Howler" criterion is repo-wide, but `audio-reader/` is excluded from every sweep in this epic. Those references are cleaned in the assembly PR at the top of the stack.