### PR TITLE
self-heal: rule updates

### DIFF
--- a/.claude/rules/authoring.md
+++ b/.claude/rules/authoring.md
@@ -38,3 +38,7 @@ specific to their artifact and link here for these five; none of them restates o
   - Bad: a comment says a display count "can drift" from the enforced limit → reported as a known
     pricing-page defect, unconfirmed.
   - Good: read the enforced limit from the current migration state before claiming the two disagree.
+  - Bad: a locale key names a feature (`roadmap.item.card-audio`, "Card Audio Upload") → reported as
+    shipped, because copy exists for it.
+  - Good: read the code that gates or renders the feature (a `done` flag, a `can_` check, a route)
+    before claiming it ships — authored copy proves a string was written, nothing about the feature.

--- a/.claude/rules/authoring.md
+++ b/.claude/rules/authoring.md
@@ -30,6 +30,11 @@ specific to their artifact and link here for these five; none of them restates o
   - Bad: `Retries the save appropriately and handles failures.`
   - Good: `Retries the save 3× at 0.5s / 1s / 2s, then marks it failed.`
 - **Label a guess.** State what you verified plainly. Anything unverified is marked as such, at the
-  point of the claim — never smuggled in beside confirmed facts.
+  point of the claim — never smuggled in beside confirmed facts. A comment or code hedging that
+  something _can_ happen is not evidence it _has_ — don't upgrade a hedge into a finding without
+  confirming the live value.
   - Bad: `The dashboard refetches because the key includes the member id.`
   - Good: `⚠️ Hunch — not code-confirmed: the refetch likely comes from the member id in the key.`
+  - Bad: a comment says a display count "can drift" from the enforced limit → reported as a known
+    pricing-page defect, unconfirmed.
+  - Good: read the enforced limit from the current migration state before claiming the two disagree.

--- a/.claude/rules/supabase.md
+++ b/.claude/rules/supabase.md
@@ -80,6 +80,10 @@ Also untracked, so still hand-written: DML (storage bucket inserts, `cron.schedu
 
 ## Migration workflow
 
+- **Migrations are an ordered log, not a set of facts.** The live value of any seeded/updated row is
+  set by the _last_ migration that writes it — grep, sort by timestamp, and read to the end before
+  quoting a value. Never assert a DB value (a plan limit, a default, a seeded row) from the first
+  matching migration.
 - `supabase migration up --local` immediately after writing — catches errors while the context is fresh. Never `supabase db reset`.
 - **Editing a migration is fair game until it ships.** If it hasn't been deployed and hasn't merged to `master`, rewrite it in place — all-local work is free game. Once it's on `master` or deployed anywhere, it's immutable: write a new timestamped migration instead. Check with `supabase migration list --local` and `git log master -- <file>`.
 - To rewrite an applied branch-local migration before PR: `supabase migration repair --status reverted --local <version>` → edit → `migration up --include-all`. Don't do this for anything already shipped.

--- a/.claude/rules/task-board-schema.md
+++ b/.claude/rules/task-board-schema.md
@@ -31,8 +31,8 @@ constants; change a field here once and every consumer follows.
   icon + field defaults): `template_id: 3af0953c224c800d984cf0b443d67d20`
 
 **Three hard limits of the Notion MCP.** `status`-type fields are special-cased: `notion-update-data-source`
-**cannot** add, rename or recolor `Status` options — only the user can, in the Notion UI (renaming
-preserves row mappings). `select`/`multi_select` options _are_ editable. There is **no archive or
+**cannot** add, rename, recolor, or delete `Status` options — only the user can, in the Notion UI
+(renaming preserves row mappings). `select`/`multi_select` options _are_ editable. There is **no archive or
 delete tool** — `notion-move-pages` only re-parents, so retiring a row means the user deletes it in the
 UI. Page titles, properties and body content are all editable via `notion-update-page`.
 
@@ -48,15 +48,14 @@ lag row writes.
 
 ### `Status` — a `status`-type field (grouped)
 
-`On Hold` · `Backlog` · `Needs More Info` · `Groomed` · `Ready` · `In Progress` · `Blocked` ·
+`On Hold` · `Backlog` · `Needs More Info` · `Ready` · `In Progress` · `Blocked` ·
 `Review` · `Duplicate` · `Won't Do` · `Done`. A plain property write — set it directly.
 
 - **`complete` group** = `Done` · `Won't Do` · `Duplicate`. A `Blocked By` blocker is cleared only
   when its status is in this group.
 - **`On Hold` = hands-off** (user-owned), same as `Assignee = Me`.
-- Lane ownership by stage: `/triage` → `Needs More Info`; `/groom` → `Groomed`; the user promotes
-  `Groomed` → `Ready`; `/work` claims `Ready` → `In Progress` → `Review`. New tickets
-  are `Backlog`.
+- Lane ownership by stage: `/triage` → `Needs More Info`; `/groom` → `Ready`; `/work` claims
+  `Ready` → `In Progress` → `Review`. New tickets are `Backlog`.
 
 ### `Priority` — `select` (a ticket's urgency)
 
@@ -103,7 +102,7 @@ overflow) lives at →[K:ticket-priority-vs-target] and in the
 - **`Me` = hands-off** — the user works it themselves; `/triage`, `/backlog`, and `/work` leave it
   alone (same meaning as `Status = On Hold`).
 - **`Fable` is the user's to assign**, never an agent's pick. `/groom` sets `Opus` or `Sonnet` when a
