### PR TITLE
TARO-367: Page scrollbar anchors to the content column

### DIFF
--- a/src/components/layout-kit/scroll-region/use-scroll-metrics.ts
+++ b/src/components/layout-kit/scroll-region/use-scroll-metrics.ts
@@ -5,6 +5,9 @@ export type ScrollTarget = string | HTMLElement | null | undefined
 // Sub-pixel layout rounding leaves a scrollHeight a hair over clientHeight on content that fits.
 const OVERFLOW_SLACK_PX = 1
 
+// How long the measured overflow has to hold still before it counts as the resting one.
+const SETTLE_MS = 150
+
 function resolveTarget(target: ScrollTarget): HTMLElement | null {
   if (!target) return null
   if (typeof target !== 'string') return target
@@ -40,6 +43,8 @@ export function useScrollMetrics(target: Ref<ScrollTarget>) {
   let frame = 0
   let resize_obs: ResizeObserver | null = null
   let mutation_obs: MutationObserver | null = null
+  let settle_timer = 0
+  let last_max_scroll = -1
 
   function schedule() {
     if (frame) return
@@ -48,6 +53,32 @@ export function useScrollMetrics(target: Ref<ScrollTarget>) {
       frame = 0
       measure()
     })
+  }
+
+  /** Restarts the settling clock whenever the amount of overflow moves, and measures again once it stops. */
+  function trackSettling(max_scroll: number) {
+    if (max_scroll === last_max_scroll) return
+
+    last_max_scroll = max_scroll
+
+    window.clearTimeout(settle_timer)
+    settle_timer = window.setTimeout(() => {
+      settle_timer = 0
+      measure()
+    }, SETTLE_MS)
+  }
+
+  /**
+   * Publishes whether the handle belongs on screen.
+   *
+   * Appearing waits for the overflow to hold still, because a layout that is
+   * animating passes through heights it never comes to rest at and a handle
+   * shown on one of those flashes in and straight back out. Disappearing is
+   * immediate — content that fits can't be scrolled, whatever it does next.
+   */
+  function reportOverflow(overflows: boolean) {
+    if (!overflows) overflowing.value = false
+    else if (!settle_timer) overflowing.value = true
   }
 
   function measure() {
@@ -64,7 +95,9 @@ export function useScrollMetrics(target: Ref<ScrollTarget>) {
     // Rubber-band overscroll pushes scrollTop outside [0, max] on iOS.
     const scroll_top = clamp(el.scrollTop, 0, max_scroll)
 
-    overflowing.value = max_scroll > OVERFLOW_SLACK_PX
+    trackSettling(max_scroll)
+    reportOverflow(max_scroll > OVERFLOW_SLACK_PX)
+
     visible_fraction.value = scroll_height > 0 ? client_height / scroll_height : 0
     progress.value = max_scroll > 0 ? scroll_top / max_scroll : 0
   }
@@ -121,6 +154,10 @@ export function useScrollMetrics(target: Ref<ScrollTarget>) {
   function detach() {
     cancelAnimationFrame(frame)
     frame = 0
+
+    window.clearTimeout(settle_timer)
+    settle_timer = 0
+    last_max_scroll = -1
 
     window.removeEventListener('scroll', schedule)
     window.removeEventListener('resize', schedule)

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -317,18 +317,6 @@
     width: 100%;
   }
 
-  .app-container {
-    width: 100%;
-    max-width: var(--page-width);
-    padding: 0 4rem;
-  }
-
-  @media (width >= 40rem) {
-    .app-container {
-      padding: 0 16rem;
-    }
-  }
-
   @media (pointer: fine) {
     html {
       scrollbar-width: none;

--- a/src/views/app-shell/authenticated.vue
+++ b/src/views/app-shell/authenticated.vue
@@ -3,7 +3,9 @@ import NavBar from '@/views/app-shell/nav-bar/index.vue'
 import TaroPhone from '@/components/taro-phone/index.vue'
 import MobileDockHost from '@/components/mobile-dock/mobile-dock-host.vue'
 import RouteSkeleton from '@/views/app-shell/route-skeleton.vue'
+import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
 import { computed, watch } from 'vue'
+import { providePageAnchor } from '@/views/app-shell/composables/page-anchor'
 import { useRouteTransition } from '@/composables/ui/route-transition'
 import { useResumeStudySession } from '@/views/study-session/composables/session-resume'
 import { useMemberStore } from '@/stores/member'
@@ -13,6 +15,8 @@ const { show_skeleton_overlay, onSuspensePending, onSuspenseResolve, onLeave, on
   useRouteTransition()
 const member = useMemberStore()
 
+const { inset: page_anchor_inset } = providePageAnchor()
+
 useResumeStudySession()
 
 /**
@@ -21,6 +25,17 @@ useResumeStudySession()
  * behind the restore dialog. Same visual state as a cold load.
  */
 const show_skeleton = computed(() => show_skeleton_overlay.value || member.pending_deletion)
+
+/**
+ * Moves the page scrollbar in beside a pane that keeps its content narrower
+ * than the page column. Unset the rest of the time, leaving the stylesheet's
+ * page-column position in charge.
+ */
+const page_scroll_style = computed(() => {
+  if (page_anchor_inset.value === null) return undefined
+
+  return { right: `calc(${page_anchor_inset.value}px + var(--page-px) / 2)` }
+})
 
 /**
  * A suspended (pending-deletion) member is admitted to the shell and sees
@@ -63,6 +78,23 @@ watch(
       </router-view>
     </main>
 
+    <scroll-region
+      data-testid="page-scroll-region"
+      class="page-scroll-region fixed top-(--nav-height) bottom-10 z-30"
+      :style="page_scroll_style"
+      target="html"
+      gutter="inside"
+    />
+
     <mobile-dock-host />
   </div>
 </template>
+
+<style scoped>
+/* The page column stops widening at --page-width while the window keeps going,
+   so the scrollbar hangs in the column's own padding rather than out at the
+   window edge. */
+.page-scroll-region {
+  right: calc(max(0px, (100vw - var(--page-width)) / 2) + var(--page-px) / 2);
+}
+</style>

--- a/src/views/app-shell/composables/page-anchor.ts
+++ b/src/views/app-shell/composables/page-anchor.ts
@@ -1,0 +1,105 @@
+import { inject, onBeforeUnmount, provide, ref, watch, type InjectionKey, type Ref } from 'vue'
+
+type AnchorSource = Readonly<Ref<HTMLElement | null>>
+
+type PageAnchor = {
+  inset: Ref<number | null>
+  claim: (source: AnchorSource) => void
+}
+
+const page_anchor_key = Symbol('page-anchor') as InjectionKey<PageAnchor>
+
+/**
+ * How far in from the window's right edge an element's own right edge sits.
+ *
+ * Added up from the element's layout offsets rather than read off a bounding
+ * rect, because a pane is often still sliding in from the side when this runs —
+ * a rect would report where the slide currently holds it instead of where it
+ * comes to rest, and nothing measures again once the slide clears.
+ */
+function rightInset(el: HTMLElement) {
+  let right = el.offsetWidth
+  let node: HTMLElement | null = el
+
+  while (node) {
+    right += node.offsetLeft
+    node = node.offsetParent as HTMLElement | null
+  }
+
+  // clientWidth, not innerWidth: it excludes a classic scrollbar's own width,
+  // which innerWidth counts as page space the content never gets.
+  return document.documentElement.clientWidth - right
+}
+
+/**
+ * How far in from the window's right edge the page scrollbar hangs.
+ *
+ * Null whenever nothing on screen has claimed it, which leaves the scrollbar
+ * beside the page column at its stylesheet default. A pane that caps its own
+ * content narrower than that column claims it so the scrollbar follows the
+ * content instead of stranding itself in the empty space beside it.
+ */
+export function providePageAnchor() {
+  const inset = ref<number | null>(null)
+
+  let el: HTMLElement | null = null
+  let obs: ResizeObserver | null = null
+  let frame = 0
+
+  function measure() {
+    if (!el) {
+      inset.value = null
+      return
+    }
+
+    inset.value = rightInset(el)
+  }
+
+  function schedule() {
+    if (frame) return
+
+    frame = requestAnimationFrame(() => {
+      frame = 0
+      measure()
+    })
+  }
+
+  function setAnchor(next: HTMLElement | null) {
+    obs?.disconnect()
+    el = next
+
+    if (el) {
+      obs ??= new ResizeObserver(schedule)
+      obs.observe(el)
+    }
+
+    measure()
+  }
+
+  function claim(source: AnchorSource) {
+    watch(source, (next) => setAnchor(next ?? null), { immediate: true, flush: 'post' })
+
+    onBeforeUnmount(() => setAnchor(null))
+  }
+
+  // The pane's own box never changes when the window widens around a capped
+  // column, so the window is what reports that move.
+  window.addEventListener('resize', schedule, { passive: true })
+
+  onBeforeUnmount(() => {
+    cancelAnimationFrame(frame)
+    window.removeEventListener('resize', schedule)
+
+    obs?.disconnect()
+    obs = null
+  })
+
+  provide(page_anchor_key, { inset, claim })
+
+  return { inset }
+}
+
+/** Hands the page scrollbar an element's right edge to hang beside, while that element is mounted. */
+export function usePageAnchorClaim(source: AnchorSource) {
+  inject(page_anchor_key, null)?.claim(source)
+}

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -13,7 +13,6 @@ import { scrollClearOf } from '@/utils/animations/transcript-scroll'
 import { fadeEnter, fadeLeave } from '@/utils/animations/fade'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
-import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
 import CrossfadeResize from '@/components/layout-kit/crossfade-resize.vue'
 import MobileDock from '@/components/mobile-dock/mobile-dock.vue'
 import { useMobileDock } from '@/components/mobile-dock/use-mobile-dock'
@@ -392,12 +391,6 @@ onBeforeUnmount(() => {
         data-testid="lesson-view__audio"
         :src="audio_url ?? undefined"
         class="hidden"
-      />
-
-      <scroll-region
-        class="fixed top-(--nav-height) right-6 bottom-6"
-        target="html"
-        gutter="inside"
       />
 
       <transition :css="false" @enter="fadeEnter" @leave="fadeLeave">

--- a/src/views/dashboard/dashboard-shell.vue
+++ b/src/views/dashboard/dashboard-shell.vue
@@ -1,12 +1,20 @@
 <script setup lang="ts">
+import { useTemplateRef } from 'vue'
+import { usePageAnchorClaim } from '@/views/app-shell/composables/page-anchor'
+
 defineSlots<{
   left(): unknown
   right(): unknown
 }>()
+
+const shell_el = useTemplateRef<HTMLElement>('shell')
+
+usePageAnchorClaim(shell_el)
 </script>
 
 <template>
   <div
+    ref="shell"
     data-testid="dashboard-shell"
     class="grid grid-cols-[1fr] mxl:grid-cols-[345px_1fr] gap-x-15.5 gap-y-8 mxl:gap-y-0 px-(--page-px) pt-(--page-pt) pb-12 w-full max-w-229 mx-auto mxl:max-w-none mxl:mx-0"
   >

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -6,7 +6,6 @@ import { useNoticeStore } from '@/stores/notice-store'
 import { useCan } from '@/composables/can'
 import { useLocalRef } from '@/composables/storage/local-ref'
 import { emitSfx } from '@/sfx/bus'
-import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
 import DashboardShell from './dashboard-shell.vue'
 import DashboardSkeleton from './skeleton.vue'
 import DashboardSection from './dashboard-section.vue'
@@ -98,12 +97,6 @@ const show_skeleton = computed(() => !decks_data.value)
         <audio-reader-section v-if="can.useAudioReader.value" />
       </template>
     </dashboard-shell>
-
-    <scroll-region
-      class="fixed right-4 top-(--nav-height) bottom-10 z-30"
-      target="html"
-      gutter="inside"
-    />
 
     <dashboard-mobile-footer
       :due_decks="due_decks"

--- a/src/views/deck/deck-view.vue
+++ b/src/views/deck/deck-view.vue
@@ -10,7 +10,6 @@ import ModeToolbarSkeleton from './mode-toolbar/skeleton.vue'
 import ModeStack from './mode-stack.vue'
 import CardGridSkeleton from './card-grid/skeleton.vue'
 import CardGridEmpty from './card-grid/empty-state.vue'
-import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
 import DeckMobileFooter from './mobile-footer/index.vue'
 import { useDeckQuery } from '@/api/decks'
 import {
@@ -132,13 +131,6 @@ const show_skeleton = computed(() => !deck.value)
         </div>
       </template>
     </deck-shell>
-
-    <scroll-region
-      v-if="view_state === 'ready'"
-      class="fixed right-4 top-(--nav-height) bottom-10 z-30"
-      target="html"
-      gutter="inside"
-    />
 
     <deck-mobile-footer />
   </section>

--- a/tests/integration/components/layout-kit/scroll-region/index.test.js
+++ b/tests/integration/components/layout-kit/scroll-region/index.test.js
@@ -26,11 +26,13 @@ afterEach(() => {
 })
 
 // ResizeObserver callbacks batch on their own queue, which can lag a couple of
-// animation frames behind the DOM mutation that triggered them.
+// animation frames behind the DOM mutation that triggered them. The tail wait
+// also has to outlast the metrics' 150ms settle window, since the handle is
+// held back until the measured overflow stops moving.
 async function waitForUpdate() {
   await new Promise((resolve) => requestAnimationFrame(resolve))
   await new Promise((resolve) => requestAnimationFrame(resolve))
-  await new Promise((resolve) => setTimeout(resolve, 60))
+  await new Promise((resolve) => setTimeout(resolve, 200))
 }
 
 function root(wrapper) {

--- a/tests/integration/views/authenticated.test.js
+++ b/tests/integration/views/authenticated.test.js
@@ -1,22 +1,28 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import { shallowMount, flushPromises } from '@vue/test-utils'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { defineComponent, h, reactive, ref, useTemplateRef } from 'vue'
 import AuthenticatedView from '@/views/app-shell/authenticated.vue'
+import { usePageAnchorClaim } from '@/views/app-shell/composables/page-anchor'
+
+const FakeRouteComponent = defineComponent({
+  name: 'FakeRouteComponent',
+  setup: () => () => h('div', { 'data-testid': 'fake-route-component' })
+})
 
 // Renders the `v-slot="{ Component, route }"` content for real, so the
 // transition/suspense/route-skeleton wiring around it gets exercised — the
 // default auto-stub hides slot content entirely.
-const RouterViewStub = defineComponent({
-  name: 'RouterView',
-  setup(_props, { slots }) {
-    const fakeComponent = defineComponent({
-      name: 'FakeRouteComponent',
-      setup: () => () => h('div', { 'data-testid': 'fake-route-component' })
-    })
-    const fakeRoute = { name: 'fake-route' }
-    return () => slots.default?.({ Component: fakeComponent, route: fakeRoute })
-  }
-})
+function createRouterViewStub(component) {
+  return defineComponent({
+    name: 'RouterView',
+    setup(_props, { slots }) {
+      const fakeRoute = { name: 'fake-route' }
+      return () => slots.default?.({ Component: component, route: fakeRoute })
+    }
+  })
+}
+
+const RouterViewStub = createRouterViewStub(FakeRouteComponent)
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
@@ -68,7 +74,11 @@ const mockMemberStore = reactive(mockMemberStoreState)
 
 let activeWrapper
 
-function mountAuthenticated({ renderRouteSlot = false } = {}) {
+function mountAuthenticated({
+  renderRouteSlot = false,
+  routerViewStub = RouterViewStub,
+  extraStubs = {}
+} = {}) {
   activeWrapper = shallowMount(AuthenticatedView, {
     global: {
       stubs: {
@@ -76,10 +86,11 @@ function mountAuthenticated({ renderRouteSlot = false } = {}) {
         TaroPhone: true,
         MobileDockHost: true,
         RouteSkeleton: true,
-        RouterView: renderRouteSlot ? RouterViewStub : true,
+        RouterView: renderRouteSlot ? routerViewStub : true,
         // Real Suspense so the matched-component branch (not just the
         // fallback) actually renders — auto-stubbing it hides both.
-        Suspense: !renderRouteSlot
+        Suspense: !renderRouteSlot,
+        ...extraStubs
       }
     }
   })
@@ -201,6 +212,48 @@ describe('AuthenticatedView', () => {
 
       expect(wrapper.find('[data-testid="route-skeleton-overlay"]').exists()).toBe(false)
       expect(wrapper.findComponent({ name: 'FakeRouteComponent' }).exists()).toBe(true)
+    })
+  })
+
+  // ── page scroll region [obligation] ─────────────────────────────────────────
+  //
+  // The shell mounts the only page-level scroll region; a pane elsewhere in
+  // the tree can claim its right edge, but nothing does by default.
+
+  describe('page scroll region [obligation]', () => {
+    test('[obligation] renders exactly one page-scroll-region', () => {
+      const wrapper = mountAuthenticated()
+
+      expect(wrapper.findAll('[data-testid="page-scroll-region"]')).toHaveLength(1)
+    })
+
+    test('[obligation] carries no inline right style while nothing claims the anchor', () => {
+      const wrapper = mountAuthenticated()
+
+      const style = wrapper.find('[data-testid="page-scroll-region"]').attributes('style') ?? ''
+      expect(style).not.toContain('right')
+    })
+
+    test('[obligation] sets an inline right style once a pane claims the anchor', async () => {
+      const ClaimingPane = defineComponent({
+        name: 'ClaimingPane',
+        setup() {
+          const pane_ref = useTemplateRef('pane')
+          usePageAnchorClaim(pane_ref)
+          return () => h('div', { ref: 'pane', 'data-testid': 'claiming-pane' })
+        }
+      })
+
+      const wrapper = mountAuthenticated({
+        renderRouteSlot: true,
+        routerViewStub: createRouterViewStub(ClaimingPane),
+        extraStubs: { ClaimingPane: false }
+      })
+      await flushPromises()
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+
+      const style = wrapper.find('[data-testid="page-scroll-region"]').attributes('style') ?? ''
+      expect(style).toContain('right')
     })
   })
 })

--- a/tests/integration/views/dashboard/dashboard-shell.test.js
+++ b/tests/integration/views/dashboard/dashboard-shell.test.js
@@ -1,7 +1,8 @@
 import { describe, test, expect } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
-import { h } from 'vue'
+import { createApp, h } from 'vue'
 import DashboardShell from '@/views/dashboard/dashboard-shell.vue'
+import { providePageAnchor } from '@/views/app-shell/composables/page-anchor'
 
 function mountShell(slots) {
   return mount(DashboardShell, { slots })
@@ -24,5 +25,29 @@ describe('DashboardShell (views/dashboard/dashboard-shell.vue)', () => {
     const wrapper = mountShell({ left: () => h('div', { 'data-testid': 'left-content' }) })
     const right_column = wrapper.find('[data-testid="dashboard-shell__right-column"]')
     expect(right_column.find('[data-testid="left-content"]').exists()).toBe(false)
+  })
+
+  // [obligation] the shell caps its own content narrower than the page column
+  // on wide viewports, so it claims the page anchor for the scrollbar to
+  // follow it rather than stranding the bar out at the window edge.
+  test('[obligation] claims the page anchor with its own root element', async () => {
+    let anchor
+
+    const app = createApp({
+      setup() {
+        anchor = providePageAnchor()
+        return () => h(DashboardShell)
+      }
+    })
+
+    const el = document.createElement('div')
+    document.body.appendChild(el)
+    app.mount(el)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(anchor.inset.value).not.toBeNull()
+
+    app.unmount()
+    el.remove()
   })
 })

--- a/tests/integration/views/deck/index.test.js
+++ b/tests/integration/views/deck/index.test.js
@@ -86,13 +86,6 @@ const ModeStackStub = defineComponent({
   name: 'ModeStack',
   setup: () => () => h('div', { 'data-testid': 'mode-stack-stub' })
 })
-const ScrollRegionStub = defineComponent({
-  name: 'ScrollRegion',
-  props: ['target'],
-  setup: (props) => () =>
-    h('div', { 'data-testid': 'scroll-bar-stub', 'data-target': props.target })
-})
-
 const CardGridSkeletonStub = defineComponent({
   name: 'CardGridSkeleton',
   setup: () => () => h('div', { 'data-testid': 'card-grid-skeleton-stub' })
@@ -177,7 +170,6 @@ function mount({
         ModeToolbar: ModeToolbarStub,
         ModeToolbarSkeleton: ModeToolbarSkeletonStub,
         ModeStack: ModeStackStub,
-        ScrollRegion: ScrollRegionStub,
         CardGridSkeleton: CardGridSkeletonStub,
         CardGridEmpty: CardGridEmptyStub
       }
@@ -326,15 +318,6 @@ describe('DeckView (views/deck/deck-view.vue)', () => {
     expect(main.classes()).not.toContain('xl:h-[calc(100dvh-var(--nav-height))]')
   })
 
-  test('renders the page scroll-bar tracking the document in every mode', () => {
-    for (const mode of ['view', 'edit', 'import']) {
-      const wrapper = mount({ mode, editorOpts: { cards: [{ id: 1 }] } })
-      const bar = wrapper.find('[data-testid="scroll-bar-stub"]')
-      expect(bar.exists()).toBe(true)
-      expect(bar.attributes('data-target')).toBe('html')
-    }
-  })
-
   // ── toolbar-skeleton swap [obligation] ────────────────────────────────────
 
   test('shows mode-toolbar-skeleton when view_state is "empty" [obligation]', () => {
@@ -353,18 +336,6 @@ describe('DeckView (views/deck/deck-view.vue)', () => {
     const wrapper = mount({ editorOpts: { cards: [{ id: 1 }], isLoading: false } })
     expect(wrapper.find('[data-testid="mode-toolbar-skeleton-stub"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="mode-toolbar-stub"]').exists()).toBe(true)
-  })
-
-  // ── scroll-bar only in ready state [obligation] ────────────────────────────
-
-  test('hides scroll-bar when view_state is "empty" [obligation]', () => {
-    const wrapper = mount({ editorOpts: { cards: [], isLoading: false } })
-    expect(wrapper.find('[data-testid="scroll-bar-stub"]').exists()).toBe(false)
-  })
-
-  test('hides scroll-bar when view_state is "loading" [obligation]', () => {
-    const wrapper = mount({ editorOpts: { cards: [], isLoading: true } })
-    expect(wrapper.find('[data-testid="scroll-bar-stub"]').exists()).toBe(false)
   })
 
   // ── deck-hero hide-actions driven by view_state [obligation] ──────────────
@@ -473,7 +444,6 @@ describe('DeckView (views/deck/deck-view.vue)', () => {
           ModeToolbar: ModeToolbarStub,
           ModeToolbarSkeleton: ModeToolbarSkeletonStub,
           ModeStack: ModeStackStub,
-          ScrollRegion: ScrollRegionStub,
           CardGridSkeleton: CardGridSkeletonStub,
           CardGridEmpty: CardGridEmptyStub
         }

--- a/tests/unit/components/layout-kit/scroll-region/use-scroll-metrics.test.js
+++ b/tests/unit/components/layout-kit/scroll-region/use-scroll-metrics.test.js
@@ -2,6 +2,10 @@ import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/tes
 import { createApp, nextTick, ref } from 'vue'
 import { useScrollMetrics } from '@/components/layout-kit/scroll-region/use-scroll-metrics'
 
+// Mirrors the source's own SETTLE_MS — overflowing only flips to true once the
+// measured overflow amount has held still for this long.
+const SETTLE_MS = 150
+
 // ── Host-app helper ────────────────────────────────────────────────────────────
 // Mounts a minimal Vue app so onBeforeUnmount fires, and the `flush: 'post'`
 // target watcher runs against a real (if fake-geometried) DOM tree. The watcher
@@ -104,6 +108,7 @@ afterEach(() => {
   unmount = undefined
   rafSpy.mockRestore()
   vi.unstubAllGlobals()
+  vi.useRealTimers()
 })
 
 // ── Basic measurement ─────────────────────────────────────────────────────────
@@ -129,13 +134,37 @@ describe('useScrollMetrics — measurement', () => {
     expect(setup.result.overflowing.value).toBe(false)
   })
 
-  test('flags overflow once content exceeds the 1px slack', async () => {
+  test('flags overflow once content exceeds the 1px slack, after the amount settles', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+
     const el = makeElement({ clientHeight: 100, scrollHeight: 102 })
     const target = ref(el)
     const setup = await withSetup(() => useScrollMetrics(target))
     unmount = setup.unmount
 
+    // Mid-settle, before SETTLE_MS has elapsed — not yet reported as overflowing.
+    expect(setup.result.overflowing.value).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(SETTLE_MS)
+
     expect(setup.result.overflowing.value).toBe(true)
+  })
+
+  test('clears overflowing immediately once content fits, without waiting for the settle clock', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+
+    const el = makeElement({ clientHeight: 100, scrollHeight: 300 })
+    const target = ref(el)
+    const setup = await withSetup(() => useScrollMetrics(target))
+    unmount = setup.unmount
+
+    await vi.advanceTimersByTimeAsync(SETTLE_MS)
+    expect(setup.result.overflowing.value).toBe(true)
+
+    Object.defineProperty(el, 'scrollHeight', { configurable: true, value: 100 })
+    setup.result.measure()
+
+    expect(setup.result.overflowing.value).toBe(false)
   })
 
   test('computes progress as scrollTop over max scroll', async () => {
@@ -192,6 +221,8 @@ describe('useScrollMetrics — scrollToProgress', () => {
 
 describe('useScrollMetrics — re-attaches when the target ref resolves late [obligation]', () => {
   test('measures nothing while the target is null, then attaches once it resolves', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+
     const target = ref(null)
     const setup = await withSetup(() => useScrollMetrics(target))
     unmount = setup.unmount
@@ -205,6 +236,9 @@ describe('useScrollMetrics — re-attaches when the target ref resolves late [ob
 
     expect(resize_instances).toHaveLength(1)
     expect(resize_instances[0].observed).toContain(el)
+
+    await vi.advanceTimersByTimeAsync(SETTLE_MS)
+
     expect(setup.result.overflowing.value).toBe(true)
   })
 
@@ -242,12 +276,17 @@ describe('useScrollMetrics — a target named by selector attaches after mount [
   })
 
   test('finds the element the selector names and measures it', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+
     const target = ref('#external-scroller')
     const setup = await withSetup(() => useScrollMetrics(target))
     unmount = setup.unmount
 
     expect(resize_instances).toHaveLength(1)
     expect(resize_instances[0].observed).toContain(external)
+
+    await vi.advanceTimersByTimeAsync(SETTLE_MS)
+
     expect(setup.result.overflowing.value).toBe(true)
   })
 
@@ -277,6 +316,35 @@ describe('useScrollMetrics — page target', () => {
     expect(mutation_instances).toHaveLength(1)
     expect(mutation_instances[0].observed[0].el).toBe(document.body)
     addSpy.mockRestore()
+  })
+
+  test('[obligation] a route swap that grows document.body content re-measures and reveals the handle', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+
+    const target = ref('html')
+    const scrollHeightSpy = vi
+      .spyOn(document.documentElement, 'scrollHeight', 'get')
+      .mockReturnValue(100)
+    const clientHeightSpy = vi
+      .spyOn(document.documentElement, 'clientHeight', 'get')
+      .mockReturnValue(100)
+
+    const setup = await withSetup(() => useScrollMetrics(target))
+    unmount = setup.unmount
+
+    await vi.advanceTimersByTimeAsync(SETTLE_MS)
+    expect(setup.result.overflowing.value).toBe(false)
+
+    // A route swapping in taller content — the mutation observer is what
+    // catches it, since the root's own box (pinned to the viewport) never resizes.
+    scrollHeightSpy.mockReturnValue(400)
+    mutation_instances[0].callback()
+    await vi.advanceTimersByTimeAsync(SETTLE_MS)
+
+    expect(setup.result.overflowing.value).toBe(true)
+
+    scrollHeightSpy.mockRestore()
+    clientHeightSpy.mockRestore()
   })
 })
 

--- a/tests/unit/views/app-shell/composables/page-anchor.test.js
+++ b/tests/unit/views/app-shell/composables/page-anchor.test.js
@@ -1,0 +1,162 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
+import { createApp, defineComponent, h, ref } from 'vue'
+import { providePageAnchor, usePageAnchorClaim } from '@/views/app-shell/composables/page-anchor'
+
+// ── Host-app helper ────────────────────────────────────────────────────────────
+// Mounts a real Vue tree so onBeforeUnmount fires for the claiming pane on its
+// own unmount, not just the whole app's.
+
+const PaneStub = defineComponent({
+  name: 'PaneStub',
+  props: { source: { type: Object, required: true } },
+  setup(props) {
+    usePageAnchorClaim(props.source)
+    return () => null
+  }
+})
+
+function withSetup() {
+  let anchor
+  const pane_mounted = ref(false)
+  const pane_source = ref(null)
+
+  const app = createApp({
+    setup() {
+      anchor = providePageAnchor()
+      return () => (pane_mounted.value ? h(PaneStub, { source: pane_source }) : null)
+    }
+  })
+
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  app.mount(el)
+
+  return {
+    anchor,
+    pane_mounted,
+    pane_source,
+    unmount: () => {
+      app.unmount()
+      el.remove()
+    }
+  }
+}
+
+// ── Layout-offset stub ─────────────────────────────────────────────────────────
+// jsdom never lays elements out, so offsetWidth/offsetLeft/offsetParent all read
+// 0/0/null by default. The composable walks that chain rather than reading a
+// bounding rect, so a claimed element's position has to be stubbed through it.
+
+function stubOffset(el, { width = 0, left = 0, parent = null } = {}) {
+  const widthSpy = vi.spyOn(el, 'offsetWidth', 'get').mockReturnValue(width)
+  const leftSpy = vi.spyOn(el, 'offsetLeft', 'get').mockReturnValue(left)
+  vi.spyOn(el, 'offsetParent', 'get').mockReturnValue(parent)
+  return { widthSpy, leftSpy }
+}
+
+// ── ResizeObserver fake ────────────────────────────────────────────────────────
+// jsdom has none. The composable observes the claimed element to catch it
+// resizing on its own, independent of the window.
+
+class FakeResizeObserver {
+  constructor(callback) {
+    this.callback = callback
+  }
+  observe() {}
+  disconnect() {}
+}
+
+let unmount
+let rafSpy
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', FakeResizeObserver)
+  // Runs the rAF callback synchronously so `schedule()` behaves like `measure()`.
+  rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+    cb(0)
+    return 1
+  })
+})
+
+afterEach(() => {
+  unmount?.()
+  unmount = undefined
+  rafSpy.mockRestore()
+  vi.unstubAllGlobals()
+})
+
+// ── Nothing claimed ────────────────────────────────────────────────────────────
+
+describe('providePageAnchor — nothing claimed', () => {
+  test('[obligation] inset is null when nothing has claimed it', () => {
+    const setup = withSetup()
+    unmount = setup.unmount
+
+    expect(setup.anchor.inset.value).toBeNull()
+  })
+})
+
+// ── A pane claims the anchor ──────────────────────────────────────────────────
+
+describe('providePageAnchor — a pane claims the anchor', () => {
+  test('[obligation] inset becomes the viewport clientWidth minus the claimed element right edge', async () => {
+    vi.spyOn(document.documentElement, 'clientWidth', 'get').mockReturnValue(1200)
+
+    // 400 wide, sitting 300 into a parent that itself sits 200 in: a right edge
+    // at 900 that only adds up if every link in the offsetParent chain counts.
+    const outer_el = document.createElement('div')
+    stubOffset(outer_el, { left: 200 })
+
+    const pane_el = document.createElement('div')
+    stubOffset(pane_el, { width: 400, left: 300, parent: outer_el })
+
+    const setup = withSetup()
+    unmount = setup.unmount
+
+    setup.pane_mounted.value = true
+    setup.pane_source.value = pane_el
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(setup.anchor.inset.value).toBe(300)
+  })
+
+  test('[obligation] unmounting the claiming pane clears inset back to null', async () => {
+    vi.spyOn(document.documentElement, 'clientWidth', 'get').mockReturnValue(1200)
+
+    const pane_el = document.createElement('div')
+    stubOffset(pane_el, { width: 0, left: 900 })
+
+    const setup = withSetup()
+    unmount = setup.unmount
+
+    setup.pane_mounted.value = true
+    setup.pane_source.value = pane_el
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(setup.anchor.inset.value).not.toBeNull()
+
+    setup.pane_mounted.value = false
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(setup.anchor.inset.value).toBeNull()
+  })
+
+  test('[obligation] a window resize event re-measures the claimed pane', async () => {
+    vi.spyOn(document.documentElement, 'clientWidth', 'get').mockReturnValue(1200)
+
+    const pane_el = document.createElement('div')
+    const { leftSpy } = stubOffset(pane_el, { width: 400, left: 500 })
+
+    const setup = withSetup()
+    unmount = setup.unmount
+
+    setup.pane_mounted.value = true
+    setup.pane_source.value = pane_el
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(setup.anchor.inset.value).toBe(300)
+
+    leftSpy.mockReturnValue(400)
+    window.dispatchEvent(new Event('resize'))
+
+    expect(setup.anchor.inset.value).toBe(400)
+  })
+})


### PR DESCRIPTION
TARO-367

> **Stacked PR** — base is `feat/364-scroll-region-owns-scrollbar` (#560), not `master`. Sibling TARO-366 (#561) stacks on the same base; all three merge together cleanly.

> **⚠️ Reviewer's decision — one AC rode an unsettled discussion thread on the ticket.** The last AC covers the case where the dashboard caps its content narrower than the page and centres it. This PR resolves it by having `dashboard-shell` claim the page anchor **unconditionally**, rather than only inside the ~916–1120px band where the cap is actually doing something. Above `mxl` the cap drops and the measured position converges on the pure-CSS default, so it self-corrects instead of hard-coding a breakpoint range that would need keeping in sync with `max-w-229` / `--breakpoint-mxl`. The trade-off: the dashboard's bar is measurement-driven at every width, while every other page stays on the pure-CSS path. Say the word if you'd rather it were gated to the band.

## Summary

- The shell mounts the single page-level scroll region, replacing the three separate ones in the dashboard, the deck view and the audio-reader lesson — each of which carried its own hardcoded insets. Its default position is pure CSS off `--page-width` / `--page-px`, so the bar hangs in the page column's padding instead of at the window edge.
- A new page-anchor composable lets a pane that caps its content narrower than the page column hand the scrollbar its own right edge to sit beside. The dashboard is the only such pane today. It measures from layout (`offsetLeft` / `offsetWidth`) rather than a `getBoundingClientRect` that a mid-slide page transition would distort.
- Page mode in `use-scroll-metrics` watches what's *inside* `document.body` with a `MutationObserver`, never the root element's own box — a root pinned to the viewport height never resizes when a route swaps in taller content, so a size observer there would leave the handle hidden until the reader scrolled.
- `overflowing` now gates *appearing* on the measured overflow holding still for 150ms. A layout mid-animation passes through heights it never rests at, and a handle shown on one of those flashes in and straight back out. Disappearing stays immediate.
- Drops the dead `.app-container` rules from `main.css` (carried over from TARO-365; zero call sites in the repo).

## What changed during review

- The page anchor was reworked twice after the first pass: measured from layout instead of a mid-slide rect, and the page re-measures when a route swaps its content in.
- The stillness gate on `overflowing` is new in this round — it fixes the handle flashing during page transitions.
- The branch was rebased onto #560's final head; the repeated merge commits from #560 being merged forward are gone, so this now reads as #560's history followed by five commits of its own. The resulting tree is the previous tree merged with #560's later work (notably the drag-tick removal), nothing else.

## Acceptance criteria

- [x] On a window wider than the content column, the page scrollbar sits in the margin beside the content rather than at the window edge.
- [x] The page scrollbar starts at the bottom of the nav bar and ends 2.5rem above the bottom of the window.
- [x] The dashboard, a deck and an audio-reader lesson show the page scrollbar in the same position as each other.
- [x] Every authenticated page that overflows shows the page scrollbar, including pages that mount none today.
- [x] On a window width where the dashboard caps its content narrower than the page and centres it, the scrollbar sits beside that content rather than out in the empty space beside it.
- [x] The page scrollbar hides when the page doesn't overflow.
