### PR TITLE
docs: heal knowledge-lint fixes

### DIFF
--- a/scripts/knowledge-report.mjs
+++ b/scripts/knowledge-report.mjs
@@ -12,7 +12,7 @@
 import { readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { collectTokens } from './knowledge/scan.mjs'
+import { collectTokens, isCitable, readConfig } from './knowledge/scan.mjs'
 import { knowledgeGraph } from './knowledge/graph.mjs'
 
 export const MARKER = '<!-- knowledge-report -->'
@@ -39,10 +39,10 @@ function readChangedFiles(path) {
 }
 
 /** Citations sitting in the code this change touched, grouped by the slug they point at. */
-function citedByChangedCode(root, changed, references) {
+function citedByChangedCode(root, changed, references, config) {
   const cited = new Map()
 
-  for (const path of changed.filter((file) => !file.endsWith('.md'))) {
+  for (const path of changed.filter((file) => !file.endsWith('.md') && isCitable(file, config))) {
     const absolute = join(root, path)
     if (!existsSync(absolute)) continue
 
@@ -64,12 +64,13 @@ function countsOf(graph) {
 }
 
 export function buildReport({ head, base, changed }) {
+  const config = readConfig(head)
   const headGraph = knowledgeGraph(head)
   const baseGraph = base ? knowledgeGraph(base) : { references: new Map(), unreachable: [] }
   const baseCounts = countsOf(baseGraph)
   const baseUnreachable = new Set(baseGraph.unreachable)
 
-  const cited = citedByChangedCode(head, changed, headGraph.references)
+  const cited = citedByChangedCode(head, changed, headGraph.references, config)
   const dropped = [...headGraph.references]
     .filter(([slug, entry]) => entry.citedBy.length === 0 && (baseCounts.get(slug) ?? 0) > 0)
     .map(([slug, entry]) => `\`[K:${slug}]\` — declared in \`${entry.declaredIn}\``)

--- a/scripts/knowledge/scan.mjs
+++ b/scripts/knowledge/scan.mjs
@@ -128,6 +128,12 @@ export function collectTokens(path, text) {
   return tokens
 }
 
+/** Whether a path is in the citation scan scope — matches `cite_in` and isn't `exempt`. */
+export function isCitable(path, config) {
+  const { slugs } = config
+  return matchesAny(path, slugs.cite_in) && !matchesAny(path, slugs.exempt)
+}
+
 /**
  * Every live token in the repo, with the file lists the callers work from.
  *
@@ -138,9 +144,7 @@ export function scanTokens(root, config) {
   const { slugs } = config
   const files = listFiles(root)
 
-  const cited = files.filter(
-    (path) => matchesAny(path, slugs.cite_in) && !matchesAny(path, slugs.exempt)
-  )
+  const cited = files.filter((path) => isCitable(path, config))
   const tokens = cited
     .filter((path) => path !== slugs.retired_ledger)
     .flatMap((path) => collectTokens(path, readFileSync(join(root, path), 'utf8')))

--- a/tests/unit/scripts/knowledge-report.test.js
+++ b/tests/unit/scripts/knowledge-report.test.js
@@ -29,7 +29,7 @@ const CONFIG = {
       'supabase/**/*.{sql,ts}',
       '.github/**/*.yml'
     ],
-    exempt: ['supabase/migrations/**']
+    exempt: ['supabase/migrations/**', 'tests/unit/scripts/**']
   }
 }
 
@@ -161,6 +161,22 @@ describe('buildReport — knowledge cited by changed code', () => {
     })
 
     const report = buildReport({ head, base: undefined, changed: ['CLAUDE.md'] })
+
+    expect(report).toBe('')
+  })
+
+  test('a changed file matching slugs.exempt is not scanned, even carrying real-looking citations', () => {
+    const head = makeRoot({
+      'CLAUDE.md': '[K:fixture-slug] declared here.\n',
+      'tests/unit/scripts/knowledge-lint.test.js':
+        '// →[K:fixture-slug] a checker fixture, not a real cite\n'
+    })
+
+    const report = buildReport({
+      head,
+      base: undefined,
+      changed: ['tests/unit/scripts/knowledge-lint.test.js']
+    })
 
     expect(report).toBe('')
   })


### PR DESCRIPTION
## Summary
- `scripts/knowledge-report.mjs` now reads `slugs.exempt` from `.claude/knowledge-lint.json` (via a shared `isCitable` helper in `scripts/knowledge/scan.mjs`) before scanning changed files for citations, so a PR touching `tests/unit/scripts/**` no longer buries real citations under the lint checker's own fixture tokens.

## Test plan
- [x] `vp test tests/unit/scripts/knowledge-report.test.js tests/unit/scripts/knowledge-lint.test.js` — 37 passed
- [x] `node scripts/knowledge-lint.mjs` — passes