-  ticket reaches `Groomed`.
+  ticket reaches `Ready`.
 
 ### Relations & system fields
 

--- a/.claude/rules/ticket-authoring.md
+++ b/.claude/rules/ticket-authoring.md
@@ -29,16 +29,15 @@ authoring: what a cut sets, what each stage owns, and the two-axis Priority/Targ
 | Field      | Value when cutting                                                                                                         |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `Status`   | **`Backlog`**, always — a new ticket is un-triaged by definition                                                           |
-| `Assignee` | **empty** — triage/groom set it (`Opus`/`Sonnet`) at `Groomed`, never at cut                                               |
+| `Assignee` | **empty** — triage/groom set it (`Opus`/`Sonnet`) at `Ready`, never at cut                                                 |
 | `Type`     | `Bug` broken · `Task` defined change · `Story` user-facing capability · `Spike` the deliverable is a decision, not shipped |
 | `Priority` | **empty** at cut time — a `/backlog` decision. Set only when the user explicitly dictates one                              |
 | `Target`   | **empty** at cut time — a `/backlog` decision, not a capture one                                                           |
 | `Epic`     | match the Epic Board; if nothing fits, propose a new epic rather than force-fit                                            |
 
-Never write `Groomed` or `Ready` — those assert the ticket is executable, which is never true at
-capture time. Never write `On Hold` or `Assignee = Me` on a fresh ticket — that's the user's own
-hands-off marker. Leave `Priority` and `Assignee` untouched unless the user explicitly asks for a
-value.
+Never write `Ready` — it asserts the ticket is executable, which is never true at capture time. Never
+write `On Hold` or `Assignee = Me` on a fresh ticket — that's the user's own hands-off marker. Leave
+`Priority` and `Assignee` untouched unless the user explicitly asks for a value.
 
 **The classification fields have an owner: `/backlog`.** `Type`, `Epic`, `Target`, and `Priority` are
 the portfolio pass's to set — it sees the whole Backlog at once and distributes them comparatively.
