### PR TITLE
TARO-337: Add the enforcement gates

### DIFF
--- a/.claude/knowledge-lint.json
+++ b/.claude/knowledge-lint.json
@@ -9,6 +9,19 @@
       }
     }
   },
+  "reachability": {
+    "roots": [
+      "CLAUDE.md",
+      "AGENTS.md",
+      ".claude/rules/*.md",
+      ".claude/agents/*.md",
+      ".claude/skills/**/*.md",
+      ".claude/knowledge/retired-slugs.md",
+      "corpus/map.md",
+      "corpus/hazards.md",
+      "corpus/**/_map.md"
+    ]
+  },
   "slugs": {
     "retired_ledger": ".claude/knowledge/retired-slugs.md",
     "declare_in": ["CLAUDE.md", "AGENTS.md", ".claude/**/*.md", "corpus/**/*.md"],

--- a/.claude/knowledge-lint.json
+++ b/.claude/knowledge-lint.json
@@ -36,6 +36,6 @@
       "supabase/**/*.{sql,ts}",
       ".github/**/*.yml"
     ],
-    "exempt": ["supabase/migrations/**", "tests/unit/scripts/knowledge-lint.test.js"]
+    "exempt": ["supabase/migrations/**", "tests/unit/scripts/**"]
   }
 }

--- a/.claude/rules/knowledge-addressing.md
+++ b/.claude/rules/knowledge-addressing.md
@@ -47,8 +47,8 @@ caps, and the scan scope. Always-on = the `always_on.include` globs minus any fi
 frontmatter, since a `paths:` rule is path-triggered rather than loaded every session.
 
 - `slugs.exempt` skips the citation scan. `supabase/migrations/**` is exempt because migrations are
-  append-only, so a pointer written into one can never be corrected; the checker's own test file is
-  exempt because its fixtures contain literal tokens. Nothing else earns a place there.
+  append-only, so a pointer written into one can never be corrected; `tests/unit/scripts/**` is
+  exempt because the checker's own fixtures contain literal tokens. Nothing else earns a place there.
 - Caps are `line_caps` — 80 lines for `CLAUDE.md`, 250 for the always-on total. A starting
   calibration, not a measured figure.
 - `line_caps.enforced` is `true` — a breach fails CI. Set it to `false` only to land a deliberate,

--- a/.claude/rules/knowledge-addressing.md
+++ b/.claude/rules/knowledge-addressing.md
@@ -53,3 +53,36 @@ frontmatter, since a `paths:` rule is path-triggered rather than loaded every se
   calibration, not a measured figure.
 - `line_caps.enforced` is `true` — a breach fails CI. Set it to `false` only to land a deliberate,
   temporary overshoot, and restore it in the change that gets back under.
+
+## Migrations answer for the record [K:knowledge-migration-gate]
+
+`scripts/migration-knowledge-gate.mjs` fails a PR whose added migration leaves recorded knowledge
+unanswered. Answer in the migration's own header, one line per group of schema objects:
+
+```sql
+-- knowledge: members, member_streaks — corpus/members/members.md
+-- knowledge: purge_downgraded_decks — unrecorded
+```
+
+- Name **every** table, view, function, type, index target, policy target and trigger target the
+  migration touches. The gate parses them itself and says how many you missed, never which.
+- The right side is the knowledge file you checked the change against — amended where this migration
+  made it false — or `unrecorded`. `unrecorded` fails when any knowledge file already describes that
+  object.
+- A migration that changes no schema object says `-- knowledge: no schema objects`.
+
+## The pull-request digest [K:knowledge-pr-digest]
+
+`scripts/knowledge-report.mjs` posts one comment, updated in place, and never blocks: the slugs the
+changed code cites, the slugs this change dropped to zero citations, and the knowledge files it left
+unroutable. It compares against the merge base, so it names only what this change caused.
+
+`reachability.roots` in the config lists the files a reader arrives at unaided; everything else is
+reachable only by being linked, `[[id]]`-referenced, or cited from a file that is.
+
+## Mechanising a prose rule [K:knowledge-mechanisation]
+
+- A PR landing a lint rule, hook, or CI check **deletes the prose rule it supersedes**, in the same
+  PR.
+- That check states the rationale and its `→[K:<slug>]` in its own failure message. A silent check
+  plus deleted prose loses the knowledge outright.

--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prepare-pr
-description: Fully autonomous — prepare a branch for PR by committing all pending work, rewriting commit messages into release-notes-friendly Conventional Commits, renaming the branch if it no longer fits the changes, running a lint + type-check gate, drafting a PR title and body, then creating a single PR directly (not a draft) and watching CI until green. Never asks for permission or feedback before the PR opens. Always bundles all branch work — committed AND uncommitted (staged + unstaged) — into exactly one PR. Use when a feature branch is code-complete and ready for review.
+description: Fully autonomous — prepare a branch for PR by committing all pending work, rewriting commit messages into release-notes-friendly Conventional Commits, renaming the branch if it no longer fits the changes, running a lint + type-check + knowledge-pointer gate, drafting a PR title and body, then creating a single PR directly (not a draft) and watching CI until green. Never asks for permission or feedback before the PR opens. Always bundles all branch work — committed AND uncommitted (staged + unstaged) — into exactly one PR. Use when a feature branch is code-complete and ready for review.
 allowed-tools: Read, Edit, Write, Bash, Glob, Grep
 argument-hint: '[--no-watch] [--ticket <ID>] [--ticket-url <URL>]'
 arguments:
@@ -38,7 +38,7 @@ Output:
 2. All branch commits grouped into a single PR.
 3. Commits renamed to **Conventional Commits** (see style guide below).
 4. Branch renamed if slug no longer fits.
-5. Working tree lint-and-type-clean (gate run, issues fixed) before any push.
+5. Working tree lint-, type- and knowledge-clean (gate run, issues fixed) before any push.
 6. Branch pushed (force-with-lease if rewritten, fresh push if new).
 7. PR **created directly** via `gh pr create` — no browser, never a draft — then its CI watched until green.
 
@@ -165,22 +165,25 @@ Rename directly — no approval pause. Record old → new in the Step 11 report:
 git branch -m <old-name> <new-name>
 ```
 
-### Step 6 — Lint + type-check gate (before any push)
+### Step 6 — Lint + type-check + knowledge gate (before any push)
 
-Run the linter **and** the type-checker on the working tree and fix everything they flag **before** pushing — these are the cheapest CI failures to catch locally, and the most annoying to discover after the PR is already open.
+Run the linter, the type-checker **and** the knowledge check on the working tree and fix everything they flag **before** pushing — these are the cheapest CI failures to catch locally, and the most annoying to discover after the PR is already open.
 
 ```sh
 vp lint
 pnpm type-check
