### PR TITLE
docs: self-heal lessons

### DIFF
--- a/.claude/agents/harness-author.md
+++ b/.claude/agents/harness-author.md
@@ -27,10 +27,11 @@ them.
 
 ## The brief is evidence, not a draft
 
-A dispatch hands you the correction, the routing and the constraints. Anything else it carries — the
-incident, the argument for why the existing rule missed, the reasoning behind the fix — is context
-for your judgement, never material to paraphrase into the file. A long brief buys no extra lines: what
-you write is whatever `rule-authoring` allows, at its density, however much you were handed.
+A dispatch hands you the correction and the routing. Anything else it carries — an incident, an
+argument for why the existing rule missed, a "verify by checking X" instruction — is context for
+your judgement, never material to paraphrase into the file. This holds even when the extra material
+names concrete examples to check: confirm them with your own grep before they reach the diff: a name
+that landed in the file only because the brief said it is a paraphrase, not a finding.
 
 ## Loop
 

--- a/.claude/rules/code-style/signatures.md
+++ b/.claude/rules/code-style/signatures.md
@@ -42,8 +42,11 @@ const payload = buildCardPayload({ ...card, ...values })
 saveCard(payload)
 ```
 
-## No vendor or competitor names in code
+## Name an interop target by its format, never a product we don't call
 
-Never name a third-party product in an identifier, comment, file, or string — including a format
-this codebase merely produces for that product to read. Name the format or role instead: an export
-this app hands off to another app is "an importer's format", not that importer's brand name.
+A dependency this codebase imports and invokes is named plainly — `stripe-webhook`,
+`STRIPE_SECRET_KEY`, `supabase/functions/` are correct, because that is the product's own name for
+code that calls it. The ban is narrower: never name a product this codebase merely **reads or writes
+a format for** — one whose format we interoperate with or compete against, without calling its
+code. An export this app hands off to another app is "an importer's format", not that importer's
+brand name.

--- a/.claude/rules/code-style/signatures.md
+++ b/.claude/rules/code-style/signatures.md
@@ -5,13 +5,13 @@
 A parameter is named for the role it plays **inside** the function, never for the UI event or call site that supplied it. `clicked_row_id` couples a low-level helper to one UI source and starts lying the moment a keyboard shortcut, context menu, or programmatic flow calls it.
 
 ```ts
-onDelete(clicked_row_id)      // bad — leaks the row-click origin into a generic helper
-onDelete(additional_card_id)  // good — describes what the argument does here
+onDelete(clicked_row_id) // bad — leaks the row-click origin into a generic helper
+onDelete(additional_card_id) // good — describes what the argument does here
 ```
 
 ## Don't wrap a promise just to re-yield it
 
-If a function doesn't *do* anything with the resolved value — transform it, branch on it, narrow it, clean up after it — return the promise instead of making the function `async` to immediately `await` it. The caller awaits either way; the wrapper only adds a microtask and a fresh promise, and implies the function does something it doesn't.
+If a function doesn't _do_ anything with the resolved value — transform it, branch on it, narrow it, clean up after it — return the promise instead of making the function `async` to immediately `await` it. The caller awaits either way; the wrapper only adds a microtask and a fresh promise, and implies the function does something it doesn't.
 
 ```ts
 // Bad
@@ -26,3 +26,24 @@ function confirmDelete() {
   return response
 }
 ```
+
+## Lift a nested call out of an argument list
+
+Don't call a function inside another call's argument list. Assign the inner result to a named local
+first, then pass the local — the call site reads as one step at a time instead of an expression the
+reader has to unwind.
+
+```ts
+// Bad
+saveCard(buildCardPayload({ ...card, ...values }))
+
+// Good
+const payload = buildCardPayload({ ...card, ...values })
+saveCard(payload)
+```
+
+## No vendor or competitor names in code
+
+Never name a third-party product in an identifier, comment, file, or string — including a format
+this codebase merely produces for that product to read. Name the format or role instead: an export
+this app hands off to another app is "an importer's format", not that importer's brand name.

--- a/.claude/rules/code-style/signatures.md
+++ b/.claude/rules/code-style/signatures.md
@@ -42,11 +42,8 @@ const payload = buildCardPayload({ ...card, ...values })
 saveCard(payload)
 ```
 
