### PR TITLE
TARO-361: Rewrite the theming rules against the shipped role system

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -19,7 +19,7 @@ paths:
 | `src/composables/` | Reusable composition functions (modal, alert, prompt, shortcuts, settings, storage, fsrs, can, per-domain folders)                              |
 | `src/stores/`      | Pinia stores: `session`, `member`, `theme`, `notice-store`, `shortcut-store`, `taro-phone`                                                      |
 | `src/views/`       | Routed pages; `authenticated.vue` wraps the protected routes                                                                                    |
-| `src/styles/`      | Global CSS + TailwindCSS 4 config; `palettes.gen.css` (generated) defines the color tokens                                                      |
+| `src/styles/`      | Global CSS + TailwindCSS 4 config; `stations.css` holds the neutral roles, `palettes.gen.css` (generated) the accent roles                      |
 | `src/sfx/`         | Custom audio engine behind the `v-sfx` directive                                                                                                |
 | `types/`           | Shared TypeScript types — outside `src/`                                                                                                        |
 

--- a/.claude/rules/css.md
+++ b/.claude/rules/css.md
@@ -17,7 +17,8 @@ editing any `.vue` file.
 
 When you do reach for a `<style>` block:
 
-- Write plain CSS with `var(--theme-*)` / `var(--color-*)` tokens — never `@apply`.
+- Write plain CSS with `var(--color-*)` role tokens — never `@apply`, never a raw shade
+  ([`theming`](./theming.md) owns which role).
 - Keep the rule scoped to the component; don't leak global selectors.
 
 If none of the conditions apply, keep it inline — even when the class list looks long, utilities beat a one-off style block.

--- a/.claude/rules/theming.md
+++ b/.claude/rules/theming.md
@@ -1,29 +1,38 @@
 ---
-lastUpdated: 2026-05-17T00:00:00Z
+lastUpdated: 2026-08-15T00:00:00Z
 paths:
   - 'src/**/*.{vue,css}'
 ---
 
 # Theming
 
-**Owns the theme token contract** — `data-theme`, `--theme-*` tokens, and when a color should follow
-the active theme vs. the static base palette. Reaches you editing any `.vue` or `.css` file.
-
-Colors go through the `data-theme` token layer — never raw hex, never hardcoded Tailwind color classes (`bg-blue-500`) for themeable colors.
+**Owns the colour-role contract** — the three switches (`data-mode`, `data-palette`, `data-station`),
+the `--color-*` roles they fill, and when a colour follows the member's palette vs. stays neutral.
+Reaches you editing any `.vue` or `.css` file. The model behind it is corpus fact ([[theming]]).
 
 ## Top-level rules
 
-- Set `data-theme` (and `data-theme-dark` when needed) on the outermost element/component that should carry the theme — descendants inherit the tokens.
-- Don't add `theme` / `themeDark` props to components — let `data-theme` / `data-theme-dark` forward via `inheritAttrs`. Exception: content teleported out of the DOM (e.g. `ui-kit/tooltip`'s popover) can't inherit, so it takes explicit `theme` / `theme_dark` props.
-- Use `--theme-*` tokens only for colors that should signal the active theme. For base chrome use the static brown/grey palette utilities, not `--theme-*`.
+- **Ask for a role, never a shade.** `bg-surface`, `text-ink`, `border-line`, `bg-(--color-accent)` —
+  never a raw hex, and never a `bg-brown-100 dark:bg-grey-900` pair for a colour a role already
+  answers. A role is already correct in both modes, so the `dark:` variant is the tell that you
+  reached past the layer.
+- **A misspelled role renders bare, not red.** The colour set is closed, so `bg-surfce` produces no
+  colour and no warning — confirm a token exists under `@theme` in `src/styles/main.css` before you
+  ship a utility you haven't seen elsewhere ([`css`](./css.md) owns the reset that causes this).
+- **Never write `data-mode` from a component.** `src/stores/theme.ts` is its only writer; read the
+  rendition by using a role, or branch on the `dark:` variant for a non-colour property.
+- **`data-palette` opts one element in, on its own root.** Attributes don't inherit, so putting it on
+  an ancestor colours nothing below it →[K:theming-palette-identity].
+- **Put `data-station` on the element that owns the surface, and pair it with `bg-surface`** —
+  [`stations`](./theming/stations.md) holds that pairing.
 - Whether a `<style>` block is warranted at all, and the plain-CSS-not-`@apply` rule once you're in
   one, are [`css`](./css.md)'s.
 
 ## Spokes
 
