### PR TITLE
Gate each rule spoke behind its hub's paths

### DIFF
--- a/.claude/rules/architecture/api-layer.md
+++ b/.claude/rules/architecture/api-layer.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # Supabase calls belong in `src/api/`
 
 All Supabase client calls must live in the appropriate `src/api/` module. Never call `supabase` directly from composables, views, or components. Components consume the domain barrel via hooks (`useXxxQuery` / `useXxxMutation`); the raw Supabase calls live in `src/api/<domain>/db/` and are internal.

--- a/.claude/rules/architecture/composition.md
+++ b/.claude/rules/architecture/composition.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # Component composition over code merging
 
 When consolidating or moving functionality between components, import and use the child component rather than inlining its template or script code.

--- a/.claude/rules/architecture/provide-inject.md
+++ b/.claude/rules/architecture/provide-inject.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # Provide/inject editor-shaped composables across deep modal trees
 
 When a composable owns a session of reactive state (e.g. `useDeckEditor`) and several nested children all need to read and write the same fields, the modal root should call the composable once and `provide()` the result. Children `inject()` and read/write directly, no prop drilling, no `field()` factory wrapping each key in a writable computed.
@@ -22,7 +28,7 @@ Reserve plain prop drilling for leaf components that take a derived slice (e.g. 
 
 When a child already owns a derived reactive value the parent also needs, the **child is the single source** and the parent consumes it. Two independent computations of "the same" condition drift — a sidebar visible while the main column fell back to its mobile layout on wide-but-short viewports.
 
-provide/inject can't carry this direction (and inside slot content, the injecting parent is the slot *definer*, not the wrapper). Use `defineExpose` + a template ref:
+provide/inject can't carry this direction (and inside slot content, the injecting parent is the slot _definer_, not the wrapper). Use `defineExpose` + a template ref:
 
 - child takes a configurable default-query prop so callers can override the condition
 - child resolves it once and surfaces it: `defineExpose({ has_sidebar })`

--- a/.claude/rules/architecture/ui-kit.md
+++ b/.claude/rules/architecture/ui-kit.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # ui-kit & layout-kit conventions
 
 ## ui-kit primitives that span multiple files live in a directory
@@ -39,7 +45,7 @@ The `layout-kit` window family follows three naming constraints, worth applying 
 
 - **`modal` is off-limits** — `dialog-card` is also a modal. Dialog vs window is the distinguishing axis: a small transient dialog against a large workflow window (`app-window`, `paged-window`).
 - **No domain-forcing names** — `settings-modal` was rejected because the surface might outgrow settings.
-- **No breakpoint words** — `mobile-sheet` was the original sin. Breakpoint behaviour is a *mode* (`'phone' | 'tablet' | 'desktop'`), not an identity.
+- **No breakpoint words** — `mobile-sheet` was the original sin. Breakpoint behaviour is a _mode_ (`'phone' | 'tablet' | 'desktop'`), not an identity.
 
 ## Check the prop surface before a CSS override
 

--- a/.claude/rules/architecture/utils.md
+++ b/.claude/rules/architecture/utils.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # Pure helpers live in directory-scoped utils, not `src/api/`
 
 `src/api/` is for functions that hit the network. Pure helpers — payload builders, diff checks, formatters, validators — belong in `src/utils/<domain>/`, alongside the domain they describe. This keeps the api layer a thin persistence surface and keeps helpers co-located with their domain instead of sprinkled across flat `src/utils/*.ts` files.
@@ -44,6 +50,6 @@ Extract to `src/utils/<domain>/` once it gains a second call site, grows non-tri
 
 ## Extend, don't add a sibling
 
-When a new capability is a *variant* of an existing function, absorb it via overloads or variadic args rather than adding `fooRandom` / `fooBatch` / `fooWithX` beside it. `emitRandomSfx` was rejected as a sibling of `emitSfx` because the random-pick logic would have been duplicated — variadic `emitSfx(...keys, opts?)` keeps the policy, error handling and category logic in one place.
+When a new capability is a _variant_ of an existing function, absorb it via overloads or variadic args rather than adding `fooRandom` / `fooBatch` / `fooWithX` beside it. `emitRandomSfx` was rejected as a sibling of `emitSfx` because the random-pick logic would have been duplicated — variadic `emitSfx(...keys, opts?)` keeps the policy, error handling and category logic in one place.
 
 If the new function would copy most of the original, merge them.

--- a/.claude/rules/architecture/vendor-chokepoint.md
+++ b/.claude/rules/architecture/vendor-chokepoint.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # Third-party SDKs get one chokepoint composable
 
 A third-party analytics/tracking SDK (Plausible, and the next one) is reached only through a single

--- a/.claude/rules/code-style/nesting.md
+++ b/.claude/rules/code-style/nesting.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # At most one level of nesting
 
 **`max-depth` in `vite.config.ts`'s `lint.rules` enforces this** — `vp lint` warns past depth 2.

--- a/.claude/rules/code-style/phases.md
+++ b/.claude/rules/code-style/phases.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # Group function bodies into visual phases
 
 A function should read as setup → core work → wrap-up, not a wall of text. Put a single blank line between phases; keep tight clusters tight.

--- a/.claude/rules/code-style/reactivity.md
+++ b/.claude/rules/code-style/reactivity.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # Watchers are a last resort
 
 `watch` / `watchEffect` is not a default. Before adding one, ask whether the same thing can be expressed declaratively — a `computed`, conditional rendering, an event handler, or a one-time `onMounted` seed.

--- a/.claude/rules/code-style/responsibility.md
+++ b/.claude/rules/code-style/responsibility.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # One responsibility per function
 
 A function either orchestrates other functions or performs one concrete piece of work — never both.

--- a/.claude/rules/code-style/signatures.md
+++ b/.claude/rules/code-style/signatures.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # Function signatures
 
 ## Name parameters for their role, not their source

--- a/.claude/rules/code-style/variants.md
+++ b/.claude/rules/code-style/variants.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{ts,vue}'
+---
+
 # Don't carry unused size / variant maps
 
 When a component takes a `size` / `variant` / `tier` prop and only one value is ever passed, drop the prop and inline the chosen variant's classes. Sizing/variant maps that exist "in case future callers need them" rot fast — the next real caller usually wants a shape the map didn't anticipate, and the unused branches force every reader to scan past dead code.

--- a/.claude/rules/comment-authoring/examples.md
+++ b/.claude/rules/comment-authoring/examples.md
@@ -1,3 +1,11 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**'
+  - 'supabase/**/*.ts'
+  - 'scripts/**'
+---
+
 # Comment examples
 
 One or more pairs per gate. The rules they encode live in

--- a/.claude/rules/knowledge-addressing.md
+++ b/.claude/rules/knowledge-addressing.md
@@ -44,9 +44,9 @@ slug declared but never cited from anywhere, and a breached line cap.
 
 `.claude/knowledge-lint.json` is the **single declared place** for the always-on file list, the
 caps, and the scan scope. Always-on = the `always_on.include` globs minus any file carrying `paths:`
-frontmatter, since a `paths:` rule is path-triggered rather than loaded every session. The globs
-reach **every** always-loading file, spokes included — a spoke has no `paths:` of its own, so it
-arrives with its hub on every run and costs the budget whether or not the hub was read.
+frontmatter, since a `paths:` rule is path-triggered rather than loaded every session. A spoke's
+`paths:` — see [`rule-authoring → Spokes`](./rule-authoring.md#spokes) — is scanned the same way: a
+spoke that inherited its hub's `paths:` is path-triggered like the hub, not always-on.
 
 - `slugs.exempt` skips the citation scan. `supabase/migrations/**` is exempt because migrations are
   append-only, so a pointer written into one can never be corrected; `tests/unit/scripts/**` is
@@ -56,10 +56,11 @@ arrives with its hub on every run and costs the budget whether or not the hub wa
   to be pointed at from elsewhere. Minting a slug and never citing it is otherwise a failure: a slug
   nobody points at cost nothing to declare and gives the next reader nothing to find, so it earns its
   keep or it's dropped — grep the file, delete the declaration.
-- Caps are `line_caps` — 80 lines for `CLAUDE.md`, 1000 for the always-on total. 1000 is the
-  measured load with a little headroom, not a target: 28 files carry 986 lines today. `aspiration`
-  is the number the payload is being shrunk toward — 400 — and the check warns on every run until
-  it's met. Shrinking is [`harness-pruner`](../agents/harness-pruner.md)'s only job.
+- Caps are `line_caps` — 80 lines for `CLAUDE.md`, 1000 for the always-on total. 1000 is measured
+  load with headroom, not a target — `node scripts/knowledge-lint.mjs` reports the current always-on
+  line count on every run. `aspiration` is the number the payload is being shrunk toward — 400 — and
+  the check warns on every run until it's met. Shrinking is
+  [`harness-pruner`](../agents/harness-pruner.md)'s only job.
 - `line_caps.enforced` is `true` — a breach fails CI. Set it to `false` only to land a deliberate,
   temporary overshoot, and restore it in the change that gets back under.
 

--- a/.claude/rules/rule-authoring.md
+++ b/.claude/rules/rule-authoring.md
@@ -58,6 +58,8 @@ A bullet that fails any gate is not a rule. Cut it or rewrite it.
 ## Spokes
 
 A rule needing a long walkthrough nests it at `.claude/rules/<rule-name>/<spoke>.md` and links it
-from `## Spokes`. The hub holds the decision; the spoke holds the detail. A spoke carries no
-frontmatter and **loads on every run, hub or no hub** — so nesting detail out of a hub buys
-readability, never budget. Give a spoke its own `paths:` when the detail is genuinely path-scoped.
+from `## Spokes`. The hub holds the decision; the spoke holds the detail. **A spoke inherits its
+hub's `paths:` verbatim** — copy the hub's frontmatter into the spoke, don't invent a narrower or
+wider one. A hub with no `paths:` (always-on) leaves its spokes always-on too; inheritance means
+matching the hub, not gating everything. Give a spoke frontmatter of its own only when its content
+is genuinely broader or narrower than the hub's globs, and say why next to the deviation.

--- a/.claude/rules/supabase/stripe-local-probing.md
+++ b/.claude/rules/supabase/stripe-local-probing.md
@@ -1,3 +1,10 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'supabase/**/*'
+  - 'src/api/**/*'
+---
+
 # Exercising Stripe locally
 
 Stripe paths can be verified end to end against the Dev Sandbox. Don't settle for "the types check out" when real money logic is involved.

--- a/.claude/rules/theming/bgx.md
+++ b/.claude/rules/theming/bgx.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{vue,css}'
+---
+
 # Textured backgrounds: `bgx-*`
 
 `src/styles/bg-utils.css` defines a `bgx-*` utility that composites a masked pattern layer over an element using a `::before` pseudo-element. Use it for decorative texture effects (e.g. diagonal stripes on hover).

--- a/.claude/rules/theming/how-it-works.md
+++ b/.claude/rules/theming/how-it-works.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{vue,css}'
+---
+
 # How theming works
 
 Colors are applied via the `data-theme` attribute, which scopes a set of semantic CSS variables defined in `src/styles/palettes.css`.

--- a/.claude/rules/theming/semantic-tokens.md
+++ b/.claude/rules/theming/semantic-tokens.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{vue,css}'
+---
+
 # Semantic surface tokens
 
 Recurring brown/grey pairs (`bg-brown-100 dark:bg-grey-700`, etc.) that mark a particular _surface role_ — input controls, page chrome, elevated cards — are defined as semantic tokens at `@theme` and overridden in the dark block in `src/styles/main.css`. Use the semantic class everywhere:

--- a/.claude/rules/theming/usage.md
+++ b/.claude/rules/theming/usage.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{vue,css}'
+---
+
 # Applying theme tokens
 
 ## At a call site

--- a/.claude/rules/theming/when-to-theme.md
+++ b/.claude/rules/theming/when-to-theme.md
@@ -1,3 +1,9 @@
+---
+lastUpdated: 2026-08-13T00:00:00Z
+paths:
+  - 'src/**/*.{vue,css}'
+---
+
 # When to theme vs use base palette
 
 Not every color should follow the active theme. Reserve `--theme-*` tokens for elements that genuinely need to signal the active theme — primary CTAs, active selections, accents, themed surfaces inside a deck cover. Base UI chrome — body labels, toggle/spinbox idle states, section headings, generic backgrounds, helper text — should use the static brown/grey palette (e.g. `text-brown-700 dark:text-brown-100`, `bg-brown-100 dark:bg-grey-700`) so the chrome stays calm and consistent regardless of which theme is active around it.


### PR DESCRIPTION
## Summary

- The hub/spoke gating was inverted. Most hubs carry `paths:` and load conditionally, but **no spoke carried any frontmatter**, so all 21 spokes loaded on every run — the cheap orienting summary was gated and the expensive detail was not. `theming.md` waited for a `.vue` file; its five spokes arrived regardless.
- Each spoke now inherits its hub's `paths:` verbatim. Where the hub is itself always-on, inheritance leaves the spoke always-on — `self-heal/shipping.md` and `toolchain/commands.md` are unchanged, since healing and shell commands have no file path to trigger on.
- Measured always-on payload: **989 → 373 lines**, under the 400 aspiration TARO-363 set, so `knowledge-lint`'s standing warning goes quiet.
- `rule-authoring.md` now states inheritance as the contract, so the next spoke someone writes carries its hub's `paths:` instead of defaulting to always-on. `knowledge-addressing.md` had a second, now-false copy of the old behaviour — deleted and replaced with a link, rather than a synced duplicate that would diverge again.

## Unverified — please confirm before merging

**It is not proven that Claude Code honours `paths:` frontmatter on a _nested_ file.** The docs say `.claude/rules/**` discovery is recursive and describe `paths:` generically, with no nesting caveat, and `paths:` demonstrably gates top-level files. But a subagent spawned in this worktree after the change still reported all 21 spokes present. That result is only meaningful if subagent prompts are built fresh from cwd rather than inherited, which I could not establish.

If nested `paths:` is **not** honoured, this branch makes the measurement worse than before: `knowledge-lint` would report 373 while ~989 still loads. The check is a fresh top-level session in this worktree, asking which `.claude/rules/**` files are in context without opening any:

- spokes absent → the change works and 373 is real
- spokes present → revert; the fix would have to be flattening spokes into their hubs, not gating them

## Open question

`total` stays at 1000 and `aspiration` at 400, untouched. With the payload now at 373 the cap has a lot of slack and would allow silent regrowth — worth tightening, but that's a call to make once the behaviour above is confirmed.
