### PR TITLE
Wave 4 assembly: register the traps and close the cross-sweep gaps

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -20,7 +20,7 @@ paths:
 | `src/stores/`      | Pinia stores: `session`, `member`, `theme`, `notice-store`, `shortcut-store`, `taro-phone`                                                      |
 | `src/views/`       | Routed pages; `authenticated.vue` wraps the protected routes                                                                                    |
 | `src/styles/`      | Global CSS + TailwindCSS 4 config; `palettes.css` defines the color tokens                                                                      |
-| `src/sfx/`         | Custom audio engine behind the `v-sfx` directive (Howler.js was removed)                                                                        |
+| `src/sfx/`         | Custom audio engine behind the `v-sfx` directive                                                                                                |
 | `types/`           | Shared TypeScript types — outside `src/`                                                                                                        |
 
 - **Routing** — public routes (welcome, auth callback, legal) vs authenticated routes behind

--- a/.claude/rules/sfx.md
+++ b/.claude/rules/sfx.md
@@ -7,7 +7,7 @@ paths:
 
 # Sound effects
 
-Audio runs through a lightweight custom engine in `src/sfx/` (Howler was removed), surfaced as the `v-sfx` directive and the imperative `emitSfx()`.
+Audio runs through a lightweight custom engine in `src/sfx/`, surfaced as the `v-sfx` directive and the imperative `emitSfx()`.
 
 ## Buttons use the `sfx` prop
 
@@ -25,7 +25,7 @@ A sound that should play for **every** instance of an action belongs in the sing
 
 Use `{ blocking: true }` when the sound must suppress a follow-on automatic one (the add chime blocks the `slide_up` that focusing fires).
 
-Centralise only for genuine instances of *that* action — don't fold in unrelated uses of the same key.
+Centralise only for genuine instances of _that_ action — don't fold in unrelated uses of the same key.
 
 ## Options go on the existing call
 

--- a/corpus/hazards.md
+++ b/corpus/hazards.md
@@ -12,20 +12,26 @@ radius: data loss and silent corruption first, design ceilings and footguns last
 You don't read this list to work. Each trap is echoed as a `→[K:<slug>]` pointer
 in the directory it bites, so it reaches you when you're standing on it.
 
-| Trap                                          | Topic                | Echoed at                                  |
-| --------------------------------------------- | -------------------- | ------------------------------------------ |
-| →[K:unconfirmed-review-loss]                  | [[study]]            | `src/views/study-session/composables/`     |
-| →[K:stall-reaper-strands-slow-jobs]           | [[audio-generation]] | `supabase/functions/transcribe-lesson/`    |
-| →[K:card-rank-byte-collation]                 | [[cards]]            | `supabase/schemas/40_cards/`               |
-| →[K:ownership-stamp-empty-under-service-role] | [[members]]          | `supabase/schemas/` (`set_member_id`)      |
-| →[K:permission-widening-ripples]              | [[permissions]]      | `supabase/schemas/` (the `can_` functions) |
-| →[K:media-lifetime-follows-notes]             | [[media]]            | `src/api/media/`                           |
-| →[K:client-owns-the-schedule]                 | [[scheduling]]       | `src/views/study-session/`                 |
-| →[K:silent-stale-cache]                       | [[data-flow]]        | `src/api/reviews/mutations/`               |
-| →[K:pin-is-presence-not-difference]           | [[pacing]]           | `src/api/review-pacing/`                   |
-| →[K:closed-color-set-fails-bare]              | [[theming]]          | `src/utils/palette/`                       |
-| →[K:public-is-read-only]                      | [[decks]]            | `src/api/decks/`                           |
-| →[K:posts-hidden-until-published]             | [[feedback]]         | `src/api/feedback/`                        |
+| Trap                                          | Topic                  | Echoed at                                  |
+| --------------------------------------------- | ---------------------- | ------------------------------------------ |
+| →[K:unconfirmed-review-loss]                  | [[study]]              | `src/views/study-session/composables/`     |
+| →[K:deleted-account-token-outlives-deletion]  | [[sessions]]           | `src/api/session.ts`, `src/stores/`        |
+| →[K:return-destination-open-redirect]         | [[return-destination]] | `src/composables/auth/`                    |
+| →[K:oauth-popup-loses-its-opener]             | [[sessions]]           | `src/api/session.ts`                       |
+| →[K:stall-reaper-strands-slow-jobs]           | [[audio-generation]]   | `supabase/functions/transcribe-lesson/`    |
+| →[K:card-rank-byte-collation]                 | [[cards]]              | `supabase/schemas/40_cards/`               |
+| →[K:ownership-stamp-empty-under-service-role] | [[members]]            | `supabase/schemas/` (`set_member_id`)      |
+| →[K:permission-widening-ripples]              | [[permissions]]        | `supabase/schemas/` (the `can_` functions) |
+| →[K:media-lifetime-follows-notes]             | [[media]]              | `src/api/media/`                           |
+| →[K:client-owns-the-schedule]                 | [[scheduling]]         | `src/views/study-session/`                 |
+| →[K:silent-stale-cache]                       | [[data-flow]]          | `src/api/reviews/mutations/`               |
+| →[K:pin-is-presence-not-difference]           | [[pacing]]             | `src/api/review-pacing/`                   |
+| →[K:closed-color-set-fails-bare]              | [[theming]]            | `src/utils/palette/`                       |
+| →[K:public-is-read-only]                      | [[decks]]              | `src/api/decks/`                           |
+| →[K:posts-hidden-until-published]             | [[feedback]]           | `src/api/feedback/`                        |
+| →[K:text-editor-ghost-click-guard]            | [[cards]]              | `src/components/card/`                     |
+| →[K:settled-transform-traps-overlays]         | [[layering]]           | `src/utils/animations/`                    |
+| →[K:ios-audio-interruption]                   | [[sound]]              | `src/sfx/`                                 |
 
 A trap with no directory to echo it into is listed in `CLAUDE.md` instead, so it
 is paid for in every session. There are none today.