+node scripts/knowledge-lint.mjs
+node scripts/migration-knowledge-gate.mjs --base origin/master
 ```
 
 - **Type-check uses `pnpm type-check` (vue-tsc), not `vp`.** CI runs `pnpm type-check`, and vue-tsc is stricter than `vp check`'s type pass — a `vp`-clean tree can still fail CI on types. Use the same command CI uses so the gate actually matches it.
-- If both clean → continue to the push.
+- **The knowledge check runs on every branch, not just doc branches.** A pointer breaks when the code it names moves. `migration-knowledge-gate.mjs` only speaks when the branch adds a migration; its answer goes in that migration's header, per [`knowledge-addressing`](../../rules/knowledge-addressing.md).
+- If all clean → continue to the push.
 - If they report errors → fix them. Most lint hits are mechanical (unused import left by a refactor, `prefer-const`, missing return); `vp lint --fix` / `vp fmt` handle the auto-fixable ones. Type errors after a refactor are usually moved/renamed symbols or a changed signature — chase them to the changed call sites.
 - Re-run both until clean. Commit the fixes onto the branch with a `fix(<scope>):` or `chore(<scope>):` Conventional Commit (or amend into the commit that introduced the issue if it hasn't been pushed yet and belongs there) so the fix rides with the work it corrects.
 - Pre-existing lint warnings unrelated to this branch's diff aren't a blocker — don't expand scope chasing them. Errors (lint or type), and warnings in code this branch touched, must be resolved.
 
-Do not push until both `vp lint` and `pnpm type-check` are clean.
+Do not push until `vp lint`, `pnpm type-check` and the knowledge checks are clean.
 
 ### Step 7 — Push the branch
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The migration gate diffs against the PR's base commit, which a
+          # shallow clone doesn't contain.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,67 @@ jobs:
       - name: Check knowledge pointers and always-on budget
         run: node scripts/knowledge-lint.mjs
 
+      - name: Check migrations answer for the record
+        if: github.event_name == 'pull_request'
+        run: node scripts/migration-knowledge-gate.mjs --base ${{ github.event.pull_request.base.sha }}
+
+  # Informational only. With no second reviewer, a blocking staleness gate is
+  # friction that gets waved through rather than read.
+  knowledge-report:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build the knowledge digest
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git worktree add "$RUNNER_TEMP/base" "$BASE_SHA"
+          git diff --name-only "$BASE_SHA...HEAD" > "$RUNNER_TEMP/changed.txt"
+          node scripts/knowledge-report.mjs \
+            --head . --base "$RUNNER_TEMP/base" --changed "$RUNNER_TEMP/changed.txt" \
+            > "$RUNNER_TEMP/report.md"
+
+      - name: Post or clear the digest comment
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: ${{ runner.temp }}/report.md
+        with:
+          script: |
+            const body = require('fs').readFileSync(process.env.REPORT_PATH, 'utf8').trim()
+            const { owner, repo } = context.repo
+            const issue_number = context.issue.number
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number
+            })
+            const existing = comments.find((one) => one.body.includes('<!-- knowledge-report -->'))
+
+            // One comment, rewritten in place — a per-line review would bury the
+            // one thing this check is for.
+            if (!body) {
+              if (existing) await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id })
+              return
+            }
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+              return
+            }
+            await github.rest.issues.createComment({ owner, repo, issue_number, body })
+
   test:
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'push'

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "oxlint",
     "format": "vp fmt src/",
     "knowledge:check": "node scripts/knowledge-lint.mjs",
+    "knowledge:migrations": "node scripts/migration-knowledge-gate.mjs",
     "build:email-templates": "node scripts/build-email-templates.mjs",
     "gen:palette-css": "node scripts/gen-palette-css.ts"
   },

--- a/scripts/knowledge-lint.mjs
+++ b/scripts/knowledge-lint.mjs
@@ -7,126 +7,20 @@
  * the single declared place for the always-on file list and the caps.
  * See .claude/rules/knowledge-addressing.md.
  */
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import {
+  KEBAB,
+  SCOPED_FRONTMATTER,
+  TOKEN,
+  countLines,
+  matchesAny,
+  readConfig,
+  scanTokens
+} from './knowledge/scan.mjs'
 
-const CONFIG_PATH = '.claude/knowledge-lint.json'
-const SKIP_DIRS = new Set([
-  '.git',
-  'node_modules',
-  'dist',
-  'coverage',
-  '.vitest-reports',
-  '.claude/worktrees'
-])
-
-// `→[K:<slug>]` cites, bare `[K:<slug>]` declares. Angle-bracket placeholders in
-// prose (`[K:<kebab-slug>]`) deliberately fall outside the character class.
-const TOKEN = /(→\s*)?\[K:([A-Za-z0-9_-]+)\]/g
-const KEBAB = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const LEDGER_ENTRY = /^\s*[-*]\s*\[K:([A-Za-z0-9_-]+)\]\s*—\s*(.*)$/
-// A rule carrying `paths:` frontmatter is path-triggered, not always-on.
-const SCOPED_FRONTMATTER = /^---\r?\n[\s\S]*?^paths:/m
-// Opens or closes a markdown code fence; group 2 is the info string a close can't have.
-const FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*(.*)$/
-
-function expandBraces(glob) {
-  const match = /\{([^{}]*)\}/.exec(glob)
-  if (!match) return [glob]
-
-  return match[1]
-    .split(',')
-    .flatMap((option) =>
-      expandBraces(glob.slice(0, match.index) + option + glob.slice(match.index + match[0].length))
-    )
-}
-
-function globToRegExp(glob) {
-  let out = ''
-
-  for (let i = 0; i < glob.length; i++) {
-    const char = glob[i]
-    if (char === '*' && glob[i + 1] === '*' && glob[i + 2] === '/') {
-      out += '(?:.*/)?'
-      i += 2
-      continue
-    }
-    if (char === '*' && glob[i + 1] === '*') {
-      out += '.*'
-      i += 1
-      continue
-    }
-    if (char === '*') {
-      out += '[^/]*'
-      continue
-    }
-    if (char === '?') {
-      out += '[^/]'
-      continue
-    }
-    out += char.replace(/[.+^${}()|[\]\\]/g, '\\$&')
-  }
-
-  return new RegExp(`^${out}$`)
-}
-
-function matchesAny(path, globs) {
-  return globs.flatMap(expandBraces).some((glob) => globToRegExp(glob).test(path))
-}
-
-function listFiles(root, dir = root, found = []) {
-  for (const entry of readdirSync(dir)) {
-    const absolute = join(dir, entry)
-    const path = relative(root, absolute)
-    if (SKIP_DIRS.has(entry) || SKIP_DIRS.has(path)) continue
-
-    if (statSync(absolute).isDirectory()) {
-      listFiles(root, absolute, found)
-      continue
-    }
-    found.push(path)
-  }
-
-  return found
-}
-
-function countLines(text) {
-  const lines = text.split('\n')
-  return lines.at(-1) === '' ? lines.length - 1 : lines.length
-}
-
-/** Every `[K:…]` token in a file, tagged as citation or declaration. Markdown fences are skipped — a token inside one is an example, not a live pointer. */
-function collectTokens(path, text) {
-  const tokens = []
-  const markdown = path.endsWith('.md')
-  let fence = null
-
-  for (const [index, line] of text.split('\n').entries()) {
-    const marker = markdown && FENCE.exec(line)
-
-    if (marker && !fence) {
-      fence = marker[1]
-      continue
-    }
-    if (
-      marker &&
-      marker[1][0] === fence[0] &&
-      marker[1].length >= fence.length &&
-      !marker[2].trim()
-    ) {
-      fence = null
-      continue
-    }
-    if (fence) continue
-
-    for (const match of line.matchAll(TOKEN)) {
-      tokens.push({ path, line: index + 1, slug: match[2], cites: Boolean(match[1]), text: line })
-    }
-  }
-
-  return tokens
-}
 
 /** Retired slugs and their epitaphs; a malformed entry is an error, not an epitaph. */
 function readLedger(root, ledgerPath) {
@@ -247,19 +141,12 @@ function checkLineCaps(root, files, alwaysOn) {
 }
 
 export function lintKnowledge(root) {
-  const config = JSON.parse(readFileSync(join(root, CONFIG_PATH), 'utf8'))
+  const config = readConfig(root)
   const { slugs, always_on } = config
-  const files = listFiles(root)
+  const { files, tokens, declarable } = scanTokens(root, config)
 
   const ledger = readLedger(root, slugs.retired_ledger)
-  const cited = files.filter(
-    (path) => matchesAny(path, slugs.cite_in) && !matchesAny(path, slugs.exempt)
-  )
-  const tokens = cited
-    .filter((path) => path !== slugs.retired_ledger)
-    .flatMap((path) => collectTokens(path, readFileSync(join(root, path), 'utf8')))
 
-  const declarable = new Set(files.filter((path) => matchesAny(path, slugs.declare_in)))
   const misplaced = tokens
     .filter((token) => !token.cites && !declarable.has(token.path))
     .map(

--- a/scripts/knowledge-lint.mjs
+++ b/scripts/knowledge-lint.mjs
@@ -22,6 +22,10 @@ import {
 
 const LEDGER_ENTRY = /^\s*[-*]\s*\[K:([A-Za-z0-9_-]+)\]\s*—\s*(.*)$/
 
+const RULE =
+  'A pointer that resolves to nothing, a slug declared twice, or an always-on file over its cap all ' +
+  'cost the reader the knowledge they came for. Fix the pointer, not the check. →[K:knowledge-lint]'
+
 /** Retired slugs and their epitaphs; a malformed entry is an error, not an epitaph. */
 function readLedger(root, ledgerPath) {
   const errors = []
@@ -192,6 +196,7 @@ function main() {
 
   for (const warning of warnings) console.error(`::warning::${warning}`)
   for (const error of errors) console.error(`::error::${error}`)
+  if (errors.length) console.error(`::error::${RULE}`)
 
   console.log(
     `knowledge-lint: ${stats.declared} slugs, ${stats.citations} citations, ` +

--- a/scripts/knowledge-report.mjs
+++ b/scripts/knowledge-report.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * The pull request's knowledge digest: slugs the changed code cites, and what
+ * this change just stranded.
+ *
+ * Reports the difference between two checkouts, never the standing state, so it
+ * speaks on the commit that caused a problem and stays silent after.
+ * Prints markdown for one sticky comment, or nothing at all.
+ *
+ *   node scripts/knowledge-report.mjs --head . --base ../base --changed changed.txt
+ */
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { collectTokens } from './knowledge/scan.mjs'
+import { knowledgeGraph } from './knowledge/graph.mjs'
+
+export const MARKER = '<!-- knowledge-report -->'
+
+function parseArgs(argv) {
+  const args = { head: process.cwd() }
+
+  for (let i = 0; i < argv.length; i += 2) {
+    if (argv[i] === '--head') args.head = argv[i + 1]
+    if (argv[i] === '--base') args.base = argv[i + 1]
+    if (argv[i] === '--changed') args.changed = argv[i + 1]
+  }
+
+  return args
+}
+
+function readChangedFiles(path) {
+  if (!path || !existsSync(path)) return []
+
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+/** Citations sitting in the code this change touched, grouped by the slug they point at. */
+function citedByChangedCode(root, changed, references) {
+  const cited = new Map()
+
+  for (const path of changed.filter((file) => !file.endsWith('.md'))) {
+    const absolute = join(root, path)
+    if (!existsSync(absolute)) continue
+
+    for (const token of collectTokens(path, readFileSync(absolute, 'utf8'))) {
+      if (!token.cites) continue
+
+      const entry = cited.get(token.slug) ?? { sites: [], declaredIn: null }
+      entry.declaredIn = references.get(token.slug)?.declaredIn ?? null
+      entry.sites.push(`${token.path}:${token.line}`)
+      cited.set(token.slug, entry)
+    }
+  }
+
+  return cited
+}
+
+function countsOf(graph) {
+  return new Map([...graph.references].map(([slug, entry]) => [slug, entry.citedBy.length]))
+}
+
+export function buildReport({ head, base, changed }) {
+  const headGraph = knowledgeGraph(head)
+  const baseGraph = base ? knowledgeGraph(base) : { references: new Map(), unreachable: [] }
+  const baseCounts = countsOf(baseGraph)
+  const baseUnreachable = new Set(baseGraph.unreachable)
+
+  const cited = citedByChangedCode(head, changed, headGraph.references)
+  const dropped = [...headGraph.references]
+    .filter(([slug, entry]) => entry.citedBy.length === 0 && (baseCounts.get(slug) ?? 0) > 0)
+    .map(([slug, entry]) => `\`[K:${slug}]\` — declared in \`${entry.declaredIn}\``)
+  const stranded = headGraph.unreachable
+    .filter((path) => !baseUnreachable.has(path))
+    .map((path) => `\`${path}\``)
+
+  const sections = []
+
+  if (cited.size) {
+    const rows = [...cited]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(
+        ([slug, entry]) =>
+          `- \`→[K:${slug}]\` — ${entry.declaredIn ?? 'no declaration'} — cited at ${entry.sites.join(', ')}`
+      )
+    sections.push(
+      `**Knowledge this change stands on.** Confirm each is still true, or amend it:\n${rows.join('\n')}`
+    )
+  }
+  if (dropped.length) {
+    sections.push(
+      `**Nothing cites these any more.** Retire the slug, or restore the pointer:\n- ${dropped.join('\n- ')}`
+    )
+  }
+  if (stranded.length) {
+    sections.push(
+      `**Nothing routes a reader to these files any more.** Link them, or delete them:\n- ${stranded.join('\n- ')}`
+    )
+  }
+
+  if (!sections.length) return ''
+
+  return `${MARKER}\n### Knowledge\n\n${sections.join('\n\n')}`
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const report = buildReport({
+    head: args.head,
+    base: args.base,
+    changed: readChangedFiles(args.changed)
+  })
+
+  if (report) console.log(report)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main()

