### PR TITLE
fix(tests): wait out the scroll-region settle window before asserting the handle

### DIFF
--- a/tests/helpers/scroll-settle.js
+++ b/tests/helpers/scroll-settle.js
@@ -1,0 +1,16 @@
+/**
+ * Waits for a `scroll-region` handle to settle after a geometry change.
+ *
+ * `useScrollMetrics` (`src/components/layout-kit/scroll-region/use-scroll-metrics.ts`)
+ * holds the handle back until the measured overflow has stayed put for its
+ * `SETTLE_MS` (150ms at time of writing) — and ResizeObserver callbacks can
+ * themselves lag a couple of animation frames behind the DOM mutation that
+ * triggered them. 200ms clears both with room to spare; if a future bump to
+ * `SETTLE_MS` outpaces this, every scroll-region handle assertion goes red
+ * together and points straight back here.
+ */
+export async function waitForScrollSettle() {
+  await new Promise((resolve) => requestAnimationFrame(resolve))
+  await new Promise((resolve) => requestAnimationFrame(resolve))
+  await new Promise((resolve) => setTimeout(resolve, 200))
+}

--- a/tests/integration/components/layout-kit/scroll-region/index.test.js
+++ b/tests/integration/components/layout-kit/scroll-region/index.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect, afterEach } from 'vite-plus/test'
 import { mount } from '@vue/test-utils'
 import { h } from 'vue'
 import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
+import { waitForScrollSettle } from '../../../../helpers/scroll-settle'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 // Tailwind's utility classes aren't compiled in this test environment, so the
@@ -25,15 +26,7 @@ afterEach(() => {
   _activeHosts = []
 })
 
-// ResizeObserver callbacks batch on their own queue, which can lag a couple of
-// animation frames behind the DOM mutation that triggered them. The tail wait
-// also has to outlast the metrics' 150ms settle window, since the handle is
-// held back until the measured overflow stops moving.
-async function waitForUpdate() {
-  await new Promise((resolve) => requestAnimationFrame(resolve))
-  await new Promise((resolve) => requestAnimationFrame(resolve))
-  await new Promise((resolve) => setTimeout(resolve, 200))
-}
+const waitForUpdate = waitForScrollSettle
 
 function root(wrapper) {
   return wrapper.find('[data-testid="scroll-region"]')

--- a/tests/integration/components/ui-kit/options-panel/index.test.js
+++ b/tests/integration/components/ui-kit/options-panel/index.test.js
@@ -6,6 +6,7 @@ const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: vi.fn() }))
 
 import OptionsPanel from '@/components/ui-kit/options-panel/index.vue'
+import { waitForScrollSettle } from '../../../../helpers/scroll-settle'
 
 const IconStub = defineComponent({
   name: 'UiIcon',
@@ -46,11 +47,7 @@ afterEach(() => {
   _activeWrappers = []
 })
 
-async function waitForUpdate() {
-  await new Promise((resolve) => requestAnimationFrame(resolve))
-  await new Promise((resolve) => requestAnimationFrame(resolve))
-  await new Promise((resolve) => setTimeout(resolve, 60))
-}
+const waitForUpdate = waitForScrollSettle
 
 function makeOverflowingPanel(height = 60) {
   const wrapper = mount(OptionsPanel, {

--- a/tests/integration/views/deck/card-import/skipped-lines-dialog.test.js
+++ b/tests/integration/views/deck/card-import/skipped-lines-dialog.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect, vi, afterEach } from 'vite-plus/test'
 import { mount as vueMount } from '@vue/test-utils'
 import SkippedLinesDialog from '@/views/deck/card-import/skipped-lines-dialog.vue'
 import { vSfx } from '@/sfx/directive'
+import { waitForScrollSettle } from '../../../../helpers/scroll-settle'
 
 const { mockEmitSfx, mockEmitHoverSfx } = vi.hoisted(() => ({
   mockEmitSfx: vi.fn(),
@@ -31,11 +32,7 @@ afterEach(() => {
   _activeWrappers = []
 })
 
-async function waitForUpdate() {
-  await new Promise((resolve) => requestAnimationFrame(resolve))
-  await new Promise((resolve) => requestAnimationFrame(resolve))
-  await new Promise((resolve) => setTimeout(resolve, 60))
-}
+const waitForUpdate = waitForScrollSettle
 
 function mountOverflowing(height = 60) {
   const lines = Array.from({ length: 40 }, (_, i) => ({ line: i + 1, text: `bad row ${i + 1}` }))


### PR DESCRIPTION
`master` is red on two integration tests. This is a **test-only fix** — the scrollbar itself is fine.

## What was wrong

`scroll-region` shows its handle only once the measured overflow has held still for `SETTLE_MS = 150` in `use-scroll-metrics` — a debounce added in #562 so a panel animating open doesn't flash a handle at heights it never rests at. Master went red at that merge (`4becd29d`).

Three suites hand-rolled their own `waitForUpdate`. The scroll-region suite waited 200 ms and passed; `options-panel` and `skipped-lines-dialog` waited 60 ms, asserting before the handle could exist:

- `tests/integration/components/ui-kit/options-panel/index.test.js:159`
- `tests/integration/views/deck/card-import/skipped-lines-dialog.test.js:86`

Confirmed by dropping `SETTLE_MS` to 20 locally, which turned both files green with no test edits.

## What changed

- New `tests/helpers/scroll-settle.js` — one `waitForScrollSettle()` (2 rAFs + 200 ms), documented as needing to outlast `SETTLE_MS`.
- All three suites now use it instead of three independently-guessed numbers.

No source files touched; `SETTLE_MS` unchanged.

## Why the shared helper

Each suite's correctness silently rode on a constant it couldn't see, so the next host to grow a handle test inherited the same trap. One place to update now, with a comment naming the dependency.

## Verification

`vp test` across all three suites: 3 files, 38 tests, all pass. `vp lint` on the four touched files: clean.