-- [`how-it-works`](./theming/how-it-works.md) — `palettes.gen.css` selector mechanics + dark-mode root
-- [`usage`](./theming/usage.md) — call-site, inside-component, CSS examples
-- [`when-to-theme`](./theming/when-to-theme.md) — themed tokens vs base palette decision rule
-- [`semantic-tokens`](./theming/semantic-tokens.md) — promoting recurring brown/grey pairs to `--color-*` roles
-- [`bgx`](./theming/bgx.md) — textured-background `bgx-*` utilities
+- [`how-it-works`](./theming/how-it-works.md) — where each role is authored, and the generated stylesheet
+- [`usage`](./theming/usage.md) — call-site, inside-component, teleport and CSS syntax
+- [`when-to-theme`](./theming/when-to-theme.md) — accent role vs. neutral station role
+- [`semantic-tokens`](./theming/semantic-tokens.md) — adding a role vs. remapping one locally
+- [`bgx`](./theming/bgx.md) — textured-background `bgx-*` utilities and their two fill roles
 - [`stations`](./theming/stations.md) — which background class pairs with a `data-station` root

--- a/.claude/rules/theming/bgx.md
+++ b/.claude/rules/theming/bgx.md
@@ -1,33 +1,45 @@
 ---
-lastUpdated: 2026-08-13T00:00:00Z
+lastUpdated: 2026-08-15T00:00:00Z
 paths:
   - 'src/**/*.{vue,css}'
 ---
 
 # Textured backgrounds: `bgx-*`
 
-**Owns the `bgx-*` textured-background utilities and how they pick up a theme color.**
+**Owns the `bgx-*` utilities in `src/styles/bg-utils.css` and which role fills the texture.**
 
-`src/styles/bg-utils.css` defines a `bgx-*` utility that composites a masked pattern layer over an element using a `::before` pseudo-element. Use it for decorative texture effects (e.g. diagonal stripes on hover).
+The utility masks a repeating pattern into a `::before` layer behind the element's own background.
 
-Key modifiers:
+| Utility               | What it does                                                 |
+| --------------------- | ------------------------------------------------------------ |
+| `bgx-<name>`          | Sets the mask image (`bgx-dot-grid`, `bgx-diagonal-stripes`) |
+| `bgx-color-(--token)` | Sets the fill colour of the mask layer                       |
+| `bgx-opacity-<n>`     | Sets opacity as a percentage (`bgx-opacity-25` → 25%)        |
+| `bgx-size-<n>`        | Sets mask-size via the spacing scale, or a length            |
+| `bgx-slide`           | Animates the mask horizontally, infinite loop                |
+| `bgx-slide-down`      | The same, vertically                                         |
+| `pattern-mask`        | The runtime variant — image supplied inline as `--bgx-image` |
 
-| Utility               | What it does                                               |
-| --------------------- | ---------------------------------------------------------- |
-| `bgx-<name>`          | Sets the mask image (e.g. `bgx-diagonal-stripes`)          |
-| `bgx-color-[<value>]` | Sets the fill color of the mask layer                      |
-| `bgx-opacity-<n>`     | Sets opacity as a percentage (e.g. `bgx-opacity-20` → 20%) |
-| `bgx-size-<n>`        | Sets mask-size via spacing scale or length                 |
-| `bgx-slide`           | Animates the mask position (infinite loop)                 |
+## Which role fills it
 
