### PR TITLE
TARO-366: Container scroll areas draw their own scroll handle

### DIFF
--- a/corpus/hazards.md
+++ b/corpus/hazards.md
@@ -38,6 +38,7 @@ in the directory it bites, so it reaches you when you're standing on it.
 | →[K:ios-audio-interruption]                     | [[sound]]              | `src/sfx/`                                                                                                               |
 | →[K:dock-height-single-owner]                   | [[mobile-dock]]        | `src/components/mobile-dock/`, `src/composables/ui/animated-height.ts`, `src/components/layout-kit/crossfade-resize.vue` |
 | →[K:fixed-roles-skip-the-station]               | [[surface-stations]]   | `src/styles/main.css`                                                                                                    |
+| →[K:station-roles-can-collide]                  | [[surface-stations]]   | `src/styles/stations.css`, `src/components/ui-kit/options-panel/index.vue`                                               |
 | →[K:app-window-fills-full-width]                | [[layout-kit]]         | `src/components/layout-kit/app-window/`                                                                                  |
 | →[K:docked-app-window-drops-body-scroll]        | [[layout-kit]]         | `src/components/layout-kit/app-window/`                                                                                  |
 | →[K:dialog-card-overflow-bleed]                 | [[dialog-card]]        | `src/components/layout-kit/dialog-card/dialog-card-body.vue`                                                             |

--- a/corpus/map.md
+++ b/corpus/map.md
@@ -49,7 +49,7 @@ See [corpus-authoring](../.claude/rules/corpus-authoring.md) for how the corpus 
 ## theming
 
 - [[theming]] — colors are roles, not shades; three switches reslot the whole screen ⚠️
-- [[surface-stations]] — four named surfaces, each hand-authored, none derived from another; a few roles opt out of every station entirely ⚠️
+- [[surface-stations]] — four named surfaces, each hand-authored, none derived from another; a few roles opt out of every station entirely, and two roles can collide into the same color ⚠️
 
 ## sessions
 