--- a/scripts/knowledge/graph.mjs
+++ b/scripts/knowledge/graph.mjs
@@ -1,0 +1,104 @@
+/**
+ * Who points at what across the knowledge layer: inbound citations per slug,
+ * and which knowledge files nothing can route a reader to.
+ *
+ * State only — the diff between two checkouts of it is what gets reported, in
+ * scripts/knowledge-report.mjs.
+ */
+import { readFileSync } from 'node:fs'
+import { join, dirname, normalize } from 'node:path'
+import { SCOPED_FRONTMATTER, matchesAny, readConfig, scanTokens } from './scan.mjs'
+
+const MD_PATH = /(?:\.{1,2}\/|[\w.-]+\/)[\w./-]*\.md/g
+const WIKI_LINK = /\[\[([\w-]+)\]\]/g
+const FRONTMATTER_ID = /^---\r?\n[\s\S]*?^id:\s*([\w-]+)\s*$/m
+
+/** Knowledge-file targets a file's prose can send a reader to: `.md` paths and `[[id]]` links. */
+function outboundLinks(path, text, byPath, byId) {
+  const targets = new Set()
+
+  for (const [mention] of text.matchAll(MD_PATH)) {
+    const relative = normalize(join(dirname(path), mention))
+    if (byPath.has(relative)) targets.add(relative)
+    if (byPath.has(normalize(mention))) targets.add(normalize(mention))
+  }
+  for (const [, id] of text.matchAll(WIKI_LINK)) {
+    if (byId.has(id)) targets.add(byId.get(id))
+  }
+
+  return targets
+}
+
+/**
+ * Every knowledge file a reader can still arrive at.
+ *
+ * Seeds are the files that load on their own — always-on, path-triggered, or
+ * named as an entry point in the config — plus anything code cites directly.
+ * From there reachability follows the links between knowledge files.
+ */
+function reachableFrom(seeds, links) {
+  const reached = new Set()
+  const queue = [...seeds]
+
+  while (queue.length) {
+    const path = queue.pop()
+    if (reached.has(path)) continue
+
+    reached.add(path)
+    for (const target of links.get(path) ?? []) queue.push(target)
+  }
+
+  return reached
+}
+
+export function knowledgeGraph(root) {
+  const config = readConfig(root)
+  const { tokens, declarable } = scanTokens(root, config)
+  const knowledgeFiles = [...declarable]
+
+  const texts = new Map(
+    knowledgeFiles.map((path) => [path, readFileSync(join(root, path), 'utf8')])
+  )
+  const byPath = new Set(knowledgeFiles)
+  const byId = new Map()
+  for (const [path, text] of texts) {
+    const id = FRONTMATTER_ID.exec(text)
+    if (id && !byId.has(id[1])) byId.set(id[1], path)
+  }
+
+  const declarations = new Map()
+  for (const token of tokens.filter((one) => !one.cites && declarable.has(one.path))) {
+    if (!declarations.has(token.slug)) declarations.set(token.slug, token.path)
+  }
+
+  const references = new Map(
+    [...declarations].map(([slug, path]) => [slug, { declaredIn: path, citedBy: [] }])
+  )
+  for (const token of tokens.filter((one) => one.cites)) {
+    references.get(token.slug)?.citedBy.push(`${token.path}:${token.line}`)
+  }
+
+  const links = new Map(
+    knowledgeFiles.map((path) => [path, outboundLinks(path, texts.get(path), byPath, byId)])
+  )
+  for (const token of tokens.filter((one) => one.cites && declarable.has(one.path))) {
+    if (declarations.has(token.slug)) links.get(token.path)?.add(declarations.get(token.slug))
+  }
+
+  const roots = config.reachability?.roots ?? []
+  const seeds = knowledgeFiles.filter(
+    (path) => matchesAny(path, roots) || SCOPED_FRONTMATTER.test(texts.get(path))
+  )
+  for (const token of tokens.filter((one) => one.cites && !declarable.has(one.path))) {
+    if (declarations.has(token.slug)) seeds.push(declarations.get(token.slug))
+  }
+
+  const reached = reachableFrom(seeds, links)
+
+  return {
+    references,
+    unreachable: knowledgeFiles
+      .filter((path) => !reached.has(path))
+      .sort((a, b) => a.localeCompare(b))
+  }
+}