-To make the texture color follow the active theme token, pass the token through the arbitrary-value bracket:
+Two roles exist for this, and they go opposite ways — pick by what the texture sits on, never by
+which one looks right in the mode you have open:
+
+- **`--color-accent-pattern` on an accent surface** — a soft sheen over an already-coloured fill.
+  This is the default fill, so a bare `bgx-<name>` on a neutral surface is almost always wrong.
+- **`--color-raised-pattern` on a neutral surface** — neutral buttons, tap sweeps, chrome dot grids.
+  It reads darker than the surface in light and lighter in dark.
 
 ```html
-<!-- fill inherits the current theme's neutral color -->
-<div class="bgx-diagonal-stripes bgx-color-[var(--theme-neutral)]" />
-
-<!-- fill follows the on-neutral token -->
-<div class="bgx-diagonal-stripes bgx-color-[var(--theme-on-neutral)]" />
+<!-- Good — neutral chrome names the neutral texture role -->
+<div class="bgx-dot-grid bgx-size-15 bgx-color-(--color-raised-pattern)" />
 ```
 
-When using `bgx-color-*` inside a themed element, always pass a `var(--theme-*)` token, not a raw color.
+- **Pass a role, never a raw colour**, to `bgx-color-*`. `currentColor` is the one exception, for a
+  sweep that must track a text colour already resolved on the element.
+- **Use `pattern-mask`, not `bgx-<name>`, when the pattern is chosen at runtime.** The `bgx-*`
+  literals must be statically scannable, so a bound pattern name never produces a utility; the
+  runtime path sets `--bgx-image` inline instead.
+- **Set a per-mode opacity through `--bgx-opacity-light` / `--bgx-opacity-dark` on `pattern-mask`**,
+  never inline on `--bgx-opacity` — an inline value outranks the dark-mode selector and freezes the
+  light strength into both modes.

--- a/.claude/rules/theming/how-it-works.md
+++ b/.claude/rules/theming/how-it-works.md
@@ -1,22 +1,29 @@
 ---
-lastUpdated: 2026-08-13T00:00:00Z
+lastUpdated: 2026-08-15T00:00:00Z
 paths:
   - 'src/**/*.{vue,css}'
 ---
 
-# How theming works
+# Where a role is authored
 
-**Owns the selector mechanics behind `data-theme`/`data-theme-dark` and the dark-mode root.**
+**Owns which file you edit to change what a role resolves to, per switch.**
 
-Colors are applied via the `data-theme` attribute, which scopes a set of semantic CSS variables defined in `src/styles/palettes.gen.css` (generated).
-
-1. Parents apply theming by setting `data-theme` (and optionally `data-theme-dark`) directly on the element or component — the value is a `MemberTheme` (e.g. `'blue-500'`, `'green-400'`).
-2. On a component, those attributes flow through to its root element via Vue's normal attribute inheritance. Components do **not** declare a `theme` / `themeDark` prop; they just let the attrs forward.
-3. `palettes.gen.css` maps each theme value to a set of `--theme-*` variables using a comma selector covering two activation conditions:
-   - `[data-theme='X']` — `(0,1,0)` always active (light or dark mode)
-   - `[data-theme='dark'] [data-theme-dark='X']` — `(0,2,0)` active when the root is dark
-     Each selector in a comma list keeps its own specificity (unlike `:is()`, which elevates all arms to the highest), so the descendant form genuinely beats the plain form in dark mode.
-4. Available tokens: `--theme-primary` / `--theme-on-primary`, `--theme-secondary` / `--theme-on-secondary`, `--theme-accent` / `--theme-on-accent`, `--theme-neutral` / `--theme-on-neutral`.
-5. Child elements reference those variables via Tailwind's arbitrary-property syntax or plain CSS.
-
-> **Dark mode root**: `use-theme` always writes an explicit `'light'` or `'dark'` to `data-theme` on `document.documentElement` — even when the user's preference is `'system'`. CSS never needs a `prefers-color-scheme` media-query fallback.
+- **Accent roles come from the registry, not the stylesheet.** Change `--color-accent`,
+  `--color-accent-muted`, `--color-on-accent` or `--color-accent-text` for a palette in
+  `src/utils/palette/registry.ts`, then run `pnpm gen:palette-css`. `src/styles/palettes.gen.css` is
+  generated — an edit there is overwritten by the next run and never reaches
+  `src/utils/cover/tokens.ts`, which must list the same palette set.
+- **Neutral roles are authored per station, by hand, in `src/styles/stations.css`** — light and dark
+  renditions both, with nothing derived from another station →[K:surface-stations-hand-authored].
+  Changing one station's value is not a signal to recompute the other three.
+- **A role only becomes a Tailwind utility once it is declared under `@theme` in
+  `src/styles/main.css`.** Adding a value in `stations.css` alone gives you a variable that
+  `var()` reads but `bg-*` / `text-*` / `border-*` never resolve.
+- **A new palette alias joins the selector list of the palette it points at**, so `danger` and `red`
+  stay one rendition — never a second block copying the values.
+- **Never gate a dark rendition on `prefers-color-scheme`.** The theme store always writes an
+  explicit `data-mode` to `documentElement`, including for the `system` preference, so a media query
+  is a second source of truth that disagrees the moment a member overrides the system.
+- **Scope a dark override with both the descendant and the self form** —
+  `[data-mode='dark'] [data-palette='x']` and `[data-mode='dark'][data-palette='x']` — or the role
+  breaks whenever the attribute lands on the moded root itself rather than below it.