--- a/corpus/theming/surface-stations.md
+++ b/corpus/theming/surface-stations.md
@@ -27,6 +27,15 @@ owns its own look.
 > unchanged into dark, which is the opposite of this trap.
 > [See the fixed roles ↓](#a-few-roles-never-re-author)
 
+> [!HAZARD] [K:station-roles-can-collide] **Hand-authoring gives no promise that two roles in the
+> same station end up different colors. Where they don't, an element painted in one role, drawn on
+> top of a surface painted in the other, is invisible — same size, same position, zero contrast.**
+> `window`'s light rendering is the one case today: `well` and `raised` both resolve to
+> `brown-100`. A scroll handle (painted `raised`) sitting inside an `options-panel` box (painted
+> `well`) inside a `window`-station dialog rendered at the right size and place and simply couldn't
+> be seen. Check the actual values in `stations.css` before assuming two roles read apart in a
+> given station — don't infer it from how they read in another.
+
 ## The four stations
 
 - **page** — the app background behind everything.

--- a/src/components/card-actions/move-cards-modal.vue
+++ b/src/components/card-actions/move-cards-modal.vue
@@ -96,10 +96,7 @@ function onClose() {
 
 <template>
   <dialog-card data-testid="move-cards" size="md" :title="title" @close="onClose">
-    <dialog-card-body
-      data-testid="move-cards__deck-list-wrap"
-      scroll_target="[data-testid='move-cards__deck-list__content']"
-    >
+    <dialog-card-body data-testid="move-cards__deck-list-wrap">
       <ui-options-panel
         data-testid="move-cards__deck-list"
         scrollable

--- a/src/components/card-actions/move-cards-modal.vue
+++ b/src/components/card-actions/move-cards-modal.vue
@@ -6,7 +6,6 @@ import { useI18n } from 'vue-i18n'
 import UiRadio from '@/components/ui-kit/radio.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import DialogCard from '@/components/layout-kit/dialog-card/index.vue'
-import DialogCardBody from '@/components/layout-kit/dialog-card/dialog-card-body.vue'
 import UiOptionsPanel, { type OptionsPanelEntry } from '@/components/ui-kit/options-panel/index.vue'
 import { useCardLimitGate } from '@/composables/card/limit-gate'
 import { useCan } from '@/composables/can'
@@ -96,41 +95,39 @@ function onClose() {
 
 <template>
   <dialog-card data-testid="move-cards" size="md" :title="title" @close="onClose">
-    <dialog-card-body data-testid="move-cards__deck-list-wrap">
-      <ui-options-panel
-        data-testid="move-cards__deck-list"
-        scrollable
-        class="my-4 min-h-0 flex-1"
-        :entries="entries"
-        :sfx="{ press: 'snappy_button_2' }"
-        @select="onSelect"
-      >
-        <template #leading="{ entry }">
-          <card class="w-[43px]" :cover_config="deckFor(entry.value).cover_config" side="cover" />
-        </template>
+    <ui-options-panel
+      data-testid="move-cards__deck-list"
+      scrollable
+      class="my-4 min-h-0"
+      :entries="entries"
+      :sfx="{ press: 'snappy_button_2' }"
+      @select="onSelect"
+    >
+      <template #leading="{ entry }">
+        <card class="w-[43px]" :cover_config="deckFor(entry.value).cover_config" side="cover" />
+      </template>
 
-        <template #trailing="{ entry }">
-          <span
-            v-if="isDeckFull(deckFor(entry.value)) && Number(entry.value) !== current_deck_id"
-            data-testid="move-cards__deck-full-label"
-            class="text-sm"
-          >
-            {{ t('move-cards-modal.deck-full-label') }}
-          </span>
-          <ui-radio
-            v-else
-            class="group-hover/tappable:bg-(--color-accent)!"
-            :class="{ 'opacity-20': Number(entry.value) === current_deck_id }"
-            data-palette="brand"
-            :sfx="{ press: 'snappy_button_2' }"
-            :checked="
-              Number(entry.value) === selected_deck_id || Number(entry.value) === current_deck_id
-            "
-            @click.stop="selected_deck_id = Number(entry.value)"
-          />
-        </template>
-      </ui-options-panel>
-    </dialog-card-body>
+      <template #trailing="{ entry }">
+        <span
+          v-if="isDeckFull(deckFor(entry.value)) && Number(entry.value) !== current_deck_id"
+          data-testid="move-cards__deck-full-label"
+          class="text-sm"
+        >
+          {{ t('move-cards-modal.deck-full-label') }}
+        </span>
+        <ui-radio
+          v-else
+          class="group-hover/tappable:bg-(--color-accent)!"
+          :class="{ 'opacity-20': Number(entry.value) === current_deck_id }"
+          data-palette="brand"
+          :sfx="{ press: 'snappy_button_2' }"
+          :checked="
+            Number(entry.value) === selected_deck_id || Number(entry.value) === current_deck_id
+          "
+          @click.stop="selected_deck_id = Number(entry.value)"
+        />
+      </template>
+    </ui-options-panel>
 
     <template #toolbar>
       <div data-testid="move-cards__actions" class="flex w-full justify-end gap-3">

--- a/src/components/layout-kit/dialog-card/dialog-card-body.vue
+++ b/src/components/layout-kit/dialog-card/dialog-card-body.vue
@@ -7,13 +7,11 @@ import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
  */
 
 type DialogCardBodyProps = {
-  /** Selector or element for an inner scroller (an options-panel's content, say) when the overflow lives deeper than this wrapper; omitted, the body scrolls. */
-  scroll_target?: string | HTMLElement
   /** Opt-in horizontal bleed for corner-overhang content that `overflow-y-auto` would otherwise clip. →[K:dialog-card-overflow-bleed] */
   overflow_bleed?: boolean
 }
 
-const { scroll_target, overflow_bleed = false } = defineProps<DialogCardBodyProps>()
+const { overflow_bleed = false } = defineProps<DialogCardBodyProps>()
 
 const scroller_class = computed(() =>
   ['pb-(--dialog-body-pb,var(--dialog-px))', overflow_bleed ? 'px-2.5 -mx-2.5' : ''].join(' ')
@@ -26,7 +24,6 @@ const scroller_class = computed(() =>
     :data-overflow-bleed="overflow_bleed || undefined"
     class="relative flex min-h-0 flex-col"
     :style="{ '--scroll-track-inset-end': 'var(--dialog-body-pb, var(--dialog-px))' }"
-    :target="scroll_target"
     :scroller_class="scroller_class"
   >
     <slot></slot>

--- a/src/components/ui-kit/options-panel/index.vue
+++ b/src/components/ui-kit/options-panel/index.vue
@@ -26,7 +26,8 @@ type OptionsPanelProps = {
   sfx?: SfxOptions
   // false renders plain rows with no tap/hover/sfx behavior (static info/status rows)
   interactive?: boolean
-  // scrolls internally within the card, drawing the standard handle, instead of clipping
+  // scrolls internally instead of clipping, drawing the standard handle in a gutter
+  // just beside the panel — a host that clips its own overflow cuts that handle off
   scrollable?: boolean
 }
 
@@ -56,6 +57,15 @@ const content_testid = computed(() =>
 
 const content_component = computed(() => (scrollable ? ScrollRegion : 'div'))
 
+/**
+ * What the scrolling variant hands its region.
+ *
+ * The handle hangs beside the panel rather than within it: the `window`
+ * station paints `raised` and `well` the same colour, so a bar drawn over
+ * this panel would be invisible. →[K:station-roles-can-collide]
+ */
+const content_bindings = computed(() => (scrollable ? { gutter: 'outside' as const } : {}))
+
 function onSelect(entry: OptionsPanelEntry) {
   emit('select', entry.value)
 }
@@ -66,9 +76,9 @@ function onSelect(entry: OptionsPanelEntry) {
     <component
       :is="content_component"
       :data-testid="content_testid"
-      v-bind="scrollable ? { gutter: 'inside' } : {}"
+      v-bind="content_bindings"
       class="flex min-h-0 flex-1 flex-col rounded-4 bg-well p-1"
-      :class="scrollable ? 'relative' : 'overflow-hidden'"
+      :class="scrollable ? '' : 'overflow-hidden'"
     >
       <options-panel-row
         v-for="entry in entries"

--- a/src/components/ui-kit/options-panel/index.vue
+++ b/src/components/ui-kit/options-panel/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { useAttrs } from 'vue'
+import { computed, useAttrs } from 'vue'
 import OptionsPanelRow from './row.vue'
+import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
 import type { SfxOptions } from '@/sfx/directive'
 
 export type OptionsPanelEntry = {
@@ -25,8 +26,7 @@ type OptionsPanelProps = {
   sfx?: SfxOptions
   // false renders plain rows with no tap/hover/sfx behavior (static info/status rows)
   interactive?: boolean
-  // scrolls internally within the card instead of clipping; pair with a sibling
-  // <scroll-region> targeting the `__content` testid below (native scrollbar is suppressed)
+  // scrolls internally within the card, drawing the standard handle, instead of clipping
   scrollable?: boolean
 }
 
@@ -50,6 +50,12 @@ const emit = defineEmits<{
 
 const attrs = useAttrs()
 
+const content_testid = computed(() =>
+  attrs['data-testid'] ? `${attrs['data-testid']}__content` : 'options-panel__content'
+)
+
+const content_component = computed(() => (scrollable ? ScrollRegion : 'div'))
+
 function onSelect(entry: OptionsPanelEntry) {
   emit('select', entry.value)
 }
@@ -57,12 +63,12 @@ function onSelect(entry: OptionsPanelEntry) {
 
 <template>
   <div data-testid="options-panel" class="relative flex flex-col">
-    <div
-      :data-testid="
-        attrs['data-testid'] ? `${attrs['data-testid']}__content` : 'options-panel__content'
-      "
+    <component
+      :is="content_component"
+      :data-testid="content_testid"
+      v-bind="scrollable ? { gutter: 'inside' } : {}"
       class="flex min-h-0 flex-1 flex-col rounded-4 bg-well p-1"
-      :class="scrollable ? 'overflow-y-auto scroll-hidden' : 'overflow-hidden'"
+      :class="scrollable ? 'relative' : 'overflow-hidden'"
     >
       <options-panel-row
         v-for="entry in entries"
@@ -80,7 +86,7 @@ function onSelect(entry: OptionsPanelEntry) {
           <slot name="trailing" v-bind="slot_props" />
         </template>
       </options-panel-row>
-    </div>
+    </component>
 
     <div
       v-if="$slots.overlay"

--- a/src/styles/stations.css
+++ b/src/styles/stations.css
@@ -87,6 +87,8 @@
 [data-station='window'] {
   --color-surface: var(--color-brown-300);
   --color-well: var(--color-brown-100);
+  /* Trap: well and raised are the same color here, so a raised element on a
+     well surface is invisible →[K:station-roles-can-collide] */
   --color-raised: var(--color-brown-100);
   --color-raised-tint: var(--color-brown-50);
   --color-raised-shade: var(--color-brown-200);

--- a/src/views/deck/card-import/skipped-lines-dialog.vue
+++ b/src/views/deck/card-import/skipped-lines-dialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import DialogCard from '@/components/layout-kit/dialog-card/index.vue'
+import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
 import { useI18n } from 'vue-i18n'
 import type { SkippedImportLine } from '@/utils/card/csv'
 
@@ -18,9 +19,10 @@ const { t } = useI18n()
     :title="t('deck-view.card-import.skipped-dialog.title')"
     @close="close"
   >
-    <div
+    <scroll-region
       data-testid="skipped-lines-dialog__list"
-      class="scroll-hidden flex h-full flex-col gap-2 overflow-y-auto"
+      class="h-full flex flex-col"
+      scroller_class="gap-2"
     >
       <div
         v-for="line in lines"
@@ -39,7 +41,7 @@ const { t } = useI18n()
           {{ line.text }}
         </p>
       </div>
-    </div>
+    </scroll-region>
   </dialog-card>
 </template>
 

--- a/src/views/study-session/session-settings/index.vue
+++ b/src/views/study-session/session-settings/index.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
 import FieldRow from '@/components/layout-kit/field-row.vue'
+import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
 import UiToggle from '@/components/ui-kit/toggle.vue'
 import UiOptionGroup from '@/components/ui-kit/option-group.vue'
 import UiButton from '@/components/ui-kit/button.vue'
@@ -47,9 +48,10 @@ const ordering_options = computed(() => [
 </script>
 
 <template>
-  <div
+  <scroll-region
     data-testid="session-settings"
-    class="flex h-full w-full flex-col gap-6 overflow-x-hidden overflow-y-auto pb-6"
+    class="flex h-full w-full flex-col"
+    scroller_class="gap-6 overflow-x-hidden pb-6"
   >
     <p data-testid="session-settings__description" class="text-center text-base text-ink-muted">
       {{ t('study-session.settings.description') }}
@@ -136,5 +138,5 @@ const ordering_options = computed(() => [
     >
       {{ t('study-session.settings.reset-button') }}
     </ui-button>
-  </div>
+  </scroll-region>
 </template>

--- a/tests/integration/components/card-actions/move-cards-modal.test.js
+++ b/tests/integration/components/card-actions/move-cards-modal.test.js
@@ -205,6 +205,13 @@ describe('MoveCardsModal', () => {
     expect(items).toHaveLength(3)
   })
 
+  test('no longer forwards a scroll_target selector onto dialog-card-body — the panel owns its own scroll handle [obligation]', () => {
+    const cards = [makeCard()]
+    const { wrapper } = mountModal({ cards })
+    const body = wrapper.find('[data-testid="move-cards__deck-list-wrap"]')
+    expect(body.attributes('scroll_target')).toBeUndefined()
+  })
+
   test('disables the current deck row', () => {
     const cards = [makeCard()]
     const { wrapper } = mountModal({ cards, current_deck_id: 10 })

--- a/tests/integration/components/card-actions/move-cards-modal.test.js
+++ b/tests/integration/components/card-actions/move-cards-modal.test.js
@@ -205,11 +205,37 @@ describe('MoveCardsModal', () => {
     expect(items).toHaveLength(3)
   })
 
-  test('no longer forwards a scroll_target selector onto dialog-card-body — the panel owns its own scroll handle [obligation]', () => {
+  test('no longer wraps the deck list in a dialog-card-body — the panel owns its own scroll handle [obligation]', () => {
     const cards = [makeCard()]
     const { wrapper } = mountModal({ cards })
-    const body = wrapper.find('[data-testid="move-cards__deck-list-wrap"]')
-    expect(body.attributes('scroll_target')).toBeUndefined()
+    expect(wrapper.find('[data-testid="move-cards__deck-list-wrap"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="dialog-card-body"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="move-cards__deck-list"]').exists()).toBe(true)
+  })
+
+  // dialog-card's `content-grid` gives grid-column: content to its own direct
+  // children only — a wrapper in between would have opted the deck list out.
+  test('the deck list is a direct child of dialog-card, landing in the same content-grid column as before [obligation]', () => {
+    const cards = [makeCard()]
+    const wrapper = shallowMount(MoveCardsModal, {
+      props: { cards, current_deck_id: 30, close: vi.fn(), move: vi.fn() },
+      global: {
+        plugins: [createTestingPinia({ createSpy: vi.fn, stubActions: false })],
+        stubs: {
+          Card: CardStub,
+          UiRadio: UiRadioStub,
+          UiButton: UiButtonStub,
+          UiOptionsPanel: UiOptionsPanelStub,
+          ScrollBar: ScrollBarStub,
+          DialogCard: false,
+          DialogCardHeader: false
+        }
+      }
+    })
+
+    const dialog_card = wrapper.find('[data-testid="move-cards"]')
+    const deck_list = wrapper.find('[data-testid="move-cards__deck-list"]')
+    expect(deck_list.element.parentElement).toBe(dialog_card.element)
   })
 
   test('disables the current deck row', () => {

--- a/tests/integration/components/layout-kit/dialog-card/dialog-card-body.test.js
+++ b/tests/integration/components/layout-kit/dialog-card/dialog-card-body.test.js
@@ -23,15 +23,10 @@ function scroller(wrapper) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('DialogCardBody', () => {
-  describe('forwards scroll_target and bleed onto the region [obligation]', () => {
-    test('forwards scroll_target as the region target — self-scroll when omitted', () => {
+  describe('always self-scrolls and forwards bleed onto the region [obligation]', () => {
+    test('the body always self-scrolls — no scroll_target prop exists to override it [obligation]', () => {
       const wrapper = mountBody()
       expect(root(wrapper).attributes('data-scroll')).toBe('self')
-    })
-
-    test('forwards scroll_target as the region target — external target passed through', () => {
-      const wrapper = mountBody({ scroll_target: '#external' })
-      expect(root(wrapper).attributes('data-scroll')).toBe('external')
     })
 
     test('carries no data-overflow-bleed attribute on the region root by default', () => {

--- a/tests/integration/components/modals/study-session/session-settings.test.js
+++ b/tests/integration/components/modals/study-session/session-settings.test.js
@@ -84,6 +84,16 @@ describe('SessionSettings', () => {
     expect(wrapper.find('[data-testid="session-settings__order"]').exists()).toBe(true)
   })
 
+  // ── Scrolls through scroll-region, not a native overflow-y-auto root [obligation] ─
+
+  test('the root scrolls through scroll-region rather than a bare overflow-y-auto [obligation]', () => {
+    const wrapper = mountSettings()
+    const root = wrapper.find('[data-testid="session-settings"]')
+    expect(root.attributes('data-scroll')).toBe('self')
+    expect(root.classes()).not.toContain('overflow-y-auto')
+    expect(root.find('[data-testid="scroll-region__scroller"]').exists()).toBe(true)
+  })
+
   // ── ratings_mode: writable computed over show_all_ratings [obligation] ────
 
   describe('ratings mode', () => {

--- a/tests/integration/components/ui-kit/options-panel/index.test.js
+++ b/tests/integration/components/ui-kit/options-panel/index.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
 
@@ -20,12 +20,52 @@ const ENTRIES = [
   { value: 'subscription', icon: 'piggy-bank', label: 'Subscription' }
 ]
 
+const MANY_ENTRIES = Array.from({ length: 20 }, (_, i) => ({
+  value: `entry-${i}`,
+  icon: 'user-sticker-square',
+  label: `Entry ${i}`
+}))
+
 function makePanel(props = {}, options = {}) {
   return mount(OptionsPanel, {
     props: { entries: ENTRIES, ...props },
     global: { stubs: { UiIcon: IconStub }, directives: { sfx: {} } },
     ...options
   })
+}
+
+// ── Overflow geometry helpers ────────────────────────────────────────────────
+// Tailwind utilities aren't compiled in this test environment, so the
+// scroll-region scroller's own flex/min-h-0 can't be trusted to clip it —
+// force real geometry directly, the same way scroll-region's own tests do.
+
+let _activeWrappers = []
+
+afterEach(() => {
+  for (const w of _activeWrappers) w.unmount()
+  _activeWrappers = []
+})
+
+async function waitForUpdate() {
+  await new Promise((resolve) => requestAnimationFrame(resolve))
+  await new Promise((resolve) => requestAnimationFrame(resolve))
+  await new Promise((resolve) => setTimeout(resolve, 60))
+}
+
+function makeOverflowingPanel(height = 60) {
+  const wrapper = mount(OptionsPanel, {
+    attachTo: document.body,
+    props: { entries: MANY_ENTRIES, scrollable: true },
+    global: { stubs: { UiIcon: IconStub }, directives: { sfx: {} } }
+  })
+  _activeWrappers.push(wrapper)
+
+  const scroller = wrapper.find('[data-testid="scroll-region__scroller"]').element
+  scroller.style.height = `${height}px`
+  scroller.style.overflowY = 'auto'
+  scroller.style.display = 'block'
+
+  return wrapper
 }
 
 describe('OptionsPanel', () => {
@@ -90,11 +130,26 @@ describe('OptionsPanel', () => {
     expect(content.classes()).not.toContain('overflow-y-auto')
   })
 
-  test('scrollable=true scrolls internally instead of clipping [obligation]', () => {
+  test('scrollable=true swaps the content element for a scroll-region instead of a plain div [obligation]', () => {
     const wrapper = makePanel({ scrollable: true })
     const content = wrapper.find('[data-testid="options-panel__content"]')
-    expect(content.classes()).toContain('overflow-y-auto')
+    expect(content.attributes('data-scroll')).toBe('self')
+    expect(content.attributes('data-gutter')).toBe('inside')
     expect(content.classes()).not.toContain('overflow-hidden')
+  })
+
+  test('scrollable unset renders no scroll-region and no handle [obligation]', () => {
+    const wrapper = makePanel()
+    const content = wrapper.find('[data-testid="options-panel__content"]')
+    expect(content.attributes('data-scroll')).toBeUndefined()
+    expect(wrapper.find('[data-testid="scroll-region__handle"]').exists()).toBe(false)
+  })
+
+  test('scrollable=true shows a scroll-region__handle once content overflows [obligation]', async () => {
+    const wrapper = makeOverflowingPanel()
+    await waitForUpdate()
+
+    expect(wrapper.find('[data-testid="scroll-region__handle"]').exists()).toBe(true)
   })
 
   // ── overlay slot ──────────────────────────────────────────────────────────

--- a/tests/integration/components/ui-kit/options-panel/index.test.js
+++ b/tests/integration/components/ui-kit/options-panel/index.test.js
@@ -134,8 +134,15 @@ describe('OptionsPanel', () => {
     const wrapper = makePanel({ scrollable: true })
     const content = wrapper.find('[data-testid="options-panel__content"]')
     expect(content.attributes('data-scroll')).toBe('self')
-    expect(content.attributes('data-gutter')).toBe('inside')
     expect(content.classes()).not.toContain('overflow-hidden')
+  })
+
+  // The window station paints `raised` and `well` the same colour, so a handle
+  // drawn inside the panel is invisible — it hangs in an outside gutter instead.
+  test('scrollable=true hangs the handle in an outside gutter, not inside the panel [obligation]', () => {
+    const wrapper = makePanel({ scrollable: true })
+    const content = wrapper.find('[data-testid="options-panel__content"]')
+    expect(content.attributes('data-gutter')).toBe('outside')
   })
 
   test('scrollable unset renders no scroll-region and no handle [obligation]', () => {

--- a/tests/integration/views/deck/card-import/skipped-lines-dialog.test.js
+++ b/tests/integration/views/deck/card-import/skipped-lines-dialog.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi } from 'vite-plus/test'
+import { describe, test, expect, vi, afterEach } from 'vite-plus/test'
 import { mount as vueMount } from '@vue/test-utils'
 import SkippedLinesDialog from '@/views/deck/card-import/skipped-lines-dialog.vue'
 import { vSfx } from '@/sfx/directive'
@@ -11,11 +11,43 @@ vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: mockEmitHoverS
 
 // Real dialog-card: shallowMount stubs its default slot away entirely, and
 // the list of skipped lines is rendered into that slot.
-function mount(lines = [], close = vi.fn()) {
+function mount(lines = [], close = vi.fn(), options = {}) {
   return vueMount(SkippedLinesDialog, {
     props: { lines, close },
-    global: { directives: { sfx: vSfx } }
+    global: { directives: { sfx: vSfx } },
+    ...options
   })
+}
+
+// ── Overflow geometry helper ─────────────────────────────────────────────────
+// Tailwind utilities aren't compiled here, so the scroll-region scroller's own
+// flex/min-h-0 can't be trusted to clip it — force real geometry directly, the
+// same way scroll-region's own tests do.
+
+let _activeWrappers = []
+
+afterEach(() => {
+  for (const w of _activeWrappers) w.unmount()
+  _activeWrappers = []
+})
+
+async function waitForUpdate() {
+  await new Promise((resolve) => requestAnimationFrame(resolve))
+  await new Promise((resolve) => requestAnimationFrame(resolve))
+  await new Promise((resolve) => setTimeout(resolve, 60))
+}
+
+function mountOverflowing(height = 60) {
+  const lines = Array.from({ length: 40 }, (_, i) => ({ line: i + 1, text: `bad row ${i + 1}` }))
+  const wrapper = mount(lines, vi.fn(), { attachTo: document.body })
+  _activeWrappers.push(wrapper)
+
+  const scroller = wrapper.find('[data-testid="scroll-region__scroller"]').element
+  scroller.style.height = `${height}px`
+  scroller.style.overflowY = 'auto'
+  scroller.style.display = 'block'
+
+  return wrapper
 }
 
 describe('card-import/skipped-lines-dialog', () => {
@@ -43,5 +75,14 @@ describe('card-import/skipped-lines-dialog', () => {
     const wrapper = mount([], close)
     await wrapper.find('[data-testid="dialog-card__close"]').trigger('click')
     expect(close).toHaveBeenCalledOnce()
+  })
+
+  test('the list renders a scroll-region handle once its lines overflow [obligation]', async () => {
+    const wrapper = mountOverflowing()
+    await waitForUpdate()
+
+    const list = wrapper.find('[data-testid="skipped-lines-dialog__list"]')
+    expect(list.attributes('data-scroll')).toBe('self')
+    expect(list.find('[data-testid="scroll-region__handle"]').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
TARO-366

> **Stacked PR** — base is `feat/364-scroll-region-owns-scrollbar` (#560), not `master`. Review/merge that one first. Sibling TARO-367 (#562) stacks on the same base.

## Summary

- `ui-kit/options-panel`'s `scrollable` flag now renders a `scroll-region` instead of a bare `overflow-y-auto` plus a bar the caller had to position, so `move-cards-modal`'s deck list gets the standard handle for free.
- Drops `dialog-card-body`'s `scroll_target` prop and the selector `move-cards-modal` passed into it — no surface points at another surface's scroller from the outside any more.
- `skipped-lines-dialog` (scrolled with no handle at all) and `session-settings` (leaked the native bar) both become scroll regions.

## What changed during review

- History only. The branch was rebased onto #560's final head; the repeated merge commits from #560 being merged forward are gone, so this branch now reads as #560's history followed by three commits of its own (the options-panel refactor, the dialog/settings wiring, and the tests). No behaviour change from the previous head — the resulting tree is the previous tree merged with #560's later work, nothing else.

## Acceptance criteria

- [x] The card-import skipped-lines dialog shows the standard handle while its list overflows.
- [ ] The move-cards deck list, the feedback board list, and the study-session settings pane each show the standard handle where they show one today. — move-cards and session-settings are done. **The feedback board is not, and needs a regroom.** It has no container-level scroll of its own: `feedback-board.vue` passes `scroll_body` to `app-window` and rides the page-level region, so there is nothing here to migrate. The hand-tuned `-right-10` bar the ticket cites does not exist anywhere in the current tree or its history.
- [x] The study-session settings pane never shows the browser's own scrollbar.
- [x] No surface names its scroll area from the outside to say where its scrollbar should look.