--- a/scripts/knowledge/migration-objects.mjs
+++ b/scripts/knowledge/migration-objects.mjs
@@ -1,0 +1,55 @@
+/**
+ * The schema objects a migration touches, as bare lowercase names.
+ *
+ * Comments and function bodies are stripped first: prose about a table, and SQL
+ * that only reads one at runtime, are not schema changes.
+ */
+const DOLLAR_QUOTED = /\$([\w]*)\$[\s\S]*?\$\1\$/g
+const BLOCK_COMMENT = /\/\*[\s\S]*?\*\//g
+const LINE_COMMENT = /--[^\n]*/g
+
+const NAME = '((?:"[^"]+"|[\\w]+)(?:\\.(?:"[^"]+"|[\\w]+))?)'
+const PATTERNS = [
+  new RegExp(
+    `\\b(?:create|alter|drop)\\s+(?:unlogged\\s+)?table\\s+(?:if\\s+(?:not\\s+)?exists\\s+|only\\s+)?${NAME}`,
+    'gi'
+  ),
+  new RegExp(
+    `\\b(?:create|alter|drop)\\s+(?:or\\s+replace\\s+)?(?:materialized\\s+)?view\\s+(?:if\\s+(?:not\\s+)?exists\\s+)?${NAME}`,
+    'gi'
+  ),
+  new RegExp(
+    `\\b(?:create|alter|drop)\\s+(?:or\\s+replace\\s+)?function\\s+(?:if\\s+exists\\s+)?${NAME}`,
+    'gi'
+  ),
+  new RegExp(`\\b(?:create|alter|drop)\\s+type\\s+(?:if\\s+(?:not\\s+)?exists\\s+)?${NAME}`, 'gi'),
+  new RegExp(
+    `\\b(?:create|drop)\\s+(?:unique\\s+)?index\\s+(?:concurrently\\s+)?(?:if\\s+(?:not\\s+)?exists\\s+)?(?:[\\w"]+\\s+)?on\\s+${NAME}`,
+    'gi'
+  ),
+  new RegExp(`\\b(?:create|alter|drop)\\s+policy\\s+(?:[^\\s]+\\s+)+?on\\s+${NAME}`, 'gi'),
+  new RegExp(
+    `\\b(?:create|drop)\\s+(?:or\\s+replace\\s+)?trigger\\s+[\\w"]+\\s+(?:[\\s\\S]*?)\\bon\\s+${NAME}`,
+    'gi'
+  )
+]
+
+/** Strips the schema qualifier and quoting — `"public"."decks"` and `decks` are one object. */
+function bareName(raw) {
+  const parts = raw.split('.').map((part) => part.replace(/"/g, '').toLowerCase())
+  return parts.at(-1)
+}
+
+export function migrationObjects(sql) {
+  const executable = sql
+    .replace(DOLLAR_QUOTED, ' ')
+    .replace(BLOCK_COMMENT, ' ')
+    .replace(LINE_COMMENT, ' ')
+
+  const found = new Set()
+  for (const pattern of PATTERNS) {
+    for (const match of executable.matchAll(pattern)) found.add(bareName(match[1]))
+  }
+
+  return [...found].sort((a, b) => a.localeCompare(b))
+}

--- a/scripts/knowledge/scan.mjs
+++ b/scripts/knowledge/scan.mjs
@@ -1,0 +1,153 @@
+/**
+ * Reading side of the knowledge layer: config, file walk, and `[K:…]` tokens.
+ *
+ * Shared by the checker (scripts/knowledge-lint.mjs) and the pointer graph
+ * (scripts/knowledge-graph.mjs) so both see one definition of what counts.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+export const CONFIG_PATH = '.claude/knowledge-lint.json'
+
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'coverage',
+  '.vitest-reports',
+  '.claude/worktrees'
+])
+
+// `→[K:<slug>]` cites, bare `[K:<slug>]` declares. Angle-bracket placeholders in
+// prose (`[K:<kebab-slug>]`) deliberately fall outside the character class.
+export const TOKEN = /(→\s*)?\[K:([A-Za-z0-9_-]+)\]/g
+export const KEBAB = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+// A rule carrying `paths:` frontmatter is path-triggered, not always-on.
+export const SCOPED_FRONTMATTER = /^---\r?\n[\s\S]*?^paths:/m
+// Opens or closes a markdown code fence; group 2 is the info string a close can't have.
+const FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*(.*)$/
+
+function expandBraces(glob) {
+  const match = /\{([^{}]*)\}/.exec(glob)
+  if (!match) return [glob]
+
+  return match[1]
+    .split(',')
+    .flatMap((option) =>
+      expandBraces(glob.slice(0, match.index) + option + glob.slice(match.index + match[0].length))
+    )
+}
+
+function globToRegExp(glob) {
+  let out = ''
+
+  for (let i = 0; i < glob.length; i++) {
+    const char = glob[i]
+    if (char === '*' && glob[i + 1] === '*' && glob[i + 2] === '/') {
+      out += '(?:.*/)?'
+      i += 2
+      continue
+    }
+    if (char === '*' && glob[i + 1] === '*') {
+      out += '.*'
+      i += 1
+      continue
+    }
+    if (char === '*') {
+      out += '[^/]*'
+      continue
+    }
+    if (char === '?') {
+      out += '[^/]'
+      continue
+    }
+    out += char.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  }
+
+  return new RegExp(`^${out}$`)
+}
+
+export function matchesAny(path, globs) {
+  return globs.flatMap(expandBraces).some((glob) => globToRegExp(glob).test(path))
+}
+
+export function listFiles(root, dir = root, found = []) {
+  for (const entry of readdirSync(dir)) {
+    const absolute = join(dir, entry)
+    const path = relative(root, absolute)
+    if (SKIP_DIRS.has(entry) || SKIP_DIRS.has(path)) continue
+
+    if (statSync(absolute).isDirectory()) {
+      listFiles(root, absolute, found)
+      continue
+    }
+    found.push(path)
+  }
+
+  return found
+}
+
+export function countLines(text) {
+  const lines = text.split('\n')
+  return lines.at(-1) === '' ? lines.length - 1 : lines.length
+}
+
+export function readConfig(root) {
+  return JSON.parse(readFileSync(join(root, CONFIG_PATH), 'utf8'))
+}
+
+/** Every `[K:…]` token in a file, tagged as citation or declaration. Markdown fences are skipped — a token inside one is an example, not a live pointer. */
+export function collectTokens(path, text) {
+  const tokens = []
+  const markdown = path.endsWith('.md')
+  let fence = null
+
+  for (const [index, line] of text.split('\n').entries()) {
+    const marker = markdown && FENCE.exec(line)
+
+    if (marker && !fence) {
+      fence = marker[1]
+      continue
+    }
+    if (
+      marker &&
+      marker[1][0] === fence[0] &&
+      marker[1].length >= fence.length &&
+      !marker[2].trim()
+    ) {
+      fence = null
+      continue
+    }
+    if (fence) continue
+
+    for (const match of line.matchAll(TOKEN)) {
+      tokens.push({ path, line: index + 1, slug: match[2], cites: Boolean(match[1]), text: line })
+    }
+  }
+
+  return tokens
+}
+
+/**
+ * Every live token in the repo, with the file lists the callers work from.
+ *
+ * `cited` is the scanned set minus exemptions; `declarable` is where a bare
+ * token is allowed to mean a declaration.
+ */
+export function scanTokens(root, config) {
+  const { slugs } = config
+  const files = listFiles(root)
+
+  const cited = files.filter(
+    (path) => matchesAny(path, slugs.cite_in) && !matchesAny(path, slugs.exempt)
+  )
+  const tokens = cited
+    .filter((path) => path !== slugs.retired_ledger)
+    .flatMap((path) => collectTokens(path, readFileSync(join(root, path), 'utf8')))
+
+  return {
+    files,
+    tokens,
+    declarable: new Set(files.filter((path) => matchesAny(path, slugs.declare_in)))
+  }
+}