@@ -166,8 +165,8 @@ untouched` line is the "do not touch tests" rule in costume — delete it.
   [`i18n`](./i18n.md).
 - **Copy carries its signed-off wording.** →[K:user-copy-signoff] — any new or changed
   user-facing string appears in the AC as its exact final wording. Reused copy is stated as reused
-  (same wording, its own key — keys aren't shared across features). A ticket with undecided copy is
-  not `Groomed`.
+  (same wording, its own key — keys aren't shared across features). A ticket with undecided copy does
+  not reach `Ready`.
 
 ## Epics
 

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -78,7 +78,7 @@ classifications are stale, not on the routine "I added a few tickets" run.
    [`task-board-schema.md`](../../rules/task-board-schema.md)). Assign by **epic**, not per ticket:
    - **`MVP` stays `MVP`.** It's the launch-scope set; don't reband an MVP ticket unless it's clearly
      not launch-gating. The current quarter (`Q3 '26`) is mostly consumed by MVP — keep it **lean**,
-     pulling in only a few genuinely high-value or already-in-flight (`Ready`/`Groomed`/`In Progress`)
+     pulling in only a few genuinely high-value or already-in-flight (`Ready`/`In Progress`)
      tickets alongside it.
    - **Give each epic a home quarter** by its strategic weight: launch-adjacent epics land in the
      current/next quarter, secondary or deferred epics in the furthest planned one. An epic's tickets

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -171,7 +171,8 @@ terms**, not a technical brief. Keep it scannable; the detail arrives as the use
   silently assume: naming, UX choices, edge-case handling, scope boundaries, which pattern to
   follow. Phrase each as the choice a user would recognise where it has one; one line, with a
   recommendation. **Surface them — never bake them in.** Hold the filepaths and symbols until the
-  decision is actually opened.
+  decision is actually opened. **A checkpoint built entirely of mechanism questions is incomplete
+  for a user-facing ticket** — include at least one on what it looks like, not just how it works.
 - **Pushback surface** — anything in the spec that looks like a hole, is ambiguous, seems
   unnecessary, or that you would do differently. One line each; make it easy to cut or redirect
   scope.

--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: groom
-description: Deep second pass over a single Notion Task Board ticket sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket, assigns a model, and lands it in `Groomed` for the user to promote to `Ready`. Owns splitting work into the smallest independently-verifiable tickets (wiring the `Blocked By` relation between the siblings), recording external blockers, and keeping the epic's decision log and fog current. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
+description: Deep second pass over a single Notion Task Board ticket sitting in `Needs More Info`. Resolves every open design decision with the user through conversation — surfacing assumptions as explicit questions, pushing back on the spec, verifying claims against real source rather than recall — then writes the decisions and their rationale into the ticket, assigns a model, and lands it in `Ready`, then waits for the user's review comments. Owns splitting work into the smallest independently-verifiable tickets (wiring the `Blocked By` relation between the siblings), recording external blockers, and keeping the epic's decision log and fog current. Technical and concise. Trigger on `/groom`, "groom this ticket", "resolve the design on X".
 allowed-tools: Read, Grep, Glob, Bash, Agent, WebFetch, WebSearch, mcp__notion__notion-query-data-sources, mcp__notion__notion-fetch, mcp__notion__notion-update-page, mcp__notion__notion-create-pages, mcp__notion__notion-search
 argument-hint: '[<ID>]'
 arguments:
@@ -16,16 +16,16 @@ because it carries unresolved design decisions. Groom **resolves them with the u
 what was decided and why, and lands the ticket executable.
 
 ```
-Needs More Info ──/groom──┬──► Groomed            (decisions resolved, model assigned)
+Needs More Info ──/groom──┬──► Ready              (decisions resolved, model assigned)
                           ├──► split into N tickets
                           ├──► On Hold            (turned out to need product input, or premature)
                           └──► stays put          (blocked on an external fact)
 ```
 