-## Name an interop target by its format, never a product we don't call
+## Don't name a competitor in code
 
-A dependency this codebase imports and invokes is named plainly — `stripe-webhook`,
-`STRIPE_SECRET_KEY`, `supabase/functions/` are correct, because that is the product's own name for
-code that calls it. The ban is narrower: never name a product this codebase merely **reads or writes
-a format for** — one whose format we interoperate with or compete against, without calling its
-code. An export this app hands off to another app is "an importer's format", not that importer's
-brand name.
+Name a format by what it is, never by a competitor product we merely interoperate with. This
+doesn't ban naming a dependency we actually call — `stripe-webhook`, `STRIPE_SECRET_KEY` are correct
+because we invoke that product's own code.

--- a/.claude/rules/comment-authoring.md
+++ b/.claude/rules/comment-authoring.md
@@ -42,6 +42,10 @@ Five, each failed on its own. Fail one, rewrite or delete.
   technical term is earned by being grounded, never led with.
 - **Everything past the first idea is load-bearing.** Cut whatever the first idea already bought.
 
+**A regex literal always fails the competent-stranger gate.** Its own syntax is never the intent, so
+it carries a comment in its position's shape naming what it matches, in plain words — not the regex
+syntax restated, not why it matches that.
+
 ## Never
 
 - A numbered walkthrough (`Three things happen:`).
@@ -51,6 +55,9 @@ Five, each failed on its own. Fail one, rewrite or delete.
 - Prose above a self-describing union.
 - A restatement of the next line.
 - A library's internal vocabulary where an observable term exists — say what the screen shows.
+- **A caller's name as the opening subject** (`Deck-hero "Export cards":`, `Bulk-panel "Export
+selected".`) — it reads as a lookup instead of naming what the function does, and goes stale the
+  moment that caller moves, renames, or gains a sibling.
 - A pointer carrying nothing a human can act on.
 - **A comment that is only a citation.** `→[K:<slug>]` is a suffix to a sentence, never a comment on
   its own — a reader skimming the diff must get the constraint without leaving the file. Enforced by

--- a/.claude/rules/comment-authoring.md
+++ b/.claude/rules/comment-authoring.md
@@ -10,7 +10,11 @@ paths:
 
 **The single source of truth for how a comment is written** — where it may sit, what shape that
 position gives it, and what it links out to instead of explaining. Reaches you on any code write. If
-a comment rule isn't stated here, it doesn't exist. Shared principles: [`authoring`](./authoring.md).
+a comment rule isn't stated here, it doesn't exist. This file outranks any feedback about a
+comment's _shape_ — a PR review, another agent, anyone — except the user explicitly asking for a
+specific comment; that's an instruction, not feedback, and feedback about a comment's _content_
+(the reviewer doesn't understand what it's protecting) is answered by fixing the comment or the PR
+reply, never by loosening these rules. Shared principles: [`authoring`](./authoring.md).
 
 A comment names the constraint a reader would otherwise violate, in a sentence they can act on. Most
 code needs none — a clear name beats a comment.
@@ -72,9 +76,6 @@ selected".`) — it reads as a lookup instead of naming what the function does, 
   [`knowledge-addressing`](./knowledge-addressing.md).
 - **A comment that wants to grow past its position's shape is the trigger to write that entry**, not
   a reason to keep typing.
-- **A reviewer's inline "why does this work this way?" is the same trigger, not an invitation to
-  answer in place.** The answer goes in the PR reply, which carries no length limit; what lands back
-  in the code is still just the sentence plus the citation.
 - The readable sentence is never optional. A pointer replaces the explanation, never the knowledge —
   someone skimming a diff gets the constraint without leaving the file.
 

--- a/.claude/rules/comment-authoring.md
+++ b/.claude/rules/comment-authoring.md
@@ -69,6 +69,9 @@ selected".`) — it reads as a lookup instead of naming what the function does, 
   [`knowledge-addressing`](./knowledge-addressing.md).
 - **A comment that wants to grow past its position's shape is the trigger to write that entry**, not
   a reason to keep typing.
