### PR TITLE
TARO-351: Count visits to the public pages with Plausible

### DIFF
--- a/src/composables/tracking.ts
+++ b/src/composables/tracking.ts
@@ -1,0 +1,16 @@
+import { trackPageview as trackPlausiblePageview } from '@/utils/analytics/plausible'
+
+/**
+ * The one place the app reports activity to an analytics provider.
+ *
+ * Call sites say what happened; which providers hear about it — or whether any
+ * do — is decided here, so a provider can be added or swapped without touching
+ * them.
+ */
+export function useTracking() {
+  function trackPageview() {
+    trackPlausiblePageview()
+  }
+
+  return { trackPageview }
+}

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -858,6 +858,7 @@
   "privacy-policy.section-4.content-2": "User data is shared only with the following service providers, solely to operate the app:",
   "privacy-policy.section-4.item-1": "Supabase — authentication, database, and backend infrastructure",
   "privacy-policy.section-4.item-2": "Stripe — payment processing for paid plans",
+  "privacy-policy.section-4.item-3": "Plausible Analytics — anonymous traffic measurement on public pages, limited to counts of page visits and where visitors arrived from.",
   "privacy-policy.section-4.footer": "No user data is shared with advertisers.",
   "privacy-policy.section-5.title": "Future Social Features",
   "privacy-policy.section-5.content": "TaroFlash may introduce optional social features in the future, such as public profiles or shared decks. If these features are added, users will be clearly informed about what information is public and given control over their participation.",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,7 +4,7 @@ import { useMemberStore } from '@/stores/member'
 import { useCan } from '@/composables/can'
 import { isPasswordRecoveryUrl } from '@/api/session'
 import { prefetchMemberById } from '@/api/members'
-import { trackPageview } from '@/utils/analytics/plausible'
+import { useTracking } from '@/composables/tracking'
 import AuthenticatedView from '@/views/app-shell/authenticated.vue'
 
 const WelcomeView = () => import('@/views/welcome/index.vue')
@@ -137,6 +137,8 @@ router.beforeEach(async (to) => {
     if (!useCan()[to.meta.capability].value) return { name: 'dashboard' }
   }
 })
+
+const { trackPageview } = useTracking()
 
 // Fires after navigation settles, so only pages actually reached are counted.
 router.afterEach((to) => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import { useMemberStore } from '@/stores/member'
 import { useCan } from '@/composables/can'
 import { isPasswordRecoveryUrl } from '@/api/session'
 import { prefetchMemberById } from '@/api/members'
+import { trackPageview } from '@/utils/analytics/plausible'
 import AuthenticatedView from '@/views/app-shell/authenticated.vue'
 
 const WelcomeView = () => import('@/views/welcome/index.vue')
@@ -26,6 +27,8 @@ declare module 'vue-router' {
     guestOnly?: boolean
     /** Gated screen: the named `useCan` capability must be true to enter. */
     capability?: 'useAudioReader'
+    /** Public marketing page: counted as a Plausible pageview. */
+    marketing?: boolean
   }
 }
 
