### PR TITLE
docs: self-heal — mechanise the one-level-of-nesting rule

### DIFF
--- a/.claude/rules/code-style/nesting.md
+++ b/.claude/rules/code-style/nesting.md
@@ -1,6 +1,11 @@
 # At most one level of nesting
 
-Don't nest more than one `if` / `for` / `try`. When a path forks, invert the condition and return early instead of pushing the main path inside an `if`.
+**`max-depth` in `vite.config.ts`'s `lint.rules` enforces this** — `vp lint` warns past depth 2.
+Still `warn`, not `error`: 14 pre-existing sites haven't been cleared, and this rule's owner can't
+touch source to clear them.
+
+When a path forks, invert the condition and return early instead of pushing the main path inside an
+`if`.
 
 ```ts
 // Good — orchestrator routes; each branch is its own one-job function

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,11 @@ export default defineConfig({
     },
     rules: {
       'no-console': 'warn',
-      'no-floating-promises': 'off'
+      'no-floating-promises': 'off',
+      // `warn`, not `error`: 14 pre-existing sites (11 src/, 3 scripts/)
+      // already exceed depth 2, and this rule's owner can't touch source to
+      // clear them.
+      'max-depth': ['warn', 2]
     }
   },
   plugins: [


### PR DESCRIPTION
## Summary

- `vite.config.ts` gains `max-depth: ['warn', 2]` so the existing "at most one level of nesting" rule fails visibly instead of only in prose — a PR review had to catch a four-level function that the rule already forbade.
- `.claude/rules/code-style/nesting.md` shrinks to the intent plus a pointer to the check, keeping the invert-and-return-early technique the lint message can't teach.

`warn` rather than `error`: 14 pre-existing sites violate it today (11 in `src/`, 3 in `scripts/`). Clearing those is tracked separately; `error` is the natural follow-up once they're gone.

`max-lines-per-function` was measured and deliberately not added — 83 violations at 40 lines, 32 at 75, almost all composables' single outer `useXxx()`, which is this codebase's idiomatic shape rather than the problem the review flagged.