--- a/.claude/rules/theming/semantic-tokens.md
+++ b/.claude/rules/theming/semantic-tokens.md
@@ -1,36 +1,31 @@
 ---
-lastUpdated: 2026-08-13T00:00:00Z
+lastUpdated: 2026-08-15T00:00:00Z
 paths:
   - 'src/**/*.{vue,css}'
 ---
 
-# Semantic surface tokens
+# Adding a role vs. remapping one
 
-**Owns when a recurring brown/grey pair gets promoted to a semantic `--color-*` token.**
+**Owns what to do when no existing role answers the colour you need.**
 
-Recurring brown/grey pairs (`bg-brown-100 dark:bg-grey-700`, etc.) that mark a particular _surface role_ — input controls, page chrome, elevated cards — are defined as semantic tokens at `@theme` and overridden in the dark block in `src/styles/main.css`. Use the semantic class everywhere:
+- **Exhaust the ten neutral roles first.** A form control's recess is `well`, a chip resting on a
+  surface is `raised`, its two-tone companions are `raised-tint` / `raised-shade` — a new role named
+  for a widget (`input`, `card-header`) duplicates one of these under a narrower name and then has to
+  be retuned separately for every station.
+- **Remap a role locally rather than adding one, when a single control needs the swap.** Setting the
+  custom property in place keeps every child utility working and costs nothing at the theme layer:
 
-```css
-/* main.css */
-@theme {
-  --color-input: var(
-    --color-brown-100
-  ); /* form-control surface (inputs, spinbox row, toggle off-track) */
-}
-
-@layer base {
-  &:where([data-theme='dark'], [data-theme='dark'] *) {
-    --color-input: var(--color-grey-700);
-  }
-}
+```html
+<!-- Good — the raised texture picks up the accent's sheen for the active row only -->
+<div class="data-[active=true]:[--color-raised-pattern:var(--color-accent-pattern)]">…</div>
 ```
 
-```vue
-<!-- Good -->
-<div class="bg-input">…</div>
-
-<!-- Bad — duplicates the dark mapping at every callsite -->
-<div class="bg-brown-100 dark:bg-grey-700">…</div>
-```
-
-When you find yourself writing the same `bg-X dark:bg-Y` pair (or `text-`, `ring-`, etc.) in ≥ 3 places, promote it to a semantic `--color-*` token — the concrete-caller threshold [`architecture/utils`](../architecture/utils.md) states generally. Name the token after the role (`input`, `surface`, `elevated`), not the colour (`brown-100`). Themed variants (`--theme-primary`) stay separate — semantic surface tokens are for non-themed chrome.
+- **A genuinely new neutral role costs a value in every station × mode**, hand-authored in
+  `src/styles/stations.css`, plus its `@theme` declaration in `src/styles/main.css`. Add one only
+  when the colour is a distinct question every station must answer — not when three call sites happen
+  to share a shade.
+- **Name a role for the job it does, never for its colour or its first caller** — `line`, not
+  `brown-300`; `skeleton-sheen`, not `tip-card-shimmer`.
+- **A colour that must stay identical across stations is a fixed role, not a station role** — declare
+  it once in `@theme` with a `data-mode='dark'` counterpart, the way `card`, `mat` and `knockout` are
+  ([[surface-stations]] holds why each opts out).

--- a/.claude/rules/theming/usage.md
+++ b/.claude/rules/theming/usage.md
@@ -1,46 +1,63 @@
 ---
-lastUpdated: 2026-08-13T00:00:00Z
+lastUpdated: 2026-08-15T00:00:00Z
 paths:
   - 'src/**/*.{vue,css}'
 ---
 
-# Applying theme tokens
+# Applying a role
 
-**Owns the call-site and in-component syntax for applying theme tokens.**
+**Owns the call-site and in-component syntax for setting a switch and consuming a role.**
 
 ## At a call site
 
-Pass `data-theme` (and `data-theme-dark` if needed) directly on the child element or component:
+Set the switch as a plain attribute on the element that should carry it — a palette name (`blue`,
+`green`, `pink`) or one of its meaning aliases (`brand`, `info`, `danger`, `error`, `success`,
+`warning`):
 
 ```vue
 <template>
