### PR TITLE
TARO-352: Measure the sign-up funnel on the welcome page

### DIFF
--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -377,6 +377,26 @@ async function runOAuthFlow(
   })
 }
 
+// A real account/session round trip lands well inside this; a returning
+// member's account is always far older, so the two never get confused.
+const NEW_ACCOUNT_WINDOW_MS = 30_000
+
+/**
+ * Whether the account behind the current session was made just now, rather
+ * than one that already existed before this sign-in.
+ *
+ * Google's flow hands back a session either way, with nothing on it that says
+ * which — so freshness is inferred from `created_at` against the moment the
+ * session resolved, not from which modal started the flow.
+ */
+export async function isNewAccountSession(): Promise<boolean> {
+  const session = await getSession()
+  const createdAt = session?.user.created_at
+  if (!createdAt) return false
+
+  return Date.now() - new Date(createdAt).getTime() < NEW_ACCOUNT_WINDOW_MS
+}
+
 export type OAuthOutcome = 'success' | 'error'
 
 /**

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -379,7 +379,7 @@ async function runOAuthFlow(
 
 // A real account/session round trip lands well inside this; a returning
 // member's account is always far older, so the two never get confused.
-const NEW_ACCOUNT_WINDOW_MS = 30_000
+const NEW_ACCOUNT_WINDOW_MS = 30_000 // 30 seconds
 
 /**
  * Whether the account behind the current session was made just now, rather

--- a/src/composables/auth/use-signup-actions.ts
+++ b/src/composables/auth/use-signup-actions.ts
@@ -4,6 +4,7 @@ import { useSessionStore } from '@/stores/session'
 import { isDisplayNameAvailable, type OAuthProvider } from '@/api/session'
 import { emitSfx } from '@/sfx/bus'
 import { validatePasswordFields } from '@/utils/password-validation'
+import { useTracking } from '@/composables/tracking'
 
 type FieldName = 'username' | 'email' | 'password' | 'confirm_password'
 
@@ -29,6 +30,7 @@ function isEmail(s: string) {
 export function useSignupActions() {
   const session = useSessionStore()
   const { t } = useI18n()
+  const tracking = useTracking()
 
   const username = ref('')
   const email = ref('')
@@ -88,7 +90,10 @@ export function useSignupActions() {
     })
     loading.value = false
 
-    if (outcome === 'success') return 'success'
+    if (outcome === 'success') {
+      tracking.trackSignupCompleted()
+      return 'success'
+    }
 
     // Email-taken surfaces inline; the modal stays open, no alert needed.
     if (outcome === 'email-taken') {

--- a/src/composables/tracking.ts
+++ b/src/composables/tracking.ts
@@ -1,4 +1,7 @@
-import { trackPageview as trackPlausiblePageview } from '@/utils/analytics/plausible'
+import {
+  trackPageview as trackPlausiblePageview,
+  trackEvent as trackPlausibleEvent
+} from '@/utils/analytics/plausible'
 
 /**
  * The one place the app reports activity to an analytics provider.
@@ -12,5 +15,15 @@ export function useTracking() {
     trackPlausiblePageview()
   }
 
-  return { trackPageview }
+  /** The sign-up modal opened, from any entry point. */
+  function trackSignupStarted() {
+    trackPlausibleEvent('Signup Started')
+  }
+
+  /** An account was just created — email/password, or a brand-new Google sign-in. */
+  function trackSignupCompleted() {
+    trackPlausibleEvent('Signup Completed')
+  }
+
+  return { trackPageview, trackSignupStarted, trackSignupCompleted }
 }

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -12,6 +12,7 @@ import {
   signOutLocal as supaSignOutLocal,
   signupEmail as supaSignupEmail,
   signInOAuth as supaSignInOAuth,
+  isNewAccountSession,
   updateEmail as supaUpdateEmail,
   updatePassword as supaUpdatePassword,
   verifyPassword as supaVerifyPassword,
@@ -42,6 +43,7 @@ import { useTaroPhoneStore } from '@/stores/taro-phone'
 import { closeAll as closeAllModals } from '@/composables/modal'
 import { clearPersistedSession } from '@/views/study-session/composables/session-persistence'
 import { consumeReturnDestination } from '@/composables/auth/return-destination'
+import { useTracking } from '@/composables/tracking'
 
 /** Why a session was torn down without the member asking to log out. */
 export type ForceLogoutReason = 'expired' | 'account-deleted'
@@ -60,6 +62,7 @@ export const useSessionStore = defineStore('sessionStore', () => {
   const notice = useNoticeStore()
   const queryCache = useQueryCache()
   const taroPhone = useTaroPhoneStore()
+  const tracking = useTracking()
 
   const user = ref<User | undefined>(undefined)
   const has_password = ref(false)
@@ -202,6 +205,10 @@ export const useSessionStore = defineStore('sessionStore', () => {
       notice.error(t('login-dialog.errors.generic'))
       return
     }
+
+    // Covers the popup leg only — a redirect leg lands on /auth/callback in a
+    // fresh page load, where this function never runs.
+    if (await isNewAccountSession()) tracking.trackSignupCompleted()
 
     onAuthenticated()
   }

--- a/src/utils/analytics/plausible.ts
+++ b/src/utils/analytics/plausible.ts
@@ -44,13 +44,22 @@ function ensureScriptLoaded(site_id: string) {
 }
 
 /**
- * Counts one visit with Plausible — only when a site id is configured for
- * this build, so staging and local runs never send anything.
+ * Sends one named event to Plausible — only when a site id is configured for
+ * this build, so staging and local runs never send anything. Carries no
+ * properties, so nothing identifying the visitor ever rides along.
  */
-export function trackPageview() {
+export function trackEvent(name: string) {
   const site_id = import.meta.env.VITE_PLAUSIBLE_SITE_ID
   if (!site_id) return
 
   ensureScriptLoaded(site_id)
-  window.plausible?.('pageview')
+  window.plausible?.(name)
+}
+
+/**
+ * Counts one visit with Plausible — only when a site id is configured for
+ * this build, so staging and local runs never send anything.
+ */
+export function trackPageview() {
+  trackEvent('pageview')
 }

--- a/src/views/auth/callback.vue
+++ b/src/views/auth/callback.vue
@@ -2,21 +2,28 @@
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { supabase } from '@/supabase-client'
-import { consumeOAuthPopupFlag } from '@/api/session'
+import { consumeOAuthPopupFlag, isNewAccountSession } from '@/api/session'
 import { consumeReturnDestination } from '@/composables/auth/return-destination'
+import { useTracking } from '@/composables/tracking'
 
 const router = useRouter()
+const tracking = useTracking()
 
 onMounted(async () => {
   await supabase.auth.getSession()
 
-  // Popup flow: the opener tab owns the navigation, so this tab just closes itself.
+  // Popup flow: the opener tab owns the navigation, so this tab just closes
+  // itself — the opener is the one that tracks completion for this leg.
   if (consumeOAuthPopupFlag()) {
     window.close()
     return
   }
 
-  // Redirect flow: land on the destination stashed before the OAuth round trip, falling back to the dashboard.
+  // Redirect flow: this tab is the one that resolves, so it's the one that
+  // tracks a brand-new account before moving on.
+  if (await isNewAccountSession()) tracking.trackSignupCompleted()
+
+  // Land on the destination stashed before the OAuth round trip, falling back to the dashboard.
   router.push(consumeReturnDestination() ?? { name: 'dashboard' })
 })
 </script>

--- a/src/views/welcome/signup/signup-modal.ts
+++ b/src/views/welcome/signup/signup-modal.ts
@@ -1,14 +1,17 @@
 import { useModal } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
+import { useTracking } from '@/composables/tracking'
 import SignupDialog from './index.vue'
 
 /** Opens the sign-up modal as a mobile sheet on small viewports. */
 export function useSignupModal() {
   const modal = useModal()
+  const tracking = useTracking()
 
   /** @param payment - preselect the paid plan when the user came from a pricing CTA. */
   function open(payment?: boolean) {
     emitSfx('snappy_button_3')
+    tracking.trackSignupStarted()
     const result = modal.open<boolean>(SignupDialog, {
       backdrop: true,
       mode: 'mobile-sheet',

--- a/tests/integration/views/auth/callback.test.js
+++ b/tests/integration/views/auth/callback.test.js
@@ -5,7 +5,9 @@ const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   push: vi.fn(),
   consumeOAuthPopupFlag: vi.fn(),
-  consumeReturnDestination: vi.fn()
+  consumeReturnDestination: vi.fn(),
+  isNewAccountSession: vi.fn(),
+  trackSignupCompleted: vi.fn()
 }))
 
 vi.mock('@/supabase-client', () => ({
@@ -17,11 +19,16 @@ vi.mock('vue-router', () => ({
 }))
 
 vi.mock('@/api/session', () => ({
-  consumeOAuthPopupFlag: mocks.consumeOAuthPopupFlag
+  consumeOAuthPopupFlag: mocks.consumeOAuthPopupFlag,
+  isNewAccountSession: mocks.isNewAccountSession
 }))
 
 vi.mock('@/composables/auth/return-destination', () => ({
   consumeReturnDestination: mocks.consumeReturnDestination
+}))
+
+vi.mock('@/composables/tracking', () => ({
+  useTracking: () => ({ trackSignupCompleted: mocks.trackSignupCompleted })
 }))
 
 import Callback from '@/views/auth/callback.vue'
@@ -35,6 +42,8 @@ describe('auth/callback', () => {
     mocks.push.mockReset()
     mocks.consumeOAuthPopupFlag.mockReset()
     mocks.consumeReturnDestination.mockReset().mockReturnValue(null)
+    mocks.isNewAccountSession.mockReset().mockResolvedValue(false)
+    mocks.trackSignupCompleted.mockReset()
     closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {})
   })
 
@@ -82,5 +91,30 @@ describe('auth/callback', () => {
     mount(Callback)
     await flushPromises()
     expect(mocks.consumeReturnDestination).not.toHaveBeenCalled()
+  })
+
+  test('popup leg never checks isNewAccountSession or fires Signup Completed — the opener owns that [obligation]', async () => {
+    mocks.consumeOAuthPopupFlag.mockReturnValue(true)
+    mocks.isNewAccountSession.mockResolvedValue(true)
+    mount(Callback)
+    await flushPromises()
+    expect(mocks.isNewAccountSession).not.toHaveBeenCalled()
+    expect(mocks.trackSignupCompleted).not.toHaveBeenCalled()
+  })
+
+  test('redirect leg fires Signup Completed when isNewAccountSession() resolves true [obligation]', async () => {
+    mocks.consumeOAuthPopupFlag.mockReturnValue(false)
+    mocks.isNewAccountSession.mockResolvedValue(true)
+    mount(Callback)
+    await flushPromises()
+    expect(mocks.trackSignupCompleted).toHaveBeenCalledOnce()
+  })
+
+  test('redirect leg does NOT fire Signup Completed when isNewAccountSession() resolves false — a returning account [obligation]', async () => {
+    mocks.consumeOAuthPopupFlag.mockReturnValue(false)
+    mocks.isNewAccountSession.mockResolvedValue(false)
+    mount(Callback)
+    await flushPromises()
+    expect(mocks.trackSignupCompleted).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/api/session.test.js
+++ b/tests/unit/api/session.test.js
@@ -71,7 +71,8 @@ import {
   requestPasswordReset,
   isAuthError,
   onSignedOut,
-  consumeOAuthPopupFlag
+  consumeOAuthPopupFlag,
+  isNewAccountSession
 } from '@/api/session'
 import logger from '@/utils/logger'
 
@@ -138,6 +139,51 @@ describe('getUser', () => {
   test('throws when supabase returns an error', async () => {
     mocks.getUser.mockResolvedValueOnce({ data: null, error: { message: 'nope' } })
     await expect(getUser()).rejects.toThrow('nope')
+  })
+})
+
+describe('isNewAccountSession', () => {
+  const NOW = new Date('2026-01-01T00:00:00.000Z').getTime()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('returns false when there is no session [obligation]', async () => {
+    mocks.getSession.mockResolvedValueOnce({ data: { session: null }, error: null })
+    await expect(isNewAccountSession()).resolves.toBe(false)
+  })
+
+  test('returns true when created_at is 29_999ms before now, just inside the 30_000ms window [obligation]', async () => {
+    const created_at = new Date(NOW - 29_999).toISOString()
+    mocks.getSession.mockResolvedValueOnce({
+      data: { session: { user: { created_at } } },
+      error: null
+    })
+    await expect(isNewAccountSession()).resolves.toBe(true)
+  })
+
+  test('returns false when created_at is exactly 30_000ms before now, at the boundary [obligation]', async () => {
+    const created_at = new Date(NOW - 30_000).toISOString()
+    mocks.getSession.mockResolvedValueOnce({
+      data: { session: { user: { created_at } } },
+      error: null
+    })
+    await expect(isNewAccountSession()).resolves.toBe(false)
+  })
+
+  test('returns false when created_at is well before the 30_000ms window, a returning account [obligation]', async () => {
+    const created_at = new Date(NOW - 60_000).toISOString()
+    mocks.getSession.mockResolvedValueOnce({
+      data: { session: { user: { created_at } } },
+      error: null
+    })
+    await expect(isNewAccountSession()).resolves.toBe(false)
   })
 })
 

--- a/tests/unit/composables/signup-modal.test.js
+++ b/tests/unit/composables/signup-modal.test.js
@@ -3,9 +3,10 @@ import { flushPromises } from '@vue/test-utils'
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────────
 
-const { mockEmitSfx, mockOpen } = vi.hoisted(() => ({
+const { mockEmitSfx, mockOpen, mockTrackSignupStarted } = vi.hoisted(() => ({
   mockEmitSfx: vi.fn(),
-  mockOpen: vi.fn()
+  mockOpen: vi.fn(),
+  mockTrackSignupStarted: vi.fn()
 }))
 
 vi.mock('@/sfx/bus', () => ({
@@ -15,6 +16,10 @@ vi.mock('@/sfx/bus', () => ({
 
 vi.mock('@/composables/modal', () => ({
   useModal: vi.fn(() => ({ open: mockOpen }))
+}))
+
+vi.mock('@/composables/tracking', () => ({
+  useTracking: () => ({ trackSignupStarted: mockTrackSignupStarted })
 }))
 
 import { useSignupModal } from '@/views/welcome/signup/signup-modal'
@@ -35,6 +40,7 @@ function makeModalResult() {
 beforeEach(() => {
   mockEmitSfx.mockReset()
   mockOpen.mockReset()
+  mockTrackSignupStarted.mockReset()
 })
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -47,6 +53,26 @@ describe('useSignupModal', () => {
     useSignupModal().open()
 
     expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_3')
+  })
+
+  test('fires Signup Started on open [obligation]', () => {
+    const { result } = makeModalResult()
+    mockOpen.mockReturnValueOnce(result)
+
+    useSignupModal().open()
+
+    expect(mockTrackSignupStarted).toHaveBeenCalledOnce()
+  })
+
+  test('fires Signup Started again on a second fresh open — no dedup [obligation]', () => {
+    const first = makeModalResult()
+    const second = makeModalResult()
+    mockOpen.mockReturnValueOnce(first.result).mockReturnValueOnce(second.result)
+
+    useSignupModal().open()
+    useSignupModal().open()
+
+    expect(mockTrackSignupStarted).toHaveBeenCalledTimes(2)
   })
 
   test('emits snappy_button_3 before pop_up_close (ordering) [obligation]', async () => {

--- a/tests/unit/composables/tracking.test.js
+++ b/tests/unit/composables/tracking.test.js
@@ -1,0 +1,37 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+
+const { mockTrackPageview, mockTrackEvent } = vi.hoisted(() => ({
+  mockTrackPageview: vi.fn(),
+  mockTrackEvent: vi.fn()
+}))
+
+vi.mock('@/utils/analytics/plausible', () => ({
+  trackPageview: mockTrackPageview,
+  trackEvent: mockTrackEvent
+}))
+
+import { useTracking } from '@/composables/tracking'
+
+beforeEach(() => {
+  mockTrackPageview.mockReset()
+  mockTrackEvent.mockReset()
+})
+
+describe('useTracking', () => {
+  test('trackPageview delegates to the plausible pageview call', () => {
+    useTracking().trackPageview()
+    expect(mockTrackPageview).toHaveBeenCalledOnce()
+  })
+
+  test('trackSignupStarted fires a "Signup Started" event with no second argument [obligation]', () => {
+    useTracking().trackSignupStarted()
+    expect(mockTrackEvent).toHaveBeenCalledWith('Signup Started')
+    expect(mockTrackEvent.mock.calls[0]).toHaveLength(1)
+  })
+
+  test('trackSignupCompleted fires a "Signup Completed" event with no second argument [obligation]', () => {
+    useTracking().trackSignupCompleted()
+    expect(mockTrackEvent).toHaveBeenCalledWith('Signup Completed')
+    expect(mockTrackEvent.mock.calls[0]).toHaveLength(1)
+  })
+})

--- a/tests/unit/composables/use-signup-actions.test.js
+++ b/tests/unit/composables/use-signup-actions.test.js
@@ -4,18 +4,27 @@ import { nextTick } from 'vue'
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────────
 
-const { mockEmitSfx, mockSignupEmail, mockSignInOAuth, mockIsDisplayNameAvailable } = vi.hoisted(
-  () => ({
-    mockEmitSfx: vi.fn(),
-    mockSignupEmail: vi.fn(),
-    mockSignInOAuth: vi.fn(),
-    mockIsDisplayNameAvailable: vi.fn()
-  })
-)
+const {
+  mockEmitSfx,
+  mockSignupEmail,
+  mockSignInOAuth,
+  mockIsDisplayNameAvailable,
+  mockTrackSignupCompleted
+} = vi.hoisted(() => ({
+  mockEmitSfx: vi.fn(),
+  mockSignupEmail: vi.fn(),
+  mockSignInOAuth: vi.fn(),
+  mockIsDisplayNameAvailable: vi.fn(),
+  mockTrackSignupCompleted: vi.fn()
+}))
 
 vi.mock('@/sfx/bus', () => ({
   emitSfx: mockEmitSfx,
   emitHoverSfx: vi.fn()
+}))
+
+vi.mock('@/composables/tracking', () => ({
+  useTracking: () => ({ trackSignupCompleted: mockTrackSignupCompleted })
 }))
 
 vi.mock('vue-i18n', () => ({
@@ -48,6 +57,7 @@ beforeEach(() => {
   setActivePinia(createPinia())
   mockEmitSfx.mockReset()
   mockSignupEmail.mockReset()
+  mockTrackSignupCompleted.mockReset()
   // Default: the chosen display name is free, so submit() proceeds to signup.
   mockIsDisplayNameAvailable.mockReset()
   mockIsDisplayNameAvailable.mockResolvedValue(true)
@@ -113,6 +123,12 @@ describe('useSignupActions', () => {
       expect(mockSignupEmail).not.toHaveBeenCalled()
     })
 
+    test('does NOT fire Signup Completed on a validation failure [obligation]', async () => {
+      const auth = useSignupActions()
+      await auth.submit()
+      expect(mockTrackSignupCompleted).not.toHaveBeenCalled()
+    })
+
     test('emits digi_powerdown sfx on validation failure [obligation]', async () => {
       const auth = useSignupActions()
       await auth.submit()
@@ -175,6 +191,14 @@ describe('useSignupActions', () => {
       expect(result).toBe('success')
     })
 
+    test('fires Signup Completed on the "success" outcome, and only then [obligation]', async () => {
+      mockSignupEmail.mockResolvedValueOnce('success')
+      const auth = useSignupActions()
+      fillValidFields(auth)
+      await auth.submit()
+      expect(mockTrackSignupCompleted).toHaveBeenCalledOnce()
+    })
+
     test('calls the store with trimmed email and display_name', async () => {
       mockSignupEmail.mockResolvedValueOnce('success')
       const auth = useSignupActions()
@@ -223,6 +247,14 @@ describe('useSignupActions', () => {
       fillValidFields(auth)
       await auth.submit()
       expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+    })
+
+    test('does NOT fire Signup Completed when the email is already taken [obligation]', async () => {
+      mockSignupEmail.mockResolvedValueOnce('email-taken')
+      const auth = useSignupActions()
+      fillValidFields(auth)
+      await auth.submit()
+      expect(mockTrackSignupCompleted).not.toHaveBeenCalled()
     })
   })
 
@@ -297,6 +329,14 @@ describe('useSignupActions', () => {
       fillValidFields(auth)
       await auth.submit()
       expect(mockEmitSfx).not.toHaveBeenCalled()
+    })
+
+    test('does NOT fire Signup Completed when the store outcome is "error" [obligation]', async () => {
+      mockSignupEmail.mockResolvedValueOnce('error')
+      const auth = useSignupActions()
+      fillValidFields(auth)
+      await auth.submit()
+      expect(mockTrackSignupCompleted).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/unit/stores/session.test.js
+++ b/tests/unit/stores/session.test.js
@@ -66,6 +66,15 @@ const { mockConsumeReturnDestination } = vi.hoisted(() => ({
   mockConsumeReturnDestination: vi.fn()
 }))
 
+const { mockIsNewAccountSession, mockTrackSignupCompleted } = vi.hoisted(() => ({
+  mockIsNewAccountSession: vi.fn(),
+  mockTrackSignupCompleted: vi.fn()
+}))
+
+vi.mock('@/composables/tracking', () => ({
+  useTracking: () => ({ trackSignupCompleted: mockTrackSignupCompleted })
+}))
+
 vi.mock('@/stores/notice-store', () => ({ useNoticeStore: () => mockNotice }))
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }))
 vi.mock('@pinia/colada', () => ({ useQueryCache: () => mockQueryCache }))
@@ -98,7 +107,8 @@ vi.mock('@/api/session', () => ({
   isPasswordRecoveryUrl: mockIsPasswordRecoveryUrl,
   waitForPasswordRecovery: mockWaitForPasswordRecovery,
   onSignedOut: mockOnSignedOut,
-  isAuthError: mockIsAuthError
+  isAuthError: mockIsAuthError,
+  isNewAccountSession: mockIsNewAccountSession
 }))
 
 vi.mock('vue-router', () => ({
@@ -143,6 +153,8 @@ beforeEach(() => {
   mockCloseAllModals.mockReset()
   mockTaroPhoneReset.mockReset()
   mockClearPersistedSession.mockReset()
+  mockIsNewAccountSession.mockReset()
+  mockTrackSignupCompleted.mockReset()
 })
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -344,6 +356,13 @@ describe('useSessionStore', () => {
       const store = useSessionStore()
       await expect(store.login('user@example.com', 'pw')).rejects.toThrow('invalid credentials')
     })
+
+    test('does NOT record a Signup Completed event [obligation]', async () => {
+      mockLogin.mockResolvedValueOnce({ user: { id: 'u1' } })
+      const store = useSessionStore()
+      await store.login('user@example.com', 'password1')
+      expect(mockTrackSignupCompleted).not.toHaveBeenCalled()
+    })
   })
 
   // ── logout ─────────────────────────────────────────────────────────────────
@@ -536,6 +555,30 @@ describe('useSessionStore', () => {
       await store.signInOAuth('google')
       expect(mockCloseAllModals).toHaveBeenCalledOnce()
       expect(mockPush).toHaveBeenCalledWith({ name: 'dashboard' })
+    })
+
+    test('fires Signup Completed on "success" when isNewAccountSession() resolves true [obligation]', async () => {
+      mockSignInOAuth.mockResolvedValueOnce('success')
+      mockIsNewAccountSession.mockResolvedValueOnce(true)
+      const store = useSessionStore()
+      await store.signInOAuth('google')
+      expect(mockTrackSignupCompleted).toHaveBeenCalledOnce()
+    })
+
+    test('does NOT fire Signup Completed on "success" when isNewAccountSession() resolves false — a returning account [obligation]', async () => {
+      mockSignInOAuth.mockResolvedValueOnce('success')
+      mockIsNewAccountSession.mockResolvedValueOnce(false)
+      const store = useSessionStore()
+      await store.signInOAuth('google')
+      expect(mockTrackSignupCompleted).not.toHaveBeenCalled()
+    })
+
+    test('does NOT fire Signup Completed on "error" outcome, even when isNewAccountSession() resolves true [obligation]', async () => {
+      mockSignInOAuth.mockResolvedValueOnce('error')
+      mockIsNewAccountSession.mockResolvedValueOnce(true)
+      const store = useSessionStore()
+      await store.signInOAuth('google')
+      expect(mockTrackSignupCompleted).not.toHaveBeenCalled()
     })
 
     test('on "error" outcome, does NOT navigate or close modals [obligation]', async () => {

--- a/tests/unit/utils/analytics/plausible.test.js
+++ b/tests/unit/utils/analytics/plausible.test.js
@@ -58,3 +58,34 @@ describe('trackPageview', () => {
     expect(window.plausible?.q).toEqual([['pageview'], ['pageview']])
   })
 })
+
+describe('trackEvent', () => {
+  test('does nothing when VITE_PLAUSIBLE_SITE_ID is unset [obligation]', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_SITE_ID', '')
+    const { trackEvent } = await import('@/utils/analytics/plausible')
+
+    trackEvent('Signup Started')
+
+    expect(scriptTags()).toHaveLength(0)
+    expect(window.plausible).toBeUndefined()
+  })
+
+  test('fires the named event once the site id is set', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_SITE_ID', SITE_ID)
+    const { trackEvent } = await import('@/utils/analytics/plausible')
+
+    trackEvent('Signup Completed')
+
+    expect(window.plausible?.q).toContainEqual(['Signup Completed'])
+  })
+
+  test('never sends a second argument alongside the event name [obligation]', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_SITE_ID', SITE_ID)
+    const { trackEvent } = await import('@/utils/analytics/plausible')
+
+    trackEvent('Signup Started')
+
+    const call = window.plausible?.q?.find((args) => args[0] === 'Signup Started')
+    expect(call).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
[TARO-352](https://app.notion.com/3b80953c224c8103a12ef00be538e46b)

## Summary

- Records `Signup Started` when the sign-up modal opens and `Signup Completed` when an account is actually created, so the welcome page's visit-to-account rate becomes visible. Built on the tracker TARO-351 installed — no second install.
- Events carry a name and nothing else, and ride the same `VITE_PLAUSIBLE_SITE_ID` gate as pageviews, so staging and local dev report nothing.
- The Google path judges new-vs-returning from the account's `created_at` against now (`isNewAccountSession()`, 30s window). **That 30s threshold is an engineering judgement, not something the ticket pinned** — flagging it as the one number worth a second opinion. Both Google legs are covered: the popup leg resolves in `signInOAuth()`, the redirect leg in `/auth/callback`.
- **Needs a follow-up outside this PR**: `Signup Started` and `Signup Completed` have to be created as goals in the Plausible dashboard before they show up there.

## Acceptance criteria

- [ ] Opening the sign-up modal records `Signup Started`, whether it was opened from the splash call-to-action or from a pricing plan. — the splash path is live and covered; the pricing plan cards have no sign-up call-to-action wired yet (nothing calls `open({ payment: true })` today), so that half has no trigger to exercise. Both would route through the same `open()` chokepoint the moment that CTA is wired.
- [x] Each fresh opening of the sign-up modal records its own `Signup Started`.
- [x] Creating an account with email and password records `Signup Completed`.
- [x] Creating a brand-new account with Google records `Signup Completed`, both when the flow returns in a popup and when it returns by redirect.
- [x] Signing in with Google to an account that already exists records nothing.
- [x] A sign-up that fails validation, is rejected, or is abandoned records no `Signup Completed`.
- [x] Signing in through the log-in modal records nothing.
- [x] No recorded event carries an email address, display name, or any other field identifying the person.
- [x] Nothing is recorded from the staging site or from a local dev run.