--- a/scripts/migration-knowledge-gate.mjs
+++ b/scripts/migration-knowledge-gate.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Blocks a migration that leaves recorded knowledge behind.
+ *
+ * Every schema object a new migration touches is answered in that migration's
+ * own header — the knowledge file the change was checked against, or
+ * `unrecorded` where nothing covers it yet.
+ *
+ *   node scripts/migration-knowledge-gate.mjs --base origin/master
+ */
+import { execFileSync } from 'node:child_process'
+import { readFileSync, existsSync } from 'node:fs'
+import { join, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { listFiles, matchesAny, readConfig } from './knowledge/scan.mjs'
+import { migrationObjects } from './knowledge/migration-objects.mjs'
+
+const MIGRATIONS = 'supabase/migrations/'
+const HEADER = /^\s*--\s*knowledge:\s*(.+?)\s*$/gm
+const NO_OBJECTS = 'no schema objects'
+const UNRECORDED = 'unrecorded'
+
+const RULE =
+  'A migration answers for the knowledge its schema change could have falsified: one ' +
+  '`-- knowledge: <objects> — <knowledge file>` header line per group, or `— unrecorded` ' +
+  'where nothing covers them. Nothing else notices when a schema change makes a recorded ' +
+  'truth false. →[K:knowledge-migration-gate]'
+
+function parseArgs(argv) {
+  const args = { base: 'origin/master', root: process.cwd() }
+
+  for (let i = 0; i < argv.length; i += 2) {
+    if (argv[i] === '--base') args.base = argv[i + 1]
+    if (argv[i] === '--root') args.root = argv[i + 1]
+  }
+
+  return args
+}
+
+function addedMigrations(root, base) {
+  const diff = execFileSync('git', ['diff', '--name-status', '--diff-filter=A', `${base}...HEAD`], {
+    cwd: root,
+    encoding: 'utf8'
+  })
+
+  return diff
+    .split('\n')
+    .map((line) => line.split('\t').at(-1)?.trim())
+    .filter((path) => path?.startsWith(MIGRATIONS) && path.endsWith('.sql'))
+}
+
+/** `<names> — <verdict>` per header line; a line the format doesn't fit is reported, not guessed. */
+function parseHeader(text) {
+  const claims = []
+  const malformed = []
+  let declaresNoObjects = false
+
+  for (const [, body] of text.matchAll(HEADER)) {
+    if (body === NO_OBJECTS) {
+      declaresNoObjects = true
+      continue
+    }
+
+    const [names, verdict, ...rest] = body.split('—').map((part) => part.trim())
+    if (!names || !verdict || rest.length) {
+      malformed.push(body)
+      continue
+    }
+
+    for (const name of names
+      .split(',')
+      .map((one) => one.trim().toLowerCase())
+      .filter(Boolean)) {
+      claims.push({ name, verdict })
+    }
+  }
+
+  return { claims, malformed, declaresNoObjects }
+}
+
+/** The knowledge file whose prose already talks about this object, if any. Domain topics answer before rules and notes do. */
+function mentionedIn(root, knowledgeFiles, name) {
+  const word = new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
+  const ranked = [...knowledgeFiles].sort(
+    (a, b) => Number(b.startsWith('corpus/')) - Number(a.startsWith('corpus/'))
+  )
+
+  return ranked.find((path) => word.test(readFileSync(join(root, path), 'utf8')))
+}
+
+export function checkMigration(root, path, knowledgeFiles) {
+  const errors = []
+  const at = basename(path)
+  const text = readFileSync(join(root, path), 'utf8')
+  const objects = migrationObjects(text)
+  const { claims, malformed, declaresNoObjects } = parseHeader(text)
+
+  for (const line of malformed) {
+    errors.push(`${at} — \`-- knowledge: ${line}\` needs \`<objects> — <knowledge file>\``)
+  }
+
+  if (!objects.length) {
+    if (!declaresNoObjects && !claims.length) {
+      errors.push(
+        `${at} — no header; a migration changing no schema object says \`-- knowledge: ${NO_OBJECTS}\``
+      )
+    }
+    return errors
+  }
+
+  const claimed = new Set(claims.map((claim) => claim.name))
+  const unknown = [...claimed].filter((name) => !objects.includes(name))
+  const missing = objects.filter((name) => !claimed.has(name)).length
+
+  for (const name of unknown) {
+    errors.push(`${at} — \`${name}\` is not a schema object this migration touches`)
+  }
+  // The missing names stay unprinted on purpose: the answer is in the migration
+  // the author just wrote, and a gate that dictates its own answer is a gate
+  // that gets pasted rather than read.
+  if (missing) {
+    errors.push(
+      `${at} — answers for ${objects.length - missing} of the ${objects.length} schema objects it touches; read the migration and name the rest`
+    )
+  }
+
+  for (const claim of claims.filter((one) => !unknown.includes(one.name))) {
+    if (claim.verdict === UNRECORDED) {
+      const mention = mentionedIn(root, knowledgeFiles, claim.name)
+      if (mention) {
+        errors.push(
+          `${at} — \`${claim.name}\` is called ${UNRECORDED}, but ${mention} describes it; cite that file and amend it where this change makes it false`
+        )
+      }
+      continue
+    }
+    if (!knowledgeFiles.includes(claim.verdict)) {
+      errors.push(`${at} — \`${claim.verdict}\` is not a knowledge file in this repo`)
+    }
+  }
+
+  return errors
+}
+
+export function gateMigrations(root, base) {
+  const config = readConfig(root)
+  const knowledgeFiles = listFiles(root).filter((path) => matchesAny(path, config.slugs.declare_in))
+  const migrations = addedMigrations(root, base).filter((path) => existsSync(join(root, path)))
+
+  return {
+    migrations,
+    errors: migrations.flatMap((path) => checkMigration(root, path, knowledgeFiles))
+  }
+}
+
+function main() {
+  const { root, base } = parseArgs(process.argv.slice(2))
+  const { migrations, errors } = gateMigrations(root, base)
+
+  for (const error of errors) console.error(`::error::${error}`)
+  if (errors.length) console.error(`::error::${RULE}`)
+
+  console.log(
+    `migration-knowledge-gate: ${migrations.length} added migrations, ${errors.length} unanswered`
+  )
+  if (errors.length) process.exit(1)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main()

--- a/scripts/migration-knowledge-gate.mjs
+++ b/scripts/migration-knowledge-gate.mjs
@@ -21,10 +21,9 @@ const NO_OBJECTS = 'no schema objects'
 const UNRECORDED = 'unrecorded'
 
 const RULE =
-  'A migration answers for the knowledge its schema change could have falsified: one ' +
-  '`-- knowledge: <objects> — <knowledge file>` header line per group, or `— unrecorded` ' +
-  'where nothing covers them. Nothing else notices when a schema change makes a recorded ' +
-  'truth false. →[K:knowledge-migration-gate]'
+  'This migration changes schema objects the knowledge layer may describe. Name them in a ' +
+  '`-- knowledge:` header with the file you checked against, or `unrecorded` if nothing ' +
+  'covers them. →[K:knowledge-migration-gate]'
 
 function parseArgs(argv) {
   const args = { base: 'origin/master', root: process.cwd() }

--- a/scripts/migration-knowledge-gate.mjs
+++ b/scripts/migration-knowledge-gate.mjs
@@ -37,10 +37,19 @@ function parseArgs(argv) {
 }
 
 function addedMigrations(root, base) {
-  const diff = execFileSync('git', ['diff', '--name-status', '--diff-filter=A', `${base}...HEAD`], {
-    cwd: root,
-    encoding: 'utf8'
-  })
+  let diff
+  try {
+    diff = execFileSync('git', ['diff', '--name-status', '--diff-filter=A', `${base}...HEAD`], {
+      cwd: root,
+      encoding: 'utf8'
+    })
+  } catch {
+    // Usually a shallow clone that doesn't contain the base commit — a passing
+    // gate there would be a false negative, so say which ref is missing.
+    throw new Error(
+      `cannot diff against ${base} — it is not in this checkout. A CI job running this gate needs fetch-depth: 0.`
+    )
+  }
 
   return diff
     .split('\n')

--- a/tests/unit/scripts/knowledge-report.test.js
+++ b/tests/unit/scripts/knowledge-report.test.js
@@ -1,0 +1,167 @@
+import { describe, test, expect, afterEach } from 'vite-plus/test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { buildReport, MARKER } from '../../../scripts/knowledge-report.mjs'
+
+// Every test builds its own throwaway head/base roots under os.tmpdir() —
+// never assert against the real repo's knowledge files.
+
+const CONFIG = {
+  always_on: {
+    include: ['CLAUDE.md', '.claude/rules/*.md'],
+    line_caps: { enforced: false, total: 250, per_file: { 'CLAUDE.md': 80 } }
+  },
+  reachability: {
+    roots: ['CLAUDE.md', '.claude/rules/*.md', 'corpus/map.md']
+  },
+  slugs: {
+    retired_ledger: '.claude/knowledge/retired-slugs.md',
+    declare_in: ['CLAUDE.md', 'AGENTS.md', '.claude/**/*.md', 'corpus/**/*.md'],
+    cite_in: [
+      'CLAUDE.md',
+      'AGENTS.md',
+      '.claude/**/*.md',
+      'corpus/**/*.md',
+      'src/**/*.{ts,js,vue}',
+      'tests/**/*.{ts,js,vue}',
+      'scripts/**/*.{ts,js,mjs}',
+      'supabase/**/*.{sql,ts}',
+      '.github/**/*.yml'
+    ],
+    exempt: ['supabase/migrations/**']
+  }
+}
+
+const createdRoots = []
+
+afterEach(() => {
+  while (createdRoots.length) {
+    const root = createdRoots.pop()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+/** Builds a temp fixture root with the given files, returns its path. */
+function makeRoot(files = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'knowledge-report-'))
+  createdRoots.push(root)
+
+  mkdirSync(join(root, '.claude'), { recursive: true })
+  writeFileSync(join(root, '.claude/knowledge-lint.json'), JSON.stringify(CONFIG, null, 2))
+
+  for (const [relPath, content] of Object.entries(files)) {
+    const absolute = join(root, relPath)
+    mkdirSync(dirname(absolute), { recursive: true })
+    writeFileSync(absolute, content)
+  }
+
+  return root
+}
+
+describe('buildReport — silence on no change', () => {
+  test('returns the empty string when nothing changed between base and head', () => {
+    const files = {
+      'CLAUDE.md': '[K:steady-slug] declared once.\n',
+      '.claude/rules/foo.md': 'Cites →[K:steady-slug] steadily.\n'
+    }
+    const head = makeRoot(files)
+    const base = makeRoot(files)
+
+    const report = buildReport({ head, base, changed: [] })
+
+    expect(report).toBe('')
+  })
+})
+
+describe('buildReport — newly-dropped-to-zero citations', () => {
+  test('a slug with >=1 citation at base and 0 at head is reported as newly dropped', () => {
+    const base = makeRoot({
+      'CLAUDE.md': '[K:was-cited] declared here.\n',
+      '.claude/rules/foo.md': 'Cites →[K:was-cited] here.\n'
+    })
+    const head = makeRoot({
+      'CLAUDE.md': '[K:was-cited] declared here.\n',
+      '.claude/rules/foo.md': 'No longer cites it.\n'
+    })
+
+    const report = buildReport({ head, base, changed: [] })
+
+    expect(report).toContain(MARKER)
+    expect(report).toContain('Nothing cites these any more')
+    expect(report).toContain('[K:was-cited]')
+  })
+
+  test('a slug already uncited at base stays silent even though it is still uncited at head', () => {
+    const base = makeRoot({
+      'CLAUDE.md': '[K:already-zero] declared, never cited.\n'
+    })
+    const head = makeRoot({
+      'CLAUDE.md': '[K:already-zero] declared, never cited.\n'
+    })
+
+    const report = buildReport({ head, base, changed: [] })
+
+    expect(report).toBe('')
+  })
+})
+
+describe('buildReport — newly-unreachable knowledge files', () => {
+  test('a knowledge file reachable at base but unreachable at head is reported as newly stranded', () => {
+    const base = makeRoot({
+      'CLAUDE.md': 'Links to [details](corpus/details.md).\n',
+      'corpus/details.md': 'reachable at base\n'
+    })
+    const head = makeRoot({
+      'CLAUDE.md': 'No longer links anywhere.\n',
+      'corpus/details.md': 'now unreachable at head\n'
+    })
+
+    const report = buildReport({ head, base, changed: [] })
+
+    expect(report).toContain(MARKER)
+    expect(report).toContain('Nothing routes a reader to these files any more')
+    expect(report).toContain('corpus/details.md')
+  })
+
+  test('a knowledge file already unreachable at base stays silent even though still unreachable at head', () => {
+    const base = makeRoot({
+      'CLAUDE.md': 'never links to the orphan\n',
+      'corpus/orphan.md': 'unreachable at base already\n'
+    })
+    const head = makeRoot({
+      'CLAUDE.md': 'still never links to the orphan\n',
+      'corpus/orphan.md': 'still unreachable at head\n'
+    })
+
+    const report = buildReport({ head, base, changed: [] })
+
+    expect(report).toBe('')
+  })
+})
+
+describe('buildReport — knowledge cited by changed code', () => {
+  test('slugs cited from a changed non-markdown file are listed, sorted, in the cited-code section', () => {
+    const head = makeRoot({
+      'CLAUDE.md': '[K:z-slug] declared here.\n[K:a-slug] declared here too.\n',
+      'src/foo.ts': '// →[K:z-slug] cited from here\n// →[K:a-slug] and here\nconst VALUE = 1\n'
+    })
+
+    const report = buildReport({ head, base: undefined, changed: ['src/foo.ts'] })
+
+    expect(report).toContain(MARKER)
+    expect(report).toContain('Knowledge this change stands on')
+    expect(report.indexOf('a-slug')).toBeLessThan(report.indexOf('z-slug'))
+    expect(report).toContain('src/foo.ts:1')
+  })
+
+  test('a markdown file in the changed set is not scanned for code citations', () => {
+    const head = makeRoot({
+      'CLAUDE.md': '[K:doc-slug] declared here.\n→[K:doc-slug] cited in the same file.\n'
+    })
+
+    const report = buildReport({ head, base: undefined, changed: ['CLAUDE.md'] })
+
+    expect(report).toBe('')
+  })
+})

--- a/tests/unit/scripts/knowledge/graph.test.js
+++ b/tests/unit/scripts/knowledge/graph.test.js
@@ -1,0 +1,166 @@
+import { describe, test, expect, afterEach } from 'vite-plus/test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { knowledgeGraph } from '../../../../scripts/knowledge/graph.mjs'
+
+// Every test builds its own throwaway root under os.tmpdir() with its own
+// .claude/knowledge-lint.json — never assert against the real repo's
+// knowledge files, which churn independently of this graph.
+
+const DEFAULT_CONFIG = {
+  always_on: {
+    include: ['CLAUDE.md', '.claude/rules/*.md'],
+    line_caps: { enforced: false, total: 250, per_file: { 'CLAUDE.md': 80 } }
+  },
+  reachability: {
+    roots: ['CLAUDE.md', '.claude/rules/*.md', 'corpus/map.md']
+  },
+  slugs: {
+    retired_ledger: '.claude/knowledge/retired-slugs.md',
+    declare_in: ['CLAUDE.md', 'AGENTS.md', '.claude/**/*.md', 'corpus/**/*.md'],
+    cite_in: [
+      'CLAUDE.md',
+      'AGENTS.md',
+      '.claude/**/*.md',
+      'corpus/**/*.md',
+      'src/**/*.{ts,js,vue}',
+      'tests/**/*.{ts,js,vue}',
+      'scripts/**/*.{ts,js,mjs}',
+      'supabase/**/*.{sql,ts}',
+      '.github/**/*.yml'
+    ],
+    exempt: ['supabase/migrations/**']
+  }
+}
+
+const createdRoots = []
+
+afterEach(() => {
+  while (createdRoots.length) {
+    const root = createdRoots.pop()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+/** Builds a temp fixture root with the given config + files, returns its path. */
+function makeRoot(files = {}, configOverrides = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'knowledge-graph-'))
+  createdRoots.push(root)
+
+  const config = { ...DEFAULT_CONFIG, ...configOverrides }
+  mkdirSync(join(root, '.claude'), { recursive: true })
+  writeFileSync(join(root, '.claude/knowledge-lint.json'), JSON.stringify(config, null, 2))
+
+  for (const [relPath, content] of Object.entries(files)) {
+    const absolute = join(root, relPath)
+    mkdirSync(dirname(absolute), { recursive: true })
+    writeFileSync(absolute, content)
+  }
+
+  return root
+}
+
+describe('knowledgeGraph — inbound citations', () => {
+  test('a declared slug with no citation has an empty citedBy list', () => {
+    const root = makeRoot({
+      'CLAUDE.md': '[K:lonely-slug] declared but never cited.\n'
+    })
+
+    const { references } = knowledgeGraph(root)
+
+    expect(references.get('lonely-slug')).toEqual({ declaredIn: 'CLAUDE.md', citedBy: [] })
+  })
+
+  test('every citation of a slug is recorded, from knowledge files and from code', () => {
+    const root = makeRoot({
+      'CLAUDE.md': '[K:shared-slug] declared here.\n',
+      '.claude/rules/foo.md': 'Cites it: →[K:shared-slug].\n',
+      'src/foo.ts': '// →[K:shared-slug] respected here too\n'
+    })
+
+    const { references } = knowledgeGraph(root)
+
+    expect(references.get('shared-slug').citedBy).toEqual([
+      '.claude/rules/foo.md:1',
+      'src/foo.ts:1'
+    ])
+  })
+})
+
+describe('knowledgeGraph — reachability', () => {
+  test('a root file (matching reachability.roots) is reachable on its own', () => {
+    const root = makeRoot({
+      'CLAUDE.md': 'plain always-on file\n'
+    })
+
+    const { unreachable } = knowledgeGraph(root)
+
+    expect(unreachable).not.toContain('CLAUDE.md')
+  })
+
+  test('a file carrying `paths:` frontmatter is reachable even outside the roots list', () => {
+    const root = makeRoot({
+      '.claude/rules/scoped-only.md': '---\npaths:\n  - src/**\n---\nscoped content\n'
+    })
+
+    const { unreachable } = knowledgeGraph(root)
+
+    expect(unreachable).not.toContain('.claude/rules/scoped-only.md')
+  })
+
+  test('a file linked by a relative .md path from a reachable file is reachable', () => {
+    const root = makeRoot({
+      'CLAUDE.md': 'See [details](corpus/details.md) for more.\n',
+      'corpus/details.md': 'the linked-to content\n'
+    })
+
+    const { unreachable } = knowledgeGraph(root)
+
+    expect(unreachable).not.toContain('corpus/details.md')
+  })
+
+  test('a file linked by a [[id]] wiki-link from a reachable file is reachable', () => {
+    const root = makeRoot({
+      'CLAUDE.md': 'See [[member-streaks]] for the domain rule.\n',
+      'corpus/streaks.md': '---\nid: member-streaks\n---\n# Streaks\n'
+    })
+
+    const { unreachable } = knowledgeGraph(root)
+
+    expect(unreachable).not.toContain('corpus/streaks.md')
+  })
+
+  test('a knowledge file whose only inbound pointer is a slug cited from code is reachable', () => {
+    const root = makeRoot({
+      'corpus/orphan.md': '[K:code-only-slug] declared here, never linked from another topic.\n',
+      'src/foo.ts': '// →[K:code-only-slug] cited from real code\n'
+    })
+
+    const { unreachable } = knowledgeGraph(root)
+
+    expect(unreachable).not.toContain('corpus/orphan.md')
+  })
+
+  test('a knowledge file with no root match, no inbound link, and no code citation is unreachable', () => {
+    const root = makeRoot({
+      'CLAUDE.md': 'plain root file, does not mention the orphan\n',
+      'corpus/truly-orphaned.md': 'nothing points here\n'
+    })
+
+    const { unreachable } = knowledgeGraph(root)
+
+    expect(unreachable).toContain('corpus/truly-orphaned.md')
+  })
+
+  test('a slug cited only from another knowledge file (not code) does not grant reachability by itself', () => {
+    const root = makeRoot({
+      'corpus/isolated.md': '[K:isolated-slug] declared on an unreachable topic.\n',
+      'corpus/also-isolated.md': 'Cites →[K:isolated-slug] from another unreachable topic.\n'
+    })
+
+    const { unreachable } = knowledgeGraph(root)
+
+    expect(unreachable).toContain('corpus/isolated.md')
+  })
+})

--- a/tests/unit/scripts/knowledge/migration-objects.test.js
+++ b/tests/unit/scripts/knowledge/migration-objects.test.js
@@ -1,0 +1,66 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { migrationObjects } from '../../../../scripts/knowledge/migration-objects.mjs'
+
+describe('migrationObjects — parsing', () => {
+  test('a plain create table is picked up', () => {
+    expect(migrationObjects('create table decks (id bigint);')).toEqual(['decks'])
+  })
+
+  test('multiple statement kinds are all collected, deduplicated and sorted', () => {
+    const sql = `
+      create table decks (id bigint);
+      alter table cards add column rank int;
+      create view due_cards as select * from cards;
+      create or replace function purge_downgraded_decks() returns void as $$ begin end; $$ language plpgsql;
+      create type deck_visibility as enum ('public', 'private');
+      create index on decks (member_id);
+      create policy "own decks" on decks for select using (true);
+      create trigger set_member_id before insert on cards for each row execute function set_member_id();
+    `
+
+    expect(migrationObjects(sql)).toEqual([
+      'cards',
+      'deck_visibility',
+      'decks',
+      'due_cards',
+      'purge_downgraded_decks'
+    ])
+  })
+})
+
+describe('migrationObjects — comments and function bodies are ignored', () => {
+  test('a line comment naming a table is not a schema change', () => {
+    const sql = '-- this migration touches the decks table for good measure\nselect 1;'
+
+    expect(migrationObjects(sql)).toEqual([])
+  })
+
+  test('a block comment naming a table is not a schema change', () => {
+    const sql = '/* create table decks (id bigint); */\nselect 1;'
+
+    expect(migrationObjects(sql)).toEqual([])
+  })
+
+  test('a dollar-quoted function body referencing a table is not a schema change', () => {
+    const sql = `
+      create function touch_media() returns trigger as $function$
+      begin
+        update public.media set updated_at = now();
+        return new;
+      end;
+      $function$ language plpgsql;
+    `
+
+    expect(migrationObjects(sql)).toEqual(['touch_media'])
+  })
+})
+
+describe('migrationObjects — name normalisation', () => {
+  test('a fully quoted, schema-qualified name normalises to the same bare name as a plain one', () => {
+    const quoted = migrationObjects('create table "public"."decks" (id bigint);')
+    const bare = migrationObjects('create table decks (id bigint);')
+
+    expect(quoted).toEqual(bare)
+    expect(quoted).toEqual(['decks'])
+  })
+})

--- a/tests/unit/scripts/migration-knowledge-gate.test.js
+++ b/tests/unit/scripts/migration-knowledge-gate.test.js
@@ -1,0 +1,188 @@
+import { describe, test, expect, afterEach } from 'vite-plus/test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { checkMigration } from '../../../scripts/migration-knowledge-gate.mjs'
+
+// Every test builds its own throwaway root under os.tmpdir() — never assert
+// against the real repo's migrations or knowledge files.
+
+const createdRoots = []
+
+afterEach(() => {
+  while (createdRoots.length) {
+    const root = createdRoots.pop()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+/** Builds a temp fixture root with the given files, returns its path. */
+function makeRoot(files = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'migration-gate-'))
+  createdRoots.push(root)
+
+  for (const [relPath, content] of Object.entries(files)) {
+    const absolute = join(root, relPath)
+    mkdirSync(dirname(absolute), { recursive: true })
+    writeFileSync(absolute, content)
+  }
+
+  return root
+}
+
+const MIGRATION_PATH = 'supabase/migrations/00001_add_decks.sql'
+
+describe('checkMigration — header covers every parsed object', () => {
+  test('a header naming all objects and a real knowledge file passes clean', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]:
+        'create table decks (id bigint);\n' + '-- knowledge: decks — corpus/decks/decks.md\n',
+      'corpus/decks/decks.md': '# Decks\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, ['corpus/decks/decks.md'])
+
+    expect(errors).toEqual([])
+  })
+
+  test('the unanswered count is reported, but never the names', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]:
+        'create table decks (id bigint);\n' +
+        'create table cards (id bigint);\n' +
+        '-- knowledge: decks — corpus/decks/decks.md\n',
+      'corpus/decks/decks.md': '# Decks\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, ['corpus/decks/decks.md'])
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/answers for 1 of the 2 schema objects/)
+    expect(errors[0]).not.toMatch(/\bcards\b/)
+  })
+})
+
+describe('checkMigration — unrecorded verdict', () => {
+  test('unrecorded is accepted when no knowledge file mentions the object', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]:
+        'create table purge_downgraded_decks (id bigint);\n' +
+        '-- knowledge: purge_downgraded_decks — unrecorded\n',
+      'corpus/decks/decks.md': '# Decks\nNothing about that table here.\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, ['corpus/decks/decks.md'])
+
+    expect(errors).toEqual([])
+  })
+
+  test('unrecorded is rejected when a knowledge file already mentions the object, word-boundary and case-insensitive', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]: 'create table media (id bigint);\n' + '-- knowledge: media — unrecorded\n',
+      'corpus/decks/decks.md': '# Decks\nThe MEDIA table stores card attachments.\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, ['corpus/decks/decks.md'])
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/unrecorded/)
+    expect(errors[0]).toContain('corpus/decks/decks.md')
+  })
+
+  test('a word-boundary match does not fire on a substring mention', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]: 'create table card (id bigint);\n' + '-- knowledge: card — unrecorded\n',
+      'corpus/decks/decks.md': '# Decks\nThe cards table has many rows.\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, ['corpus/decks/decks.md'])
+
+    expect(errors).toEqual([])
+  })
+
+  test('a corpus/ file is preferred over a .claude/ file when both mention the object', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]: 'create table media (id bigint);\n' + '-- knowledge: media — unrecorded\n',
+      '.claude/rules/notes.md': 'A stray note mentioning the media table.\n',
+      'corpus/decks/decks.md': 'The media table stores card attachments.\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, [
+      '.claude/rules/notes.md',
+      'corpus/decks/decks.md'
+    ])
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('corpus/decks/decks.md')
+    expect(errors[0]).not.toContain('.claude/rules/notes.md')
+  })
+})
+
+describe('checkMigration — no schema objects', () => {
+  test('a migration touching no schema object passes with the literal marker', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]:
+        'grant select on all tables in schema public to authenticated;\n' +
+        '-- knowledge: no schema objects\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, [])
+
+    expect(errors).toEqual([])
+  })
+
+  test('a migration touching no schema object with no header at all fails', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]: 'grant select on all tables in schema public to authenticated;\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, [])
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/no schema objects/)
+  })
+})
+
+describe('checkMigration — unknown claims', () => {
+  test('an object claimed but not touched is reported as unknown and excluded from other checks', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]:
+        'create table decks (id bigint);\n' +
+        '-- knowledge: decks — corpus/decks/decks.md\n' +
+        '-- knowledge: cards — corpus/decks/decks.md\n',
+      'corpus/decks/decks.md': '# Decks\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, ['corpus/decks/decks.md'])
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/`cards` is not a schema object this migration touches/)
+  })
+})
+
+describe('checkMigration — malformed header and missing knowledge file', () => {
+  test('a header line with no em-dash separator is malformed', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]: 'create table decks (id bigint);\n' + '-- knowledge: decks\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, [])
+
+    expect(errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('needs `<objects> — <knowledge file>`')])
+    )
+  })
+
+  test('a header naming a knowledge file that does not exist in the repo fails', () => {
+    const root = makeRoot({
+      [MIGRATION_PATH]:
+        'create table decks (id bigint);\n' + '-- knowledge: decks — corpus/nope.md\n'
+    })
+
+    const errors = checkMigration(root, MIGRATION_PATH, ['corpus/decks/decks.md'])
+
+    expect(errors).toEqual([
+      expect.stringContaining('`corpus/nope.md` is not a knowledge file in this repo')
+    ])
+  })
+})


