### PR TITLE
self-heal: rule updates

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -38,3 +38,4 @@ Read the relevant one before editing:
 - **Adding helpers, defaults, formatters, validators** → [`utils`](./architecture/utils.md)
 - **Shared editor state across nested components / modals** → [`provide-inject`](./architecture/provide-inject.md)
 - **Touching `src/components/ui-kit/` or `src/components/layout-kit/`** → [`ui-kit`](./architecture/ui-kit.md)
+- **Wiring a third-party analytics/tracking SDK** → [`vendor-chokepoint`](./architecture/vendor-chokepoint.md)

--- a/.claude/rules/architecture/vendor-chokepoint.md
+++ b/.claude/rules/architecture/vendor-chokepoint.md
@@ -1,0 +1,20 @@
+# Third-party SDKs get one chokepoint composable
+
+A third-party analytics/tracking SDK (Plausible, and the next one) is reached only through a single
+app-owned composable — `useTracking()` for tracking. Routers, views, and components call the
+composable and name what happened; the composable is the only file that imports the vendor module.
+Swapping or adding a provider then touches one file, not every call site.
+
+```ts
+// Bad — router imports the vendor SDK directly
+import { trackPageview } from '@/utils/analytics/plausible'
+
+// Good — router calls the chokepoint; only it imports the vendor module
+import { useTracking } from '@/composables/tracking'
+const { trackPageview } = useTracking()
+```
+
+Keep the composable small until a second provider actually lands — this is the chokepoint, not the
+place to build out a provider-abstraction layer speculatively. Naming the vendor inside that one
+file is fine; call sites and the composable's own exports stay vendor-neutral —
+[`code-style/signatures`](../code-style/signatures.md).


### PR DESCRIPTION
Automated rule updates from self-heal dispatch.

- docs(architecture): route third-party tracking SDKs through one chokepoint composable