-`Groomed` is **not** the finish line — it opens the user's review. Expect the user to leave inline
-comments on the ticket and ping you to read them; folding those into the ticket is part of every
-grooming session (§7). The true end is promotion to `Ready` — the lane `/work` pulls from — which is
-the user's own gate. Groom never sets `Ready` on its own; do it only if the user explicitly asks.
+Landing `Ready` is the finish line, but it opens the user's review first. Expect the user to leave
+inline comments on the ticket and ping you to read them; folding those into the ticket is part of
+every grooming session (§7). If the user leaves no review, the session is done — `Ready` is where
+`/work` pulls from.
 
 One ticket at a time, conversationally. This is the opposite of `/triage`'s batching — depth is
 the whole point.
@@ -80,7 +80,7 @@ an invitation to redesign.
 
 For every new or changed user-facing string, **pause** and present **at least 3 reasonably-varied
 options per line**; only the user's chosen wording lands, verbatim, in the AC. Reused copy is stated
-as reused. Undecided copy keeps the ticket out of `Groomed`.
+as reused. Undecided copy keeps the ticket out of `Ready`.
 
 ## Board constants
 
@@ -89,8 +89,8 @@ The board **schema** — data sources, every field and its option list — lives
 voice** live in [`ticket-authoring.md`](../../rules/ticket-authoring.md). Read both before writing
 anything to the board. This skill declares only its lanes and its own passes.
 
-- Lanes: pulls from `Needs More Info`; lands at `Groomed`; may park at `On Hold`. Never sets `Ready`
-  / `In Progress` / `Review` / `Done` / `Blocked` — promoting `Groomed` → `Ready` is the user's gate.
+- Lanes: pulls from `Needs More Info`; lands at `Ready`; may park at `On Hold`. Never sets
+  `In Progress` / `Review` / `Done` / `Blocked`.
 - **Retype to `Spike`** when grooming reveals the deliverable is a decision or recommendation rather
   than shipped behaviour — and drop the now-redundant `"Spike:"` title prefix.
 
@@ -251,20 +251,19 @@ first.
 restatement), add any approved fog to `## Not yet specified`, delete the fog bullet that this
 session **graduated** into a ticket, and add any approved `## Out of scope` ruling.
 
-Then set `Status = Groomed` **and an `Assignee`** — the ticket is fully resolved and waiting for the
-user to promote it into `Ready`, the lane `/work` pulls from.
+Then set `Status = Ready` **and an `Assignee`** — the ticket is fully resolved and lands directly in
+the lane `/work` pulls from.
 
 - **`Assignee` is mandatory and is `Opus` or `Sonnet` only** — pick by fit: `Opus` for
   architectural, cross-cutting, ambiguous, or security/backend-sensitive work; `Sonnet` for
   well-scoped feature/bug work with a clear spec. **Never set `Fable`** — the user downgrades to
   Fable himself when he wants it. Never leave `Assignee` empty or `Me`. `/work` pins each subagent to
   this model.
-- A ticket still carrying an unmade design or taste call does **not** reach `Groomed`, even labelled
+- A ticket still carrying an unmade design or taste call does **not** reach `Ready`, even labelled
   "decide during pairing" — that is what `Needs More Info` is for, and this pass exists to settle it.
-  The only thing that may ride into `Groomed` is a decision genuinely blocked on an external fact
+  The only thing that may ride into `Ready` is a decision genuinely blocked on an external fact
   (§4), recorded under `## Blocked on`; if the ticket cannot land without that fact, it stays in
   `Needs More Info`.
-- **Never set `Ready`** — promoting `Groomed` → `Ready` is the user's own review gate, not groom's.
 
 Also sweep for **copy that the change makes false** — existing `src/locales/en-us.json` strings
 asserting the old behaviour ("this cannot be undone"). List them in the body as required edits.
@@ -277,8 +276,8 @@ on the epic. No prose.
 
 ### 7. RESOLVE COMMENTS — the review loop
 