+- **A reviewer's inline "why does this work this way?" is the same trigger, not an invitation to
+  answer in place.** The answer goes in the PR reply, which carries no length limit; what lands back
+  in the code is still just the sentence plus the citation.
 - The readable sentence is never optional. A pointer replaces the explanation, never the knowledge —
   someone skimming a diff gets the constraint without leaving the file.
 

--- a/.claude/rules/comment-authoring.md
+++ b/.claude/rules/comment-authoring.md
@@ -27,6 +27,9 @@ code needs none — a clear name beats a comment.
 In `<style>`, a comment above a selector is a symbol doc; one inside a declaration block follows the
 in-body rule.
 
+**A body comment sits trailing on the line it annotates, wrapping above only when it doesn't fit
+there.** Above-the-line is the fallback shape, not the default.
+
 **There is no line cap.** Length follows position — a comment that outgrows its position's shape is
 a missing knowledge entry, not a longer comment.
 

--- a/.claude/rules/comment-authoring/examples.md
+++ b/.claude/rules/comment-authoring/examples.md
@@ -1,6 +1,6 @@
 # Comment examples
 
-Five pairs, one per gate. The rules they encode live in
+One or more pairs per gate. The rules they encode live in
 [`comment-authoring`](../comment-authoring.md).
 
 ## Everything past the first idea is load-bearing
@@ -39,6 +39,18 @@ onAccent?: boolean
  * @param total_card_count - Persisted card count for the deck, passed in so
  *   this stays independent of the decks query.
  */
+```
+
+`deck-hero.vue`
+
+```typescript
+// Bad — opens on the caller's name, not what the function does
+/** Deck-hero "Export cards": the whole deck, ignoring any selection. */
+async function onExportCards() { … }
+
+// Good
+/** Exports the whole deck, whatever happens to be selected. */
+async function onExportCards() { … }
 ```
 
 ## Name the operation, not a consequence at one call site

--- a/.claude/rules/corpus-authoring.md
+++ b/.claude/rules/corpus-authoring.md
@@ -38,8 +38,11 @@ concept, or a newly-exposed hazard. The altitude _is_ the churn control; there i
 - **Never** — reword correct prose for taste, restructure for its own sake, add examples, or
   document implementation detail.
 
-A large real change (a new domain area, a topic splitting in two) lands **isolated**: its own commit,
-scoped to `corpus/`, never mixed into a code commit, so the user takes or drops it as one unit.
+**A corpus edit that cites or is cited by code lands in the same commit as that code.** A hazard's
+declaration in `corpus/` and its echo in `src/` (see Hazards below) are two halves of one atomic
+change — `knowledge-lint` fails either half alone, so splitting them across commits produces a
+commit that cannot pass CI on its own. Only a corpus edit with **no** accompanying code change —
+correcting a stale topic, splitting a topic on its own — lands as its own commit.
 
 ## Shape
 

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -238,8 +238,7 @@ handled the same way:
    tell your replies from their own; feedback given in chat is answered in chat. Leave the ticket in
    `Review`.
 5. **Dispatch self-heal for this round before starting the next PR** (§ Self-heal) — every standing
-   preference the user just stated, not only the ones about claim/handoff/review mechanics. A round
-   that only fixes the diff and moves on is the failure mode this step exists to close.
+   preference the user stated this round, not only ones about claim/handoff/review mechanics.
 
 Repeat per PR until the user merges. **Never merge and never set `Done` yourself** — that stays the
 user's call, exactly as at first handoff.

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -237,6 +237,9 @@ handled the same way:
 4. **Answer the thread.** If the feedback came on the PR, reply prefixed `🤖 Claude:` so the user can
    tell your replies from their own; feedback given in chat is answered in chat. Leave the ticket in
    `Review`.
+5. **Dispatch self-heal for this round before starting the next PR** (§ Self-heal) — every standing
+   preference the user just stated, not only the ones about claim/handoff/review mechanics. A round
+   that only fixes the diff and moves on is the failure mode this step exists to close.
 
 Repeat per PR until the user merges. **Never merge and never set `Done` yourself** — that stays the
 user's call, exactly as at first handoff.


### PR DESCRIPTION
Landing self-heal lessons from corrections. One commit per lesson.

- docs(comment-authoring): don't open a comment on the caller's name