--- a/corpus/map.md
+++ b/corpus/map.md
@@ -45,6 +45,16 @@ See [corpus-authoring](../.claude/rules/corpus-authoring.md) for how the corpus 
 
 - [[theming]] — colors are roles, not shades; three switches reslot the whole screen ⚠️
 
+## sessions
+
+- [[sessions]] — a token the browser holds for an hour; the server can end a session without the browser noticing ⚠️
+- [[return-destination]] — where sign-in sends you back to, taken from an unauthenticated param ⚠️
+
+## sfx
+
+- [[sound]] — one shared audio channel; iOS breaks it on lock and only a completed tap reopens it ⚠️
+
 ## architecture
 
 - [[data-flow]] — server data is a named cache; a write owns marking its own data stale ⚠️
+- [[layering]] — a finished animation still traps the popovers inside it ⚠️

--- a/src/composables/audio-reader/audio-player.ts
+++ b/src/composables/audio-reader/audio-player.ts
@@ -8,8 +8,8 @@ import { useNoticeStore } from '@/stores/notice-store'
  * Uses a requestAnimationFrame loop while playing so `current_time` updates
  * smoothly for the transcript highlight (the `timeupdate` event alone fires too
  * coarsely, ~4x/sec); it reconciles against `timeupdate` while paused/seeking.
- * Native `<audio>` (not Howler) because it streams via HTTP range requests and
- * gives free seeking — Howler is for short SFX.
+ * A native `<audio>` element rather than the sfx engine: it streams over HTTP
+ * range requests, so seeking anywhere in a long recording costs nothing.
  *
  * @param target - the audio element (template ref); binding follows it as it mounts/unmounts.
  * @example

--- a/src/composables/ui/media-query.ts
+++ b/src/composables/ui/media-query.ts
@@ -126,15 +126,9 @@ function matchCached(media: string): Ref<boolean> {
 }
 
 /**
- * Reactive boolean for a responsive condition, expressed as a token query.
- *
- * **Atoms** — `w>=md` / `w<md` (width), `h>=lg` / `h<sm` (height),
- * `fine` / `coarse` (pointer), `dark` / `light` (color scheme).
- *
- * **Combinator** — `&` (all) or `|` (any); one type per query, mixing throws.
- * `>=` atoms read naturally under `&` ("big enough = every minimum met"),
- * `<` atoms under `|` ("too small = any maximum exceeded"). A `<` atom under
- * `&` throws (a width/height band would need `max-*` support — add it then).
+ * Reactive boolean for a responsive condition, written as a token query like
+ * `w>=md & fine`. The token vocabulary and which combinator each atom is legal
+ * under are spelled out at →[K:media-query-token-language].
  *
  * The returned ref is app-lifetime cached and shared across callers; it never
  * tears down, so it's safe to read from setup, render, or transition hooks.


### PR DESCRIPTION
Top of the wave-4 stack — no ticket. This is the coordination commit six parallel sweeps could not write themselves.

## Why it exists

Four of the six sweeps produced traps belonging in `corpus/hazards.md`, and several needed rows in `corpus/map.md`. Six agents editing one shared index concurrently is a guaranteed conflict, so every sweep was told to report its row instead of writing it. This collects them.

## What's in it

**The register** — eight new rows in `corpus/hazards.md`, placed by the file's own blast-radius ordering (data loss first, design ceilings last):

- `deleted-account-token-outlives-deletion`, `return-destination-open-redirect`, `oauth-popup-loses-its-opener` near the top — all token/session-shaped.
- `text-editor-ghost-click-guard`, `settled-transform-traps-overlays`, `ios-audio-interruption` at the bottom as footguns and ceilings.
- New `corpus/map.md` sections for `sessions`, `sfx`, and the `layering` topic.

**Two gaps no ticket owned:**

- **Howler.** TARO-343's criterion is repo-wide, but the remaining references sit in `src/composables/audio-reader/audio-player.ts` — a tree every sweep deliberately excludes — plus `.claude/rules/sfx.md` and `architecture.md`. All three now describe the engine by what it is rather than the library it replaced.
- **`[K:media-query-token-language]`** was declared by TARO-343 but its only call site is in TARO-338's scope, so it shipped uncited with the full spec still duplicated in the docstring. Now cited.

## Gates

- `node scripts/knowledge-lint.mjs` — green: **53 slugs, 104 citations, 228/250 always-on lines**.
- `pnpm type-check` — clean.
- `vp lint src/composables` — 0 warnings, 0 errors.

The type-check needed a `vp install` first: `fractional-indexing` is declared in `package.json` on both this branch and `master` but was missing from the local `node_modules`. Stale install, not a regression — the lockfile is untouched.