-Landing `Groomed` starts the user's review; it does not end the session. The user leaves inline
-comments on the ticket and pings you to read them — expect this on every groom. When pinged:
+Landing `Ready` opens the user's review, but the session isn't waiting on it — if the user leaves no
+comments, grooming is done. When the user does leave inline comments and pings you to read them:
 
 - Read every open discussion with `notion-get-comments` (`include_all_blocks: true`, unresolved
   only) so you see comments anchored to specific ACs, not just page-level ones.
@@ -287,8 +286,8 @@ comments on the ticket and pings you to read them — expect this on every groom
   new one, or add an AC; a taste/design fork still goes back to the user, never baked.
 - Fold each resolution into the body (ACs + companion `## Tech details`) and update the epic if the
   decision shifted a `## Decisions so far` gist or exposed fresh fog.
-- Loop until the user is satisfied. The session ends when **the user** promotes the ticket to
-  `Ready` — not when you wrote `Groomed`.
+- Loop until the user is satisfied, or stops commenting — either ends the session; the ticket stays
+  in `Ready` throughout.
 
 The self-heal reflex still applies here: a comment that reveals a miss in how this pass runs heals
 the skill (§ Self-heal), separate from the ticket edit.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -90,7 +90,7 @@ the single source, [`ticket-authoring.md`](../../rules/ticket-authoring.md).
 ## Guardrails
 
 - Only ever touch the Task Board named in the rule — never a backup or duplicate.
-- Every ticket ends in `Needs More Info`. Never route to `Groomed`/`Ready`/`On Hold` or set
+- Every ticket ends in `Needs More Info`. Never route to `Ready`/`On Hold` or set
   `In Progress`/`Review`/`Done`.
 - Propose `Epic`/`Type`/`Priority`/`Target`, never apply unasked.
 - Don't touch tests. Don't write code — this skill reads Notion (and lightly, code) and writes

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -13,7 +13,7 @@ lastUpdated: 2026-08-01T20:00:00Z
 
 ## What this skill does
 
-Pulls groomed, user-promoted tickets off the board, works them **autonomously in parallel**, and
+Pulls groomed tickets off the board, works them **autonomously in parallel**, and
 lands each at an **open PR** for your review. It never merges and never marks a ticket `Done` — you
 close the loop.
 
@@ -22,8 +22,7 @@ out one worktree-isolated subagent per ticket, then organizes the branches they 
 CI-green PRs. The orchestrator never edits ticket code itself — subagents do. After the PRs open it
 stays live for your review feedback (§ Review & feedback loop).
 
-- **Source lane** — `Ready` (you promote `Groomed` → `Ready` yourself; that promotion is the human
-  gate this skill trusts).
+- **Source lane** — `Ready` (`/groom` lands tickets there itself, after its review loop).
 - **Model** — each ticket's `Assignee` (`Fable` / `Opus` / `Sonnet`), one subagent pinned to it.
 - **Tests** — the golden "no tests" rule is **suspended here**: each subagent runs the `update-tests`
   skill to cover its own change. The orchestrator never authors ticket code or tests.
@@ -34,7 +33,7 @@ stays live for your review feedback (§ Review & feedback loop).
   constants (fields, options, relations) live in
   [`task-board-schema.md`](../../rules/task-board-schema.md).
 - `Status` lanes this skill uses: pulls from `Ready`; claims to `In Progress`; lands at `Review`;
-  parks stuck work at `Blocked`. Never sets `Done` / `Duplicate` / `Groomed`.
+  parks stuck work at `Blocked`. Never sets `Done` / `Duplicate`.
 - `Assignee`: `Fable` · `Opus` · `Sonnet` — the model each subagent is pinned to. **`Assignee = Me`
   and `Status = On Hold` are both hands-off** (user-owned) and never eligible.
 - Status and field writes are plain `notion-update-page` property writes — no transition step.


### PR DESCRIPTION
Lessons healed from corrections this session.

- docs(supabase): quote the last migration that writes a value, not the first
- docs(authoring): a hedge in code is not evidence it fired