### PR TITLE
TARO-360: Every hardcoded shade routes through a colour role

### DIFF
--- a/corpus/hazards.md
+++ b/corpus/hazards.md
@@ -34,6 +34,7 @@ in the directory it bites, so it reaches you when you're standing on it.
 | →[K:settled-transform-traps-overlays]         | [[layering]]           | `src/utils/animations/`                                                                                                  |
 | →[K:ios-audio-interruption]                   | [[sound]]              | `src/sfx/`                                                                                                               |
 | →[K:dock-height-single-owner]                 | [[mobile-dock]]        | `src/components/mobile-dock/`, `src/composables/ui/animated-height.ts`, `src/components/layout-kit/crossfade-resize.vue` |
+| →[K:fixed-roles-skip-the-station]             | [[surface-stations]]   | `src/styles/main.css`                                                                                                    |
 
 A trap with no directory to echo it into is listed in `CLAUDE.md` instead, so it
 is paid for in every session. There are none today.

--- a/corpus/map.md
+++ b/corpus/map.md
@@ -45,7 +45,7 @@ See [corpus-authoring](../.claude/rules/corpus-authoring.md) for how the corpus 
 ## theming
 
 - [[theming]] — colors are roles, not shades; three switches reslot the whole screen ⚠️
-- [[surface-stations]] — four named surfaces, each hand-authored, none derived from another
+- [[surface-stations]] — four named surfaces, each hand-authored, none derived from another; a few roles opt out of every station entirely ⚠️
 
 ## sessions
 

--- a/corpus/theming/surface-stations.md
+++ b/corpus/theming/surface-stations.md
@@ -22,7 +22,10 @@ owns its own look.
 > testing and disappears in the other.**
 > A selected-swatch tick tried `well`, the natural-sounding pick — and `well` happens to be the
 > darkest shade in the `window` station's dark rendition, so the badge inverted into the fill it was