### PR DESCRIPTION
[TARO-337](https://app.notion.com/p/3b60953c224c812fbe46ca7ff32a9ec0)

> Base of the wave-5 stack. Merge this before #530.

## The gates

**Migration gate — blocking.** `scripts/migration-knowledge-gate.mjs`, wired into the existing unconditional `knowledge` job. A migration answers for the schema objects it touches in its own header, so the answer is versioned, in the diff, and re-checked on every push:

```sql
-- knowledge: members, member_streaks — corpus/members/members.md
-- knowledge: purge_downgraded_decks — unrecorded
```

`scripts/knowledge/migration-objects.mjs` parses the objects independently — tables, views, functions, types, index/policy/trigger targets — stripping comments and dollar-quoted bodies so prose about a table and a runtime `UPDATE` don't count.

**Slug echo + orphan report — informational.** `scripts/knowledge-report.mjs` posts one comment, found by a hidden marker, rewritten in place, deleted when there's nothing to say. Three sections: slugs the changed code cites, slugs this change dropped to zero citations, knowledge files it left unroutable. It diffs against a worktree of the merge-base, so it names only what this change caused — the repo's three already-unreachable files stay silent.

**Mechanisation rules.** New `## Mechanising a prose rule` in `knowledge-addressing.md`: a PR landing a check deletes the prose it supersedes, and the check states its rationale and slug in its failure message. Both new checks do; `knowledge-lint.mjs` gained the rationale line it was missing.

**`prepare-pr`** now runs the pointer check and the migration gate in its pre-push step.

## How the opt-out resists reflexive use

The ticket asks for an escape hatch that can't be pasted without thought. Three levers:

- **The gate never prints the answer.** On a mismatch it says "answers for 1 of the 2 schema objects it touches" and stops — the names are in the migration you just wrote. A check that dictates its own answer key gets pasted rather than read. Locked in by a test so a later edit can't "helpfully" add them.
- **A name not in this migration is an error**, so last PR's header fails immediately.
- **`unrecorded` is machine-checked against the corpus.** If any knowledge file names that object, `unrecorded` fails and names the file to cite and amend. Domain nouns can never take the lazy answer; a one-off internal function legitimately can.

## Worth your eye

- **Stricter than AC 1 as written.** The criterion allows "amends the knowledge" as a silent pass; the header is required either way, with the amended file named as the verdict. Otherwise the amend branch is satisfied by touching any rule file — exactly the reflexive escape the ticket asks to design out. Say the word and I'll add the silent pass.
- `tests/unit/scripts/**` is now exempt from the citation scan wholesale, since the new fixtures carry literal `[K:…]` tokens. Rule prose updated to match.
- Failure copy signed off by the user.

62 tests across 5 files. `vp lint` 0 errors, `pnpm type-check` green, knowledge lint 233/250.