@@ -59,17 +62,19 @@ const router = createRouter({
       path: '/welcome',
       name: 'welcome',
       component: WelcomeView,
-      meta: { guestOnly: true }
+      meta: { guestOnly: true, marketing: true }
     },
     {
       path: '/privacy',
       name: 'privacy-policy',
-      component: PrivacyPolicyView
+      component: PrivacyPolicyView,
+      meta: { marketing: true }
     },
     {
       path: '/terms',
       name: 'terms-of-service',
-      component: TermsOfServiceView
+      component: TermsOfServiceView,
+      meta: { marketing: true }
     },
     {
       path: '/auth/callback',
@@ -131,6 +136,11 @@ router.beforeEach(async (to) => {
     await resolveMember()
     if (!useCan()[to.meta.capability].value) return { name: 'dashboard' }
   }
+})
+
+// Fires after navigation settles, so only pages actually reached are counted.
+router.afterEach((to) => {
+  if (to.meta.marketing) trackPageview()
 })
 
 export default router

--- a/src/utils/analytics/plausible.ts
+++ b/src/utils/analytics/plausible.ts
@@ -17,6 +17,10 @@ let script_injected = false
  * Loads Plausible's per-site script once, queuing any `plausible()` calls
  * made before it finishes loading, then turns off autocapture so only the
  * explicit `trackPageview()` calls below ever count a visit.
+ *
+ * The queue has to be the global `window.plausible` — that name is where the
+ * vendor script looks when it lands, and anything it doesn't find there is
+ * dropped rather than sent. Keep it a global even though nothing else reads it.
  */
 function ensureScriptLoaded(site_id: string) {
   if (script_injected) return

--- a/src/utils/analytics/plausible.ts
+++ b/src/utils/analytics/plausible.ts
@@ -1,4 +1,9 @@
-type PlausibleQueueFn = ((...args: unknown[]) => void) & { q?: unknown[][] }
+type PlausibleInitOptions = { autoCapturePageviews?: boolean }
+type PlausibleQueueFn = ((...args: unknown[]) => void) & {
+  q?: unknown[][]
+  o?: PlausibleInitOptions
+  init?: (options?: PlausibleInitOptions) => void
+}
 
 declare global {
   interface Window {
@@ -9,36 +14,39 @@ declare global {
 let script_injected = false
 
 /**
- * Loads Plausible's manual-pageview script once, queuing any `plausible()`
- * calls made before it finishes loading.
+ * Loads Plausible's per-site script once, queuing any `plausible()` calls
+ * made before it finishes loading, then turns off autocapture so only the
+ * explicit `trackPageview()` calls below ever count a visit.
  */
-function ensureScriptLoaded(domain: string) {
+function ensureScriptLoaded(site_id: string) {
   if (script_injected) return
   script_injected = true
 
-  window.plausible =
+  const plausible: PlausibleQueueFn =
     window.plausible ||
     ((...args: unknown[]) => {
-      const fn = window.plausible!
-      fn.q = fn.q || []
-      fn.q.push(args)
+      plausible.q = plausible.q || []
+      plausible.q.push(args)
     })
+  plausible.init = plausible.init || ((options) => (plausible.o = options ?? {}))
+  window.plausible = plausible
 
   const script = document.createElement('script')
-  script.defer = true
-  script.dataset.domain = domain
-  script.src = 'https://plausible.io/js/script.manual.js'
+  script.async = true
+  script.src = `https://plausible.io/js/${site_id}.js`
   document.head.appendChild(script)
+
+  plausible.init({ autoCapturePageviews: false })
 }
 
 /**
- * Counts one visit with Plausible — only when a site domain is configured
- * for this build, so staging and local runs never send anything.
+ * Counts one visit with Plausible — only when a site id is configured for
+ * this build, so staging and local runs never send anything.
  */
 export function trackPageview() {
-  const domain = import.meta.env.VITE_PLAUSIBLE_DOMAIN
-  if (!domain) return
+  const site_id = import.meta.env.VITE_PLAUSIBLE_SITE_ID
+  if (!site_id) return
 
-  ensureScriptLoaded(domain)
+  ensureScriptLoaded(site_id)
   window.plausible?.('pageview')
 }

--- a/src/utils/analytics/plausible.ts
+++ b/src/utils/analytics/plausible.ts
@@ -1,0 +1,44 @@
+type PlausibleQueueFn = ((...args: unknown[]) => void) & { q?: unknown[][] }
+
+declare global {
+  interface Window {
+    plausible?: PlausibleQueueFn
+  }
+}
+
+let script_injected = false
+
+/**
+ * Loads Plausible's manual-pageview script once, queuing any `plausible()`
+ * calls made before it finishes loading.
+ */
+function ensureScriptLoaded(domain: string) {
+  if (script_injected) return
+  script_injected = true
+
+  window.plausible =
+    window.plausible ||
+    ((...args: unknown[]) => {
+      const fn = window.plausible!
+      fn.q = fn.q || []
+      fn.q.push(args)
+    })
+
+  const script = document.createElement('script')
+  script.defer = true
+  script.dataset.domain = domain
+  script.src = 'https://plausible.io/js/script.manual.js'
+  document.head.appendChild(script)
+}
+
+/**
+ * Counts one visit with Plausible — only when a site domain is configured
+ * for this build, so staging and local runs never send anything.
+ */
+export function trackPageview() {
+  const domain = import.meta.env.VITE_PLAUSIBLE_DOMAIN
+  if (!domain) return
+
+  ensureScriptLoaded(domain)
+  window.plausible?.('pageview')
+}

--- a/src/views/privacy-policy.vue
+++ b/src/views/privacy-policy.vue
@@ -80,6 +80,7 @@ const { t } = useI18n()
       <ul class="list-disc list-inside ml-4 space-y-1">
         <li>{{ t('privacy-policy.section-4.item-1') }}</li>
         <li>{{ t('privacy-policy.section-4.item-2') }}</li>
+        <li>{{ t('privacy-policy.section-4.item-3') }}</li>
       </ul>
       <p class="leading-relaxed">{{ t('privacy-policy.section-4.footer') }}</p>
     </section>

--- a/tests/unit/router/index.test.js
+++ b/tests/unit/router/index.test.js
@@ -15,13 +15,15 @@ const {
   mockMemberStore,
   mockUseCan,
   mockPrefetchMemberById,
-  mockIsPasswordRecoveryUrl
+  mockIsPasswordRecoveryUrl,
+  mockTrackPageview
 } = vi.hoisted(() => ({
   mockSessionStore: { ensureResolved: vi.fn() },
   mockMemberStore: {},
   mockUseCan: vi.fn(),
   mockPrefetchMemberById: vi.fn(),
-  mockIsPasswordRecoveryUrl: vi.fn()
+  mockIsPasswordRecoveryUrl: vi.fn(),
+  mockTrackPageview: vi.fn()
 }))
 
 vi.mock('@/stores/session', () => ({
@@ -44,11 +46,16 @@ vi.mock('@/api/members', () => ({
   prefetchMemberById: mockPrefetchMemberById
 }))
 
+vi.mock('@/utils/analytics/plausible', () => ({
+  trackPageview: mockTrackPageview
+}))
+
 // Not under test here; avoids pulling in the real view (and its own composable
 // tree) just to resolve the route table.
 vi.mock('@/views/app-shell/authenticated.vue', () => ({ default: {} }))
 
 const guardHolder = vi.hoisted(() => ({ current: undefined }))
+const afterEachHolder = vi.hoisted(() => ({ current: undefined }))
 
 vi.mock('vue-router', async (importOriginal) => {
   const actual = await importOriginal()
@@ -60,6 +67,11 @@ vi.mock('vue-router', async (importOriginal) => {
       instance.beforeEach = (guard) => {
         guardHolder.current = guard
         return originalBeforeEach(guard)
+      }
+      const originalAfterEach = instance.afterEach.bind(instance)
+      instance.afterEach = (hook) => {
+        afterEachHolder.current = hook
+        return originalAfterEach(hook)
       }
       return instance
     }
@@ -84,6 +96,7 @@ beforeEach(() => {
   mockUseCan.mockReset().mockReturnValue({ useAudioReader: { value: true } })
   mockPrefetchMemberById.mockReset().mockResolvedValue(undefined)
   mockIsPasswordRecoveryUrl.mockReset().mockReturnValue(false)
+  mockTrackPageview.mockReset()
 })
 
 describe('router — the single auth checkpoint', () => {
@@ -251,6 +264,38 @@ describe('router — the single auth checkpoint', () => {
       })
       expect(mockUseCan).not.toHaveBeenCalled()
       expect(mockPrefetchMemberById).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── marketing pageview tracking ─────────────────────────────────────────────
+
+  describe('marketing pageview tracking', () => {
+    test('registers exactly one afterEach hook', () => {
+      expect(typeof afterEachHolder.current).toBe('function')
+    })
+
+    test.each([['/welcome'], ['/privacy'], ['/terms']])(
+      '%s is marked marketing and counts a pageview [obligation]',
+      (path) => {
+        const to = resolveTo(path)
+
+        afterEachHolder.current(to)
+
+        expect(mockTrackPageview).toHaveBeenCalledTimes(1)
+      }
+    )
+
+    test.each([
+      ['/dashboard'],
+      ['/deck/123'],
+      ['/audio-reader/collection/1/lesson/2'],
+      ['/auth/callback']
+    ])('%s is not marked marketing and does not count a pageview [obligation]', (path) => {
+      const to = resolveTo(path)
+
+      afterEachHolder.current(to)
+
+      expect(mockTrackPageview).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/utils/analytics/plausible.test.js
+++ b/tests/unit/utils/analytics/plausible.test.js
@@ -1,0 +1,58 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+
+const PLAUSIBLE_SRC = 'https://plausible.io/js/script.manual.js'
+
+function scriptTags() {
+  return Array.from(document.head.querySelectorAll(`script[src="${PLAUSIBLE_SRC}"]`))
+}
+
+function clearInjectedScripts() {
+  scriptTags().forEach((el) => el.remove())
+  delete window.plausible
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  clearInjectedScripts()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  clearInjectedScripts()
+})
+
+describe('trackPageview', () => {
+  test('does nothing when VITE_PLAUSIBLE_DOMAIN is unset [obligation]', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', '')
+    const { trackPageview } = await import('@/utils/analytics/plausible')
+
+    trackPageview()
+
+    expect(scriptTags()).toHaveLength(0)
+    expect(window.plausible).toBeUndefined()
+  })
+
+  test('injects the manual-pageview script and fires a pageview when the domain is set [obligation]', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'taroflash.app')
+    const { trackPageview } = await import('@/utils/analytics/plausible')
+
+    trackPageview()
+
+    const scripts = scriptTags()
+    expect(scripts).toHaveLength(1)
+    expect(scripts[0].dataset.domain).toBe('taroflash.app')
+    expect(scripts[0].src).toBe(PLAUSIBLE_SRC)
+    expect(window.plausible?.q).toContainEqual(['pageview'])
+  })
+
+  test('injects the script only once across repeated calls, but fires a pageview every time [obligation]', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'taroflash.app')
+    const { trackPageview } = await import('@/utils/analytics/plausible')
+
+    trackPageview()
+    trackPageview()
+
+    expect(scriptTags()).toHaveLength(1)
+    expect(window.plausible?.q).toEqual([['pageview'], ['pageview']])
+  })
+})

--- a/tests/unit/utils/analytics/plausible.test.js
+++ b/tests/unit/utils/analytics/plausible.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 
-const PLAUSIBLE_SRC = 'https://plausible.io/js/script.manual.js'
+const SITE_ID = 'pa-8mf8Xc6JDbJ3SFPBHKhKu'
+const PLAUSIBLE_SRC = `https://plausible.io/js/${SITE_ID}.js`
 
 function scriptTags() {
   return Array.from(document.head.querySelectorAll(`script[src="${PLAUSIBLE_SRC}"]`))
@@ -22,8 +23,8 @@ afterEach(() => {
 })
 
 describe('trackPageview', () => {
-  test('does nothing when VITE_PLAUSIBLE_DOMAIN is unset [obligation]', async () => {
-    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', '')
+  test('does nothing when VITE_PLAUSIBLE_SITE_ID is unset [obligation]', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_SITE_ID', '')
     const { trackPageview } = await import('@/utils/analytics/plausible')
 
     trackPageview()
@@ -32,21 +33,22 @@ describe('trackPageview', () => {
     expect(window.plausible).toBeUndefined()
   })
 
-  test('injects the manual-pageview script and fires a pageview when the domain is set [obligation]', async () => {
-    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'taroflash.app')
+  test('injects the per-site script, disables autocapture, and fires a pageview when the site id is set [obligation]', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_SITE_ID', SITE_ID)
     const { trackPageview } = await import('@/utils/analytics/plausible')
 
     trackPageview()
 
     const scripts = scriptTags()
     expect(scripts).toHaveLength(1)
-    expect(scripts[0].dataset.domain).toBe('taroflash.app')
     expect(scripts[0].src).toBe(PLAUSIBLE_SRC)
+    expect(scripts[0].async).toBe(true)
+    expect(window.plausible?.o).toEqual({ autoCapturePageviews: false })
     expect(window.plausible?.q).toContainEqual(['pageview'])
   })
 
   test('injects the script only once across repeated calls, but fires a pageview every time [obligation]', async () => {
-    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'taroflash.app')
+    vi.stubEnv('VITE_PLAUSIBLE_SITE_ID', SITE_ID)
     const { trackPageview } = await import('@/utils/analytics/plausible')
 
     trackPageview()


### PR DESCRIPTION
[TARO-351](https://app.notion.com/p/3b80953c224c81c78658de42d2fa7dcf)

## Summary

- Counts a pageview on the welcome, privacy and terms routes only, via a `router.afterEach` hook keyed off a new `marketing` route meta flag — no page inside the signed-in app is ever counted.
- Loads Plausible's per-site script lazily and once, with autocapture off, so every send is explicit. Gated on `VITE_PLAUSIBLE_SITE_ID`: absent, the script never loads and nothing is sent, which keeps staging and local runs silent.
- Discloses Plausible as a third entry in the privacy policy's data-sharing list.
- No cookie banner, no consent prompt, no identifier that follows anyone between visits.