-> supposed to stand out from. [See the fixed roles ↓](#a-few-roles-never-re-author)
+> supposed to stand out from. The roles that opt out fix only the station axis — each still swaps
+> light/dark with the mode. Read "fixed" as mode-invariant and a badge tuned for light survives
+> unchanged into dark, which is the opposite of this trap.
+> [See the fixed roles ↓](#a-few-roles-never-re-author)
 
 ## The four stations
 
@@ -52,15 +55,20 @@ never the station, never a shade:
 - **ink** / **ink-muted** — body text and secondary text
 - **skeleton** / **skeleton-sheen** — a loading placeholder bar and the highlight sweeping across it
 
-## A few roles never re-author
+## A few roles never re-author — by station, not by mode
 
-`card`/`on-card`, `mat`, and `knockout`/`on-knockout` are fixed — the same color in every mode and
-every station, never picked up from a station's own set. Each opts out for the same reason: it
-isn't actually resting on a station's surface. A flashcard carries its own identity everywhere it
-appears; an avatar's mat is color-tuned once, in both modes, so an avatar image reads the same
-wherever it's mounted; a knockout badge or ring — the tick on a selected swatch, the outline around
-it — sits directly on an accent fill, not on the station behind it, so following the station would
-sink it into whatever's behind the swatch.
+`card`/`on-card`, `mat`, and `knockout`/`on-knockout` are fixed on the station axis only: the same
+color regardless of which station they sit in, never picked up from a station's own set. Each opts
+out for the same reason — it isn't actually resting on a station's surface. A flashcard carries its
+own identity everywhere it appears; an avatar's mat is color-tuned once per mode, so an avatar image
+reads the same wherever it's mounted; a knockout badge or ring — the tick on a selected swatch, the
+outline around it — sits directly on an accent fill, not on the station behind it, so following the
+station would sink it into whatever's behind the swatch.
+
+They are **not** fixed on the mode axis. All three pairs still swap to a dark rendition when the
+page goes dark — `stations.css` carries a `[data-mode='dark']` value for each of them, same as any
+station-derived role would. "Fixed" here means "the station switch doesn't move it," not "no switch
+moves it."
 
 ## What this isn't
 

--- a/corpus/theming/surface-stations.md
+++ b/corpus/theming/surface-stations.md
@@ -2,9 +2,9 @@
 id: surface-stations
 domain: theming
 status: current
-hazard: false
+hazard: true
 related: [theming]
-updated: 2026-08-12
+updated: 2026-08-13
 ---
 
 # Surface stations
@@ -15,6 +15,14 @@ A surface carries a station name — `page`, `panel`, `window`, or `float` — a
 on it reads its neutral colors off that name. There's no ladder between the four; a thing doesn't
 get darker because it's "more raised" than another. It just belongs to a station, and that station
 owns its own look.
+
+> [!HAZARD] [K:fixed-roles-skip-the-station] **A station role assumes the thing wearing it is
+> resting on a station. Something that isn't — a badge sitting on an accent fill, not on the page,
+> panel, window, or float behind it — can borrow a station role that looks fine in the mode you're
+> testing and disappears in the other.**
+> A selected-swatch tick tried `well`, the natural-sounding pick — and `well` happens to be the
+> darkest shade in the `window` station's dark rendition, so the badge inverted into the fill it was
+> supposed to stand out from. [See the fixed roles ↓](#a-few-roles-never-re-author)
 
 ## The four stations
 
@@ -43,6 +51,16 @@ never the station, never a shade:
 - **line** — dividers, hairlines, seams
 - **ink** / **ink-muted** — body text and secondary text
 - **skeleton** / **skeleton-sheen** — a loading placeholder bar and the highlight sweeping across it
+
+## A few roles never re-author
+
+`card`/`on-card`, `mat`, and `knockout`/`on-knockout` are fixed — the same color in every mode and
+every station, never picked up from a station's own set. Each opts out for the same reason: it
+isn't actually resting on a station's surface. A flashcard carries its own identity everywhere it
+appears; an avatar's mat is color-tuned once, in both modes, so an avatar image reads the same
+wherever it's mounted; a knockout badge or ring — the tick on a selected swatch, the outline around
+it — sits directly on an accent fill, not on the station behind it, so following the station would
+sink it into whatever's behind the swatch.
 
 ## What this isn't
 

--- a/src/components/billing/checkout-modal/success-view.vue
+++ b/src/components/billing/checkout-modal/success-view.vue
@@ -10,7 +10,7 @@ const { t } = useI18n()
     data-testid="checkout__success"
     class="flex flex-col items-center gap-3 px-(--checkout-padding) py-10 text-center"
   >
-    <ui-icon src="party-popper" class="size-18 text-blue-500" />
+    <ui-icon src="party-popper" class="size-18 text-(--color-accent-text)" />
     <h2 data-testid="checkout__success-heading" class="text-2xl text-ink">
       {{ t('billing.checkout.success-heading') }}
     </h2>

--- a/src/components/card/card-cover.vue
+++ b/src/components/card/card-cover.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, useTemplateRef } from 'vue'
-import { SKELETON_COVER, coverBindings } from '@/utils/cover'
+import { SKELETON_COVER, coverBindings, coverIconPalette } from '@/utils/cover'
 import { useImageReveal } from '@/composables/card/image-reveal'
 import UiIcon from '@/components/ui-kit/icon.vue'
 
@@ -19,10 +19,7 @@ const bindings = computed(() => {
   return coverBindings(has_image.value ? SKELETON_COVER : cover, { border: false })
 })
 
-/** Yellow, except on a yellow cover — there the icon would vanish into the fill. */
-const icon_palette = computed<PaletteName>(() =>
-  cover?.palette === 'yellow' ? 'purple' : 'yellow'
-)
+const icon_palette = computed(() => coverIconPalette(cover?.palette))
 </script>
 
 <template>

--- a/src/components/card/card-cover.vue
+++ b/src/components/card/card-cover.vue
@@ -46,7 +46,7 @@ const bindings = computed(() => {
     <div
       v-else-if="cover?.icon"
       data-testid="card-cover__icon"
-      class="card-cover__icon [&>svg]:w-full [&>svg]:h-full text-yellow-500 dark:text-yellow-700"
+      class="card-cover__icon [&>svg]:w-full [&>svg]:h-full"
       style="width: var(--cover-icon-size); height: var(--cover-icon-size)"
     >
       <ui-icon :src="cover.icon" />

--- a/src/components/card/card-cover.vue
+++ b/src/components/card/card-cover.vue
@@ -46,7 +46,8 @@ const bindings = computed(() => {
     <div
       v-else-if="cover?.icon"
       data-testid="card-cover__icon"
-      class="card-cover__icon [&>svg]:w-full [&>svg]:h-full"
+      data-palette="yellow"
+      class="card-cover__icon [&>svg]:w-full [&>svg]:h-full text-(--color-accent)"
       style="width: var(--cover-icon-size); height: var(--cover-icon-size)"
     >
       <ui-icon :src="cover.icon" />
@@ -64,13 +65,11 @@ const bindings = computed(() => {
   border: var(--face-border-width) solid var(--color-accent);
 }
 
-/* No palette → neutral cover: the border and icon step off the accent onto the
-   raised chrome roles, matching the neutral fill above. */
+/* No palette → neutral cover: the border steps off the accent onto the raised
+   chrome role, matching the neutral fill above. The icon keeps its own palette
+   either way — it is not part of the cover's colour. */
 .card-cover:not([data-palette]) {
   border-color: var(--color-raised);
-}
-.card-cover:not([data-palette]) .card-cover__icon {
-  color: var(--color-ink);
 }
 
 /* Applied only once the image decodes; before that the neutral skeleton chrome

--- a/src/components/card/card-cover.vue
+++ b/src/components/card/card-cover.vue
@@ -18,6 +18,11 @@ const bindings = computed(() => {
   if (decoded.value) return null
   return coverBindings(has_image.value ? SKELETON_COVER : cover, { border: false })
 })
+
+/** Yellow, except on a yellow cover — there the icon would vanish into the fill. */
+const icon_palette = computed<PaletteName>(() =>
+  cover?.palette === 'yellow' ? 'purple' : 'yellow'
+)
 </script>
 
 <template>
@@ -46,7 +51,7 @@ const bindings = computed(() => {
     <div
       v-else-if="cover?.icon"
       data-testid="card-cover__icon"
-      data-palette="yellow"
+      :data-palette="icon_palette"
       class="card-cover__icon [&>svg]:w-full [&>svg]:h-full text-(--color-accent)"
       style="width: var(--cover-icon-size); height: var(--cover-icon-size)"
     >

--- a/src/components/card/card-face.vue
+++ b/src/components/card/card-face.vue
@@ -79,11 +79,11 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
 }
 
 .card-face[data-mode='edit']:focus-within {
-  outline: 2px solid var(--color-blue-500);
+  outline: 2px solid var(--color-accent);
 }
 
 .card-container[data-error] .card-face {
-  outline: 2px solid var(--color-red-500);
+  outline: 2px solid var(--color-accent);
 }
 
 /* DOM order is always image-region then text-region; layout reorders/repositions
@@ -207,20 +207,13 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
 .card-container[data-active]
   .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
   .card-face__image-region {
-  outline-color: var(--color-brown-500);
+  outline-color: var(--color-ink-muted);
 }
 
 .card-container[data-dragging]
   .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
   .card-face__image-region {
-  outline-color: var(--color-blue-500);
-}
-
-[data-mode='dark']
-  .card-container[data-dragging]
-  .card-face[data-mode='edit'][data-image='true']:not([data-layout='behind'])
-  .card-face__image-region {
-  outline-color: var(--color-blue-650);
+  outline-color: var(--color-accent);
 }
 
 /* Behind images have no padded region to frame; while dragging, pull the image
@@ -241,15 +234,9 @@ const text_scale = computed(() => cardTextScale(attributes?.text_size))
 
 .card-container[data-dragging]
   .card-face[data-mode='edit'][data-layout='behind'][data-image='true'] {
-  outline: 3px dashed var(--color-blue-500);
+  outline: 3px dashed var(--color-accent);
   outline-offset: -3px;
   transition: outline-color 0.15s ease;
-}
-
-[data-mode='dark']
-  .card-container[data-dragging]
-  .card-face[data-mode='edit'][data-layout='behind'][data-image='true'] {
-  outline-color: var(--color-blue-650);
 }
 
 .card-face__text-editor {

--- a/src/components/card/face-image-layer.vue
+++ b/src/components/card/face-image-layer.vue
@@ -162,7 +162,7 @@ defineExpose({
   <div
     v-if="pending"
     data-testid="face-image-layer__loading"
-    class="absolute inset-0 z-30 flex items-center justify-center rounded-(--face-radius) bg-white/70 dark:bg-stone-700/70"
+    class="absolute inset-0 z-30 flex items-center justify-center rounded-(--face-radius) bg-(--color-card)/70"
   >
     <ui-icon src="loading-dots" class="size-12 text-ink-muted" />
   </div>
@@ -174,11 +174,9 @@ defineExpose({
     :text="t('card.image-editor.upload-image-button')"
     position="top"
     :gap="4"
-    theme="blue-500"
-    theme-dark="blue-650"
     data-testid="face-image-layer__add"
     :aria-label="t('card.image-editor.upload-image-button')"
-    class="absolute! top-(--face-padding) right-(--face-padding) z-20 cursor-pointer text-ink-muted transition-[color,opacity] duration-150 hover:text-blue-500 dark:text-brown-100 dark:hover:text-blue-650"
+    class="absolute! top-(--face-padding) right-(--face-padding) z-20 cursor-pointer text-ink-muted transition-[color,opacity] duration-150 hover:text-(--color-accent)"
     :class="hovered ? 'opacity-100' : 'opacity-0'"
     v-sfx="{ hover: TYPE_SFX }"
     @click.stop="onAddClick"

--- a/src/components/card/face-overlay.vue
+++ b/src/components/card/face-overlay.vue
@@ -26,6 +26,7 @@ const { t } = useI18n()
     v-if="error"
     data-testid="face-overlay__error"
     data-error
+    data-palette="error"
     class="face-overlay"
     :data-variant="variant"
     @mousedown.stop
@@ -78,42 +79,23 @@ const { t } = useI18n()
 }
 
 .face-overlay[data-variant='full'] {
-  border: 3px dashed var(--color-blue-500);
+  border: 3px dashed var(--color-accent);
   border-radius: var(--face-radius);
-  background-color: var(--color-white);
+  background-color: var(--color-card);
 
-  color: var(--color-blue-500);
-}
-
-[data-mode='dark'] .face-overlay[data-variant='full'] {
-  background-color: var(--color-stone-700);
-}
-
-[data-mode='dark'] .face-overlay[data-variant='full']:not([data-error]) {
-  border-color: var(--color-blue-650);
-  color: var(--color-blue-650);
-}
-
-.face-overlay[data-variant='full'][data-error] {
-  border-color: var(--color-red-500);
-  color: var(--color-red-500);
+  color: var(--color-accent);
 }
 
 /* Inherits the radius of whatever region it scrims (image region / corners
    backdrop) and stays invisible until hovered/dragged (`active`) or erroring. */
 .face-overlay[data-variant='inset'] {
-  background-color: color-mix(in srgb, var(--color-white) 85%, transparent);
+  background-color: color-mix(in srgb, var(--color-card) 85%, transparent);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
 
   border-radius: inherit;
-  color: var(--color-brown-700);
+  color: var(--color-on-card);
   opacity: 0;
-}
-
-[data-mode='dark'] .face-overlay[data-variant='inset'] {
-  background-color: color-mix(in srgb, var(--color-stone-700) 85%, transparent);
-  color: var(--color-brown-100);
 }
 
 .face-overlay[data-variant='inset'][data-active] {
@@ -123,17 +105,13 @@ const { t } = useI18n()
 
 .face-overlay[data-variant='inset'][data-error] {
   pointer-events: auto;
-  color: var(--color-red-500);
+  color: var(--color-accent);
   opacity: 1;
 }
 
 /* Dragging a file over the card turns the scrim blue, matching the empty-card
    drop affordance. The drag state lives on the card root, set by the card. */
 .card-container[data-dragging] .face-overlay:not([data-error]) {
-  color: var(--color-blue-500);
-}
-
-[data-mode='dark'] .card-container[data-dragging] .face-overlay:not([data-error]) {
-  color: var(--color-blue-650);
+  color: var(--color-accent);
 }
 </style>

--- a/src/components/card/index.vue
+++ b/src/components/card/index.vue
@@ -106,6 +106,7 @@ function onLeave(el: Element, done: () => void) {
     class="card-container"
     :class="{ 'pointer-events-none': disabled }"
     :data-error="error || undefined"
+    :data-palette="error ? 'danger' : undefined"
     :data-active="image_layer?.active || undefined"
     :data-dragging="image_layer?.dragging || cover_image?.dragging.value || undefined"
     :data-loading="image_layer?.pending || undefined"
@@ -223,7 +224,7 @@ function onLeave(el: Element, done: () => void) {
 
     --card-bg-color: var(--color-card);
     --card-text-color: var(--color-on-card);
-    --card-text-color--placeholder: var(--color-brown-500);
+    --card-text-color--placeholder: var(--color-ink-muted);
 
     aspect-ratio: var(--aspect-card);
     position: relative;

--- a/src/components/card/text-editor.vue
+++ b/src/components/card/text-editor.vue
@@ -187,7 +187,7 @@ defineExpose({ focus })
   /* Hosts (card-face, the loading scrim) hide this by setting the var, not by selecting into our internals. */
   display: var(--text-editor-placeholder-display, flex);
   pointer-events: none;
-  color: var(--color-brown-300);
+  color: var(--color-ink-muted);
   /* Matches the editor so the hint's line box fits a content-height region without clipping. */
   line-height: 1.2;
 }

--- a/src/components/charts/stacked-bar.vue
+++ b/src/components/charts/stacked-bar.vue
@@ -6,7 +6,7 @@ type Segment = { value: number; colorClass: string; key?: string | number }
 const {
   segments,
   heightClass = 'h-4',
-  trackClass = 'bg-brown-300/70 dark:bg-grey-700'
+  trackClass = 'bg-raised/70'
 } = defineProps<{
   segments: Segment[]
   heightClass?: string

--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -75,7 +75,7 @@ const is_locked = computed(() => locked ?? deck?.is_locked ?? false)
       icon-only
       icon-left="lock"
       neutral
-      class="absolute! -top-1 -right-1 z-10 ring-4 ring-brown-100 dark:ring-grey-900 pointer-events-none"
+      class="absolute! -top-1 -right-1 z-10 ring-4 ring-surface pointer-events-none"
       :class="
         !$slots['corner-action']
           ? 'opacity-100'

--- a/src/components/deck/pinned-preview.vue
+++ b/src/components/deck/pinned-preview.vue
@@ -29,7 +29,7 @@ const emit = defineEmits<{
       <card
         data-testid="deck-pinned-preview__shadow-card"
         class="absolute! -top-2 right-1 w-(--card-w-full)"
-        face_classes="bg-white! dark:bg-stone-700!"
+        face_classes="bg-(--color-card)!"
       />
     </template>
 

--- a/src/components/layout-kit/app-window/index.vue
+++ b/src/components/layout-kit/app-window/index.vue
@@ -123,7 +123,7 @@ const showHeader = computed(() => Boolean(slots.header || slots['header-content'
               ]"
             >
               <slot name="header-content">
-                <h1 class="text-5xl text-white">{{ title }}</h1>
+                <h1 class="text-5xl">{{ title }}</h1>
               </slot>
             </div>
           </slot>

--- a/src/components/member/avatar-picker-modal.vue
+++ b/src/components/member/avatar-picker-modal.vue
@@ -52,19 +52,19 @@ function onAvatarSelect(avatar: string) {
           :data-testid="`avatar-picker-modal__option-${avatar}`"
           :data-selected="avatar === selected || undefined"
           v-sfx="{ hover: TYPE_SFX }"
-          class="rounded-10 cursor-pointer hover:bg-(--color-accent) hover:bgx-diagonal-stripes hover:bgx-slide data-selected:bg-(--color-accent) data-selected:bgx-diagonal-stripes data-selected:border-6 border-white relative aspect-square p-2"
+          class="rounded-10 cursor-pointer hover:bg-(--color-accent) hover:bgx-diagonal-stripes hover:bgx-slide data-selected:bg-(--color-accent) data-selected:bgx-diagonal-stripes data-selected:border-6 border-surface relative aspect-square p-2"
           @click="onAvatarSelect(avatar)"
         >
           <div
             v-if="!loaded.has(avatar)"
             data-testid="avatar-picker-modal__skeleton"
-            class="h-full w-full rounded-8 animate-pulse bg-brown-300 bgx-diagonal-stripes"
+            class="h-full w-full rounded-8 animate-pulse bg-skeleton bgx-diagonal-stripes"
           />
           <avatar-image v-else :avatar="avatar" class="h-full w-full" />
 
           <div
             v-if="avatar === selected"
-            class="absolute -top-2 -right-2 bg-white p-1.5 size-8 rounded-full flex items-center justify-center"
+            class="absolute -top-2 -right-2 bg-surface p-1.5 size-8 rounded-full flex items-center justify-center"
           >
             <ui-icon src="check" class="text-(--color-accent-text)" />
           </div>

--- a/src/components/member/avatar-picker-modal.vue
+++ b/src/components/member/avatar-picker-modal.vue
@@ -66,7 +66,7 @@ function onAvatarSelect(avatar: string) {
             v-if="avatar === selected"
             class="absolute -top-2 -right-2 bg-knockout p-1.5 size-8 rounded-full flex items-center justify-center"
           >
-            <ui-icon src="check" class="text-on-knockout" />
+            <ui-icon src="check" class="text-(--color-accent-text)" />
           </div>
         </button>
       </div>

--- a/src/components/member/avatar-picker-modal.vue
+++ b/src/components/member/avatar-picker-modal.vue
@@ -52,7 +52,7 @@ function onAvatarSelect(avatar: string) {
           :data-testid="`avatar-picker-modal__option-${avatar}`"
           :data-selected="avatar === selected || undefined"
           v-sfx="{ hover: TYPE_SFX }"
-          class="rounded-10 cursor-pointer hover:bg-(--color-accent) hover:bgx-diagonal-stripes hover:bgx-slide data-selected:bg-(--color-accent) data-selected:bgx-diagonal-stripes data-selected:border-6 border-surface relative aspect-square p-2"
+          class="rounded-10 cursor-pointer hover:bg-(--color-accent) hover:bgx-diagonal-stripes hover:bgx-slide data-selected:bg-(--color-accent) data-selected:bgx-diagonal-stripes data-selected:border-6 border-knockout relative aspect-square p-2"
           @click="onAvatarSelect(avatar)"
         >
           <div
@@ -64,9 +64,9 @@ function onAvatarSelect(avatar: string) {
 
           <div
             v-if="avatar === selected"
-            class="absolute -top-2 -right-2 bg-surface p-1.5 size-8 rounded-full flex items-center justify-center"
+            class="absolute -top-2 -right-2 bg-knockout p-1.5 size-8 rounded-full flex items-center justify-center"
           >
-            <ui-icon src="check" class="text-(--color-accent-text)" />
+            <ui-icon src="check" class="text-on-knockout" />
           </div>
         </button>
       </div>

--- a/src/components/member/member-badge.vue
+++ b/src/components/member/member-badge.vue
@@ -62,12 +62,15 @@ function onEditAvatar(e: MouseEvent) {
     <div data-testid="member-badge__info" class="flex flex-col min-w-0 flex-1">
       <span
         data-testid="member-badge__name"
-        class="block font-semibold text-3xl text-brown-100 truncate"
+        class="block font-semibold text-3xl text-(--color-on-accent) truncate"
         :title="displayName"
       >
         {{ displayName || t('member-badge.name-placeholder') }}
       </span>
-      <div data-testid="member-badge__description" class="text-sm text-brown-100 wrap-break-word">
+      <div
+        data-testid="member-badge__description"
+        class="text-sm text-(--color-on-accent) wrap-break-word"
+      >
         <slot name="description">{{ description || t('member-badge.description-fallback') }}</slot>
       </div>
     </div>

--- a/src/components/member/member-card.vue
+++ b/src/components/member/member-card.vue
@@ -32,7 +32,7 @@ const body_bindings = computed(() => memberCoverBindings(cover))
   <div
     data-testid="member-card"
     data-station="panel"
-    class="bg-surface rounded-8 border-surface flex w-89 flex-col overflow-hidden border-8 shadow-[-1px_-1px_0_0_var(--color-brown-100)] dark:shadow-[-1px_-1px_0_0_var(--color-grey-900)]"
+    class="bg-surface rounded-8 border-surface flex w-89 flex-col overflow-hidden border-8 shadow-[-1px_-1px_0_0_var(--color-surface)]"
   >
     <div data-testid="member-card__header" class="flex items-center justify-center px-9 pt-4 pb-1">
       <h1
@@ -80,7 +80,7 @@ const body_bindings = computed(() => memberCoverBindings(cover))
 
       <div
         data-testid="member-card__registration"
-        class="align-center flex w-full justify-between text-sm font-semibold text-brown-100 mt-2"
+        class="align-center flex w-full justify-between text-sm font-semibold text-(--color-on-accent) mt-2"
       >
         <p>{{ t('member-card.field.registration-label', { date: created_on }) }}</p>
         <p aria-hidden="true">&lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt; &lt;</p>

--- a/src/components/taro-phone/app-shell.vue
+++ b/src/components/taro-phone/app-shell.vue
@@ -55,7 +55,7 @@ function spawnBurst() {
         data-testid="phone-app"
         v-bind="$attrs"
         :data-active="playing || null"
-        class="rounded-6 pointer-fine:rounded-6 size-16.5 cursor-pointer hover:scale-110 focus:scale-110 transition-transform duration-50 flex items-center justify-center text-white group outline-none bg-(--color-accent) tap:bgx-diagonal-stripes animation-safe:tap:bgx-slide p-0.5"
+        class="rounded-6 pointer-fine:rounded-6 size-16.5 cursor-pointer hover:scale-110 focus:scale-110 transition-transform duration-50 flex items-center justify-center text-(--color-on-accent) group outline-none bg-(--color-accent) tap:bgx-diagonal-stripes animation-safe:tap:bgx-slide p-0.5"
         @click="onClick"
       >
         <slot>

--- a/src/components/taro-phone/taro-phone-sm.vue
+++ b/src/components/taro-phone/taro-phone-sm.vue
@@ -18,7 +18,8 @@ const store = useTaroPhoneStore()
     <div
       v-if="store.notification_count > 0"
       data-testid="notification-badge"
-      class="absolute top-0 left-0 w-4 h-4 bg-red-500 outline-4 outline-surface rounded-full"
+      data-palette="danger"
+      class="absolute top-0 left-0 w-4 h-4 bg-(--color-accent) outline-4 outline-surface rounded-full"
     ></div>
 
     <div class="w-full h-full bg-well rounded-2.5"></div>

--- a/src/components/ui-kit/pattern-picker.vue
+++ b/src/components/ui-kit/pattern-picker.vue
@@ -45,14 +45,14 @@ function onPatternSelect(p: DeckCoverPattern | undefined) {
         :data-selected="pattern === selected_pattern || undefined"
         v-sfx="{ hover: TYPE_SFX }"
         v-bind="swatchBindings(pattern)"
-        class="w-14.5 aspect-square rounded-6 rounded-tr-3 rounded-bl-3 cursor-pointer bg-(--color-accent) hover:ring-4 data-selected:ring-4 ring-surface relative"
+        class="w-14.5 aspect-square rounded-6 rounded-tr-3 rounded-bl-3 cursor-pointer bg-(--color-accent) hover:ring-4 data-selected:ring-4 ring-knockout relative"
         @click="onPatternSelect(pattern)"
       >
         <div
           v-if="pattern === selected_pattern"
-          class="absolute -top-2 -right-2 bg-surface p-1.5 size-6.5 rounded-full flex items-center justify-center"
+          class="absolute -top-2 -right-2 bg-knockout p-1.5 size-6.5 rounded-full flex items-center justify-center"
         >
-          <ui-icon src="check" class="text-(--color-accent-text)" />
+          <ui-icon src="check" class="text-on-knockout" />
         </div>
       </button>
     </div>

--- a/src/components/ui-kit/pattern-picker.vue
+++ b/src/components/ui-kit/pattern-picker.vue
@@ -52,7 +52,7 @@ function onPatternSelect(p: DeckCoverPattern | undefined) {
           v-if="pattern === selected_pattern"
           class="absolute -top-2 -right-2 bg-knockout p-1.5 size-6.5 rounded-full flex items-center justify-center"
         >
-          <ui-icon src="check" class="text-on-knockout" />
+          <ui-icon src="check" class="text-(--color-accent-text)" />
         </div>
       </button>
     </div>

--- a/src/components/ui-kit/pattern-picker.vue
+++ b/src/components/ui-kit/pattern-picker.vue
@@ -45,12 +45,12 @@ function onPatternSelect(p: DeckCoverPattern | undefined) {
         :data-selected="pattern === selected_pattern || undefined"
         v-sfx="{ hover: TYPE_SFX }"
         v-bind="swatchBindings(pattern)"
-        class="w-14.5 aspect-square rounded-6 rounded-tr-3 rounded-bl-3 cursor-pointer bg-(--color-accent) hover:ring-4 data-selected:ring-4 ring-white relative"
+        class="w-14.5 aspect-square rounded-6 rounded-tr-3 rounded-bl-3 cursor-pointer bg-(--color-accent) hover:ring-4 data-selected:ring-4 ring-surface relative"
         @click="onPatternSelect(pattern)"
       >
         <div
           v-if="pattern === selected_pattern"
-          class="absolute -top-2 -right-2 bg-white p-1.5 size-6.5 rounded-full flex items-center justify-center"
+          class="absolute -top-2 -right-2 bg-surface p-1.5 size-6.5 rounded-full flex items-center justify-center"
         >
           <ui-icon src="check" class="text-(--color-accent-text)" />
         </div>

--- a/src/components/ui-kit/pinned-card.vue
+++ b/src/components/ui-kit/pinned-card.vue
@@ -23,7 +23,7 @@ defineSlots<{
       class="absolute -top-8 right-15 -translate-x-1/2 z-10 drop-shadow-2xs transition-opacity duration-100"
       :class="tucked && 'opacity-0'"
     >
-      <ui-icon src="paperclip" class="w-16 h-16 -rotate-186 text-grey-300 dark:text-grey-700" />
+      <ui-icon src="paperclip" class="w-16 h-16 -rotate-186 text-raised-shade" />
     </div>
 
     <div data-testid="ui-pinned-card__card" class="rotate-4 drop-shadow-sm">

--- a/src/components/ui-kit/radio.vue
+++ b/src/components/ui-kit/radio.vue
@@ -35,7 +35,7 @@ const onClick = tap(undefined, {
     v-sfx="{ hover: sfx.hover, focus: sfx.focus, blur: sfx.blur, debounce: sfx.debounce }"
     @click="onClick"
   >
-    <ui-icon v-if="checked" class="size-5 text-white" src="check" />
+    <ui-icon v-if="checked" class="size-5 text-(--color-on-accent)" src="check" />
     <ui-icon v-if="intermediate" class="size-5" src="subtract" />
   </div>
 </template>

--- a/src/components/ui-kit/scroll-bar.vue
+++ b/src/components/ui-kit/scroll-bar.vue
@@ -208,7 +208,7 @@ function isPageTarget(el: HTMLElement) {
 .ui-kit-scroll-bar {
   --bar-color: var(--color-ink-muted);
   --thumb-color: var(--color-ink-muted);
-  --thumb-hover-color: var(--color-purple-400);
+  --thumb-hover-color: var(--color-accent-muted);
 
   --transition-dur: 0.05s;
   --transition: background-color 0.05s ease-in-out, outline 0.05s ease-in-out;

--- a/src/components/ui-kit/scroll-bar.vue
+++ b/src/components/ui-kit/scroll-bar.vue
@@ -206,9 +206,9 @@ function isPageTarget(el: HTMLElement) {
 
 <style scoped>
 .ui-kit-scroll-bar {
-  --bar-color: var(--color-ink-muted);
-  --thumb-color: var(--color-ink-muted);
-  --thumb-hover-color: var(--color-accent-muted);
+  --bar-color: var(--color-raised);
+  --thumb-color: var(--color-raised);
+  --thumb-hover-color: var(--color-accent);
 
   --transition-dur: 0.05s;
   --transition: background-color 0.05s ease-in-out, outline 0.05s ease-in-out;

--- a/src/components/ui-kit/scroll-bar.vue
+++ b/src/components/ui-kit/scroll-bar.vue
@@ -197,7 +197,7 @@ function isPageTarget(el: HTMLElement) {
     <div
       ref="thumbEl"
       data-testid="ui-kit-scroll-bar__thumb"
-      class="ui-kit-scroll-bar__thumb hover:bgx-diagonal-stripes hover:bgx-color-(--color-raised-pattern)"
+      class="ui-kit-scroll-bar__thumb hover:bgx-diagonal-stripes"
       :style="thumbStyle"
       @pointerdown.stop.prevent="onThumbPointerDown"
     />

--- a/src/components/ui-kit/slider.vue
+++ b/src/components/ui-kit/slider.vue
@@ -125,7 +125,7 @@ const KEY_DELTAS: Record<string, number> = {
 
     <div
       data-testid="ui-kit-slider__handle"
-      class="absolute inset-y-2.5 w-1 -translate-x-1/2 rounded-full bg-(--color-on-accent) dark:bg-brown-100"
+      class="absolute inset-y-2.5 w-1 -translate-x-1/2 rounded-full bg-(--color-on-accent)"
       :style="{ left: offsetOf(value) }"
     ></div>
 
@@ -135,7 +135,7 @@ const KEY_DELTAS: Record<string, number> = {
       aria-hidden="true"
       data-testid="ui-kit-slider__tick"
       :data-visible="tick > value"
-      class="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-brown-500 transition-opacity dark:bg-grey-700"
+      class="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-ink-muted transition-opacity"
       :class="tick > value ? 'opacity-100' : 'opacity-0'"
       :style="{ left: offsetOf(tick) }"
     ></span>

--- a/src/components/ui-kit/tabs.vue
+++ b/src/components/ui-kit/tabs.vue
@@ -54,7 +54,6 @@ function onHover(index: number) {
     <ui-tooltip
       v-for="(tab, index) in tabs"
       data-testid="ui-kit-tabs__tab"
-      theme="white"
       :gap="-4"
       :suppress="active_tab === index"
       class="ui-kit-tabs__tab"

--- a/src/components/ui-kit/tape.vue
+++ b/src/components/ui-kit/tape.vue
@@ -9,7 +9,7 @@ defineProps<{
     data-testid="ui-kit-tape"
     class="inline-flex items-center justify-center whitespace-nowrap px-8 py-2 bg-(--color-accent)/70 tape-edges"
   >
-    <span v-if="label" data-testid="ui-kit-tape__label" class="text-brown-100 text-xl">
+    <span v-if="label" data-testid="ui-kit-tape__label" class="text-(--color-on-accent) text-xl">
       {{ label }}
     </span>
   </div>

--- a/src/components/ui-kit/textarea.vue
+++ b/src/components/ui-kit/textarea.vue
@@ -69,6 +69,7 @@ function onInput() {
         v-if="max_chars !== undefined"
         data-testid="ui-kit-textarea-char-count"
         class="ui-kit-textarea-char-count"
+        :data-palette="at_limit ? 'danger' : undefined"
         :class="{ 'ui-kit-textarea-char-count--limit': at_limit }"
       >
         {{ char_count }}/{{ max_chars }}
@@ -134,12 +135,12 @@ function onInput() {
   text-align: right;
   font-size: var(--text-xs);
   line-height: var(--text-xs--line-height);
-  color: var(--color-brown-500) !important;
+  color: var(--color-ink-muted) !important;
   margin-top: 4px;
 }
 
 .ui-kit-textarea-char-count--limit {
-  color: var(--color-red-500);
+  color: var(--color-accent-text);
 }
 
 .ui-kit-textarea-container--text-left textarea {

--- a/src/components/ui-kit/theme-picker.vue
+++ b/src/components/ui-kit/theme-picker.vue
@@ -42,13 +42,13 @@ function onThemeSelect(option: PaletteName) {
         :data-testid="`theme-picker__option-${option}`"
         :data-palette="option"
         v-sfx="{ hover: TYPE_SFX }"
-        class="w-9 shrink-0 aspect-square bg-(--color-accent) rounded-8 rounded-tr-3 cursor-pointer relative! hover:outline-5 outline-white"
-        :class="{ 'outline-5 outline-white': isSelected(option) }"
+        class="w-9 shrink-0 aspect-square bg-(--color-accent) rounded-8 rounded-tr-3 cursor-pointer relative! hover:outline-5 outline-surface"
+        :class="{ 'outline-5 outline-surface': isSelected(option) }"
         @click="onThemeSelect(option)"
       >
         <div
           v-if="isSelected(option)"
-          class="absolute -top-2 -right-2 bg-white p-1.5 size-6.5 rounded-full flex items-center justify-center"
+          class="absolute -top-2 -right-2 bg-surface p-1.5 size-6.5 rounded-full flex items-center justify-center"
         >
           <ui-icon src="check" class="text-(--color-accent-text)" />
         </div>

--- a/src/components/ui-kit/theme-picker.vue
+++ b/src/components/ui-kit/theme-picker.vue
@@ -42,15 +42,15 @@ function onThemeSelect(option: PaletteName) {
         :data-testid="`theme-picker__option-${option}`"
         :data-palette="option"
         v-sfx="{ hover: TYPE_SFX }"
-        class="w-9 shrink-0 aspect-square bg-(--color-accent) rounded-8 rounded-tr-3 cursor-pointer relative! hover:outline-5 outline-surface"
-        :class="{ 'outline-5 outline-surface': isSelected(option) }"
+        class="w-9 shrink-0 aspect-square bg-(--color-accent) rounded-8 rounded-tr-3 cursor-pointer relative! hover:outline-5 outline-knockout"
+        :class="{ 'outline-5 outline-knockout': isSelected(option) }"
         @click="onThemeSelect(option)"
       >
         <div
           v-if="isSelected(option)"
-          class="absolute -top-2 -right-2 bg-surface p-1.5 size-6.5 rounded-full flex items-center justify-center"
+          class="absolute -top-2 -right-2 bg-knockout p-1.5 size-6.5 rounded-full flex items-center justify-center"
         >
-          <ui-icon src="check" class="text-(--color-accent-text)" />
+          <ui-icon src="check" class="text-on-knockout" />
         </div>
       </button>
     </div>

--- a/src/components/ui-kit/theme-picker.vue
+++ b/src/components/ui-kit/theme-picker.vue
@@ -50,7 +50,7 @@ function onThemeSelect(option: PaletteName) {
           v-if="isSelected(option)"
           class="absolute -top-2 -right-2 bg-knockout p-1.5 size-6.5 rounded-full flex items-center justify-center"
         >
-          <ui-icon src="check" class="text-on-knockout" />
+          <ui-icon src="check" class="text-(--color-accent-text)" />
         </div>
       </button>
     </div>

--- a/src/components/ui-kit/toggle.vue
+++ b/src/components/ui-kit/toggle.vue
@@ -44,7 +44,7 @@ function onChange() {
       />
       <span
         data-testid="ui-kit-toggle__switch-handle"
-        class="size-5 rounded-full transition-all duration-100 ease-in-out bg-brown-500 dark:bg-brown-300 peer-checked:bg-(--color-on-accent) peer-checked:translate-x-full group-hover/toggle:scale-110"
+        class="size-5 rounded-full transition-all duration-100 ease-in-out bg-ink-muted peer-checked:bg-(--color-on-accent) peer-checked:translate-x-full group-hover/toggle:scale-110"
       ></span>
     </span>
   </label>

--- a/src/composables/billing/use-checkout-elements.ts
+++ b/src/composables/billing/use-checkout-elements.ts
@@ -50,9 +50,11 @@ export function useCheckoutElements(options: UseCheckoutElementsOptions) {
       if (!stripeInstance) throw new Error('Stripe.js failed to load')
       stripe = stripeInstance
 
+      const host = container_ref.value ?? document.documentElement
+
       checkout = stripe.initCheckoutElementsSdk({
         clientSecret,
-        elementsOptions: { appearance: getStripeAppearance(is_dark.value), fonts: STRIPE_FONTS }
+        elementsOptions: { appearance: getStripeAppearance(host), fonts: STRIPE_FONTS }
       })
 
       payment_element = checkout.createPaymentElement({ layout: 'tabs' })
@@ -73,7 +75,16 @@ export function useCheckoutElements(options: UseCheckoutElementsOptions) {
     payment_element?.destroy()
   })
 
-  watch(is_dark, (dark) => checkout?.changeAppearance(getStripeAppearance(dark)))
+  // Post-flush so the page has already been switched over to the new mode — the
+  // appearance is read back off the live element, not computed from the flag.
+  watch(
+    is_dark,
+    () => {
+      const host = container_ref.value ?? document.documentElement
+      checkout?.changeAppearance(getStripeAppearance(host))
+    },
+    { flush: 'post' }
+  )
 
   async function confirm(): Promise<ConfirmOutcome> {
     if (!checkout) return { status: 'error', message: options.genericErrorMessage }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -117,14 +117,14 @@
   --color-card: var(--color-white);
   --color-on-card: var(--color-brown-700);
 
-  /* A badge or ring that separates an accent fill from itself — a selected
-     swatch's tick, the outline around it. Flat across stations because it rests
-     on the accent rather than on a station, but it still swaps with the mode.
-     Dark in stations.css.
+  /* Separates an accent fill from itself — the disc behind a selected swatch's
+     tick, the ring around the swatch. Flat across stations because it rests on
+     the accent rather than on a station, but it still swaps with the mode (dark
+     in stations.css): the tick on it is the palette's own hue, which inverts
+     between modes and would go illegible against a frozen white.
      Trap: a station role assumes the thing wearing it rests on a station
      →[K:fixed-roles-skip-the-station] */
   --color-knockout: var(--color-white);
-  --color-on-knockout: var(--color-brown-700);
 
   /* Media backdrop for user avatars. FIXED, not station-relative: avatar images
      are colour-tuned to read against it, so it must be identical everywhere —

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -118,9 +118,9 @@
   --color-on-card: var(--color-brown-700);
 
   /* A badge or ring that separates an accent fill from itself — a selected
-     swatch's tick, the outline around it. FIXED in both modes: it sits on the
-     accent, never on the station, so following the station would sink it into
-     whatever is behind the swatch.
+     swatch's tick, the outline around it. Flat across stations because it rests
+     on the accent rather than on a station, but it still swaps with the mode.
+     Dark in stations.css.
      Trap: a station role assumes the thing wearing it rests on a station
      →[K:fixed-roles-skip-the-station] */
   --color-knockout: var(--color-white);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -117,6 +117,13 @@
   --color-card: var(--color-white);
   --color-on-card: var(--color-brown-700);
 
+  /* A badge or ring that separates an accent fill from itself — a selected
+     swatch's tick, the outline around it. FIXED in both modes: it sits on the
+     accent, never on the station, so following the station would sink it into
+     whatever is behind the swatch. */
+  --color-knockout: var(--color-white);
+  --color-on-knockout: var(--color-brown-700);
+
   /* Media backdrop for user avatars. FIXED, not station-relative: avatar images
      are colour-tuned to read against it, so it must be identical everywhere —
      one tuning pass for light, one for dark. Dark in stations.css. */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -120,7 +120,9 @@
   /* A badge or ring that separates an accent fill from itself — a selected
      swatch's tick, the outline around it. FIXED in both modes: it sits on the
      accent, never on the station, so following the station would sink it into
-     whatever is behind the swatch. */
+     whatever is behind the swatch.
+     Trap: a station role assumes the thing wearing it rests on a station
+     →[K:fixed-roles-skip-the-station] */
   --color-knockout: var(--color-white);
   --color-on-knockout: var(--color-brown-700);
 

--- a/src/styles/stations.css
+++ b/src/styles/stations.css
@@ -25,7 +25,6 @@
   --color-on-card: var(--color-brown-100);
 
   --color-knockout: var(--color-black);
-  --color-on-knockout: var(--color-brown-100);
   --color-mat: var(--color-stone-900);
 }
 

--- a/src/styles/stations.css
+++ b/src/styles/stations.css
@@ -23,6 +23,9 @@
 
   --color-card: var(--color-stone-700);
   --color-on-card: var(--color-brown-100);
+
+  --color-knockout: var(--color-black);
+  --color-on-knockout: var(--color-brown-100);
   --color-mat: var(--color-stone-900);
 }
 

--- a/src/utils/billing/stripe-theme.ts
+++ b/src/utils/billing/stripe-theme.ts
@@ -5,10 +5,6 @@
 import type { Appearance } from '@stripe/stripe-js'
 import { FONT_FAMILY, FONT_URL } from '@/styles/fonts'
 
-function token(name: string): string {
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
-}
-
 /** Stripe doesn't parse `color-mix()` / alpha functions — build an 8-digit hex. */
 function withAlpha(hex: string, percent: number): string {
   const clean = hex.replace('#', '')
@@ -19,19 +15,43 @@ function withAlpha(hex: string, percent: number): string {
 }
 
 /**
- * @param is_dark - Pass the app's own dark-mode flag, not the system
- *   preference — the form has to match the panel it sits in.
+ * The colour a role resolves to for `host`.
+ *
+ * Read it off the element the form actually sits in, never off the page root —
+ * that is what makes the fields pick up the surrounding surface, the member's
+ * colour, and light or dark without any of the three being spelled out here.
  */
-export function getStripeAppearance(is_dark: boolean): Appearance {
-  const danger = token(is_dark ? '--color-red-600' : '--color-red-500')
-  const accent = token(is_dark ? '--color-blue-650' : '--color-blue-500')
+function role(host: HTMLElement, name: string): string {
+  return getComputedStyle(host).getPropertyValue(name).trim()
+}
 
-  const background = token(is_dark ? '--color-stone-900' : '--color-brown-50')
-  const surface = token(is_dark ? '--color-grey-700' : '--color-brown-100')
-  const surfaceHover = token(is_dark ? '--color-grey-900' : '--color-brown-200')
-  const border = token(is_dark ? '--color-grey-700' : '--color-brown-300')
-  const text = token(is_dark ? '--color-brown-300' : '--color-brown-700')
-  const placeholder = token(is_dark ? '--color-brown-500' : '--color-brown-500')
+/** The colour a role resolves to for `host` once `palette` is put on it. */
+function paletteRole(host: HTMLElement, palette: string, name: string): string {
+  const probe = document.createElement('span')
+  probe.dataset.palette = palette
+  host.appendChild(probe)
+
+  const value = role(probe, name)
+  probe.remove()
+
+  return value
+}
+
+/**
+ * How the embedded payment form should look.
+ *
+ * @param host - The element the form is mounted into.
+ */
+export function getStripeAppearance(host: HTMLElement): Appearance {
+  const accent = role(host, '--color-accent')
+  const danger = paletteRole(host, 'danger', '--color-accent')
+
+  const background = role(host, '--color-well')
+  const surface = role(host, '--color-surface')
+  const surfaceHover = role(host, '--color-raised')
+  const border = role(host, '--color-line')
+  const text = role(host, '--color-ink')
+  const placeholder = role(host, '--color-ink-muted')
 
   return {
     theme: 'flat',

--- a/src/utils/billing/stripe-theme.ts
+++ b/src/utils/billing/stripe-theme.ts
@@ -17,9 +17,9 @@ function withAlpha(hex: string, percent: number): string {
 /**
  * The colour a role resolves to for `host`.
  *
- * Read it off the element the form actually sits in, never off the page root —
- * that is what makes the fields pick up the surrounding surface, the member's
- * colour, and light or dark without any of the three being spelled out here.
+ * @param host - The element the form sits in, never the page root — reading it
+ *   here is what picks up the surrounding surface, the member's colour and the
+ *   current mode without any of the three being named.
  */
 function role(host: HTMLElement, name: string): string {
   return getComputedStyle(host).getPropertyValue(name).trim()

--- a/src/utils/cover/tokens.ts
+++ b/src/utils/cover/tokens.ts
@@ -25,6 +25,11 @@ export const SUPPORTED_ICONS: string[] = [
 
 export const BORDER_SIZE_PX = 16
 
+/** Yellow, except on a yellow cover — there the icon would vanish into the fill. */
+export function coverIconPalette(cover_palette?: PaletteName): PaletteName {
+  return cover_palette === 'yellow' ? 'purple' : 'yellow'
+}
+
 // The cover a deck wears while it's still loading. Every skeleton reads this
 // one, so a loading deck looks the same wherever it appears.
 export const SKELETON_COVER: DeckCover = {

--- a/src/views/app-shell/nav-bar/index.vue
+++ b/src/views/app-shell/nav-bar/index.vue
@@ -17,14 +17,14 @@ onMounted(() => {
   <nav
     data-testid="nav-bar-container"
     ref="nav-bar"
-    class="w-full sticky top-0 z-50 transform-[translateZ(0)] pt-4 pb-8 bg-blue-500 dark:bg-blue-650 wave-bottom-[30px] flex justify-center"
+    class="w-full sticky top-0 z-50 transform-[translateZ(0)] pt-4 pb-8 bg-(--color-accent) wave-bottom-[30px] flex justify-center"
   >
     <div
       data-testid="nav-bar"
       class="flex w-full max-w-(--page-width) items-center max-sm:justify-center gap-4 sm:px-(--page-px) relative"
     >
       <back-button class="absolute! left-4" />
-      <div class="flex items-center gap-1 text-4xl text-brown-100">
+      <div class="flex items-center gap-1 text-4xl text-(--color-on-accent)">
         <ui-icon src="logo" class="h-9" />
         <div>{{ t('app.title') }}</div>
       </div>

--- a/src/views/audio-reader/collection-card.vue
+++ b/src/views/audio-reader/collection-card.vue
@@ -18,7 +18,7 @@ const { t } = useI18n()
   <div
     data-testid="collection-card"
     data-station="panel"
-    class="group relative flex w-56 flex-col gap-3 rounded-7 bg-brown-200 p-4 text-left dark:bg-grey-700"
+    class="group relative flex w-56 flex-col gap-3 rounded-7 bg-surface p-4 text-left"
   >
     <button
       data-testid="collection-card__open"
@@ -28,7 +28,7 @@ const { t } = useI18n()
     >
       <span
         data-testid="collection-card__icon"
-        class="flex size-10 items-center justify-center rounded-full bg-blue-500 text-white dark:bg-blue-650"
+        class="flex size-10 items-center justify-center rounded-full bg-(--color-accent) text-(--color-on-accent)"
       >
         <ui-icon src="card-deck" class="h-5" />
       </span>

--- a/src/views/audio-reader/collection-edit-modal.vue
+++ b/src/views/audio-reader/collection-edit-modal.vue
@@ -165,7 +165,8 @@ watch(
 
       <section
         data-testid="collection-edit__danger-zone"
-        class="flex flex-col gap-2 rounded-7 border border-red-300 p-4 dark:border-red-500/40"
+        data-palette="danger"
+        class="flex flex-col gap-2 rounded-7 border border-(--color-accent-muted) p-4"
       >
         <h3 class="text-xl text-ink">
           {{ t('collection-edit.danger-zone.heading') }}

--- a/src/views/audio-reader/lesson-card.vue
+++ b/src/views/audio-reader/lesson-card.vue
@@ -42,9 +42,7 @@ const status_icon = computed(() => {
   return 'music-note'
 })
 
-const icon_class = computed(() =>
-  is_failed.value ? 'bg-red-500 text-white' : 'bg-blue-500 text-white dark:bg-blue-650'
-)
+const icon_palette = computed(() => (is_failed.value ? 'danger' : undefined))
 
 const processing_label = computed(() =>
   lesson.phase ? PHASE_KEYS[lesson.phase] : 'audio-reader.lesson-card.processing-fallback'
@@ -60,7 +58,7 @@ const error_label = computed(
     data-testid="lesson-card"
     data-station="panel"
     :data-status="lesson.status"
-    class="group relative flex w-56 flex-col gap-3 rounded-7 bg-brown-200 p-4 text-left dark:bg-grey-700"
+    class="group relative flex w-56 flex-col gap-3 rounded-7 bg-surface p-4 text-left"
   >
     <button
       data-testid="lesson-card__open"
@@ -71,8 +69,8 @@ const error_label = computed(
     >
       <span
         data-testid="lesson-card__icon"
-        class="flex size-10 items-center justify-center rounded-full"
-        :class="icon_class"
+        :data-palette="icon_palette"
+        class="flex size-10 items-center justify-center rounded-full bg-(--color-accent) text-(--color-on-accent)"
       >
         <ui-icon :src="status_icon" class="h-5" />
       </span>

--- a/src/views/audio-reader/lesson/chapter-list.vue
+++ b/src/views/audio-reader/lesson/chapter-list.vue
@@ -39,7 +39,7 @@ const active_index = computed(() => {
       data-testid="chapter-list__item"
       :data-active="i === active_index"
       type="button"
-      class="flex shrink-0 cursor-pointer items-center gap-3 rounded-7 bg-brown-200 px-4 py-2 text-left text-brown-700 data-[active=true]:bg-blue-500 data-[active=true]:text-white xl:shrink dark:bg-grey-700 dark:text-brown-200 dark:data-[active=true]:bg-blue-650"
+      class="flex shrink-0 cursor-pointer items-center gap-3 rounded-7 bg-raised px-4 py-2 text-left text-ink data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-on-accent) xl:shrink"
       @click="emit('seek', chapter.start)"
     >
       <span data-testid="chapter-list__time" class="shrink-0 text-base tabular-nums opacity-70">

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -283,7 +283,7 @@ onBeforeUnmount(() => {
             data-testid="lesson-view__chapter"
             :data-active="chapter.id === lesson_id"
             type="button"
-            class="shrink-0 cursor-pointer rounded-7 bg-brown-200 px-4 py-2 text-left text-base text-brown-700 data-[active=true]:bg-blue-500 data-[active=true]:text-white xl:shrink dark:bg-grey-700 dark:text-brown-200 dark:data-[active=true]:bg-blue-650"
+            class="shrink-0 cursor-pointer rounded-7 bg-raised px-4 py-2 text-left text-base text-ink data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-on-accent) xl:shrink"
             @click="goToChapter(chapter.id)"
           >
             <span class="line-clamp-1">{{ chapter.title }}</span>

--- a/src/views/audio-reader/lesson/scrubber.vue
+++ b/src/views/audio-reader/lesson/scrubber.vue
@@ -60,7 +60,7 @@ function onScrubMove(e: PointerEvent) {
     <span
       v-if="layout === 'inline'"
       data-testid="scrubber__current"
-      class="hidden shrink-0 text-base text-ink-muted tabular-nums sm:block dark:text-brown-300"
+      class="hidden shrink-0 text-base text-ink-muted tabular-nums sm:block"
     >
       {{ current_label }}
     </span>
@@ -69,7 +69,7 @@ function onScrubMove(e: PointerEvent) {
       ref="track"
       data-testid="scrubber__track"
       :data-layout="layout"
-      class="relative h-2.5 min-w-0 cursor-pointer touch-none rounded-full bg-brown-200 data-[layout=inline]:flex-1 dark:bg-grey-700"
+      class="relative h-2.5 min-w-0 cursor-pointer touch-none rounded-full bg-well data-[layout=inline]:flex-1"
       role="slider"
       :aria-valuemin="0"
       :aria-valuemax="100"
@@ -79,13 +79,13 @@ function onScrubMove(e: PointerEvent) {
     >
       <div
         data-testid="scrubber__fill"
-        class="absolute top-0 left-0 h-2.5 rounded-full bg-blue-500 dark:bg-blue-650"
+        class="absolute top-0 left-0 h-2.5 rounded-full bg-(--color-accent)"
         :style="{ width: fill_width }"
       ></div>
 
       <div
         data-testid="scrubber__thumb"
-        class="absolute top-1/2 left-0 size-4 rounded-full bg-blue-500 dark:bg-blue-650"
+        class="absolute top-1/2 left-0 size-4 rounded-full bg-(--color-accent)"
         :style="{ left: `${progress}%`, translate: `-${progress}% -50%` }"
       ></div>
     </div>
@@ -93,7 +93,7 @@ function onScrubMove(e: PointerEvent) {
     <span
       v-if="layout === 'inline'"
       data-testid="scrubber__duration"
-      class="hidden shrink-0 text-base text-ink-muted tabular-nums sm:block dark:text-brown-300"
+      class="hidden shrink-0 text-base text-ink-muted tabular-nums sm:block"
     >
       {{ duration_label }}
     </span>
@@ -101,7 +101,7 @@ function onScrubMove(e: PointerEvent) {
     <div
       v-if="layout === 'stacked'"
       data-testid="scrubber__labels"
-      class="absolute inset-x-0 top-full mt-1 flex justify-between text-base text-ink-muted tabular-nums dark:text-brown-300"
+      class="absolute inset-x-0 top-full mt-1 flex justify-between text-base text-ink-muted tabular-nums"
     >
       <span data-testid="scrubber__current">{{ current_label }}</span>
       <span data-testid="scrubber__duration">{{ duration_label }}</span>

--- a/src/views/audio-reader/term-popover/term-card.vue
+++ b/src/views/audio-reader/term-popover/term-card.vue
@@ -142,11 +142,7 @@ watch(
 </script>
 
 <template>
-  <div
-    data-testid="term-card"
-    class="relative [--skeleton-sheen:var(--color-brown-200)] dark:[--skeleton-sheen:var(--color-brown-500)]"
-    :class="{ 'overflow-hidden': sliding }"
-  >
+  <div data-testid="term-card" class="relative" :class="{ 'overflow-hidden': sliding }">
     <transition
       :css="false"
       @enter="onSlideEnter"
@@ -229,10 +225,7 @@ watch(
             {{ result.reading }}
           </span>
 
-          <span
-            v-else-if="is_loading"
-            class="term-card__skeleton h-4 w-24 rounded-2 bg-brown-500 dark:bg-brown-500"
-          />
+          <span v-else-if="is_loading" class="term-card__skeleton h-4 w-24 rounded-2 bg-skeleton" />
         </div>
 
         <ui-divider class="my-3">
@@ -260,9 +253,9 @@ watch(
             aria-busy="true"
             :aria-label="t('audio-reader.popover.loading')"
           >
-            <span class="term-card__skeleton h-6 w-3/5 rounded-2 bg-brown-500 dark:bg-brown-500" />
-            <span class="term-card__skeleton h-4 w-full rounded-2 bg-brown-500 dark:bg-brown-500" />
-            <span class="term-card__skeleton h-4 w-4/5 rounded-2 bg-brown-500 dark:bg-brown-500" />
+            <span class="term-card__skeleton h-6 w-3/5 rounded-2 bg-skeleton" />
+            <span class="term-card__skeleton h-4 w-full rounded-2 bg-skeleton" />
+            <span class="term-card__skeleton h-4 w-4/5 rounded-2 bg-skeleton" />
           </div>
 
           <p
@@ -275,10 +268,7 @@ watch(
           </p>
 
           <div v-else-if="result" data-testid="term-card__result" class="flex flex-col gap-1">
-            <p
-              data-testid="term-card__translation"
-              class="text-3xl text-brown-700 capitalize dark:text-brown-200"
-            >
+            <p data-testid="term-card__translation" class="text-3xl text-ink capitalize">
               {{ result.translation }}
             </p>
             <p
@@ -335,7 +325,7 @@ body:not(.animation-safe) .term-card__skeleton::after {
   position: absolute;
   inset: 0;
   transform: translateX(-100%);
-  background: linear-gradient(90deg, transparent, var(--skeleton-sheen), transparent);
+  background: linear-gradient(90deg, transparent, var(--color-skeleton-sheen), transparent);
   animation: term-card-skeleton-sweep 1.4s ease-in-out infinite;
 }
 

--- a/src/views/audio-reader/transcript/index.vue
+++ b/src/views/audio-reader/transcript/index.vue
@@ -262,7 +262,7 @@ watch(
         data-testid="transcript-view__hover"
         aria-hidden="true"
         :data-playing="tap_active"
-        class="group/pill pointer-events-none absolute left-0 top-0 -z-10 rounded-2 bg-blue-500 opacity-0 dark:bg-blue-650"
+        class="group/pill pointer-events-none absolute left-0 top-0 -z-10 rounded-2 bg-(--color-accent) opacity-0"
       >
         <div
           data-testid="transcript-view__hover-texture"
@@ -288,7 +288,7 @@ watch(
           <h2 class="text-xl font-medium text-ink-muted">
             {{ rows[vrow.index].chapter_title }}
           </h2>
-          <hr class="w-16 border-brown-700 dark:border-brown-700" />
+          <hr class="w-16 border-ink" />
         </div>
 
         <transcript-segment

--- a/src/views/audio-reader/transcript/segment.vue
+++ b/src/views/audio-reader/transcript/segment.vue
@@ -16,7 +16,7 @@ const { group, index } = defineProps<{
         data-testid="transcript-word"
         :data-word-index="word.index"
         :data-word-text="word.display"
-        class="group/word cursor-pointer transition-colors duration-700 ease-out data-[playing=true]:duration-100 data-[active=true]:duration-100 data-[active=true]:text-white not-data-[active=true]:data-[playing=true]:text-blue-500 dark:not-data-[active=true]:data-[playing=true]:text-blue-650"
+        class="group/word cursor-pointer transition-colors duration-700 ease-out data-[playing=true]:duration-100 data-[active=true]:duration-100 data-[active=true]:text-(--color-on-accent) not-data-[active=true]:data-[playing=true]:text-(--color-accent-text)"
         ><span
           data-word-base
           class="inline-block origin-center leading-none transition-transform duration-700 ease-out group-data-[playing=true]/word:scale-115 group-data-[playing=true]/word:duration-100"

--- a/src/views/audio-reader/transcript/word.vue
+++ b/src/views/audio-reader/transcript/word.vue
@@ -11,7 +11,7 @@ defineProps<{
     data-testid="transcript-word"
     :data-word-index="index"
     :data-word-text="display"
-    class="group/word cursor-pointer transition-colors duration-700 ease-out data-[playing=true]:duration-100 data-[active=true]:duration-100 data-[active=true]:text-white not-data-[active=true]:data-[playing=true]:text-blue-500 dark:not-data-[active=true]:data-[playing=true]:text-blue-650"
+    class="group/word cursor-pointer transition-colors duration-700 ease-out data-[playing=true]:duration-100 data-[active=true]:duration-100 data-[active=true]:text-(--color-on-accent) not-data-[active=true]:data-[playing=true]:text-(--color-accent-text)"
     ><span
       data-word-base
       class="inline-block origin-center leading-none transition-transform duration-700 ease-out group-data-[playing=true]/word:scale-115 group-data-[playing=true]/word:duration-100"

--- a/src/views/audio-reader/upload-lesson-modal/index.vue
+++ b/src/views/audio-reader/upload-lesson-modal/index.vue
@@ -119,7 +119,7 @@ function errorKeyFor(error: unknown): string {
 
       <label
         data-testid="upload-lesson__file"
-        class="flex cursor-pointer items-center gap-3 rounded-7 border-2 border-dashed border-brown-500 p-4 text-brown-700 dark:border-grey-700 dark:text-brown-300"
+        class="flex cursor-pointer items-center gap-3 rounded-7 border-2 border-dashed border-line p-4 text-ink"
       >
         <ui-icon src="music-note" class="h-5" />
         <span data-testid="upload-lesson__file-name">

--- a/src/views/audio-reader/upload-lesson-modal/script-select.vue
+++ b/src/views/audio-reader/upload-lesson-modal/script-select.vue
@@ -33,7 +33,7 @@ function onOption(e: MouseEvent, value: TranscriptScript) {
       {{ t('audio-reader.upload.script-label') }}
     </span>
 
-    <div class="flex gap-1 rounded-5 bg-brown-100 p-1 dark:bg-stone-900">
+    <div class="flex gap-1 rounded-5 bg-well p-1">
       <button
         v-for="option in OPTIONS"
         :key="option.value"
@@ -41,7 +41,7 @@ function onOption(e: MouseEvent, value: TranscriptScript) {
         data-testid="upload-lesson__script-option"
         :data-value="option.value"
         :data-active="script === option.value"
-        class="flex-1 cursor-pointer rounded-4 px-3 py-2 text-sm transition-colors data-[active=false]:text-brown-700 data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-on-accent) data-[active=false]:hover:bg-(--color-accent)/10 dark:data-[active=false]:text-brown-300"
+        class="flex-1 cursor-pointer rounded-4 px-3 py-2 text-sm transition-colors data-[active=false]:text-ink data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-on-accent) data-[active=false]:hover:bg-(--color-accent)/10"
         :data-playing="playing || null"
         v-sfx="{ hover: TYPE_SFX }"
         @click="(e) => onOption(e, option.value)"

--- a/src/views/dashboard/dashboard-section.vue
+++ b/src/views/dashboard/dashboard-section.vue
@@ -19,7 +19,7 @@ defineSlots<{
       <h2
         data-testid="dashboard-section__label"
         class="text-3xl"
-        :class="loading ? 'text-brown-300 dark:text-stone-700' : 'text-ink'"
+        :class="loading ? 'text-skeleton' : 'text-ink'"
       >
         {{ label }}
       </h2>

--- a/src/views/dashboard/deck-grid/item.vue
+++ b/src/views/dashboard/deck-grid/item.vue
@@ -79,7 +79,7 @@ function onOptionSelect(option: DropdownOption) {
             :trigger-icon="dropdown?.open ? 'close' : 'more'"
             position="bottom-end"
             :options="deck_options"
-            class="[&>button]:ring-4 [&>button]:ring-brown-100 dark:[&>button]:ring-grey-900"
+            class="[&>button]:ring-4 [&>button]:ring-surface"
             @select="onOptionSelect"
           />
         </div>

--- a/src/views/dashboard/deck-grid/sort-options.vue
+++ b/src/views/dashboard/deck-grid/sort-options.vue
@@ -36,7 +36,7 @@ function onOptionClicked(option: SortOption) {
       :key="option.key"
       :data-testid="`deck-grid-sort-options__${option.key}`"
       :data-active="option.key === selected"
-      class="cursor-pointer shrink-0 data-[active=true]:text-brown-700 data-[active=true]:underline data-[active=true]:underline-offset-8 dark:data-[active=true]:text-brown-100"
+      class="cursor-pointer shrink-0 data-[active=true]:text-ink data-[active=true]:underline data-[active=true]:underline-offset-8"
       @click="onOptionClicked(option.key)"
     >
       {{ t(option.label_key) }}

--- a/src/views/dashboard/review-inbox/item.vue
+++ b/src/views/dashboard/review-inbox/item.vue
@@ -21,7 +21,8 @@ const { disabled = false } = defineProps<ReviewInboxItemProps>()
 
     <div
       data-testid="review-inbox-item__due-badge"
-      class="absolute -top-1 -right-1 min-w-7 h-7 px-1.5 aspect-square rounded-full bg-red-400 dark:bg-red-500 ring-3 ring-surface flex items-center justify-center text-sm font-semibold text-white"
+      data-palette="danger"
+      class="absolute -top-1 -right-1 min-w-7 h-7 px-1.5 aspect-square rounded-full bg-(--color-accent) ring-3 ring-surface flex items-center justify-center text-sm font-semibold text-(--color-on-accent)"
     >
       {{ deck.due_count }}
     </div>

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -55,17 +55,16 @@ function onClick(e: MouseEvent) {
     data-testid="card-list-item"
     :data-id="card.id"
     :data-dragging="dragging"
-    class="group/listitem relative grid w-full grid-cols-1 sm:grid-cols-[1fr_auto_1fr] sm:gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-[color,background-color,box-shadow] duration-150 ease-in-out hover:not-focus-within:bg-brown-200 dark:hover:not-focus-within:bg-stone-900 data-[dragging=true]:not-focus-within:bg-brown-200 dark:data-[dragging=true]:not-focus-within:bg-stone-900 data-[dragging=true]:shadow-sm"
+    class="group/listitem relative grid w-full grid-cols-1 sm:grid-cols-[1fr_auto_1fr] sm:gap-x-6 place-items-center rounded-6 bg-transparent p-0 sm:p-6 transition-[color,background-color,box-shadow] duration-150 ease-in-out hover:not-focus-within:bg-raised-tint data-[dragging=true]:not-focus-within:bg-raised-tint data-[dragging=true]:shadow-sm"
     :class="{
       'cursor-pointer': is_selecting,
-      'focus-within:bg-brown-300 hover:focus-within:bg-brown-300 dark:focus-within:bg-blue-650 dark:hover:focus-within:bg-blue-650':
-        !is_selecting
+      'focus-within:bg-raised hover:focus-within:bg-raised': !is_selecting
     }"
     @mousedown="onClick"
   >
     <button
       data-testid="card-list-item__reorder"
-      class="hidden h-12 w-12 cursor-grab touch-none items-center justify-center rounded-full bg-brown-300 text-lg text-brown-700 sm:flex group-focus-within/listitem:bg-brown-100 row-span-2 dark:bg-stone-700 dark:text-brown-100 dark:group-focus-within/listitem:bg-stone-900"
+      class="hidden h-12 w-12 cursor-grab touch-none items-center justify-center rounded-full bg-raised text-lg text-ink sm:flex group-focus-within/listitem:bg-surface row-span-2"
       v-sfx="dragging ? {} : { hover: TYPE_SFX }"
       @click.stop
       @pointerdown="emit('reorderPointerdown', $event)"

--- a/src/views/deck/card-grid/grid-item.vue
+++ b/src/views/deck/card-grid/grid-item.vue
@@ -126,7 +126,7 @@ watch(
       trigger-only
       :trigger-icon="dropdown?.open ? 'close' : 'more'"
       position="bottom-end"
-      class="absolute -top-1 -right-1 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto data-[active=true]:opacity-100 data-[active=true]:pointer-events-auto [&>button]:ring-4 [&>button]:ring-brown-100 dark:[&>button]:ring-grey-900"
+      class="absolute -top-1 -right-1 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto data-[active=true]:opacity-100 data-[active=true]:pointer-events-auto [&>button]:ring-4 [&>button]:ring-surface"
       :options="menu_options"
       @select="onMenuSelect"
     />

--- a/src/views/deck/card-import/drop-zone.vue
+++ b/src/views/deck/card-import/drop-zone.vue
@@ -74,6 +74,7 @@ watch(drag_depth, (now, was) => {
     data-testid="card-import-drop-zone"
     :data-active="drag_depth > 0 || undefined"
     :data-error="error ? '' : undefined"
+    :data-palette="error ? 'danger' : undefined"
     class="card-import-drop-zone"
     v-sfx="{ hover: TYPE_SFX }"
     @dragenter="onDragEnter"
@@ -152,27 +153,27 @@ watch(drag_depth, (now, was) => {
    never produces a hover, so the drag state has to claim the same treatment. */
 .card-import-drop-zone:hover,
 .card-import-drop-zone[data-active] {
-  border-color: var(--color-blue-500);
-  color: var(--color-blue-500);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 /* Below the dock's own breakpoint the zone lives in the bottom bar, where there
    is no pointer to hover it — resting neutral would leave it neutral forever. */
 @media (width < 52rem) {
   .card-import-drop-zone {
-    border-color: var(--color-blue-500);
-    color: var(--color-blue-500);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
   }
 }
 
 /* A file held over the zone fills it in, so the drop target reads as live
    without the prompt changing under the pointer. */
 .card-import-drop-zone[data-active] {
-  background-color: color-mix(in srgb, var(--color-blue-500) 15%, var(--color-well));
+  background-color: color-mix(in srgb, var(--color-accent) 15%, var(--color-well));
 }
 
 .card-import-drop-zone[data-error] {
-  border-color: var(--color-red-500);
-  color: var(--color-red-500);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 </style>

--- a/src/views/deck/cover-designer/icon-picker.vue
+++ b/src/views/deck/cover-designer/icon-picker.vue
@@ -1,17 +1,22 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { emitSfx } from '@/sfx/bus'
 import { TYPE_SFX } from '@/sfx/config'
 import UiIcon from '@/components/ui-kit/icon.vue'
+import { coverIconPalette } from '@/utils/cover'
 
 const { t } = useI18n()
 
 type IconPickerProps = {
   supported_icons: string[]
   icon: string | undefined
+  palette: PaletteName | undefined
 }
 
-const { icon } = defineProps<IconPickerProps>()
+const { icon, palette } = defineProps<IconPickerProps>()
+
+const icon_palette = computed(() => coverIconPalette(palette))
 
 const emit = defineEmits<{
   (e: 'update:icon', icon: string | undefined): void
@@ -40,10 +45,10 @@ function onIconSelect(value: string | undefined) {
         :data-testid="`icon-picker__option-${name}`"
         :data-selected="name === icon || undefined"
         v-sfx="{ hover: TYPE_SFX }"
-        class="w-14.5 aspect-square rounded-6 cursor-pointer flex items-center justify-center bg-raised text-ink-muted [&_svg]:size-6 data-selected:bg-(--color-accent) data-selected:text-(--color-accent-muted) hover:bg-(--color-accent) hover:text-(--color-accent-muted) hover:bgx-diagonal-stripes hover:bgx-opacity-10 data-selected:bgx-diagonal-stripes data-selected:bgx-opacity-10 transition-colors duration-75 hover:[&_svg]:scale-120 hover:[&_svg]:rotate-6"
+        class="w-14.5 aspect-square rounded-6 cursor-pointer flex items-center justify-center bg-raised [&_svg]:size-6 data-selected:bg-(--color-accent) hover:bg-(--color-accent) hover:bgx-diagonal-stripes hover:bgx-opacity-10 data-selected:bgx-diagonal-stripes data-selected:bgx-opacity-10 transition-colors duration-75 hover:[&_svg]:scale-120 hover:[&_svg]:rotate-6"
         @click="onIconSelect(name)"
       >
-        <ui-icon :src="name" />
+        <ui-icon :src="name" :data-palette="icon_palette" class="text-(--color-accent)" />
       </button>
     </div>
   </div>

--- a/src/views/deck/cover-designer/icon-picker.vue
+++ b/src/views/deck/cover-designer/icon-picker.vue
@@ -45,10 +45,14 @@ function onIconSelect(value: string | undefined) {
         :data-testid="`icon-picker__option-${name}`"
         :data-selected="name === icon || undefined"
         v-sfx="{ hover: TYPE_SFX }"
-        class="w-14.5 aspect-square rounded-6 cursor-pointer flex items-center justify-center bg-raised [&_svg]:size-6 data-selected:bg-(--color-accent) hover:bg-(--color-accent) hover:bgx-diagonal-stripes hover:bgx-opacity-10 data-selected:bgx-diagonal-stripes data-selected:bgx-opacity-10 transition-colors duration-75 hover:[&_svg]:scale-120 hover:[&_svg]:rotate-6"
+        class="w-14.5 aspect-square rounded-6 cursor-pointer flex items-center justify-center bg-raised text-ink-muted [&_svg]:size-6 data-selected:bg-(--color-accent) hover:bg-(--color-accent) hover:text-(--color-accent-muted) hover:bgx-diagonal-stripes hover:bgx-opacity-10 data-selected:bgx-diagonal-stripes data-selected:bgx-opacity-10 transition-colors duration-75 hover:[&_svg]:scale-120 hover:[&_svg]:rotate-6"
         @click="onIconSelect(name)"
       >
-        <ui-icon :src="name" :data-palette="icon_palette" class="text-(--color-accent)" />
+        <ui-icon
+          :src="name"
+          :data-palette="icon_palette"
+          :class="name === icon && 'text-(--color-accent)'"
+        />
       </button>
     </div>
   </div>

--- a/src/views/deck/cover-designer/index.vue
+++ b/src/views/deck/cover-designer/index.vue
@@ -34,6 +34,7 @@ const { t } = useI18n()
       <icon-picker
         :supported_icons="SUPPORTED_ICONS"
         :icon="config.icon"
+        :palette="config.palette"
         @update:icon="config.icon = $event"
       />
     </section-list>

--- a/src/views/deck/deck-hero/bulk-actions.vue
+++ b/src/views/deck/deck-hero/bulk-actions.vue
@@ -82,7 +82,7 @@ function onSelect(value: string) {
       @press="actions.onDeleteCards()"
     >
       {{ t('deck-view.bulk-actions.delete-prefix') }}
-      <span class="bg-brown-100 px-1 py-0.5 -rotate-5 rounded-1.5 text-red-500 dark:text-red-600">
+      <span class="bg-(--color-on-accent) px-1 py-0.5 -rotate-5 rounded-1.5 text-(--color-accent)">
         {{ selection.selected_count.value }}
       </span>
       {{ t('deck-view.bulk-actions.delete-cards-label', selection.selected_count.value) }}

--- a/src/views/deck/deck-hero/study-button.vue
+++ b/src/views/deck/deck-hero/study-button.vue
@@ -32,14 +32,14 @@ function onStudyClicked() {
     :disabled="is_disabled"
     @press="onStudyClicked"
   >
-    <div v-if="has_due_cards" class="text-brown-100">
+    <div v-if="has_due_cards" class="text-(--color-on-accent)">
       {{ t('deck-view.hero.study') }}
-      <span class="bg-brown-100 dark:text-blue-650 text-blue-500 px-1 py-0.5 -rotate-5 rounded-1.5">
+      <span class="bg-(--color-on-accent) text-(--color-accent) px-1 py-0.5 -rotate-5 rounded-1.5">
         {{ deck.due_count }}
       </span>
       {{ t('deck-view.hero.cards-label') }}
     </div>
-    <div v-else class="text-brown-100">
+    <div v-else class="text-(--color-on-accent)">
       {{ t('deck-view.hero.no-cards-due') }}
     </div>
   </ui-button>

--- a/src/views/deck/deck-settings/index.vue
+++ b/src/views/deck/deck-settings/index.vue
@@ -192,10 +192,7 @@ watch([preview_el, aside_el], ([preview]) => {
         class="w-full flex flex-col max-md:items-center max-md:text-center"
         :class="layout_mode === 'tablet' && 'pt-4'"
       >
-        <h1
-          data-testid="deck-settings__header-title"
-          class="flex items-center gap-3 text-5xl text-white"
-        >
+        <h1 data-testid="deck-settings__header-title" class="flex items-center gap-3 text-5xl">
           {{ header_title }}
         </h1>
       </div>

--- a/src/views/deck/deck-settings/tab-design/card-designer/image-layout-picker.vue
+++ b/src/views/deck/deck-settings/tab-design/card-designer/image-layout-picker.vue
@@ -34,7 +34,7 @@ function onSelect(value: CardImageLayout) {
       type="button"
       :data-testid="`image-layout-picker__option-${option}`"
       :data-active="selected === option"
-      class="group relative flex cursor-pointer flex-col items-center gap-2 rounded-8 p-2 transition-colors hover:bg-brown-500 dark:hover:bg-grey-700 hover:bgx-diagonal-stripes hover:bgx-opacity-10 data-[active=true]:bg-(--color-accent) data-[active=true]:bgx-diagonal-stripes data-[active=true]:bgx-opacity-10"
+      class="group relative flex cursor-pointer flex-col items-center gap-2 rounded-8 p-2 transition-colors hover:bg-raised-shade hover:bgx-diagonal-stripes hover:bgx-opacity-10 data-[active=true]:bg-(--color-accent) data-[active=true]:bgx-diagonal-stripes data-[active=true]:bgx-opacity-10"
       @click="onSelect(option)"
       v-sfx="{ hover: selected === option ? undefined : TYPE_SFX }"
     >
@@ -46,7 +46,7 @@ function onSelect(value: CardImageLayout) {
 
       <span
         data-testid="image-layout-picker__label"
-        class="text-sm text-brown-700 group-hover:text-(--color-on-accent) group-data-[active=true]:text-(--color-on-accent) dark:text-brown-100"
+        class="text-sm text-ink group-hover:text-(--color-on-accent) group-data-[active=true]:text-(--color-on-accent)"
       >
         {{ t(`deck.settings-modal.design.card-designer.image-layout.option-${option}`) }}
       </span>

--- a/src/views/deck/deck-settings/tab-design/card-designer/layout-skeleton.vue
+++ b/src/views/deck/deck-settings/tab-design/card-designer/layout-skeleton.vue
@@ -10,7 +10,7 @@ const { layout } = defineProps<LayoutSkeletonProps>()
   <div
     data-testid="layout-skeleton"
     :data-layout="layout"
-    class="relative h-full w-full overflow-hidden rounded-(--face-radius) bg-brown-100 dark:bg-stone-700 p-3"
+    class="relative h-full w-full overflow-hidden rounded-(--face-radius) bg-card p-3"
   >
     <div
       class="flex h-full w-full flex-col justify-center gap-3"
@@ -20,8 +20,8 @@ const { layout } = defineProps<LayoutSkeletonProps>()
         data-testid="layout-skeleton__text"
         class="flex shrink-0 flex-col gap-1 items-center z-1"
       >
-        <span class="h-1.5 w-3/4 rounded-full bg-brown-500"></span>
-        <span class="h-1.5 w-1/2 rounded-full bg-brown-500"></span>
+        <span class="h-1.5 w-3/4 rounded-full bg-ink-muted"></span>
+        <span class="h-1.5 w-1/2 rounded-full bg-ink-muted"></span>
       </div>
       <div
         data-testid="layout-skeleton__image"

--- a/src/views/deck/mobile-editor/index.vue
+++ b/src/views/deck/mobile-editor/index.vue
@@ -29,7 +29,7 @@ onUnmounted(() => onClosed())
     :close_label="t('deck-view.mobile-editor.done-button')"
     size="lg"
     class="bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-(--color-raised-pattern)"
-    bg_class="bg-brown-300 dark:bg-grey-900"
+    bg_class="bg-surface"
     @close="close"
   >
     <template #header-end>

--- a/src/views/settings/index.vue
+++ b/src/views/settings/index.vue
@@ -147,10 +147,7 @@ watch(layout_mode, (mode) => {
           layout_mode === 'phone' ? 'items-center text-center' : layout_mode === 'tablet' && 'pt-4'
         "
       >
-        <h1
-          data-testid="settings__header-title"
-          class="flex items-center gap-3 text-5xl text-white"
-        >
+        <h1 data-testid="settings__header-title" class="flex items-center gap-3 text-5xl">
           {{ header_title }}
         </h1>
       </div>

--- a/src/views/settings/tab-subscription/plan-pill.vue
+++ b/src/views/settings/tab-subscription/plan-pill.vue
@@ -41,12 +41,12 @@ defineSlots<{
           <div
             v-if="status || description"
             data-testid="plan-pill__meta"
-            class="flex items-center gap-2 text-brown-200 text-sm"
+            class="flex items-center gap-2 text-(--color-on-accent) text-sm"
           >
             <span
               v-if="status"
               data-testid="plan-pill__status"
-              class="rounded-2 bg-brown-100 px-2 py-0.5 text-(--color-accent-text)"
+              class="rounded-2 bg-surface px-2 py-0.5 text-(--color-accent-text)"
             >
               {{ status }}
             </span>

--- a/src/views/settings/tab-subscription/plan-section.vue
+++ b/src/views/settings/tab-subscription/plan-section.vue
@@ -54,7 +54,8 @@ const view = computed(() =>
     <p
       v-if="errored"
       data-testid="billing-settings__plan-error"
-      class="text-red-500 py-4 text-center"
+      data-palette="danger"
+      class="text-(--color-accent-text) py-4 text-center"
     >
       {{ t('settings.subscription.error') }}
     </p>

--- a/src/views/study-session/session-studying/card/study-card.vue
+++ b/src/views/study-session/session-studying/card/study-card.vue
@@ -283,6 +283,7 @@ function toSwipeZone(offset: number) {
       <div class="absolute inset-0 overflow-hidden rounded-(--face-radius)">
         <div
           data-testid="review-label--fail"
+          data-palette="danger"
           class="review-label review-label--fail"
           :class="{ 'review-label--visible': failVisible }"
         >
@@ -326,7 +327,7 @@ function toSwipeZone(offset: number) {
   font-size: var(--text-3xl);
   line-height: var(--text-3xl--line-height);
 
-  background: var(--color-white);
+  background: var(--color-card);
   border-radius: inherit;
   pointer-events: none;
   opacity: 0;
@@ -339,16 +340,9 @@ function toSwipeZone(offset: number) {
     opacity var(--duration) linear;
 }
 
-[data-mode='dark'] .review-label {
-  background: var(--color-stone-700);
-}
-
-.review-label--fail {
-  color: var(--color-red-500);
-}
-
+.review-label--fail,
 .review-label--pass {
-  color: var(--color-blue-500);
+  color: var(--color-accent);
 }
 
 .review-label--visible {

--- a/src/views/study-session/session-studying/session-progress.vue
+++ b/src/views/study-session/session-studying/session-progress.vue
@@ -25,7 +25,7 @@ const total = computed(() => cards.value.length)
     <div v-else class="relative w-full">
       <p
         data-testid="study-session__studying-count"
-        class="absolute inset-0 flex items-center justify-center text-center text-brown-700 transition-opacity duration-300 dark:text-brown-100 bg-raised rounded-3 border-2 border-raised"
+        class="absolute inset-0 flex items-center justify-center text-center text-ink transition-opacity duration-300 bg-raised rounded-3 border-2 border-raised"
         :class="is_cover ? 'opacity-100' : 'opacity-0 pointer-events-none'"
       >
         {{ $t('study-session.flashcard.studying-count', total) }}

--- a/src/views/study-session/session-studying/study-edit-footer.vue
+++ b/src/views/study-session/session-studying/study-edit-footer.vue
@@ -23,7 +23,7 @@ function onDone(e: MouseEvent) {
     <button
       data-testid="study-card-edit__flip"
       :data-active="flip_playing || null"
-      class="text-brown-700 cursor-pointer rounded-full bg-white px-13 py-4 hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
+      class="text-ink cursor-pointer rounded-full bg-raised px-13 py-4 hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
       @click="onFlip"
     >
       {{ $t('study.flashcard.edit-footer.flip-button') }}
@@ -31,7 +31,7 @@ function onDone(e: MouseEvent) {
     <button
       data-testid="study-card-edit__done"
       :data-active="done_playing || null"
-      class="cursor-pointer rounded-full bg-(--color-accent) px-13 py-4 text-white hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
+      class="cursor-pointer rounded-full bg-(--color-accent) px-13 py-4 text-(--color-on-accent) hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
       @click="onDone"
     >
       {{ $t('study-session.edit.done') }}

--- a/src/views/study-session/session-summary/category-page/summary-card-editor.vue
+++ b/src/views/study-session/session-summary/category-page/summary-card-editor.vue
@@ -39,7 +39,7 @@ function onDone() {
       <button
         type="button"
         data-testid="session-summary__card-editor-flip"
-        class="text-brown-700 cursor-pointer rounded-full bg-white px-13 py-4 hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
+        class="text-ink cursor-pointer rounded-full bg-raised px-13 py-4 hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
         @click="onFlip"
       >
         {{ t('study.flashcard.edit-footer.flip-button') }}
@@ -47,7 +47,7 @@ function onDone() {
       <button
         type="button"
         data-testid="session-summary__card-editor-done"
-        class="cursor-pointer rounded-full bg-(--color-accent) px-13 py-4 text-white hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
+        class="cursor-pointer rounded-full bg-(--color-accent) px-13 py-4 text-(--color-on-accent) hover:-translate-0.5 hover:shadow-sm transition-all duration-50"
         @click="onDone"
       >
         {{ t('study-session.edit.done') }}

--- a/src/views/study-session/session-summary/category-page/summary-card.vue
+++ b/src/views/study-session/session-summary/category-page/summary-card.vue
@@ -111,7 +111,7 @@ function onCardClick() {
       trigger-only
       :trigger-icon="dropdown?.open ? 'close' : 'more'"
       position="bottom-end"
-      class="absolute -top-1 -right-1 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto data-[active=true]:opacity-100 data-[active=true]:pointer-events-auto [&>button]:ring-4 [&>button]:ring-brown-100 dark:[&>button]:ring-grey-900"
+      class="absolute -top-1 -right-1 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto data-[active=true]:opacity-100 data-[active=true]:pointer-events-auto [&>button]:ring-4 [&>button]:ring-surface"
       :options="menu_options"
       @select="onMenuSelect"
     />

--- a/src/views/welcome/reset-password/success.vue
+++ b/src/views/welcome/reset-password/success.vue
@@ -10,7 +10,7 @@ const { t } = useI18n()
     data-testid="reset-password-modal__success"
     class="h-full flex flex-col items-center justify-center gap-4 text-center"
   >
-    <ui-icon src="party-popper" class="size-18 text-blue-500" />
+    <ui-icon src="party-popper" class="size-18 text-(--color-accent-text)" />
     <h2 data-testid="reset-password-modal__success-heading" class="text-2xl text-ink">
       {{ t('reset-password-modal.success-heading') }}
     </h2>

--- a/src/views/welcome/section-features/feature-card.vue
+++ b/src/views/welcome/section-features/feature-card.vue
@@ -8,22 +8,13 @@ import { useWelcomeWidth } from '../welcome-layout'
 type FeatureCardProps = {
   feature_key: string
   icon: string
-  accent: string
-  accent_dark: string
   cover: DeckCover
   side?: CardSide
 }
 
 type FeatureCardTier = 'sm' | 'lg' | 'xl'
 
-const {
-  feature_key,
-  icon,
-  accent,
-  accent_dark,
-  cover,
-  side = 'front'
-} = defineProps<FeatureCardProps>()
+const { feature_key, icon, cover, side = 'front' } = defineProps<FeatureCardProps>()
 
 const { t } = useI18n()
 const width = useWelcomeWidth()
@@ -68,12 +59,7 @@ const description_size = computed(() => DESCRIPTION_SIZE[size.value])
 </script>
 
 <template>
-  <card
-    :class="card_width"
-    :side="side"
-    :cover_config="cover"
-    :style="{ '--accent': accent, '--accent-dark': accent_dark }"
-  >
+  <card :class="card_width" :side="side" :cover_config="cover">
     <template #front>
       <div
         data-testid="feature-card__face"
@@ -84,7 +70,8 @@ const description_size = computed(() => DESCRIPTION_SIZE[size.value])
         <ui-icon
           data-testid="feature-card__icon"
           :src="icon"
-          class="justify-self-center text-(--accent) dark:text-(--accent-dark)"
+          :data-palette="cover.palette"
+          class="justify-self-center text-(--color-accent)"
           :class="icon_size"
         />
 

--- a/src/views/welcome/section-features/index.vue
+++ b/src/views/welcome/section-features/index.vue
@@ -10,8 +10,6 @@ import FeatureCard from './feature-card.vue'
 type Feature = {
   key: string
   icon: string
-  accent: string
-  accent_dark: string
   cover: DeckCover
 }
 
@@ -28,8 +26,6 @@ const features: Feature[] = [
   {
     key: 'experience',
     icon: 'paint-brush',
-    accent: 'var(--color-purple-500)',
-    accent_dark: 'var(--color-purple-700)',
     cover: {
       palette: 'purple',
       pattern: 'diagonal-stripes',
@@ -39,8 +35,6 @@ const features: Feature[] = [
   {
     key: 'mobile',
     icon: 'mobile-phone',
-    accent: 'var(--color-green-500)',
-    accent_dark: 'var(--color-green-800)',
     cover: {
       palette: 'green',
       pattern: 'squiggle',
@@ -50,15 +44,11 @@ const features: Feature[] = [
   {
     key: 'scheduling',
     icon: 'clock',
-    accent: 'var(--color-pink-500)',
-    accent_dark: 'var(--color-pink-700)',
     cover: { palette: 'pink', pattern: 'aztec', icon: 'clock' }
   },
   {
     key: 'upcoming',
     icon: 'shooting-star',
-    accent: 'var(--color-yellow-500)',
-    accent_dark: 'var(--color-yellow-700)',
     cover: {
       palette: 'yellow',
       pattern: 'bank-note',
@@ -151,8 +141,6 @@ watch(width, buildReveals, { flush: 'post' })
           <feature-card
             :feature_key="feature.key"
             :icon="feature.icon"
-            :accent="feature.accent"
-            :accent_dark="feature.accent_dark"
             :cover="feature.cover"
             :side="sides[index]"
           />

--- a/src/views/welcome/section-roadmap/index.vue
+++ b/src/views/welcome/section-roadmap/index.vue
@@ -36,7 +36,8 @@ const entries: OptionsPanelEntry[] = items.map((item) => ({
 <template>
   <section
     data-testid="welcome-roadmap"
-    class="w-full bg-green-500 dark:bg-green-800 flex justify-center"
+    data-palette="success"
+    class="w-full bg-(--color-accent) flex justify-center"
   >
     <div
       data-testid="welcome-roadmap__panel"
@@ -60,8 +61,8 @@ const entries: OptionsPanelEntry[] = items.map((item) => ({
             class="flex shrink-0 items-center justify-center size-8 rounded-full"
             :class="
               itemFor(entry.value).done
-                ? 'bg-green-500 dark:bg-green-800 text-brown-100'
-                : 'border-3 border-dashed border-brown-500'
+                ? 'bg-(--color-accent) text-(--color-on-accent)'
+                : 'border-3 border-dashed border-line'
             "
           >
             <ui-icon v-if="itemFor(entry.value).done" src="check" class="size-4.5" />
@@ -71,9 +72,7 @@ const entries: OptionsPanelEntry[] = items.map((item) => ({
         <template #trailing="{ entry }">
           <span
             class="text-base"
-            :class="
-              itemFor(entry.value).done ? 'text-green-600 dark:text-green-800' : 'text-ink-muted'
-            "
+            :class="itemFor(entry.value).done ? 'text-(--color-accent-text)' : 'text-ink-muted'"
           >
             {{
               itemFor(entry.value).done

--- a/src/views/welcome/splash/index.vue
+++ b/src/views/welcome/splash/index.vue
@@ -19,7 +19,7 @@ const height = useWelcomeHeight()
     <section
       data-testid="welcome-hero"
       data-station="window"
-      class="flex flex-col w-full h-[95lvh] min-h-160 py-7.5 max-lg:pb-10 max-h-250 relative bg-brown-300 dark:bg-stone-900 wave-bottom-[30px] bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-(--color-raised-pattern) bg-center overflow-hidden"
+      class="flex flex-col w-full h-[95lvh] min-h-160 py-7.5 max-lg:pb-10 max-h-250 relative bg-surface wave-bottom-[30px] bgx-dot-grid bgx-size-15 bgx-opacity-25 dark:bgx-opacity-10 bgx-color-(--color-raised-pattern) bg-center overflow-hidden"
     >
       <splash-nav />
 

--- a/src/views/welcome/splash/splash-nav.vue
+++ b/src/views/welcome/splash/splash-nav.vue
@@ -24,7 +24,8 @@ const width = useWelcomeWidth()
         position="bottom"
         data-testid="welcome-hero__beta"
         :text="t('welcome-view.hero.beta-tooltip')"
-        class="ml-1 rounded-3 bg-pink-400 dark:bg-pink-700 px-2.5 py-0.5 text-lg text-brown-100 cursor-default"
+        data-palette="pink"
+        class="ml-1 rounded-3 bg-(--color-accent) px-2.5 py-0.5 text-lg text-(--color-on-accent) cursor-default"
       >
         {{ t('welcome-view.hero.beta-pill') }}
       </ui-tooltip>

--- a/src/views/welcome/welcome-footer.vue
+++ b/src/views/welcome/welcome-footer.vue
@@ -6,20 +6,20 @@ const { t } = useI18n()
 
 <template>
   <div data-testid="welcome-footer" data-station="panel" class="w-full bg-surface">
-    <div class="w-full bg-blue-500 dark:bg-blue-650 wave-top-[30px] py-20">
+    <div class="w-full bg-(--color-accent) text-(--color-on-accent) wave-top-[30px] py-20">
       <div class="w-full max-w-(--page-width) mx-auto px-4 sm:px-16 flex flex-col gap-10">
         <div class="grid grid-cols-2 gap-10">
           <div class="flex flex-col gap-5">
-            <h2 class="text-4xl text-brown-100">{{ t('app.footer.about') }}</h2>
-            <p class="text-brown-100">
+            <h2 class="text-4xl">{{ t('app.footer.about') }}</h2>
+            <p>
               {{ t('app.footer.description') }}
             </p>
           </div>
 
           <div class="flex flex-col gap-5">
-            <h2 class="text-4xl text-brown-100">{{ t('app.footer.resources') }}</h2>
-            <a class="text-brown-100" href="/privacy">{{ t('app.footer.privacy-policy') }}</a>
-            <a class="text-brown-100" href="/terms">{{ t('app.footer.terms-of-service') }}</a>
+            <h2 class="text-4xl">{{ t('app.footer.resources') }}</h2>
+            <a href="/privacy">{{ t('app.footer.privacy-policy') }}</a>
+            <a href="/terms">{{ t('app.footer.terms-of-service') }}</a>
           </div>
         </div>
       </div>

--- a/tests/integration/components/card/card-cover.test.js
+++ b/tests/integration/components/card/card-cover.test.js
@@ -59,6 +59,34 @@ describe('CardCover', () => {
   })
 })
 
+describe('CardCover — icon palette [obligation]', () => {
+  // coverIconPalette() keeps the icon legible against its own fill — yellow
+  // by default, purple on a yellow cover — independent of the cover's own
+  // data-palette (or lack of one).
+
+  test('colours the icon purple when the cover palette is yellow', () => {
+    const wrapper = mountCover({ icon: 'star', palette: 'yellow' })
+    expect(wrapper.find('[data-testid="card-cover__icon"]').attributes('data-palette')).toBe(
+      'purple'
+    )
+  })
+
+  test('colours the icon yellow for a non-yellow cover palette', () => {
+    const wrapper = mountCover({ icon: 'star', palette: 'blue' })
+    expect(wrapper.find('[data-testid="card-cover__icon"]').attributes('data-palette')).toBe(
+      'yellow'
+    )
+  })
+
+  test('keeps the icon coloured yellow on a palette-less (neutral) cover [obligation]', () => {
+    const wrapper = mountCover({ icon: 'star' })
+    expect(wrapper.find('[data-testid="card-cover"]').attributes('data-palette')).toBeUndefined()
+    expect(wrapper.find('[data-testid="card-cover__icon"]').attributes('data-palette')).toBe(
+      'yellow'
+    )
+  })
+})
+
 describe('CardCover — image cover [obligation]', () => {
   // A custom cover image fills the cover on its own — the palette/pattern/icon
   // chrome must never show behind it, not even before the image has decoded.

--- a/tests/integration/components/card/face-overlay.test.js
+++ b/tests/integration/components/card/face-overlay.test.js
@@ -87,6 +87,12 @@ describe('FaceOverlay — error state', () => {
     expect(error_el.attributes('data-variant')).toBe('inset')
   })
 
+  test('carries data-palette="error" on the error element [obligation]', () => {
+    const wrapper = mountOverlay({ error: 'oops' })
+    const error_el = wrapper.find('[data-testid="face-overlay__error"]')
+    expect(error_el.attributes('data-palette')).toBe('error')
+  })
+
   test('clicking the error element re-emits browse (re-pick after error) [obligation]', async () => {
     const wrapper = mountOverlay({ error: 'oops' })
     await wrapper.find('[data-testid="face-overlay__error"]').trigger('click')

--- a/tests/integration/components/card/index.test.js
+++ b/tests/integration/components/card/index.test.js
@@ -156,6 +156,16 @@ describe('Card (cover side)', () => {
     expect(wrapper.find('[data-testid="card"]').attributes('data-error')).toBeDefined()
   })
 
+  test('does not set data-palette on the root when error is false [obligation]', () => {
+    const wrapper = mountCard({ error: false })
+    expect(wrapper.find('[data-testid="card"]').attributes('data-palette')).toBeUndefined()
+  })
+
+  test('sets data-palette="danger" on the root when error is true [obligation]', () => {
+    const wrapper = mountCard({ error: true })
+    expect(wrapper.find('[data-testid="card"]').attributes('data-palette')).toBe('danger')
+  })
+
   // ── shimmer prop [obligation] ─────────────────────────────────────────────
 
   test('renders .card-shimmer overlay when shimmer=true [obligation]', () => {

--- a/tests/integration/components/deck/cover-designer/icon-picker.test.js
+++ b/tests/integration/components/deck/cover-designer/icon-picker.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
 import IconPicker from '@/views/deck/cover-designer/icon-picker.vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
 
 const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
@@ -12,12 +13,17 @@ function makePicker(props = {}) {
     props: {
       supported_icons: SUPPORTED_ICONS,
       icon: undefined,
+      palette: undefined,
       ...props
     },
     global: {
       directives: { sfx: {} }
     }
   })
+}
+
+function optionIcon(wrapper, name) {
+  return wrapper.find(`[data-testid="icon-picker__option-${name}"]`).findComponent(UiIcon)
 }
 
 beforeEach(() => {
@@ -57,5 +63,62 @@ describe('IconPicker', () => {
     expect(wrapper.emitted('update:icon')).toBeUndefined()
     // Still plays a sound (powerdown) on the no-op.
     expect(mockEmitSfx).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('IconPicker — icon palette [obligation]', () => {
+  // coverIconPalette() keeps the icon legible against its own card's fill —
+  // sits on the ui-icon itself, never the button, so the button's own
+  // --color-accent (the deck's chosen palette) still drives its own fill.
+
+  test('sets data-palette to yellow on every option icon for a non-yellow cover palette', () => {
+    const wrapper = makePicker({ palette: 'blue' })
+    SUPPORTED_ICONS.forEach((name) => {
+      expect(optionIcon(wrapper, name).attributes('data-palette')).toBe('yellow')
+    })
+  })
+
+  test('sets data-palette to purple on every option icon when the cover palette is yellow', () => {
+    const wrapper = makePicker({ palette: 'yellow' })
+    SUPPORTED_ICONS.forEach((name) => {
+      expect(optionIcon(wrapper, name).attributes('data-palette')).toBe('purple')
+    })
+  })
+
+  test('does not put data-palette on the option button itself [obligation]', () => {
+    const wrapper = makePicker({ palette: 'yellow' })
+    expect(
+      wrapper.find('[data-testid="icon-picker__option-book"]').attributes('data-palette')
+    ).toBeUndefined()
+  })
+})
+
+describe('IconPicker — colours only the selected option [obligation]', () => {
+  // A fixed mid-review after every option was coloured, not just the picked
+  // one — the selected icon alone takes the accent fill colour.
+
+  test('colours the selected option icon with the accent colour', () => {
+    const wrapper = makePicker({ icon: 'book' })
+    expect(optionIcon(wrapper, 'book').classes()).toContain('text-(--color-accent)')
+  })
+
+  test('leaves unselected option icons uncoloured', () => {
+    const wrapper = makePicker({ icon: 'book' })
+    expect(optionIcon(wrapper, 'card-deck').classes()).not.toContain('text-(--color-accent)')
+    expect(optionIcon(wrapper, 'school-cap').classes()).not.toContain('text-(--color-accent)')
+  })
+
+  test('unselected options keep the button base text-ink-muted class', () => {
+    const wrapper = makePicker({ icon: 'book' })
+    expect(wrapper.find('[data-testid="icon-picker__option-card-deck"]').classes()).toContain(
+      'text-ink-muted'
+    )
+  })
+
+  test('unselected options keep the button hover:text-(--color-accent-muted) class', () => {
+    const wrapper = makePicker({ icon: 'book' })
+    expect(wrapper.find('[data-testid="icon-picker__option-card-deck"]').classes()).toContain(
+      'hover:text-(--color-accent-muted)'
+    )
   })
 })

--- a/tests/integration/components/deck/cover-designer/index.test.js
+++ b/tests/integration/components/deck/cover-designer/index.test.js
@@ -71,6 +71,7 @@ describe('CoverDesigner toolbar', () => {
 
     const iconProps = wrapper.findComponent(IconPickerStub).props()
     expect(iconProps.icon).toBe(SUPPORTED_ICONS[0])
+    expect(iconProps.palette).toBe('pink')
     expect(iconProps.supported_icons).toEqual(
       expect.arrayContaining([SUPPORTED_ICONS[0], SUPPORTED_ICONS[1]])
     )

--- a/tests/integration/components/member/avatar-picker-modal.test.js
+++ b/tests/integration/components/member/avatar-picker-modal.test.js
@@ -39,6 +39,7 @@ const DialogCardBodyStub = defineComponent({
 
 import AvatarPickerModal from '@/components/member/avatar-picker-modal.vue'
 import AvatarImage from '@/components/member/avatar-image.vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
 
 function mountModal(props = {}) {
   return shallowMount(AvatarPickerModal, {
@@ -179,5 +180,13 @@ describe('AvatarPickerModal', () => {
     const otter = wrapper.find('[data-testid="avatar-picker-modal__option-otter"]')
     expect(otter.find('[data-testid="avatar-picker-modal__skeleton"]').exists()).toBe(true)
     expect(otter.findComponent(AvatarImage).exists()).toBe(false)
+  })
+
+  test('colours the selection tick with the accent-text token, not a fixed neutral [obligation]', () => {
+    const wrapper = mountModal({ selected: 'otter' })
+    const tick = wrapper
+      .find('[data-testid="avatar-picker-modal__option-otter"]')
+      .findComponent(UiIcon)
+    expect(tick.classes()).toContain('text-(--color-accent-text)')
   })
 })

--- a/tests/integration/components/modals/collection-edit/index.test.js
+++ b/tests/integration/components/modals/collection-edit/index.test.js
@@ -315,6 +315,15 @@ describe('CollectionEditModal', () => {
     })
   })
 
+  describe('danger zone', () => {
+    test('the danger-zone section carries data-palette="danger" [obligation]', () => {
+      const { wrapper } = mountModal()
+      expect(
+        wrapper.find('[data-testid="collection-edit__danger-zone"]').attributes('data-palette')
+      ).toBe('danger')
+    })
+  })
+
   describe('lessons_error watch', () => {
     test('shows a notice with the error message when lessons_error becomes truthy', async () => {
       const { wrapper } = mountModal({ collection_id: 1 })

--- a/tests/integration/components/modals/study-session/study-card.test.js
+++ b/tests/integration/components/modals/study-session/study-card.test.js
@@ -264,6 +264,14 @@ describe('StudyCard', () => {
     expect(failLabel.classes()).toContain('review-label--visible')
   })
 
+  test('fail label carries data-palette="danger" [obligation]', async () => {
+    const wrapper = mountStudyCard()
+    await flushPromises()
+
+    const failLabel = wrapper.find('[data-testid="review-label--fail"]')
+    expect(failLabel.attributes('data-palette')).toBe('danger')
+  })
+
   test('pass label is not visible below threshold', async () => {
     const wrapper = mountStudyCard()
     await flushPromises()

--- a/tests/integration/components/settings/tab-subscription/plan-section.test.js
+++ b/tests/integration/components/settings/tab-subscription/plan-section.test.js
@@ -218,6 +218,28 @@ describe('plan-section — error state', () => {
     expect(wrapper.find('[data-testid="plan-pill"]').exists()).toBe(false)
   })
 
+  test('the plan-error paragraph carries data-palette="danger" [obligation]', async () => {
+    memberState.plan = 'paid'
+    const PlanSection = (await import('@/views/settings/tab-subscription/plan-section.vue')).default
+    const wrapper = shallowMount(PlanSection, {
+      props: {
+        subscriptionQuery: makeSubscriptionQuery(null, { error: new Error('boom') })
+      },
+      global: {
+        plugins: [createTestingPinia({ createSpy: vi.fn })],
+        stubs: {
+          LabeledSection: LabeledSectionStub,
+          PlanPill: PlanPillStub,
+          PlanActions: PlanActionsStub,
+          PaidFeatures: PaidFeaturesStub
+        }
+      }
+    })
+    expect(
+      wrapper.find('[data-testid="billing-settings__plan-error"]').attributes('data-palette')
+    ).toBe('danger')
+  })
+
   test('free member with error does NOT show the error — free member never loads billing [obligation]', async () => {
     memberState.plan = 'free'
     const PlanSection = (await import('@/views/settings/tab-subscription/plan-section.vue')).default

--- a/tests/integration/components/taro-phone/taro-phone-sm.test.js
+++ b/tests/integration/components/taro-phone/taro-phone-sm.test.js
@@ -23,6 +23,16 @@ describe('TaroPhoneSm — notification badge', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.find('[data-testid="notification-badge"]').exists()).toBe(true)
   })
+
+  test('the badge carries data-palette="danger" [obligation]', async () => {
+    const wrapper = makeWrapper()
+    const store = useTaroPhoneStore()
+    store.notify('settings', 1)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="notification-badge"]').attributes('data-palette')).toBe(
+      'danger'
+    )
+  })
 })
 
 describe('TaroPhoneSm — open', () => {

--- a/tests/integration/components/ui-kit/pattern-picker.test.js
+++ b/tests/integration/components/ui-kit/pattern-picker.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
 import UiPatternPicker from '@/components/ui-kit/pattern-picker.vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
 
 const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
@@ -66,5 +67,11 @@ describe('UiPatternPicker', () => {
     const wrapper = makePicker()
     const swatch = wrapper.find('[data-testid="pattern-picker__option-aztec"]')
     expect(swatch.attributes('style') || '').toContain('--bgx-size')
+  })
+
+  test('colours the selection tick with the accent-text token, not a fixed neutral [obligation]', () => {
+    const wrapper = makePicker({ selected_pattern: 'wave' })
+    const tick = wrapper.find('[data-testid="pattern-picker__option-wave"]').findComponent(UiIcon)
+    expect(tick.classes()).toContain('text-(--color-accent-text)')
   })
 })

--- a/tests/integration/components/ui-kit/textarea.test.js
+++ b/tests/integration/components/ui-kit/textarea.test.js
@@ -82,10 +82,22 @@ describe('UiTextarea — max_chars', () => {
     expect(counter.classes()).not.toContain('ui-kit-textarea-char-count--limit')
   })
 
+  test('counter has no data-palette when below the limit [obligation]', () => {
+    const wrapper = mountTextarea({ max_chars: 100, value: 'hi' })
+    const counter = wrapper.find('[data-testid="ui-kit-textarea-char-count"]')
+    expect(counter.attributes('data-palette')).toBeUndefined()
+  })
+
   test('counter has the --limit class when at the limit [obligation]', () => {
     const wrapper = mountTextarea({ max_chars: 5, value: 'hello' })
     const counter = wrapper.find('[data-testid="ui-kit-textarea-char-count"]')
     expect(counter.classes()).toContain('ui-kit-textarea-char-count--limit')
+  })
+
+  test('counter has data-palette="danger" at the character limit [obligation]', () => {
+    const wrapper = mountTextarea({ max_chars: 5, value: 'hello' })
+    const counter = wrapper.find('[data-testid="ui-kit-textarea-char-count"]')
+    expect(counter.attributes('data-palette')).toBe('danger')
   })
 
   test('counter has the --limit class when over the limit [obligation]', () => {

--- a/tests/integration/components/ui-kit/theme-picker.test.js
+++ b/tests/integration/components/ui-kit/theme-picker.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
 import UiThemePicker from '@/components/ui-kit/theme-picker.vue'
+import UiIcon from '@/components/ui-kit/icon.vue'
 
 const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
@@ -55,5 +56,11 @@ describe('UiThemePicker', () => {
 
     expect(wrapper.emitted('update:palette')).toBeUndefined()
     expect(mockEmitSfx).toHaveBeenCalledTimes(1)
+  })
+
+  test('colours the selection tick with the accent-text token, not a fixed neutral [obligation]', () => {
+    const wrapper = makePicker({ palette: 'blue' })
+    const tick = wrapper.find('[data-testid="theme-picker__option-blue"]').findComponent(UiIcon)
+    expect(tick.classes()).toContain('text-(--color-accent-text)')
   })
 })

--- a/tests/integration/views/audio-reader/lesson-card.test.js
+++ b/tests/integration/views/audio-reader/lesson-card.test.js
@@ -74,6 +74,18 @@ describe('LessonCard', () => {
     )
   })
 
+  test('the icon carries no data-palette when the lesson is not failed [obligation]', () => {
+    expect(
+      mountCard(ready).find('[data-testid="lesson-card__icon"]').attributes('data-palette')
+    ).toBeUndefined()
+  })
+
+  test('the icon carries data-palette="danger" when the lesson has failed [obligation]', () => {
+    expect(
+      mountCard(failed).find('[data-testid="lesson-card__icon"]').attributes('data-palette')
+    ).toBe('danger')
+  })
+
   describe('ready', () => {
     test('shows the date and a music-note icon, and the open button is enabled', () => {
       const w = mountCard(ready)

--- a/tests/integration/views/dashboard/dashboard-section.test.js
+++ b/tests/integration/views/dashboard/dashboard-section.test.js
@@ -29,15 +29,11 @@ describe('DashboardSection — default slot', () => {
 })
 
 describe('DashboardSection — loading prop [obligation]', () => {
-  test('uses the flat loading color classes when loading is true', () => {
+  test('uses the flat loading color class when loading is true', () => {
     const wrapper = mountSection({ label: 'All Decks', loading: true })
     const label = wrapper.find('[data-testid="dashboard-section__label"]')
-    expect(label.classes()).toEqual(
-      expect.arrayContaining(['text-brown-300', 'dark:text-stone-700'])
-    )
-    expect(label.classes()).not.toEqual(
-      expect.arrayContaining(['text-brown-700', 'dark:text-brown-300'])
-    )
+    expect(label.classes()).toEqual(expect.arrayContaining(['text-skeleton']))
+    expect(label.classes()).not.toEqual(expect.arrayContaining(['text-ink']))
   })
 
   test('uses the default heading color classes when loading is false', () => {

--- a/tests/integration/views/dashboard/review-inbox/item.test.js
+++ b/tests/integration/views/dashboard/review-inbox/item.test.js
@@ -40,6 +40,13 @@ describe('ReviewInboxItem', () => {
     expect(wrapper.find('[data-testid="review-inbox-item__due-badge"]').text()).toBe('7')
   })
 
+  test('the due-count badge carries data-palette="danger" [obligation]', () => {
+    const wrapper = mount({ id: 1, due_count: 7 })
+    expect(
+      wrapper.find('[data-testid="review-inbox-item__due-badge"]').attributes('data-palette')
+    ).toBe('danger')
+  })
+
   test('plays the type hover sfx on hover [obligation]', () => {
     const wrapper = mount({ id: 1, due_count: 3 })
     wrapper

--- a/tests/integration/views/dashboard/skeleton.test.js
+++ b/tests/integration/views/dashboard/skeleton.test.js
@@ -69,9 +69,7 @@ describe('DashboardSkeleton (views/dashboard/skeleton.vue)', () => {
     const wrapper = mountSkeleton()
     const labels = wrapper.findAll('[data-testid="dashboard-section__label"]')
     for (const label of labels) {
-      expect(label.classes()).toEqual(
-        expect.arrayContaining(['text-brown-300', 'dark:text-stone-700'])
-      )
+      expect(label.classes()).toEqual(expect.arrayContaining(['text-skeleton']))
     }
   })
 

--- a/tests/integration/views/deck/card-import/drop-zone.test.js
+++ b/tests/integration/views/deck/card-import/drop-zone.test.js
@@ -28,12 +28,26 @@ describe('card-import/drop-zone', () => {
     expect(wrapper.find('[data-testid="card-import-drop-zone__error"]').exists()).toBe(false)
   })
 
+  test('does not set data-palette on the root when there is no error [obligation]', () => {
+    const wrapper = mount()
+    expect(wrapper.find('[data-testid="card-import-drop-zone"]').attributes('data-palette')).toBe(
+      undefined
+    )
+  })
+
   test('renders the error state and hides the browse prompt when error is set', () => {
     const wrapper = mount({ error: 'Choose a .csv or .txt file' })
     expect(wrapper.find('[data-testid="card-import-drop-zone__error"]').text()).toBe(
       'Choose a .csv or .txt file'
     )
     expect(wrapper.find('[data-testid="card-import-drop-zone__browse"]').exists()).toBe(false)
+  })
+
+  test('sets data-palette="danger" on the root when error is set [obligation]', () => {
+    const wrapper = mount({ error: 'bad file' })
+    expect(wrapper.find('[data-testid="card-import-drop-zone"]').attributes('data-palette')).toBe(
+      'danger'
+    )
   })
 
   test('dismiss-error button emits dismiss-error', async () => {

--- a/tests/integration/views/welcome/section-features.test.js
+++ b/tests/integration/views/welcome/section-features.test.js
@@ -21,7 +21,7 @@ const SectionHeaderStub = defineComponent({
 
 const FeatureCardStub = defineComponent({
   name: 'FeatureCard',
-  props: ['feature_key', 'icon', 'accent', 'accent_dark'],
+  props: ['feature_key', 'icon', 'cover'],
   setup(props) {
     return () =>
       h('div', {

--- a/tests/integration/views/welcome/section-features/feature-card.test.js
+++ b/tests/integration/views/welcome/section-features/feature-card.test.js
@@ -8,8 +8,9 @@ import { welcomeWidthKey } from '@/views/welcome/welcome-layout'
 const UiIconStub = defineComponent({
   name: 'UiIcon',
   props: ['src'],
-  setup(props) {
-    return () => h('span', { 'data-testid': 'feature-card__icon', 'data-src': props.src })
+  inheritAttrs: false,
+  setup(props, { attrs }) {
+    return () => h('span', { 'data-testid': 'feature-card__icon', 'data-src': props.src, ...attrs })
   }
 })
 
@@ -45,8 +46,7 @@ function mountFeatureCard(props = {}) {
     props: {
       feature_key: 'experience',
       icon: 'paint-brush',
-      accent: 'var(--color-purple-500)',
-      accent_dark: 'var(--color-purple-700)',
+      cover: { theme: 'purple-500', pattern: 'diagonal-stripes', palette: 'purple' },
       ...props
     },
     global: {
@@ -93,34 +93,19 @@ describe('FeatureCard', () => {
   })
 
   test('renders mobile card heading from i18n key', () => {
-    const wrapper = mountFeatureCard({
-      feature_key: 'mobile',
-      icon: 'mobile-phone',
-      accent: 'var(--color-blue-500)',
-      accent_dark: 'var(--color-blue-650)'
-    })
+    const wrapper = mountFeatureCard({ feature_key: 'mobile', icon: 'mobile-phone' })
     const face = wrapper.find('[data-testid="feature-card__face"]')
     expect(face.text()).toContain('Made For Mobile')
   })
 
   test('renders scheduling card heading from i18n key', () => {
-    const wrapper = mountFeatureCard({
-      feature_key: 'scheduling',
-      icon: 'clock',
-      accent: 'var(--color-pink-500)',
-      accent_dark: 'var(--color-pink-700)'
-    })
+    const wrapper = mountFeatureCard({ feature_key: 'scheduling', icon: 'clock' })
     const face = wrapper.find('[data-testid="feature-card__face"]')
     expect(face.text()).toContain('Spaced Repetition')
   })
 
   test('renders upcoming card heading from i18n key', () => {
-    const wrapper = mountFeatureCard({
-      feature_key: 'upcoming',
-      icon: 'shooting-star',
-      accent: 'var(--color-yellow-500)',
-      accent_dark: 'var(--color-yellow-700)'
-    })
+    const wrapper = mountFeatureCard({ feature_key: 'upcoming', icon: 'shooting-star' })
     const face = wrapper.find('[data-testid="feature-card__face"]')
     expect(face.text()).toContain('More On The Way')
   })
@@ -131,6 +116,12 @@ describe('FeatureCard', () => {
     const wrapper = mountFeatureCard({ icon: 'paint-brush' })
     const icon = wrapper.find('[data-testid="feature-card__icon"]')
     expect(icon.attributes('data-src')).toBe('paint-brush')
+  })
+
+  test('renders the icon with the cover’s palette as data-palette [obligation]', () => {
+    const wrapper = mountFeatureCard({ cover: { theme: 'pink-500', palette: 'pink' } })
+    const icon = wrapper.find('[data-testid="feature-card__icon"]')
+    expect(icon.attributes('data-palette')).toBe('pink')
   })
 
   // ── side / cover forwarding ──────────────────────────────────────────────────

--- a/tests/integration/views/welcome/section-roadmap/index.test.js
+++ b/tests/integration/views/welcome/section-roadmap/index.test.js
@@ -88,6 +88,13 @@ describe('SectionRoadmap', () => {
     expect(wrapper.find('[data-testid="welcome-roadmap"]').exists()).toBe(true)
   })
 
+  test('the section carries data-palette="success" [obligation]', () => {
+    const wrapper = mountRoadmap()
+    expect(wrapper.find('[data-testid="welcome-roadmap"]').attributes('data-palette')).toBe(
+      'success'
+    )
+  })
+
   test('renders the section header', () => {
     const wrapper = mountRoadmap()
     expect(wrapper.find('[data-testid="section-header"]').exists()).toBe(true)

--- a/tests/integration/views/welcome/splash/splash-nav.test.js
+++ b/tests/integration/views/welcome/splash/splash-nav.test.js
@@ -86,6 +86,13 @@ describe('SplashNav', () => {
     expect(wrapper.find('[data-testid="welcome-hero__beta"]').exists()).toBe(true)
   })
 
+  test('the beta pill carries data-palette="pink" [obligation]', () => {
+    const wrapper = mountSplashNav()
+    expect(wrapper.find('[data-testid="welcome-hero__beta"]').attributes('data-palette')).toBe(
+      'pink'
+    )
+  })
+
   // ── Login component [obligation] ──────────────────────────────────────────
 
   test('renders the LoginDialogue component in the nav [obligation]', () => {

--- a/tests/unit/composables/billing/use-checkout-elements.test.js
+++ b/tests/unit/composables/billing/use-checkout-elements.test.js
@@ -29,14 +29,19 @@ import { useThemeStore } from '@/stores/theme'
 import { getStripeAppearance, STRIPE_FONTS } from '@/utils/billing/stripe-theme'
 
 let app
+let mount_target
 
 afterEach(() => {
   app?.unmount()
   app = null
+  mount_target?.remove()
+  mount_target = null
 })
 
 // useTemplateRef needs a real render tree with a matching `ref` element, so
-// mount a host component instead of calling the composable bare.
+// mount a host component instead of calling the composable bare. Mounting
+// into an element attached to the document lets getComputedStyle resolve
+// inherited custom properties the way the real page does.
 function withSetup(options) {
   let result
   app = createApp({
@@ -45,7 +50,10 @@ function withSetup(options) {
       return () => h('div', { ref: 'container' })
     }
   })
-  app.mount(document.createElement('div'))
+  mount_target = document.createElement('div')
+  document.body.appendChild(mount_target)
+  const instance = app.mount(mount_target)
+  result.container_el = instance.$el
   return result
 }
 
@@ -285,18 +293,16 @@ describe('useCheckoutElements — confirm()', () => {
 })
 
 describe('useCheckoutElements — dark-mode reactivity', () => {
-  test('[obligation] initializes the Checkout SDK with the light appearance when is_dark starts false', async () => {
+  test('[obligation] initializes the Checkout SDK with the appearance read off the mounted container', async () => {
     const stripe = makeStripe()
     mockLoadStripe.mockResolvedValue(stripe)
 
-    withSetup(baseOptions())
+    const result = withSetup(baseOptions())
     await flushPromises()
 
-    expect(stripe.initCheckoutElementsSdk).toHaveBeenCalledWith(
-      expect.objectContaining({
-        elementsOptions: { appearance: getStripeAppearance(false), fonts: STRIPE_FONTS }
-      })
-    )
+    const [[{ elementsOptions }]] = stripe.initCheckoutElementsSdk.mock.calls
+    expect(elementsOptions.fonts).toBe(STRIPE_FONTS)
+    expect(elementsOptions.appearance).toEqual(getStripeAppearance(result.container_el))
   })
 
   test('[obligation] calls checkout.changeAppearance when is_dark toggles after mount, not just at init', async () => {
@@ -311,7 +317,27 @@ describe('useCheckoutElements — dark-mode reactivity', () => {
     useThemeStore().is_dark.value = true
     await flushPromises()
 
-    expect(changeAppearance).toHaveBeenCalledWith(getStripeAppearance(true))
+    expect(changeAppearance).toHaveBeenCalledTimes(1)
+  })
+
+  test('[obligation] re-reads colours off the container after data-mode flips, since the watcher is flush: post', async () => {
+    const changeAppearance = vi.fn()
+    const checkout = makeCheckoutSdk({ changeAppearance })
+    mockLoadStripe.mockResolvedValue(makeStripe({ checkout }))
+
+    const result = withSetup(baseOptions())
+    await flushPromises()
+
+    // Simulate the app's dark-mode switch landing on the DOM before the
+    // watcher fires — flush: 'post' means this write is already visible.
+    result.container_el.style.setProperty('--color-accent', '#111827')
+
+    useThemeStore().is_dark.value = true
+    await flushPromises()
+
+    expect(changeAppearance).toHaveBeenCalledWith(
+      expect.objectContaining({ variables: expect.objectContaining({ colorPrimary: '#111827' }) })
+    )
   })
 })
 

--- a/tests/unit/utils/billing/stripe-theme.test.js
+++ b/tests/unit/utils/billing/stripe-theme.test.js
@@ -1,55 +1,80 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vite-plus/test'
 import { getStripeAppearance, STRIPE_FONTS } from '@/utils/billing/stripe-theme'
 
-const TOKENS = {
-  '--color-red-500': '#e11d48',
-  '--color-red-600': '#be123c',
-  '--color-blue-500': '#3b82f6',
-  '--color-blue-650': '#1d4ed8',
-  '--color-stone-900': '#1c1917',
-  '--color-grey-700': '#374151',
-  '--color-grey-900': '#111827',
-  '--color-brown-50': '#fdf6ec',
-  '--color-brown-100': '#f5e9d6',
-  '--color-brown-200': '#ecd9bc',
-  '--color-brown-300': '#e0c49a',
-  '--color-brown-700': '#5c4530',
-  '--color-brown-500': '#9c7b52'
+const HOST_TOKENS = {
+  '--color-accent': '#3b82f6',
+  '--color-well': '#fdf6ec',
+  '--color-surface': '#f5e9d6',
+  '--color-raised': '#ecd9bc',
+  '--color-line': '#e0c49a',
+  '--color-ink': '#5c4530',
+  '--color-ink-muted': '#9c7b52'
 }
 
+const DANGER_ACCENT = '#e11d48'
+
+let host
+
 beforeEach(() => {
-  Object.entries(TOKENS).forEach(([name, value]) => {
-    document.documentElement.style.setProperty(name, value)
-  })
+  host = document.createElement('div')
+  Object.entries(HOST_TOKENS).forEach(([name, value]) => host.style.setProperty(name, value))
+  document.body.appendChild(host)
+
+  // The host's own accent stands in for a caller-set --theme-primary; the
+  // danger probe below deliberately gets a different value so a test can
+  // tell whether colorDanger came from the probe or leaked from the host.
+  const style = document.createElement('style')
+  style.textContent = `[data-palette='danger'] { --color-accent: ${DANGER_ACCENT}; }`
+  document.head.appendChild(style)
 })
 
 afterEach(() => {
-  Object.keys(TOKENS).forEach((name) => document.documentElement.style.removeProperty(name))
+  host.remove()
 })
 
-describe('getStripeAppearance — light/dark token selection', () => {
-  test('resolves the light-mode danger and accent colors when is_dark is false', () => {
-    const appearance = getStripeAppearance(false)
+describe('getStripeAppearance — reads colours off the host element', () => {
+  test('reads accent, background, surface, border, text and placeholder off the given host', () => {
+    const appearance = getStripeAppearance(host)
 
-    expect(appearance.variables.colorDanger).toBe(TOKENS['--color-red-500'])
-    expect(appearance.variables.colorPrimary).toBe(TOKENS['--color-blue-500'])
-    expect(appearance.variables.colorBackground).toBe(TOKENS['--color-brown-50'])
-    expect(appearance.variables.colorText).toBe(TOKENS['--color-brown-700'])
+    expect(appearance.variables.colorPrimary).toBe(HOST_TOKENS['--color-accent'])
+    expect(appearance.variables.colorBackground).toBe(HOST_TOKENS['--color-well'])
+    expect(appearance.variables.colorText).toBe(HOST_TOKENS['--color-ink'])
+    expect(appearance.variables.colorTextPlaceholder).toBe(HOST_TOKENS['--color-ink-muted'])
+    expect(appearance.rules['.Tab--selected'].backgroundColor).toBe(HOST_TOKENS['--color-surface'])
+    expect(appearance.rules['.Tab:hover'].backgroundColor).toBe(HOST_TOKENS['--color-raised'])
+    expect(appearance.rules['.Input'].border).toContain(HOST_TOKENS['--color-line'])
   })
 
-  test('resolves the dark-mode danger and accent colors when is_dark is true', () => {
-    const appearance = getStripeAppearance(true)
+  test('does not read colours off document.documentElement', () => {
+    document.documentElement.style.setProperty('--color-accent', '#000000')
+    document.documentElement.style.setProperty('--color-well', '#000000')
 
-    expect(appearance.variables.colorDanger).toBe(TOKENS['--color-red-600'])
-    expect(appearance.variables.colorPrimary).toBe(TOKENS['--color-blue-650'])
-    expect(appearance.variables.colorBackground).toBe(TOKENS['--color-stone-900'])
-    expect(appearance.variables.colorText).toBe(TOKENS['--color-brown-300'])
+    const appearance = getStripeAppearance(host)
+
+    expect(appearance.variables.colorPrimary).toBe(HOST_TOKENS['--color-accent'])
+    expect(appearance.variables.colorBackground).toBe(HOST_TOKENS['--color-well'])
+
+    document.documentElement.style.removeProperty('--color-accent')
+    document.documentElement.style.removeProperty('--color-well')
+  })
+
+  test('colorDanger comes from a data-palette="danger" probe, not the host’s own accent', () => {
+    const appearance = getStripeAppearance(host)
+
+    expect(appearance.variables.colorDanger).toBe(DANGER_ACCENT)
+    expect(appearance.variables.colorDanger).not.toBe(HOST_TOKENS['--color-accent'])
+  })
+
+  test('leaves no probe node behind on the host after resolving colorDanger', () => {
+    getStripeAppearance(host)
+
+    expect(host.children).toHaveLength(0)
   })
 })
 
 describe('getStripeAppearance — static shape', () => {
   test('always returns the flat theme, above labels, and condensed inputs', () => {
-    const appearance = getStripeAppearance(false)
+    const appearance = getStripeAppearance(host)
 
     expect(appearance.theme).toBe('flat')
     expect(appearance.labels).toBe('above')
@@ -57,16 +82,18 @@ describe('getStripeAppearance — static shape', () => {
   })
 
   test('builds an 8-digit alpha hex for the focused Input box-shadow', () => {
-    const appearance = getStripeAppearance(false)
+    const appearance = getStripeAppearance(host)
 
-    expect(appearance.rules['.Input:focus'].boxShadow).toContain(`${TOKENS['--color-blue-500']}40`)
+    expect(appearance.rules['.Input:focus'].boxShadow).toContain(
+      `${HOST_TOKENS['--color-accent']}40`
+    )
   })
 
   test('pins selected-tab label/icon color back to the base text color', () => {
-    const appearance = getStripeAppearance(false)
+    const appearance = getStripeAppearance(host)
 
-    expect(appearance.rules['.TabLabel--selected'].color).toBe(TOKENS['--color-brown-700'])
-    expect(appearance.rules['.TabIcon--selected'].color).toBe(TOKENS['--color-brown-700'])
+    expect(appearance.rules['.TabLabel--selected'].color).toBe(HOST_TOKENS['--color-ink'])
+    expect(appearance.rules['.TabIcon--selected'].color).toBe(HOST_TOKENS['--color-ink'])
   })
 })
 

--- a/tests/unit/utils/cover/tokens.test.js
+++ b/tests/unit/utils/cover/tokens.test.js
@@ -1,0 +1,19 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { SUPPORTED_PALETTES, coverIconPalette } from '@/utils/cover'
+
+describe('coverIconPalette', () => {
+  test('returns purple when the cover palette is yellow, so the icon never vanishes into the fill', () => {
+    expect(coverIconPalette('yellow')).toBe('purple')
+  })
+
+  test('returns yellow when the cover has no palette', () => {
+    expect(coverIconPalette(undefined)).toBe('yellow')
+  })
+
+  test.each(SUPPORTED_PALETTES.filter((palette) => palette !== 'yellow'))(
+    'returns yellow for the %s cover palette',
+    (palette) => {
+      expect(coverIconPalette(palette)).toBe('yellow')
+    }
+  )
+})


### PR DESCRIPTION
[TARO-360](https://app.notion.com/3b90953c224c8134a071d3e652083fa8)

## Summary

- Every hardcoded shade in `src/` now asks for a role instead of naming a colour, so all 51 screens follow the member's palette and the mode. `dark:` colour variants are gone across `src/` — a role already carries both renditions.
- Fixes three that read wrong: text on a filled accent control is legible on all seven palettes, the audio reader's private blue ramp now follows the member's colour, and the payment form reads its colours off the panel it mounts in rather than re-deriving a ramp behind its own `is_dark` ternary.
- Badges and status dots carry the meaning (`danger` / `success` / `error`) rather than a picked hue; the flashcard paints from `--color-card`, and skeletons use the skeleton fill and sheen roles.