-  <ui-button data-theme="blue-500" data-theme-dark="blue-300">Save</ui-button>
+  <ui-button data-palette="danger">Delete</ui-button>
 
-  <div data-theme="green-400">
-    <div class="bg-(--theme-primary) text-(--theme-on-primary)">...</div>
+  <div data-palette="green">
+    <span class="bg-(--color-accent) text-(--color-on-accent)">…</span>
   </div>
 </template>
 ```
 
-If `data-theme-dark` is omitted, the same `data-theme` value applies in dark mode.
+- **Prefer the meaning over the colour** where one exists — `data-palette="danger"` survives a
+  repoint in the registry; `data-palette="red"` freezes today's answer.
+- **Bind `undefined`, never `''`, to switch a palette off.** The neutral branch keys off the
+  attribute being absent, and an empty string still matches `[data-palette]`.
 
-## Inside a themed component
+## Inside a component
 
-Don't declare `theme` / `themeDark` props. With default `inheritAttrs`, `data-theme` and `data-theme-dark` from the call site flow onto the component's root automatically. Consume the scoped tokens anywhere inside:
+- **Don't declare a `palette` / `station` prop to re-emit as an attribute.** With default
+  `inheritAttrs`, a caller's `data-palette` lands on the component root on its own; a prop only earns
+  its place when the component picks the value itself (`:data-palette="error ? 'danger' : undefined"`).
+- **Drive the neutral/accent split off the attribute's presence, not a boolean prop** — one selector
+  covers both states and can't disagree with the attribute:
 
-```vue
-<template>
-  <div class="bg-(--theme-primary) text-(--theme-on-primary)">...</div>
-</template>
+```css
+.ui-kit-tag {
+  --tag-bg: var(--color-raised);
+}
+.ui-kit-tag[data-palette] {
+  --tag-bg: var(--color-accent);
+}
 ```
 
-If the component uses `defineOptions({ inheritAttrs: false })`, forward the attrs explicitly onto the root that should carry the theme.
+## Teleported content
 
-## In CSS / `<style>`
+**Teleporting to `<body>` severs the attribute chain — restate the switch on the teleported node.**
+Read the trigger's resolved palette (`trigger.closest('[data-palette]')`) and bind it onto the
+floating element; floating chrome also declares its own `data-station="float"`, since the station it
+was mounted under no longer reaches it.
+
+## In CSS
 
 ```css
 .my-component {
-  background-color: var(--theme-primary);
-  color: var(--theme-on-primary);
+  background-color: var(--color-accent);
+  color: var(--color-on-accent);
 }
 ```

--- a/.claude/rules/theming/when-to-theme.md
+++ b/.claude/rules/theming/when-to-theme.md
@@ -1,18 +1,37 @@
 ---
-lastUpdated: 2026-08-13T00:00:00Z
+lastUpdated: 2026-08-15T00:00:00Z
 paths:
   - 'src/**/*.{vue,css}'
 ---
 
-# When to theme vs use base palette
+# Accent role vs. neutral role
 
-**Owns the decision between a `--theme-*` token and the static base palette.**
+**Owns the choice between an accent role, which follows the member's palette, and a neutral station
+role, which doesn't.**
 
-Not every color should follow the active theme. Reserve `--theme-*` tokens for elements that genuinely need to signal the active theme — primary CTAs, active selections, accents, themed surfaces inside a deck cover. Base UI chrome — body labels, toggle/spinbox idle states, section headings, generic backgrounds, helper text — should use the static brown/grey palette (e.g. `text-brown-700 dark:text-brown-100`, `bg-brown-100 dark:bg-grey-700`) so the chrome stays calm and consistent regardless of which theme is active around it.
+The split is by _switch_, not by shade: the accent roles (`accent`, `accent-muted`, `on-accent`,
+`accent-text`, `accent-pattern`) are answered by `data-palette`; every neutral role (`surface`,
+`well`, `raised`, `raised-tint`, `raised-shade`, `line`, `ink`, `ink-muted`, `skeleton`,
+`skeleton-sheen`) is answered by `data-station`. The two sets are disjoint, so a choice between them
+is a choice about which switch should move the element.
 
-Rule of thumb:
+- **Default to a neutral role.** Reach for an accent role only where the element carries identity or
+  a semantic meaning: a primary action, a selected or checked state, a destructive control, a deck
+  cover. Chrome — labels, idle states, dividers, panels, skeletons — stays neutral, so it reads the
+  same whichever palette the member picked.
+- **An accent role needs `data-palette` on that same element.** An accent role with no palette in
+  scope falls back to the blue default rather than the colour you meant, which reads as correct on a
+  blue account and wrong on every other.
+- **Never re-derive a rendition with a `dark:` variant** — `bg-raised`, not
+  `bg-brown-300 dark:bg-stone-700`. Both renditions already live in the role, and the pair drifts
+  from the station the moment either is retuned.
+- **Text on a neutral surface uses `accent-text`, not `accent`.** `accent` is tuned as a fill and
+  goes illegible at body size; `accent-text` is the same identity darkened to read as text.
+- **Text on an accent fill uses `on-accent`** — pairing `text-ink` with an accent background hands
+  the label a colour tuned for the station behind it, not for the fill it's actually sitting on.
+- **A role that isn't resting on a station doesn't take one.** A badge or ring on an accent fill uses
+  the fixed `knockout` / `card` / `mat` roles; borrowing a station role there looks right in one mode
+  and inverts in the other →[K:fixed-roles-skip-the-station].
 
-- **Themed**: the _active_ / _checked_ / _selected_ state of an interactive element, primary buttons, accent borders, themed cover surfaces.
-- **Base palette**: labels, idle/off states, section headings, modal chrome, dividers, generic surfaces.
-
-Mixing is normal in one component — e.g. a toggle's label and off-track stay base palette, while the on-track and on-handle pick up `--theme-primary` / `--theme-on-primary`.
+Mixing both in one component is normal — a toggle's label and off-track stay neutral while the
+on-track takes `accent` / `on-accent`.


### PR DESCRIPTION
[TARO-361](https://app.notion.com/3b90953c224c812ba2cfe4462748296d)

## Summary

- Rewrites `theming.md` and its five stale spokes against the system that actually ships: `data-mode` / `data-palette` / `data-station` with `--color-*` roles. The old prose taught `data-theme` / `data-theme-dark` / `--theme-*`, cited the deleted `src/styles/palettes.css`, named eight tokens that were never defined, invented `theme` / `theme_dark` props on the tooltip, and taught a `--color-input` token with zero uses in `src/`.
- `when-to-theme.md` taught the raw `bg-X dark:bg-Y` pattern the role layer replaced — the exact opposite of the system. It now splits by switch instead: five accent roles answer to `data-palette`, ten neutral roles to `data-station`, and the old pattern is an explicit prohibition.
- Follows the sibling cross-references out of `css.md` (drops `var(--theme-*)`) and `architecture.md` (the `src/styles/` row now names `stations.css` and `palettes.gen.css`).
- The ticket's tech details named `data-depth` as the third switch; it does not exist. TARO-359 replaced it with `data-station`, so the rewrite is against named surface stations, verified against `src/styles/` rather than the ticket text. `theming/stations.md` was added after the ticket was cut and is already current — left untouched.

## Acceptance criteria

- [x] Every example in the guidance produces visible colour when used as written.
- [x] The guidance names only attributes, colour roles and files that exist in the app today.
- [x] The rule for when a colour should follow the member's chosen colour versus stay neutral matches how the app actually splits the two.
- [x] The textured-background guidance names the two texture roles the app defines.
