### PR TITLE
TARO-263: Role vocabulary and seam-owned sounds for sfx

### DIFF
--- a/.claude/rules/sfx.md
+++ b/.claude/rules/sfx.md
@@ -35,8 +35,10 @@ sound-shaped prop beside it, and never a `silent` boolean.
 <ui-tappable :sfx="{ hover: false }">…</ui-tappable>
 ```
 
-Every primitive already defaults its own `press`, `hover` and `rejected`, so pass a channel only to
-change it. `press` / `tap_pre` route through staged-tap; the directive handles `hover` and `focus`.
+Every primitive already defaults its own `hover`, so pass that channel only to change it. **`press`
+never defaults** — a button stays silent on press until a call site names a role, because most
+already play their own cue from the handler behind `@press`. `press` / `tap_pre` route through
+staged-tap; the directive handles `hover` and `focus`.
 
 ## A recurring sound lives in its seam
 

--- a/.claude/rules/sfx.md
+++ b/.claude/rules/sfx.md
@@ -12,41 +12,55 @@ adding sound to any `.vue` component.
 
 Audio runs through a lightweight custom engine in `src/sfx/`, surfaced as the `v-sfx` directive and the imperative `emitSfx()`.
 
-## Buttons use the `sfx` prop
+## Name the intent, never the file
 
-`UiButton` orchestrates its own click sounds through `useStagedTap`. Pass them as a prop — never call `emitSfx` for a button click, which bypasses the orchestration.
+`src/sfx/roles.ts` is the only place an audio filename may appear. Everywhere else names a
+`namespace.intent` role from that catalogue — `ui.press`, `dialog.close`, `card.flip-away`.
+
+- **A trigger no listed role covers is a question for the user, not a new role you mint.** Adding a
+  role is a decision about what the app sounds like; the catalogue is closed until they make it.
+- **Volume, bus and debounce belong to the role, not the call.** `emitSfx` takes no options bar
+  `preview_bus`, which the audio-settings sliders use to hear a drag on the dial it moves and which
+  cannot change which sound plays.
+- **Reach the player through `src/sfx/volume-seam.ts`** — it is the only path from the member's
+  audio preferences to what comes out of the speakers.
+
+## The `sfx` prop is one shape across ui-kit and layout-kit
+
+`sfx?: SfxOptions` — each channel takes a role, or `false` to silence it. Never add a second
+sound-shaped prop beside it, and never a `silent` boolean.
 
 ```html
 <ui-button :sfx="{ press: 'ui.select' }">…</ui-button>
+<ui-tappable :sfx="{ hover: false }">…</ui-tappable>
 ```
 
-Keys routed through staged-tap: `press`, `tap_pre`, `tap_post`. The directive handles `hover`, `focus`, `blur`.
+Every primitive already defaults its own `press`, `hover` and `rejected`, so pass a channel only to
+change it. `press` / `tap_pre` route through staged-tap; the directive handles `hover` and `focus`.
 
 ## A recurring sound lives in its seam
 
 A sound that should play for **every** instance of an action belongs in the single function that performs it — a store action, a mutation, a mode setter — not wired at each call site, where copies drift and double up ([`architecture/api-layer`](./architecture/api-layer.md) states the general rule). The deck mode-switch chime lives in `setMode`, and the per-call-site duplicates were deleted.
 
-`PlayOptions` (`src/sfx/player.ts`) is `{ volume?, debounce?, bus? }` — there is no option that suppresses a follow-on sound. When a caller needs a different cue for the same seam-owned transition, give the seam function an optional sound parameter defaulting to its usual cue (`setMode(mode, chime = 'select')`) and have the caller pass its own — never fire a second sound alongside the seam's.
+There is no option that suppresses a follow-on sound. When a caller needs a different cue for the same seam-owned transition, give the seam function an optional role parameter defaulting to its usual cue (`setMode(mode, chime = 'ui.select')`) and have the caller pass its own — never fire a second sound alongside the seam's.
 
-Centralise only for genuine instances of _that_ action — don't fold in unrelated uses of the same key.
+Centralise only for genuine instances of _that_ action — don't fold in unrelated uses of the same role.
 
-## Every sound debounces by default — say so when a cue can't take it
+## Every sound debounces by default — set the role's own when a cue can't take it
 
 `player.ts` runs every call through a shared 10ms trailing debounce keyed by sound name, whether or
-not the caller mentioned it. That's invisible at the call site, so a rhythmic or latency-sensitive
+not the role asked for one. That's invisible at the call site, so a rhythmic or latency-sensitive
 cue — one paced by something other than the debounce itself, like a drag's `requestAnimationFrame`
 loop or a countdown tick — inherits a delay that lands wherever the timer happens to fire, not on the
-beat the caller intended. Pass `debounce: 0` explicitly on any call whose timing is driven by
-something other than user click-spam.
+beat the caller intended. Give such a role `debounce: 0` in `roles.ts`; a call site can't set one.
 
-```html
-<!-- Bad — default debounce free-floats the sound off the drag's own cadence -->
-emitSfx('drag.detent')
+## Don't double up on one element
 
-<!-- Good — timing is the caller's; nothing shared should reschedule it -->
-emitSfx('drag.detent', { debounce: 0 })
-```
+If a click handler already calls `emitSfx(...)` imperatively, don't add a parallel `v-sfx` press
+binding next to it — it double-plays and splits the configuration surface. Leave `v-sfx` to
+hover/focus on that element.
 
-## Options go on the existing call
-
-If a click handler already calls `emitSfx(...)` imperatively, pass options to **that call**. Don't add a parallel `v-sfx="{ click: … }"` next to it — it double-plays and splits the configuration surface, leaving it ambiguous which one carries the options. Leave `v-sfx` to hover/focus/blur on that element.
+**One `v-sfx` per element, ever.** The directive keys its listeners off the element, so a second
+binding that falls through to the same root — a `v-sfx` on a component whose own root already
+carries one — silently replaces the first without cleaning it up and leaks its listeners. Pass the
+`sfx` prop to the child instead of binding the directive over it.

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,7 @@ import NoticePanel from '@/components/ui-kit/notice/panel.vue'
 import UiModal from '@/components/ui-kit/modal/index.vue'
 import { springScaleIn } from '@/utils/animations/modal'
 import { noticeToastListLeave } from '@/utils/animations/notice-toast'
-import audio_player from '@/sfx/player'
+import { applyMemberVolumes, setupAudio } from '@/sfx/volume-seam'
 import { installAudioLifecycle } from '@/sfx/lifecycle'
 import { installSafeAreaPadding } from '@/composables/ui/safe-area'
 import { useSessionStore } from '@/stores/session'
@@ -15,7 +15,7 @@ import { onMounted, onBeforeUnmount } from 'vue'
 import logger from '@/utils/logger'
 import { useThemeStore } from '@/stores/theme'
 import { useMemberStore } from '@/stores/member'
-import { withMemberPreferencesDefaults, toBusVolumes } from '@/utils/member/preferences'
+import { withMemberPreferencesDefaults } from '@/utils/member/preferences'
 import { watch } from 'vue'
 
 const { t } = useI18n()
@@ -56,7 +56,7 @@ watch(
       'data-left-hand',
       String(resolved.accessibility.left_hand)
     )
-    audio_player.setVolumeConfig(toBusVolumes(resolved.audio))
+    applyMemberVolumes(resolved.audio)
   },
   { immediate: true, deep: true }
 )
@@ -82,8 +82,7 @@ onMounted(() => {
   }
 
   scheduleIdle(() => {
-    audio_player
-      .setup()
+    setupAudio()
       .then(() => {
         teardownAudioLifecycle = installAudioLifecycle()
       })

--- a/src/components/billing/checkout-modal/use-checkout.ts
+++ b/src/components/billing/checkout-modal/use-checkout.ts
@@ -51,7 +51,7 @@ export function useCheckout(close: (response?: CheckoutResponse) => void) {
     return 'form'
   })
 
-  onMounted(() => emitSfx('dialog.open'))
+  onMounted(() => emitSfx('dialog.open-chime'))
   onBeforeUnmount(() => emitSfx('dialog.close'))
 
   useModalRequestClose(() => {

--- a/src/components/billing/checkout-modal/use-checkout.ts
+++ b/src/components/billing/checkout-modal/use-checkout.ts
@@ -51,7 +51,7 @@ export function useCheckout(close: (response?: CheckoutResponse) => void) {
     return 'form'
   })
 
-  onMounted(() => emitSfx('wooden_chime_ring'))
+  onMounted(() => emitSfx('dialog.open'))
   onBeforeUnmount(() => emitSfx('dialog.close'))
 
   useModalRequestClose(() => {

--- a/src/components/billing/checkout-modal/use-checkout.ts
+++ b/src/components/billing/checkout-modal/use-checkout.ts
@@ -52,7 +52,7 @@ export function useCheckout(close: (response?: CheckoutResponse) => void) {
   })
 
   onMounted(() => emitSfx('wooden_chime_ring'))
-  onBeforeUnmount(() => emitSfx('pop_up_close'))
+  onBeforeUnmount(() => emitSfx('dialog.close'))
 
   useModalRequestClose(() => {
     if (status.value === 'confirming') return
@@ -81,7 +81,7 @@ export function useCheckout(close: (response?: CheckoutResponse) => void) {
     is_confirming.value = false
     is_success.value = true
 
-    emitSfx('success_1')
+    emitSfx('notice.success')
     await wait(SUCCESS_DISPLAY_MS)
     close({ upgraded: true })
   }

--- a/src/components/card-actions/move-cards-modal.vue
+++ b/src/components/card-actions/move-cards-modal.vue
@@ -100,7 +100,7 @@ function onClose() {
       scrollable
       class="my-4 min-h-0"
       :entries="entries"
-      :sfx="{ press: 'snappy_button_2' }"
+      :sfx="{ press: 'ui.press' }"
       @select="onSelect"
     >
       <template #leading="{ entry }">
@@ -120,7 +120,7 @@ function onClose() {
           class="group-hover/tappable:bg-(--color-accent)!"
           :class="{ 'opacity-20': Number(entry.value) === current_deck_id }"
           data-palette="brand"
-          :sfx="{ press: 'snappy_button_2' }"
+          :sfx="{ press: 'ui.press' }"
           :checked="
             Number(entry.value) === selected_deck_id || Number(entry.value) === current_deck_id
           "

--- a/src/components/card-actions/move-cards-modal.vue
+++ b/src/components/card-actions/move-cards-modal.vue
@@ -88,7 +88,7 @@ function onSelect(value: string) {
 }
 
 function onClose() {
-  emitSfx('pop_up_close')
+  emitSfx('dialog.close')
   close(false)
 }
 </script>

--- a/src/components/card/face-image-layer.vue
+++ b/src/components/card/face-image-layer.vue
@@ -9,7 +9,6 @@ import { CARD_IMAGE_MAX_BYTES, useFaceImageUpload } from '@/composables/card'
 import { cardImageUrl } from '@/api/media'
 import { CARD_ATTRIBUTES_DEFAULTS } from '@/utils/deck/defaults'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 import { type SfxOptions } from '@/sfx/directive'
 import { playButtonTap } from '@/utils/animations/button-tap'
 import { bytesToMbLabel } from '@/utils/file-size'
@@ -178,7 +177,7 @@ defineExpose({
     :aria-label="t('card.image-editor.upload-image-button')"
     class="absolute! top-(--face-padding) right-(--face-padding) z-20 cursor-pointer text-ink-muted transition-[color,opacity] duration-150 hover:text-(--color-accent)"
     :class="hovered ? 'opacity-100' : 'opacity-0'"
-    v-sfx="{ hover: TYPE_SFX }"
+    v-sfx="{ hover: 'ui.hover' }"
     @click.stop="onAddClick"
   >
     <span ref="addIcon" class="inline-flex">

--- a/src/components/card/face-image-layer.vue
+++ b/src/components/card/face-image-layer.vue
@@ -99,7 +99,7 @@ function onRootPointerLeave() {
 
 /** Scopes the hover chime to the image region; behind/full-bleed play it card-wide instead, via `card_sfx`. */
 function onRegionPointerEnter() {
-  emitSfx('tap_05')
+  emitSfx('gesture.tick')
   onPointerEnter()
 }
 

--- a/src/components/card/face-image-layer.vue
+++ b/src/components/card/face-image-layer.vue
@@ -9,7 +9,7 @@ import { CARD_IMAGE_MAX_BYTES, useFaceImageUpload } from '@/composables/card'
 import { cardImageUrl } from '@/api/media'
 import { CARD_ATTRIBUTES_DEFAULTS } from '@/utils/deck/defaults'
 import { emitSfx } from '@/sfx/bus'
-import { type SfxOptions } from '@/sfx/directive'
+import { type SfxOptions } from '@/sfx/roles'
 import { playButtonTap } from '@/utils/animations/button-tap'
 import { bytesToMbLabel } from '@/utils/file-size'
 import { useMatchMedia } from '@/composables/ui/media-query'
@@ -71,7 +71,7 @@ const region_dropzone = computed(
 )
 /** Hover chime for behind/full-bleed layouts; region layout scopes its own chime instead (see onRegionPointerEnter). */
 const card_sfx = computed<SfxOptions | undefined>(() =>
-  has_image.value && dropzone_mode.value === 'corners' ? { hover: 'tap_05' } : undefined
+  has_image.value && dropzone_mode.value === 'corners' ? { hover: 'ui.hover' } : undefined
 )
 
 const error_message = computed(() => {

--- a/src/components/card/index.vue
+++ b/src/components/card/index.vue
@@ -9,7 +9,7 @@ import ImageDropzone from './image-dropzone.vue'
 import { type CoverImage } from '@/composables/deck/cover-image'
 import { type CardBase } from '@type/card'
 import { cardImageUrl } from '@/api/media'
-import { type SfxOptions } from '@/sfx/directive'
+import { type SfxOptions } from '@/sfx/roles'
 import { flipEnter, flipLeave } from '@/utils/animations/flip'
 
 type CardProps = Partial<CardBase> & {

--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -2,7 +2,6 @@
 import Card from '@/components/card/index.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiTappable from '@/components/ui-kit/tappable.vue'
-import { TYPE_SFX } from '@/sfx/config'
 import type { SfxOptions } from '@/sfx/directive'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -57,7 +56,7 @@ const is_locked = computed(() => locked ?? deck?.is_locked ?? false)
       dragging && 'drop-shadow-sm'
     ]"
     :active="active"
-    :sfx="{ hover: TYPE_SFX, ...sfx }"
+    :sfx="{ hover: 'ui.hover', ...sfx }"
     @tap="emit('press', $event)"
   >
     <card

--- a/src/components/deck/deck-thumbnail.vue
+++ b/src/components/deck/deck-thumbnail.vue
@@ -2,7 +2,7 @@
 import Card from '@/components/card/index.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiTappable from '@/components/ui-kit/tappable.vue'
-import type { SfxOptions } from '@/sfx/directive'
+import type { SfxOptions } from '@/sfx/roles'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 

--- a/src/components/deck/new-deck-card.vue
+++ b/src/components/deck/new-deck-card.vue
@@ -2,7 +2,6 @@
 import Card from '@/components/card/index.vue'
 import UiTappable from '@/components/ui-kit/tappable.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
-import { TYPE_SFX } from '@/sfx/config'
 import { useI18n } from 'vue-i18n'
 
 type NewDeckCardProps = {
@@ -24,7 +23,7 @@ const { t } = useI18n()
     :aria-label="t('dashboard.create-deck-button')"
     class="pointer-fine:hover:scale-102 data-[tap-active=true]:scale-101 pointer-coarse:data-[tap-active=true]:scale-105 pointer-fine:transition-transform duration-75 relative cursor-pointer h-min touch-manipulation"
     :class="(loading || disabled) && 'opacity-disabled pointer-events-none'"
-    :sfx="{ hover: TYPE_SFX, press: 'pop_up_pop' }"
+    :sfx="{ hover: 'ui.hover', press: 'pop_up_pop' }"
     @tap="!disabled && emit('press', $event)"
   >
     <card side="front">

--- a/src/components/deck/new-deck-card.vue
+++ b/src/components/deck/new-deck-card.vue
@@ -23,7 +23,7 @@ const { t } = useI18n()
     :aria-label="t('dashboard.create-deck-button')"
     class="pointer-fine:hover:scale-102 data-[tap-active=true]:scale-101 pointer-coarse:data-[tap-active=true]:scale-105 pointer-fine:transition-transform duration-75 relative cursor-pointer h-min touch-manipulation"
     :class="(loading || disabled) && 'opacity-disabled pointer-events-none'"
-    :sfx="{ hover: 'ui.hover', press: 'pop_up_pop' }"
+    :sfx="{ hover: 'ui.hover', press: 'dialog.open' }"
     @tap="!disabled && emit('press', $event)"
   >
     <card side="front">

--- a/src/components/feedback/feedback-board.vue
+++ b/src/components/feedback/feedback-board.vue
@@ -15,7 +15,7 @@ const modal = useModal()
 const { data: items } = useFeedbackItemsQuery()
 
 function onSubmitPress() {
-  emitSfx('dialog.open')
+  emitSfx('dialog.open-chime')
   modal.open(FeedbackSubmitDialog, { backdrop: true, mode: 'popup' })
 }
 </script>

--- a/src/components/feedback/feedback-board.vue
+++ b/src/components/feedback/feedback-board.vue
@@ -15,7 +15,7 @@ const modal = useModal()
 const { data: items } = useFeedbackItemsQuery()
 
 function onSubmitPress() {
-  emitSfx('wooden_chime_ring')
+  emitSfx('dialog.open')
   modal.open(FeedbackSubmitDialog, { backdrop: true, mode: 'popup' })
 }
 </script>

--- a/src/components/feedback/feedback-card.vue
+++ b/src/components/feedback/feedback-card.vue
@@ -7,7 +7,6 @@ import MemberPolaroid from '@/components/member/member-polaroid.vue'
 import { emitSfx } from '@/sfx/bus'
 import { useNoticeStore } from '@/stores/notice-store'
 import { useToggleFeedbackVoteMutation } from '@/api/feedback'
-import { TYPE_SFX } from '@/sfx/config'
 
 const { item } = defineProps<{ item: FeedbackItem }>()
 
@@ -62,7 +61,7 @@ async function onToggleVote() {
         data-palette="pink"
         class="flex cursor-pointer items-center justify-center duration-100 disabled:opacity-disabled hover:scale-110 hover:rotate-5"
         :class="item.voted_by_me ? 'text-(--color-accent-text)' : 'text-ink-muted'"
-        v-sfx="{ hover: TYPE_SFX }"
+        v-sfx="{ hover: 'ui.hover' }"
         @click="onToggleVote"
       >
         <ui-icon src="symbol-hearts" class="size-6" />

--- a/src/components/feedback/feedback-card.vue
+++ b/src/components/feedback/feedback-card.vue
@@ -20,7 +20,7 @@ async function onToggleVote() {
   const was_voted = item.voted_by_me
 
   try {
-    emitSfx(was_voted ? 'toggle_off' : 'generic_notification_9')
+    emitSfx(was_voted ? 'ui.toggle-off' : 'notice.info')
     if (!was_voted) burst_id.value++
     await toggleVote.mutateAsync(item.id)
   } catch {

--- a/src/components/feedback/feedback-submit-dialog.vue
+++ b/src/components/feedback/feedback-submit-dialog.vue
@@ -40,7 +40,7 @@ async function onSubmit() {
       body: body.value.trim() || undefined,
       type: UNCATEGORIZED_TYPE
     })
-    emitSfx('generic_notification_9')
+    emitSfx('notice.info')
     notice.success(t('toast.success.feedback-submitted'))
     close(true)
   } catch {
@@ -49,7 +49,7 @@ async function onSubmit() {
 }
 
 function onClose() {
-  emitSfx('pop_up_close')
+  emitSfx('dialog.close')
   close(false)
 }
 </script>

--- a/src/components/layout-kit/dialog-card/index.vue
+++ b/src/components/layout-kit/dialog-card/index.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n'
 import DialogCardHeader from './dialog-card-header.vue'
 import { provideDialogCardViewport, type DialogCardViewport } from './dialog-card-viewport.ts'
 import UiButton from '@/components/ui-kit/button.vue'
-import type { SfxOptions } from '@/sfx/directive'
+import type { SfxOptions } from '@/sfx/roles'
 
 export type DialogCardSize = 'sm' | 'md' | 'lg'
 
@@ -38,7 +38,7 @@ export type DialogCardProps = {
   show_close_button?: boolean
   close_label?: string
   close_disabled?: boolean
-  close_sfx?: SfxOptions
+  sfx?: SfxOptions
   size?: DialogCardSize
   full_bleed_at?: string
   dialog_px?: string
@@ -56,7 +56,7 @@ const {
   show_close_button = true,
   close_label,
   close_disabled = false,
-  close_sfx,
+  sfx = {},
   size = 'md',
   full_bleed_at,
   dialog_px,
@@ -144,7 +144,7 @@ defineExpose({ viewport })
               icon-left="close"
               icon-only
               rounded-full
-              :sfx="close_sfx"
+              :sfx="{ press: sfx.close ?? 'dialog.close' }"
               :disabled="close_disabled"
               @press="emit('close')"
             >

--- a/src/components/layout-kit/paged-window/directory-page.vue
+++ b/src/components/layout-kit/paged-window/directory-page.vue
@@ -45,11 +45,7 @@ function onSelect(value: string) {
       :data-testid="`directory-page__nav-group--${group.key}`"
       :label="group.heading"
     >
-      <ui-options-panel
-        :entries="group.entries"
-        :sfx="{ press: 'snappy_button_5' }"
-        @select="onSelect"
-      />
+      <ui-options-panel :entries="group.entries" :sfx="{ press: 'ui.press' }" @select="onSelect" />
     </labeled-section>
 
     <slot name="footer"></slot>

--- a/src/components/layout-kit/paged-window/index.vue
+++ b/src/components/layout-kit/paged-window/index.vue
@@ -7,7 +7,7 @@ import { useWindowLayout, windowLayoutKey } from './layout'
 import { usePageTransition } from './page-transition'
 import type { OptionsPanelEntry } from '@/components/ui-kit/options-panel/index.vue'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX, type SoundKey } from '@/sfx/config'
+import { type SoundKey } from '@/sfx/config'
 import uid from '@/utils/uid'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
@@ -58,7 +58,7 @@ const {
   phone_query = 'w<md',
   desktop_query = 'w>=lg & fine',
   between,
-  hover_sfx = TYPE_SFX,
+  hover_sfx = 'ui.hover',
   select_sfx = 'snappy_button_5',
   reselect_sfx = 'digi_powerdown',
   stretch_page = false

--- a/src/components/layout-kit/paged-window/index.vue
+++ b/src/components/layout-kit/paged-window/index.vue
@@ -7,7 +7,7 @@ import { useWindowLayout, windowLayoutKey } from './layout'
 import { usePageTransition } from './page-transition'
 import type { OptionsPanelEntry } from '@/components/ui-kit/options-panel/index.vue'
 import { emitSfx } from '@/sfx/bus'
-import { type SoundKey } from '@/sfx/config'
+import type { SfxOptions } from '@/sfx/roles'
 import uid from '@/utils/uid'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
@@ -38,9 +38,7 @@ export type PagedWindowProps = PagedWindowFrameProps & {
   phone_query?: string
   desktop_query?: string
   between?: () => void | Promise<void>
-  hover_sfx?: SoundKey | SoundKey[] | ''
-  select_sfx?: SoundKey | ''
-  reselect_sfx?: SoundKey | ''
+  sfx?: SfxOptions
   /** Stretches the page column to the full content height instead of sizing to its content, so a page can pin its own footer to the bottom. Off by default. */
   stretch_page?: boolean
 }
@@ -58,9 +56,7 @@ const {
   phone_query = 'w<md',
   desktop_query = 'w>=lg & fine',
   between,
-  hover_sfx = 'ui.hover',
-  select_sfx = 'snappy_button_5',
-  reselect_sfx = 'digi_powerdown',
+  sfx = {},
   stretch_page = false
 } = defineProps<PagedWindowProps>()
 
@@ -147,12 +143,12 @@ function onFrameClose() {
 
 function selectPage(value: string) {
   if (value === displayed_page.value) {
-    if (reselect_sfx) emitSfx(reselect_sfx)
+    if (sfx.reselect !== false) emitSfx(sfx.reselect ?? 'ui.deselect')
     emit('reselect', value)
     return
   }
 
-  if (select_sfx) emitSfx(select_sfx)
+  if (sfx.select !== false) emitSfx(sfx.select ?? 'ui.press')
   nav_direction.value = 'forward'
   active.value = value
   emit('select', value)
@@ -221,7 +217,7 @@ function onDirectoryNavigate(value: string) {
                 ? 'text-(--color-accent-text) hover:bg-(--color-accent)/10 data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-on-accent)'
                 : 'text-ink data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-on-accent) hover:bg-(--color-raised) hover:text-(--color-ink)'
             ]"
-            v-sfx="page.value === displayed_page ? {} : { hover: hover_sfx }"
+            v-sfx="page.value === displayed_page ? {} : { hover: sfx.hover ?? 'ui.hover' }"
             @click="selectPage(page.value)"
           >
             <ui-icon v-if="page.icon" :src="page.icon" class="w-6 h-6" />

--- a/src/components/member/avatar-picker-modal.vue
+++ b/src/components/member/avatar-picker-modal.vue
@@ -7,7 +7,6 @@ import AvatarImage from './avatar-image.vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import { AVATAR_KEYS, loadAvatarUrl } from './avatars'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 
 type AvatarPickerModalProps = {
   selected?: string
@@ -51,7 +50,7 @@ function onAvatarSelect(avatar: string) {
           :key="avatar"
           :data-testid="`avatar-picker-modal__option-${avatar}`"
           :data-selected="avatar === selected || undefined"
-          v-sfx="{ hover: TYPE_SFX }"
+          v-sfx="{ hover: 'ui.hover' }"
           class="rounded-10 cursor-pointer hover:bg-(--color-accent) hover:bgx-diagonal-stripes hover:bgx-slide data-selected:bg-(--color-accent) data-selected:bgx-diagonal-stripes data-selected:border-6 border-knockout relative aspect-square p-2"
           @click="onAvatarSelect(avatar)"
         >

--- a/src/components/member/avatar-picker-modal.vue
+++ b/src/components/member/avatar-picker-modal.vue
@@ -19,7 +19,7 @@ const { t } = useI18n()
 const loaded = reactive(new Set<string>())
 
 onMounted(() => {
-  emitSfx('dialog.open')
+  emitSfx('dialog.open-chime')
   AVATAR_KEYS.forEach((avatar) => loadAvatarUrl(avatar)?.then(() => loaded.add(avatar)))
 })
 

--- a/src/components/member/avatar-picker-modal.vue
+++ b/src/components/member/avatar-picker-modal.vue
@@ -19,7 +19,7 @@ const { t } = useI18n()
 const loaded = reactive(new Set<string>())
 
 onMounted(() => {
-  emitSfx('wooden_chime_ring')
+  emitSfx('dialog.open')
   AVATAR_KEYS.forEach((avatar) => loadAvatarUrl(avatar)?.then(() => loaded.add(avatar)))
 })
 
@@ -40,7 +40,6 @@ function onAvatarSelect(avatar: string) {
     size="lg"
     data-palette="blue"
     :title="t('avatar-picker-modal.title')"
-    :close_sfx="{ press: 'pop_up_close' }"
     @close="close()"
   >
     <dialog-card-body data-testid="avatar-picker-modal__scroll-area">

--- a/src/components/member/avatar-picker-modal.vue
+++ b/src/components/member/avatar-picker-modal.vue
@@ -25,11 +25,11 @@ onMounted(() => {
 
 function onAvatarSelect(avatar: string) {
   if (avatar === selected) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.deselect')
     return
   }
 
-  emitSfx('toggle_on')
+  emitSfx('ui.toggle-on')
   close(avatar)
 }
 </script>

--- a/src/components/member/member-badge.vue
+++ b/src/components/member/member-badge.vue
@@ -5,17 +5,15 @@ import { memberCoverBindings } from './cover'
 import AvatarImage from './avatar-image.vue'
 import UiButton from '@/components/ui-kit/button.vue'
 import UiTappable from '@/components/ui-kit/tappable.vue'
-import type { SfxOptions } from '@/sfx/directive'
 
 type MemberBadgeProps = {
   displayName?: string
   description?: string
   cover?: MemberCover
-  sfx?: SfxOptions
   editable?: boolean
 }
 
-const { displayName, description, cover, sfx, editable = false } = defineProps<MemberBadgeProps>()
+const { displayName, description, cover, editable = false } = defineProps<MemberBadgeProps>()
 defineSlots<{ actions?: () => any; description?: () => any }>()
 const emit = defineEmits<{ click: [e: MouseEvent]; 'edit-avatar': [] }>()
 
@@ -32,7 +30,6 @@ function onEditAvatar(e: MouseEvent) {
 <template>
   <ui-tappable
     as="div"
-    :sfx="sfx"
     data-testid="member-badge"
     v-bind="body_bindings"
     style="--badge-radius: 42px; --badge-padding: 14px"

--- a/src/components/taro-phone/app-launcher.vue
+++ b/src/components/taro-phone/app-launcher.vue
@@ -38,7 +38,7 @@ function focusApp(index: number, emit_hover_sfx = true) {
   }
 
   apps[active_index]?.focus()
-  if (emit_hover_sfx) emitHoverSfx('ui.hover')
+  if (emit_hover_sfx) emitHoverSfx('phone.app-focus')
 }
 
 function activateFocused() {
@@ -55,7 +55,7 @@ function onMouseOverApp(e: MouseEvent) {
 
   apps[active_index]?.blur()
   active_index = -1
-  emitHoverSfx('ui.hover')
+  emitHoverSfx('phone.app-focus')
 }
 
 function _getApps() {

--- a/src/components/taro-phone/app-launcher.vue
+++ b/src/components/taro-phone/app-launcher.vue
@@ -38,7 +38,7 @@ function focusApp(index: number, emit_hover_sfx = true) {
   }
 
   apps[active_index]?.focus()
-  if (emit_hover_sfx) emitHoverSfx('pop_drip_mid')
+  if (emit_hover_sfx) emitHoverSfx('ui.hover')
 }
 
 function activateFocused() {
@@ -55,7 +55,7 @@ function onMouseOverApp(e: MouseEvent) {
 
   apps[active_index]?.blur()
   active_index = -1
-  emitHoverSfx('pop_drip_mid')
+  emitHoverSfx('ui.hover')
 }
 
 function _getApps() {

--- a/src/components/taro-phone/apps/darkmode-app.vue
+++ b/src/components/taro-phone/apps/darkmode-app.vue
@@ -29,7 +29,7 @@ const title = computed(() => t(active_mode_config.value.labelKey))
 
 function cycleMode() {
   cycle()
-  emitSfx('select')
+  emitSfx('ui.select')
 }
 </script>
 

--- a/src/components/taro-phone/apps/logout-app.vue
+++ b/src/components/taro-phone/apps/logout-app.vue
@@ -13,8 +13,8 @@ function onPress() {
     title: t('phone.apps.logout.title'),
     message: t('phone.apps.logout.description'),
     confirmLabel: t('phone.apps.logout.confirm'),
-    cancelAudio: 'digi_powerdown',
-    confirmAudio: 'toggle_off'
+    cancelAudio: 'dialog.dismiss',
+    confirmAudio: 'ui.toggle-off'
   })
 
   response.then((result) => {

--- a/src/components/taro-phone/index.vue
+++ b/src/components/taro-phone/index.vue
@@ -33,13 +33,13 @@ function togglePhone() {
 
 function openPhone() {
   store.open()
-  emitSfx('dialog.open')
+  emitSfx('phone.open')
   document.addEventListener('pointerdown', onPageClick)
 }
 
 function closePhone() {
   store.close()
-  emitSfx('dialog.open')
+  emitSfx('phone.close')
   document.removeEventListener('pointerdown', onPageClick)
 }
 

--- a/src/components/taro-phone/index.vue
+++ b/src/components/taro-phone/index.vue
@@ -33,13 +33,13 @@ function togglePhone() {
 
 function openPhone() {
   store.open()
-  emitSfx('pop_window')
+  emitSfx('dialog.open')
   document.addEventListener('pointerdown', onPageClick)
 }
 
 function closePhone() {
   store.close()
-  emitSfx('pop_window')
+  emitSfx('dialog.open')
   document.removeEventListener('pointerdown', onPageClick)
 }
 

--- a/src/components/ui-kit/alert.vue
+++ b/src/components/ui-kit/alert.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { type SoundKey } from '@/sfx/config'
+import type { SfxRole } from '@/sfx/roles'
 import { emitSfx } from '@/sfx/bus'
 import { type ModalCloseFn, useModalRequestClose } from '@/composables/modal'
 
@@ -13,8 +13,8 @@ const { cancelLabel, confirmLabel, close, cancelAudio, confirmAudio, type } = de
   message?: string
   title?: string
   type?: AlertType
-  cancelAudio?: SoundKey
-  confirmAudio?: SoundKey
+  cancelAudio?: SfxRole
+  confirmAudio?: SfxRole
   close: ModalCloseFn<boolean>
 }>()
 

--- a/src/components/ui-kit/alert.vue
+++ b/src/components/ui-kit/alert.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { TYPE_SFX, type SoundKey } from '@/sfx/config'
+import { type SoundKey } from '@/sfx/config'
 import { emitSfx } from '@/sfx/bus'
 import { type ModalCloseFn, useModalRequestClose } from '@/composables/modal'
 
@@ -68,7 +68,7 @@ function onKeydown(e: KeyboardEvent) {
         data-testid="ui-kit-alert__cancel"
         class="ui-kit-alert__cancel group"
         @click="onCancel"
-        v-sfx="{ hover: TYPE_SFX }"
+        v-sfx="{ hover: 'ui.hover' }"
       >
         {{ cancelText }}
         <div class="ui-kit-alert__hover-effect group-hover:opacity-100! group-focus:opacity-100!">
@@ -83,7 +83,7 @@ function onKeydown(e: KeyboardEvent) {
         :data-palette="palette"
         class="ui-kit-alert__confirm group"
         @click="onConfirm"
-        v-sfx="{ hover: TYPE_SFX }"
+        v-sfx="{ hover: 'ui.hover' }"
       >
         {{ confirmText }}
         <div class="ui-kit-alert__hover-effect group-hover:opacity-100! group-focus:opacity-100!">

--- a/src/components/ui-kit/button-group.vue
+++ b/src/components/ui-kit/button-group.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import UiButton from '@/components/ui-kit/button.vue'
 import type { ButtonProps } from '@/components/ui-kit/button.vue'
-import type { SfxOptions } from '@/sfx/directive'
+import type { SfxOptions } from '@/sfx/roles'
 
 export type ButtonGroupOption = {
   label: string

--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -101,9 +101,12 @@ function onClick(e: MouseEvent) {
     return
   }
 
+  // A button stays silent on press unless the call site names a role. Most
+  // already play their own cue from the handler behind @press, so a default
+  // here would sound twice on every one of them.
   tap((ev) => emit('press', ev), {
     preAudio: sfx.tap_pre || undefined,
-    audio: sfx.press === false ? undefined : (sfx.press ?? 'ui.press')
+    audio: sfx.press || undefined
   })(e)
 }
 </script>

--- a/src/components/ui-kit/button.vue
+++ b/src/components/ui-kit/button.vue
@@ -3,8 +3,8 @@ import { computed, useSlots } from 'vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import UiTooltip from '@/components/ui-kit/tooltip.vue'
 import { useStagedTap } from '@/composables/ui/staged-tap'
-import type { SfxOptions } from '@/sfx/directive'
-import { TYPE_SFX } from '@/sfx/config'
+import { emitSfx } from '@/sfx/bus'
+import type { SfxOptions } from '@/sfx/roles'
 
 defineOptions({ inheritAttrs: false })
 
@@ -66,15 +66,13 @@ const slots = useSlots()
 
 const { playing, tap } = useStagedTap({ animate: tapAnimate ? 'pop' : 'quiet' })
 
-// Only hover/focus/blur reach v-sfx — press-phase sounds are routed through
+// Only hover/focus reach v-sfx — press-phase sounds are routed through
 // staged-tap in onClick so they fire at the correct phase for each pointer.
 const merged_sfx = computed<SfxOptions>(() => {
   if (disabled) return {}
   return {
-    hover: sfx.hover ?? TYPE_SFX,
-    focus: sfx.focus,
-    blur: sfx.blur,
-    debounce: sfx.debounce
+    hover: sfx.hover ?? 'ui.hover',
+    focus: sfx.focus
   }
 })
 
@@ -89,6 +87,8 @@ function onClick(e: MouseEvent) {
   if ((e.target as HTMLElement).closest?.('.btn-trailing')) return
 
   if (disabled) {
+    if (sfx.rejected !== false) emitSfx(sfx.rejected ?? 'ui.rejected')
+
     // clickWhenDisabled still surfaces the press (e.g. to flag a validation
     // error); otherwise a disabled button emits nothing and blocks the default.
     if (clickWhenDisabled) emit('press', e)
@@ -102,12 +102,8 @@ function onClick(e: MouseEvent) {
   }
 
   tap((ev) => emit('press', ev), {
-    preAudio: sfx.tap_pre,
-    audio: sfx.press,
-    audioOpts: {
-      debounce: sfx.debounce
-    },
-    postAudio: sfx.tap_post
+    preAudio: sfx.tap_pre || undefined,
+    audio: sfx.press === false ? undefined : (sfx.press ?? 'ui.press')
   })(e)
 }
 </script>

--- a/src/components/ui-kit/dropdown-button/caret.vue
+++ b/src/components/ui-kit/dropdown-button/caret.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import { type ButtonProps } from '../button.vue'
 import { flipEnter, flipLeave } from '@/utils/animations/flip'
-import { TYPE_SFX } from '@/sfx/config'
 
 type DropdownCaretProps = {
   open: boolean
@@ -73,7 +72,7 @@ function onLeave(el: Element, done: () => void) {
             : 'bg-raised-tint text-ink shadow-[inset_0_0_0_1px_var(--color-accent)]'
         ]"
         data-testid="dropdown-button__trigger"
-        v-sfx="{ hover: disabled ? undefined : TYPE_SFX }"
+        v-sfx="{ hover: disabled ? undefined : 'ui.hover' }"
         @keydown.enter.space.stop.prevent="!disabled && emit('toggle')"
       >
         <ui-icon

--- a/src/components/ui-kit/dropdown-button/index.vue
+++ b/src/components/ui-kit/dropdown-button/index.vue
@@ -136,7 +136,7 @@ onUnmounted(() => {
 
 function toggle() {
   if (disabled) return
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   if (popover_open.value) return close()
 
   close_open_menu?.()

--- a/src/components/ui-kit/dropdown-button/menu.vue
+++ b/src/components/ui-kit/dropdown-button/menu.vue
@@ -3,7 +3,6 @@ import { ref } from 'vue'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import { type ButtonProps } from '../button.vue'
 import { useStagedTap } from '@/composables/ui/staged-tap'
-import { TYPE_SFX } from '@/sfx/config'
 import type { DropdownOption } from './types'
 
 type DropdownMenuProps = {
@@ -59,7 +58,7 @@ function onOptionTap(option: DropdownOption, e: MouseEvent) {
           :data-active="option.selected || null"
           :data-tapping="tapping_value === option.value || null"
           data-testid="dropdown-button__option"
-          v-sfx="option.disabled ? {} : { hover: TYPE_SFX }"
+          v-sfx="option.disabled ? {} : { hover: 'ui.hover' }"
           @click="onOptionTap(option, $event)"
         >
           <div

--- a/src/components/ui-kit/input.vue
+++ b/src/components/ui-kit/input.vue
@@ -40,7 +40,7 @@ const value = defineModel<string>('value')
     <div data-testid="ui-kit-input" class="ui-kit-input" :data-palette="error ? 'danger' : 'info'">
       <input
         v-bind="$attrs"
-        v-sfx.focus="'type_05'"
+        v-sfx.focus="'ui.focus'"
         :placeholder="placeholder"
         :maxlength="maxLength"
         v-model="value"

--- a/src/components/ui-kit/notice/panel.vue
+++ b/src/components/ui-kit/notice/panel.vue
@@ -86,7 +86,7 @@ function onActionClick(action: NoticeAction) {
         icon-only
         size="lg"
         icon-left="close"
-        :sfx="{ press: 'snappy_button_5' }"
+        :sfx="{ press: 'ui.press' }"
         @press="closePanel"
       >
         {{ t('notice.close-label') }}
@@ -111,7 +111,7 @@ function onActionClick(action: NoticeAction) {
           v-for="action in notice.actions"
           :key="action.label"
           full-width
-          :sfx="{ press: action.sfx?.press ?? 'snappy_button_5' }"
+          :sfx="{ press: action.sfx?.press || 'ui.press' }"
           @press="onActionClick(action)"
         >
           {{ action.label }}

--- a/src/components/ui-kit/notice/toast.vue
+++ b/src/components/ui-kit/notice/toast.vue
@@ -74,7 +74,7 @@ function onActionClick(action: NoticeAction) {
         v-for="action in notice.actions"
         :key="action.label"
         size="sm"
-        :sfx="{ press: action.sfx?.press ?? 'snappy_button_5' }"
+        :sfx="{ press: action.sfx?.press || 'ui.press' }"
         @press="onActionClick(action)"
       >
         {{ action.label }}
@@ -88,7 +88,7 @@ function onActionClick(action: NoticeAction) {
       icon-only
       icon-left="close"
       class="absolute! -right-2 -top-2 [--btn-bg-color:var(--color-well)]! opacity-0 transition-opacity group-hover/notice-toast:opacity-100 group-focus-within/notice-toast:opacity-100"
-      :sfx="{ press: 'snappy_button_5' }"
+      :sfx="{ press: 'ui.press' }"
       @press="closeToast"
     >
       {{ t('notice.close-label') }}

--- a/src/components/ui-kit/option-group.vue
+++ b/src/components/ui-kit/option-group.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts" generic="T extends string | number">
 import UiTappable from '@/components/ui-kit/tappable.vue'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 
 type UiOptionGroupProps<V> = {
   options: { value: V; label: string; disabled?: boolean }[]
@@ -18,7 +17,7 @@ const emit = defineEmits<{ (e: 'update:value', value: T): void }>()
 function onTap(option: UiOptionGroupProps<T>['options'][number]) {
   if (option.disabled) return
 
-  emitSfx(option.value === active.value ? 'digi_powerdown' : 'select')
+  emitSfx(option.value === active.value ? 'ui.rejected' : 'ui.select')
   emit('update:value', option.value)
 }
 </script>
@@ -35,7 +34,7 @@ function onTap(option: UiOptionGroupProps<T>['options'][number]) {
     <ui-tappable
       v-for="option in options"
       :key="String(option.value)"
-      v-sfx="{ hover: option.value === active || option.disabled ? undefined : TYPE_SFX }"
+      :sfx="{ hover: option.value !== active && !option.disabled && 'ui.hover', press: false }"
       as="button"
       type="button"
       data-testid="ui-option-group__option"

--- a/src/components/ui-kit/options-panel/index.vue
+++ b/src/components/ui-kit/options-panel/index.vue
@@ -2,7 +2,7 @@
 import { computed, useAttrs } from 'vue'
 import OptionsPanelRow from './row.vue'
 import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
-import type { SfxOptions } from '@/sfx/directive'
+import type { SfxOptions } from '@/sfx/roles'
 
 export type OptionsPanelEntry = {
   value: string

--- a/src/components/ui-kit/options-panel/row.vue
+++ b/src/components/ui-kit/options-panel/row.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import UiIcon from '../icon.vue'
 import UiTappable from '../tappable.vue'
-import type { SfxOptions } from '@/sfx/directive'
+import type { SfxOptions } from '@/sfx/roles'
 import type { OptionsPanelEntry } from './index.vue'
 
 type OptionsPanelRowProps = {

--- a/src/components/ui-kit/options-panel/row.vue
+++ b/src/components/ui-kit/options-panel/row.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import UiIcon from '../icon.vue'
 import UiTappable from '../tappable.vue'
-import { TYPE_SFX } from '@/sfx/config'
 import type { SfxOptions } from '@/sfx/directive'
 import type { OptionsPanelEntry } from './index.vue'
 
@@ -39,7 +38,7 @@ function onSelect() {
             type: 'button',
             active_on_hover: true,
             active: entry.selected,
-            sfx: { hover: TYPE_SFX, ...sfx }
+            sfx: { hover: 'ui.hover', ...sfx }
           }
         : {}
     "

--- a/src/components/ui-kit/pattern-picker.vue
+++ b/src/components/ui-kit/pattern-picker.vue
@@ -21,11 +21,11 @@ function swatchBindings(p: DeckCoverPattern) {
 
 function onPatternSelect(p: DeckCoverPattern | undefined) {
   if (p === selected_pattern) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.deselect')
     return
   }
 
-  emitSfx('toggle_on')
+  emitSfx('ui.toggle-on')
   emit('update:pattern', p)
 }
 </script>

--- a/src/components/ui-kit/pattern-picker.vue
+++ b/src/components/ui-kit/pattern-picker.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import UiIcon from '@/components/ui-kit/icon.vue'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 import { COVER_PATTERNS, coverBindings } from '@/utils/cover'
 
 type PatternPickerProps = {
@@ -43,7 +42,7 @@ function onPatternSelect(p: DeckCoverPattern | undefined) {
         :key="pattern"
         :data-testid="`pattern-picker__option-${pattern}`"
         :data-selected="pattern === selected_pattern || undefined"
-        v-sfx="{ hover: TYPE_SFX }"
+        v-sfx="{ hover: 'ui.hover' }"
         v-bind="swatchBindings(pattern)"
         class="w-14.5 aspect-square rounded-6 rounded-tr-3 rounded-bl-3 cursor-pointer bg-(--color-accent) hover:ring-4 data-selected:ring-4 ring-knockout relative"
         @click="onPatternSelect(pattern)"

--- a/src/components/ui-kit/prompt.vue
+++ b/src/components/ui-kit/prompt.vue
@@ -5,7 +5,7 @@ import UiButton from '@/components/ui-kit/button.vue'
 import UiInput from '@/components/ui-kit/input.vue'
 import { type ModalCloseFn, useModalRequestClose } from '@/composables/modal'
 import { emitSfx } from '@/sfx/bus'
-import { type SoundKey } from '@/sfx/config'
+import type { SfxRole } from '@/sfx/roles'
 
 type UiPromptProps = {
   title: string
@@ -16,8 +16,8 @@ type UiPromptProps = {
   confirmLabel: string
   cancelLabel?: string
   maxLength?: number
-  cancelAudio?: SoundKey
-  confirmAudio?: SoundKey
+  cancelAudio?: SfxRole
+  confirmAudio?: SfxRole
   close: ModalCloseFn<string>
 }
 

--- a/src/components/ui-kit/radio.vue
+++ b/src/components/ui-kit/radio.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import UiIcon from '@/components/ui-kit/icon.vue'
 import { useStagedTap } from '@/composables/ui/staged-tap'
-import type { SfxOptions } from '@/sfx/directive'
+import type { SfxOptions } from '@/sfx/roles'
 
 const {
   checked,
@@ -18,8 +18,7 @@ const {
 
 const { playing, tap } = useStagedTap({ triggerAt: 'press' })
 const onClick = tap(undefined, {
-  audio: sfx.press ?? 'select',
-  audioOpts: { debounce: sfx.debounce }
+  audio: sfx.press || 'ui.select'
 })
 </script>
 
@@ -32,7 +31,7 @@ const onClick = tap(undefined, {
       'bg-well hover:bg-(--color-accent) data-[active=true]:bg-(--color-accent)': !checked
     }"
     :data-active="playing || active || null"
-    v-sfx="{ hover: sfx.hover, focus: sfx.focus, blur: sfx.blur, debounce: sfx.debounce }"
+    v-sfx="{ hover: sfx.hover ?? 'ui.hover', focus: sfx.focus }"
     @click="onClick"
   >
     <ui-icon v-if="checked" class="size-5 text-(--color-on-accent)" src="check" />

--- a/src/components/ui-kit/scroll-bar.vue
+++ b/src/components/ui-kit/scroll-bar.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
-import { TYPE_SFX } from '@/sfx/config'
 
 type UiScrollBarProps = {
   /** Reading position — 0 at the top of the content, 1 at the bottom. */
@@ -125,7 +124,7 @@ function onTrackPointerDown(e: PointerEvent) {
   >
     <div
       ref="thumb"
-      v-sfx="{ hover: TYPE_SFX }"
+      v-sfx="{ hover: 'ui.hover' }"
       data-testid="ui-kit-scroll-bar__thumb"
       :data-active="dragging"
       class="ui-kit-scroll-bar__thumb hover:bgx-diagonal-stripes"

--- a/src/components/ui-kit/select-menu.vue
+++ b/src/components/ui-kit/select-menu.vue
@@ -29,7 +29,7 @@ const current_label = computed(() => options.find((o) => o.value === modelValue)
 function onSelect(option: DropdownOption) {
   const value = option.value as T
 
-  emitSfx(value === modelValue ? 'digi_powerdown' : 'select')
+  emitSfx(value === modelValue ? 'ui.deselect' : 'ui.select')
   emit('update:modelValue', value)
 }
 </script>

--- a/src/components/ui-kit/slider.vue
+++ b/src/components/ui-kit/slider.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, ref, useTemplateRef } from 'vue'
 import { useGestures } from '@/composables/ui/gestures'
 import { emitSfx } from '@/sfx/bus'
-import type { Bus, SoundKey } from '@/sfx/config'
+import type { Bus } from '@/sfx/config'
 
 type SliderProps = {
   min?: number
@@ -10,15 +10,22 @@ type SliderProps = {
   step?: number
   label?: string
   ticks?: boolean
-  /** Sound played on each notch while dragging; `bus` routes its volume. */
-  sfx?: { tick?: SoundKey; bus?: Bus }
+  /** For a slider that sets a volume dial: hear the drag on the dial it moves. */
+  preview_bus?: Bus
 }
 
 const MAX_TICKS = 20
 const EDGE_PX = 20
 const EDGE = `${EDGE_PX}px`
 
-const { min = 0, max = 100, step = 1, label, ticks = true, sfx = {} } = defineProps<SliderProps>()
+const {
+  min = 0,
+  max = 100,
+  step = 1,
+  label,
+  ticks = true,
+  preview_bus
+} = defineProps<SliderProps>()
 
 const value = defineModel<number>({ required: true })
 
@@ -80,7 +87,7 @@ function applyX(client_x: number) {
   if (stepped === value.value) return
 
   value.value = stepped
-  emitSfx(sfx.tick ?? 'tap_05', { bus: sfx.bus })
+  emitSfx('gesture.tick', preview_bus)
 }
 
 function onKeydown(e: KeyboardEvent) {

--- a/src/components/ui-kit/spinbox/button.vue
+++ b/src/components/ui-kit/spinbox/button.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import UiIcon from '@/components/ui-kit/icon.vue'
 import UiTappable from '@/components/ui-kit/tappable.vue'
-import { TYPE_SFX } from '@/sfx/config'
 
 type SpinboxButtonProps = {
   icon: string
@@ -20,7 +19,7 @@ const emit = defineEmits<{
     as="button"
     type="button"
     :disabled="disabled"
-    :sfx="{ hover: TYPE_SFX, press: 'select' }"
+    :sfx="{ hover: 'ui.hover', press: 'select' }"
     bgx_color="var(--color-accent-pattern)"
     class="inline-flex items-center justify-center aspect-square h-8 rounded-3 text-ink cursor-pointer transition-[background-color,color] duration-100 hover:bg-accent hover:text-on-accent data-[tap-active=true]:bg-accent data-[tap-active=true]:text-on-accent disabled:opacity-disabled disabled:hover:bg-transparent disabled:hover:text-ink"
     @tap="emit('click')"

--- a/src/components/ui-kit/spinbox/button.vue
+++ b/src/components/ui-kit/spinbox/button.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{
     as="button"
     type="button"
     :disabled="disabled"
-    :sfx="{ hover: 'ui.hover', press: 'select' }"
+    :sfx="{ hover: 'ui.hover', press: 'ui.select' }"
     bgx_color="var(--color-accent-pattern)"
     class="inline-flex items-center justify-center aspect-square h-8 rounded-3 text-ink cursor-pointer transition-[background-color,color] duration-100 hover:bg-accent hover:text-on-accent data-[tap-active=true]:bg-accent data-[tap-active=true]:text-on-accent disabled:opacity-disabled disabled:hover:bg-transparent disabled:hover:text-ink"
     @tap="emit('click')"

--- a/src/components/ui-kit/spinbox/index.vue
+++ b/src/components/ui-kit/spinbox/index.vue
@@ -92,7 +92,7 @@ function onArrow(direction: 1 | -1) {
   if (direction === 1) increment()
   else decrement()
 
-  emitSfx('select', { debounce: ARROW_SFX_DEBOUNCE_MS })
+  emitSfx('ui.select', { debounce: ARROW_SFX_DEBOUNCE_MS })
 }
 </script>
 

--- a/src/components/ui-kit/spinbox/index.vue
+++ b/src/components/ui-kit/spinbox/index.vue
@@ -25,7 +25,6 @@ const {
 const value = defineModel<number>('value', { required: true })
 
 /** Keeps a held arrow key from machine-gunning the step sound on every repeat. */
-const ARROW_SFX_DEBOUNCE_MS = 40
 
 const focused = ref(false)
 
@@ -87,12 +86,15 @@ function increment() {
 // until they are handled here — and only here, on the input, so they step the value while it holds
 // focus and stay the page's arrows otherwise.
 function onArrow(direction: 1 | -1) {
-  if (direction === 1 ? !can_increment.value : !can_decrement.value) return
+  if (direction === 1 ? !can_increment.value : !can_decrement.value) {
+    emitSfx('ui.rejected')
+    return
+  }
 
   if (direction === 1) increment()
   else decrement()
 
-  emitSfx('ui.select', { debounce: ARROW_SFX_DEBOUNCE_MS })
+  emitSfx('ui.select')
 }
 </script>
 

--- a/src/components/ui-kit/tabs.vue
+++ b/src/components/ui-kit/tabs.vue
@@ -39,13 +39,13 @@ function onTabClick(index: number) {
     storage.set(storageKey, index.toString())
   }
 
-  emitSfx('etc_camera_shutter')
+  emitSfx('ui.select')
   emit('update:activeTab', index)
 }
 
 function onHover(index: number) {
   if (active_tab.value === index) return
-  emitHoverSfx('click_04')
+  emitHoverSfx('ui.hover')
 }
 </script>
 

--- a/src/components/ui-kit/tag-button.vue
+++ b/src/components/ui-kit/tag-button.vue
@@ -2,7 +2,6 @@
 import { computed } from 'vue'
 import { buildTagButtonMask, outsetSideFor, type NotchSide } from '@/utils/tag-button/mask'
 import UiIcon from '@/components/ui-kit/icon.vue'
-import { TYPE_SFX } from '@/sfx/config'
 
 type TagButtonProps = {
   notchSide?: NotchSide
@@ -39,7 +38,7 @@ const padding = computed(() => {
 </script>
 
 <template>
-  <span class="ui-tag-button-shell inline-block hover:scale-105" v-sfx="{ hover: TYPE_SFX }">
+  <span class="ui-tag-button-shell inline-block hover:scale-105" v-sfx="{ hover: 'ui.hover' }">
     <button
       data-testid="ui-kit-tag-button"
       type="button"

--- a/src/components/ui-kit/tappable.vue
+++ b/src/components/ui-kit/tappable.vue
@@ -6,7 +6,7 @@ import {
   useStagedTap
 } from '@/composables/ui/staged-tap'
 import { useMatchMedia } from '@/composables/ui/media-query'
-import type { SfxOptions } from '@/sfx/directive'
+import type { SfxOptions } from '@/sfx/roles'
 
 type UiTappableProps = {
   as?: string
@@ -44,10 +44,8 @@ const hovering = ref(false)
 
 function onClick(e: MouseEvent) {
   tap((ev) => emit('tap', ev), {
-    preAudio: sfx.tap_pre,
-    audio: sfx.press,
-    audioOpts: { debounce: sfx.debounce },
-    postAudio: sfx.tap_post
+    preAudio: sfx.tap_pre || undefined,
+    audio: sfx.press || undefined
   })(e)
 }
 
@@ -65,7 +63,7 @@ function onPointerLeave() {
     :is="as"
     :data-tap-active="playing || hovering || active || null"
     class="group/tappable relative isolate"
-    v-sfx="{ hover: sfx.hover, focus: sfx.focus, blur: sfx.blur, debounce: sfx.debounce }"
+    v-sfx="{ hover: sfx.hover ?? 'ui.hover', focus: sfx.focus }"
     @pointerenter="onPointerEnter"
     @pointerleave="onPointerLeave"
     @click="onClick"

--- a/src/components/ui-kit/textarea.vue
+++ b/src/components/ui-kit/textarea.vue
@@ -58,7 +58,7 @@ function onInput() {
     >
       <textarea
         v-bind="$attrs"
-        v-sfx.focus="'type_05'"
+        v-sfx.focus="'ui.focus'"
         :placeholder="placeholder"
         :maxlength="max_chars"
         v-model="value"

--- a/src/components/ui-kit/theme-picker.vue
+++ b/src/components/ui-kit/theme-picker.vue
@@ -20,11 +20,11 @@ function isSelected(option: PaletteName) {
 
 function onThemeSelect(option: PaletteName) {
   if (isSelected(option)) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.deselect')
     return
   }
 
-  emitSfx('toggle_on')
+  emitSfx('ui.toggle-on')
   emit('update:palette', option)
 }
 </script>

--- a/src/components/ui-kit/theme-picker.vue
+++ b/src/components/ui-kit/theme-picker.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 import UiIcon from '@/components/ui-kit/icon.vue'
 
 type ThemePickerProps = {
@@ -41,7 +40,7 @@ function onThemeSelect(option: PaletteName) {
         :key="option"
         :data-testid="`theme-picker__option-${option}`"
         :data-palette="option"
-        v-sfx="{ hover: TYPE_SFX }"
+        v-sfx="{ hover: 'ui.hover' }"
         class="w-9 shrink-0 aspect-square bg-(--color-accent) rounded-8 rounded-tr-3 cursor-pointer relative! hover:outline-5 outline-knockout"
         :class="{ 'outline-5 outline-knockout': isSelected(option) }"
         @click="onThemeSelect(option)"

--- a/src/components/ui-kit/toggle.vue
+++ b/src/components/ui-kit/toggle.vue
@@ -1,20 +1,19 @@
 <script setup lang="ts">
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
+import type { SfxOptions } from '@/sfx/roles'
 
 type ToggleProps = {
-  // Suppresses hover + select sfx — for contexts like dev/debug tooling that
-  // shouldn't make noise, not a general-purpose per-instance mute.
-  silent?: boolean
+  sfx?: SfxOptions
   disabled?: boolean
 }
 
-const { silent = false, disabled = false } = defineProps<ToggleProps>()
+const { sfx = {}, disabled = false } = defineProps<ToggleProps>()
 
 const checked = defineModel<boolean>('checked')
 
 function onChange() {
-  if (!silent) emitSfx('select')
+  const picked = sfx.press ?? 'ui.select'
+  if (picked !== false) emitSfx(picked)
 }
 </script>
 
@@ -25,7 +24,7 @@ function onChange() {
     :data-disabled="disabled"
     class="group/toggle flex items-center justify-between gap-2"
     :class="disabled ? 'pointer-events-none opacity-disabled' : 'cursor-pointer'"
-    v-sfx="silent ? {} : { hover: TYPE_SFX }"
+    v-sfx="{ hover: sfx.hover ?? 'ui.hover' }"
   >
     <span data-testid="ui-kit-toggle__label" class="text-ink">
       <slot></slot>

--- a/src/composables/admin/use-admin-modal.ts
+++ b/src/composables/admin/use-admin-modal.ts
@@ -7,7 +7,7 @@ export function useAdminModal() {
   const modal = useModal()
 
   function open() {
-    emitSfx('snappy_button_3')
+    emitSfx('dialog.open')
 
     const result = modal.open(AdminComponent, {
       backdrop: true,
@@ -16,7 +16,7 @@ export function useAdminModal() {
       mobile_below_height: 'md'
     })
 
-    result.response.then(() => emitSfx('pop_up_close'))
+    result.response.then(() => emitSfx('dialog.close'))
 
     return result
   }

--- a/src/composables/alert.ts
+++ b/src/composables/alert.ts
@@ -1,7 +1,7 @@
 import { useModal } from './modal'
 import { emitSfx } from '@/sfx/bus'
 import alert, { type AlertType } from '@/components/ui-kit/alert.vue'
-import { type SoundKey } from '@/sfx/config'
+import type { SfxRole } from '@/sfx/roles'
 
 type AlertArgs = {
   title?: string
@@ -9,9 +9,9 @@ type AlertArgs = {
   confirmLabel?: string
   cancelLabel?: string
   backdrop?: boolean
-  openAudio?: SoundKey
-  cancelAudio?: SoundKey
-  confirmAudio?: SoundKey
+  openAudio?: SfxRole
+  cancelAudio?: SfxRole
+  confirmAudio?: SfxRole
 }
 
 export function useAlert() {
@@ -28,8 +28,8 @@ export function useAlert() {
   function _openAlert(type: AlertType, args?: AlertArgs) {
     const {
       backdrop,
-      openAudio = 'etc_woodblock_stuck',
-      cancelAudio = 'digi_powerdown',
+      openAudio = 'notice.error',
+      cancelAudio = 'dialog.dismiss',
       ...props
     } = args ?? {}
 

--- a/src/composables/audio-reader/collection-create-modal.ts
+++ b/src/composables/audio-reader/collection-create-modal.ts
@@ -12,12 +12,12 @@ export function useCollectionCreateModal() {
   const modal = useModal()
 
   function open() {
-    emitSfx('snappy_button_3')
+    emitSfx('dialog.open')
     const result = modal.open<CollectionCreateResponse>(CollectionCreate, {
       backdrop: true,
       mode: 'mobile-sheet'
     })
-    result.response.then(() => emitSfx('pop_up_close'))
+    result.response.then(() => emitSfx('dialog.close'))
     return result
   }
 

--- a/src/composables/audio-reader/collection-edit-modal.ts
+++ b/src/composables/audio-reader/collection-edit-modal.ts
@@ -12,13 +12,13 @@ export function useCollectionEditModal() {
   const modal = useModal()
 
   function open(collection_id: number) {
-    emitSfx('snappy_button_3')
+    emitSfx('dialog.open')
     const result = modal.open<CollectionEditResponse>(CollectionEdit, {
       props: { collection_id },
       backdrop: true,
       mode: 'mobile-sheet'
     })
-    result.response.then(() => emitSfx('pop_up_close'))
+    result.response.then(() => emitSfx('dialog.close'))
     return result
   }
 

--- a/src/composables/audio-reader/lesson-reader.ts
+++ b/src/composables/audio-reader/lesson-reader.ts
@@ -130,7 +130,7 @@ export function useLessonReader(id: MaybeRefOrGetter<number>) {
    * footer in place of the toolbar on mobile).
    */
   function openTerm(next: TermSelection) {
-    emitSfx('pop_up_pop')
+    emitSfx('dialog.open')
     player.pause()
 
     selection.value = next

--- a/src/composables/audio-reader/reader-highlights.ts
+++ b/src/composables/audio-reader/reader-highlights.ts
@@ -682,7 +682,7 @@ export function useReaderHighlights(
     focus_index.value = tap.index
     touch_point.value = { x: tap.x, y: tap.y }
     navigator.vibrate?.(10)
-    emitSfx('tap_05')
+    emitSfx('gesture.tick')
   }
 
   function beginDrag(event: PointerEvent) {
@@ -718,7 +718,7 @@ export function useReaderHighlights(
     if (anchor_index.value !== null) {
       if (index !== null && index !== focus_index.value) {
         focus_index.value = index
-        emitSfx('tap_05')
+        emitSfx('gesture.tick')
       }
       return
     }
@@ -758,7 +758,7 @@ export function useReaderHighlights(
     if (index === null || index === focus_index.value) return
 
     focus_index.value = index
-    emitSfx('tap_05')
+    emitSfx('gesture.tick')
   }
 
   function onPointerUp(event: PointerEvent) {

--- a/src/composables/audio-reader/upload-lesson-modal.ts
+++ b/src/composables/audio-reader/upload-lesson-modal.ts
@@ -12,13 +12,13 @@ export function useUploadLessonModal() {
   const modal = useModal()
 
   function open(collection_id: number) {
-    emitSfx('snappy_button_3')
+    emitSfx('dialog.open')
     const result = modal.open<UploadLessonResponse>(UploadLesson, {
       props: { collection_id },
       backdrop: true,
       mode: 'mobile-sheet'
     })
-    result.response.then(() => emitSfx('pop_up_close'))
+    result.response.then(() => emitSfx('dialog.close'))
     return result
   }
 

--- a/src/composables/auth/use-forgot-password-actions.ts
+++ b/src/composables/auth/use-forgot-password-actions.ts
@@ -44,7 +44,7 @@ export function useForgotPasswordActions() {
     submitError.value = ''
 
     if (!validate()) {
-      emitSfx('digi_powerdown')
+      emitSfx('ui.rejected')
       return 'invalid'
     }
 
@@ -57,7 +57,7 @@ export function useForgotPasswordActions() {
       return 'success'
     }
 
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
     submitError.value = t('forgot-password-modal.errors.generic')
     return 'error'
   }

--- a/src/composables/auth/use-login-actions.ts
+++ b/src/composables/auth/use-login-actions.ts
@@ -64,7 +64,7 @@ export function useLoginActions() {
     submitError.value = ''
 
     if (!validate()) {
-      emitSfx('digi_powerdown')
+      emitSfx('ui.rejected')
       return 'invalid'
     }
 
@@ -74,7 +74,7 @@ export function useLoginActions() {
 
     if (outcome === 'success') return 'success'
 
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
     submitError.value = t(LOGIN_ERROR_KEYS[outcome])
     return 'error'
   }

--- a/src/composables/auth/use-reset-password-actions.ts
+++ b/src/composables/auth/use-reset-password-actions.ts
@@ -38,7 +38,7 @@ export function useResetPasswordActions() {
 
   async function submit(): Promise<SubmitResult> {
     if (!validate()) {
-      emitSfx('etc_woodblock_stuck')
+      emitSfx('notice.error')
       return 'invalid'
     }
 
@@ -51,7 +51,7 @@ export function useResetPasswordActions() {
       return 'success'
     }
 
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
 
     if (outcome === 'weak-password') {
       errors.value = { ...errors.value, password: t('reset-password-modal.validation-weak') }

--- a/src/composables/auth/use-signup-actions.ts
+++ b/src/composables/auth/use-signup-actions.ts
@@ -69,7 +69,7 @@ export function useSignupActions() {
   /** Validate, then create the account. See the hook doc for the result contract. */
   async function submit(): Promise<SubmitResult> {
     if (!validate()) {
-      emitSfx('digi_powerdown')
+      emitSfx('ui.rejected')
       return 'invalid'
     }
 
@@ -77,7 +77,7 @@ export function useSignupActions() {
 
     if (!(await isDisplayNameAvailable(username.value.trim()))) {
       loading.value = false
-      emitSfx('etc_woodblock_stuck')
+      emitSfx('notice.error')
       errors.value = {
         ...errors.value,
         username: t('signup-dialog.form-validation.username-already-in-use')
@@ -97,7 +97,7 @@ export function useSignupActions() {
 
     // Email-taken surfaces inline; the modal stays open, no alert needed.
     if (outcome === 'email-taken') {
-      emitSfx('etc_woodblock_stuck')
+      emitSfx('notice.error')
       errors.value = {
         ...errors.value,
         email: t('signup-dialog.form-validation.email-already-in-use')

--- a/src/composables/card/face-image-upload.ts
+++ b/src/composables/card/face-image-upload.ts
@@ -61,7 +61,7 @@ export function useFaceImageUpload({ card, side, fileInput, rootEl }: UseFaceIma
     maxBytes: CARD_IMAGE_MAX_BYTES,
     fileInput,
     onFile: uploadFile,
-    onError: () => emitSfx('digi_powerdown'),
+    onError: () => emitSfx('ui.rejected'),
     guard: guardCardImage
   })
 
@@ -103,7 +103,7 @@ export function useFaceImageUpload({ card, side, fileInput, rootEl }: UseFaceIma
       return
     }
 
-    emitSfx('music_plink_ok')
+    emitSfx('dialog.confirm')
     reveal_pending = true
     pending.value = false
   }
@@ -126,7 +126,7 @@ export function useFaceImageUpload({ card, side, fileInput, rootEl }: UseFaceIma
    * deletion runs, and the trash sfx plays once the removal lands.
    */
   async function onRemove() {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     clearError()
 
     const img = faceImageEl()
@@ -136,7 +136,7 @@ export function useFaceImageUpload({ card, side, fileInput, rootEl }: UseFaceIma
 
     try {
       await mutations.deleteCardImage(toValue(card).id!, toValue(side))
-      emitSfx('trash_crumple_short')
+      emitSfx('card.delete')
     } catch {
       notice.error(t('toast.error.card-image-delete-failed'))
     } finally {
@@ -151,12 +151,12 @@ export function useFaceImageUpload({ card, side, fileInput, rootEl }: UseFaceIma
   async function openPicker() {
     if (!(await guardCardImage())) return
 
-    emitSfx('select')
+    emitSfx('ui.select')
     browse()
   }
 
   function onDismissError() {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     clearError()
   }
 
@@ -185,7 +185,7 @@ export function useFaceImageUpload({ card, side, fileInput, rootEl }: UseFaceIma
 
   // Chime once when a drag first enters the card (not on every child dragenter).
   watch(dragging, (now, was) => {
-    if (now && !was && can_upload.value) emitSfx('music_plink_mid')
+    if (now && !was && can_upload.value) emitSfx('gesture.zone-cross')
   })
 
   // Reveal waits for the refetched path to reach the DOM, not the upload call. `flush: 'post'`

--- a/src/composables/card/prompts.ts
+++ b/src/composables/card/prompts.ts
@@ -22,7 +22,7 @@ export function useCardPrompts() {
       title: t('alert.delete-card.title', { count }),
       message: t('alert.delete-card.message', { count }),
       confirmLabel: t('alert.delete-card.confirm'),
-      confirmAudio: 'trash_crumple_short'
+      confirmAudio: 'card.delete'
     })
     return response
   }
@@ -41,7 +41,7 @@ export function useCardPrompts() {
     current_deck_id: number | undefined,
     move: (deck_id: number) => Promise<void>
   ) {
-    emitSfx('double_pop_up')
+    emitSfx('dialog.open')
 
     const { response } = modal.open<{ deck_id: number }>(MoveCardsModal, {
       backdrop: true,

--- a/src/composables/deck/cover-image.ts
+++ b/src/composables/deck/cover-image.ts
@@ -51,7 +51,7 @@ export function useCoverImage(
     maxBytes: COVER_IMAGE_MAX_BYTES,
     fileInput: file_input,
     onFile: stageFile,
-    onError: () => emitSfx('digi_powerdown')
+    onError: () => emitSfx('ui.rejected')
   })
 
   const has_image = computed(() => !!toValue(cover).image_path)
@@ -76,12 +76,12 @@ export function useCoverImage(
     staged_url = URL.createObjectURL(file)
     staged_file.value = file
     toValue(cover).image_path = staged_url
-    emitSfx('music_plink_ok')
+    emitSfx('dialog.confirm')
   }
 
   /** Clear the cover image — drops any staged file and reverts to palette/pattern/icon. */
   function onRemove() {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     clearError()
     revokeStaged()
     staged_file.value = null
@@ -90,12 +90,12 @@ export function useCoverImage(
 
   /** Open the file picker. No paid gate — a custom cover is free. */
   function openPicker() {
-    emitSfx('select')
+    emitSfx('ui.select')
     browse()
   }
 
   function onDismissError() {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     clearError()
   }
 

--- a/src/composables/deck/danger-actions.ts
+++ b/src/composables/deck/danger-actions.ts
@@ -56,7 +56,7 @@ export function useDeckDangerActions(
       title: t('alert.delete-deck.title'),
       message: t('alert.delete-deck.message'),
       confirmLabel: t('alert.delete-deck.confirm'),
-      confirmAudio: 'trash_crumple_short'
+      confirmAudio: 'card.delete'
     }).response
     if (!confirmed) return
 

--- a/src/composables/deck/editor.ts
+++ b/src/composables/deck/editor.ts
@@ -134,7 +134,7 @@ export function useDeckEditor(deck?: Deck) {
   /** Switch the design tab's previewed side. No-op when already active. */
   function setActiveSide(side: CardSide) {
     if (side === active_side.value) return
-    emitSfx('slide_up')
+    emitSfx('nav.page-forward')
     active_side.value = side
   }
 

--- a/src/composables/deck/settings-modal.ts
+++ b/src/composables/deck/settings-modal.ts
@@ -19,7 +19,7 @@ export function useDeckSettingsModal() {
    *   (e.g. `{ tab: 'design', side: 'front' }`); both override any persisted state.
    */
   function open(deck: Deck, options: OpenOptions = {}) {
-    emitSfx('snappy_button_3')
+    emitSfx('dialog.open')
     const result = modal.open<DeckSettingsResponse>(DeckSettings, {
       backdrop: true,
       mode: 'mobile-sheet',
@@ -27,7 +27,7 @@ export function useDeckSettingsModal() {
       mobile_below_height: 'md',
       props: { deck, initial_page: options.tab, initial_side: options.side }
     })
-    result.response.then(() => emitSfx('pop_up_close'))
+    result.response.then(() => emitSfx('dialog.close'))
     return result
   }
 

--- a/src/composables/feedback/use-feedback-modal.ts
+++ b/src/composables/feedback/use-feedback-modal.ts
@@ -7,14 +7,14 @@ export function useFeedbackModal() {
   const modal = useModal()
 
   function open() {
-    emitSfx('snappy_button_3')
+    emitSfx('dialog.open')
     const result = modal.open(FeedbackBoard, {
       backdrop: true,
       mode: 'mobile-sheet',
       mobile_below_width: 'msm',
       mobile_below_height: 'md'
     })
-    result.response.then(() => emitSfx('pop_up_close'))
+    result.response.then(() => emitSfx('dialog.close'))
     return result
   }
 

--- a/src/composables/member/danger-actions.ts
+++ b/src/composables/member/danger-actions.ts
@@ -37,7 +37,7 @@ export function useMemberDangerActions(close: () => void): MemberDangerActions {
       title: t('alert.delete-account.title'),
       message: t('alert.delete-account.message'),
       confirmLabel: t('alert.delete-account.confirm'),
-      confirmAudio: 'trash_crumple_short'
+      confirmAudio: 'card.delete'
     }).response
     if (!confirmed) return
 

--- a/src/composables/prompt.ts
+++ b/src/composables/prompt.ts
@@ -1,7 +1,7 @@
 import { useModal } from './modal'
 import { emitSfx } from '@/sfx/bus'
 import prompt from '@/components/ui-kit/prompt.vue'
-import { type SoundKey } from '@/sfx/config'
+import type { SfxRole } from '@/sfx/roles'
 
 type PromptArgs = {
   title: string
@@ -13,9 +13,9 @@ type PromptArgs = {
   cancelLabel?: string
   maxLength?: number
   backdrop?: boolean
-  openAudio?: SoundKey
-  cancelAudio?: SoundKey
-  confirmAudio?: SoundKey
+  openAudio?: SfxRole
+  cancelAudio?: SfxRole
+  confirmAudio?: SfxRole
 }
 
 /**
@@ -30,12 +30,7 @@ export function usePrompt() {
   const modal = useModal()
 
   function ask(args: PromptArgs) {
-    const {
-      backdrop,
-      openAudio = 'etc_woodblock_stuck',
-      cancelAudio = 'digi_powerdown',
-      ...props
-    } = args
+    const { backdrop, openAudio = 'notice.error', cancelAudio = 'dialog.dismiss', ...props } = args
 
     emitSfx(openAudio)
 

--- a/src/composables/ui/staged-tap.ts
+++ b/src/composables/ui/staged-tap.ts
@@ -2,10 +2,7 @@ import { ref } from 'vue'
 import { useMatchMedia } from '@/composables/ui/media-query'
 import { BUTTON_TAP_DURATION, playButtonTap } from '@/utils/animations/button-tap'
 import { emitSfx } from '@/sfx/bus'
-import type { PlayOptions } from '@/sfx/player'
-import type { SoundKey } from '@/sfx/config'
-
-type SfxKey = SoundKey
+import type { SfxRole } from '@/sfx/roles'
 
 export type StagedTapAnimate = 'pop' | 'quiet'
 export type StagedTapPhase = 'press' | 'peak' | 'done'
@@ -27,13 +24,9 @@ export interface StagedTapOptions {
 
 export interface TapCallOptions {
   /** Coarse only — fires at press, before the animation starts (an "arm" cue). */
-  preAudio?: SfxKey
+  preAudio?: SfxRole
   /** Primary click-feedback sound; fires immediately on fine, at the action phase on coarse. */
-  audio?: SfxKey
-  /** Options forwarded to emitSfx for the main audio key (volume, debounce, bus). */
-  audioOpts?: PlayOptions
-  /** Coarse only — fires after the animation completes. */
-  postAudio?: SfxKey
+  audio?: SfxRole
   /** Fires on every call, even one that bails as already-playing. */
   onTap?: (e: MouseEvent) => void
   /** Override the composable-level triggerAt for this specific call. */
@@ -48,7 +41,6 @@ export interface TapCallOptions {
  * Sound phases:
  * - preAudio  — coarse only, fires at press before animation (arm/haptic cue)
  * - audio     — all pointers; fires immediately on fine, at the action phase on coarse
- * - postAudio — coarse only, fires after animation completes
  */
 export function useStagedTap(options: StagedTapOptions = {}) {
   const {
@@ -73,7 +65,7 @@ export function useStagedTap(options: StagedTapOptions = {}) {
       tapOpts.onTap?.(e)
 
       if (activeOn === 'coarse-only' && !is_coarse.value) {
-        if (tapOpts.audio) emitSfx(tapOpts.audio, tapOpts.audioOpts)
+        if (tapOpts.audio) emitSfx(tapOpts.audio)
         action?.(e)
         return
       }
@@ -83,7 +75,7 @@ export function useStagedTap(options: StagedTapOptions = {}) {
 
       if (tapOpts.preAudio) emitSfx(tapOpts.preAudio)
       if (phase === 'press') {
-        if (tapOpts.audio) emitSfx(tapOpts.audio, tapOpts.audioOpts)
+        if (tapOpts.audio) emitSfx(tapOpts.audio)
         action?.(e)
       }
 
@@ -94,19 +86,17 @@ export function useStagedTap(options: StagedTapOptions = {}) {
         const { peak, done } = playButtonTap(target, duration, { yoyo, hold })
         await peak
         if (phase === 'peak') {
-          if (tapOpts.audio) emitSfx(tapOpts.audio, tapOpts.audioOpts)
+          if (tapOpts.audio) emitSfx(tapOpts.audio)
           action?.(e)
         }
         await done
-        if (tapOpts.postAudio) emitSfx(tapOpts.postAudio)
         if (phase === 'done') action?.(e)
       } else {
         await new Promise<void>((resolve) => setTimeout(resolve, duration * 1000))
         if (phase !== 'press') {
-          if (tapOpts.audio) emitSfx(tapOpts.audio, tapOpts.audioOpts)
+          if (tapOpts.audio) emitSfx(tapOpts.audio)
           action?.(e)
         }
-        if (tapOpts.postAudio) emitSfx(tapOpts.postAudio)
       }
 
       playing.value = false

--- a/src/composables/use-reorder-drag.ts
+++ b/src/composables/use-reorder-drag.ts
@@ -232,7 +232,7 @@ export function useReorderDrag(opts: ReorderDragOptions) {
       document.documentElement.scrollHeight - document.documentElement.clientHeight
     )
 
-    emitSfx('generic_button_15')
+    emitSfx('ui.press')
     document.body.style.userSelect = 'none'
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onEnd)

--- a/src/composables/use-reorder-drag.ts
+++ b/src/composables/use-reorder-drag.ts
@@ -126,7 +126,7 @@ export function useReorderDrag(opts: ReorderDragOptions) {
     while (next - ideal > 0.5 + HYSTERESIS && next > 0) next--
 
     if (next === target_index.value) return
-    if (target_index.value !== null) emitSfx('tap_05')
+    if (target_index.value !== null) emitSfx('gesture.tick')
     target_index.value = next
   }
 
@@ -202,7 +202,7 @@ export function useReorderDrag(opts: ReorderDragOptions) {
 
     stopTracking()
 
-    if (from !== null) emitSfx('snappy_button_5')
+    if (from !== null) emitSfx('ui.press')
 
     // Hand the new order over and clear the offsets in the same tick — split across
     // two, the row draws once back at its old spot and visibly snaps.

--- a/src/sfx/bus.ts
+++ b/src/sfx/bus.ts
@@ -1,19 +1,26 @@
 import logger from '@/utils/logger'
-import { type SoundKey } from './config'
-import player, { type PlayOptions } from './player'
+import type { Bus, SoundKey } from './config'
+import player from './player'
+import { roleDef, type SfxRole } from './roles'
 import { pointerStationaryAfterClick } from './pointer-activity'
 
 /**
- * Plays a sound effect. Pass a single key, or an array of keys to pick one
- * uniformly at random.
+ * Plays the sound a role stands for.
  *
- * @returns A promise that resolves when the sound has finished playing.
+ * @param preview_bus - Only for the audio settings sliders, so a drag is heard
+ *   on the bus that slider sets. It can move which volume dial scales the
+ *   sound, never which sound plays.
  */
-export function emitSfx(keys: SoundKey | SoundKey[], opts: PlayOptions = {}): Promise<void> {
-  const key = _pick(keys)
+export function emitSfx(role: SfxRole, preview_bus?: Bus): Promise<void> {
+  const def = roleDef(role)
+  const key = _pick(def.sound)
   if (!key) return Promise.resolve()
 
-  return player.play(key, opts).catch((e) => logger.error((e as Error).message, e))
+  const bus = preview_bus ?? def.bus
+
+  return player.play(key, { bus, debounce: def.debounce }).catch((e) => {
+    logger.error((e as Error).message, e)
+  })
 }
 
 /**
@@ -22,19 +29,17 @@ export function emitSfx(keys: SoundKey | SoundKey[], opts: PlayOptions = {}): Pr
  * Silent on touch, and silent when the pointer hasn't moved since the last
  * click — that means the UI moved under a still cursor rather than the person
  * moving onto something, and the sound would collide with the click's own.
- *
- * @returns A promise that resolves when the sound has finished playing.
  */
-export function emitHoverSfx(keys: SoundKey | SoundKey[], opts: PlayOptions = {}): Promise<void> {
+export function emitHoverSfx(role: SfxRole): Promise<void> {
   if (_isTouchPrimary()) return Promise.resolve()
   if (pointerStationaryAfterClick()) return Promise.resolve()
-  return emitSfx(keys, { ...opts, bus: 'hover' })
+  return emitSfx(role)
 }
 
-function _pick(keys: SoundKey | SoundKey[]): SoundKey | undefined {
-  if (!Array.isArray(keys)) return keys
-  if (keys.length === 0) return undefined
-  return keys[Math.floor(Math.random() * keys.length)]
+function _pick(sound: SoundKey | SoundKey[]): SoundKey | undefined {
+  if (!Array.isArray(sound)) return sound
+  if (sound.length === 0) return undefined
+  return sound[Math.floor(Math.random() * sound.length)]
 }
 
 function _isTouchPrimary(): boolean {

--- a/src/sfx/config.ts
+++ b/src/sfx/config.ts
@@ -11,25 +11,18 @@ export type SoundDef = {
 // One entry per audio file — keep the list flat. A sound's identity is its
 // file, and its bus is resolved when it's emitted, not by where it sits here.
 export const SOUNDS = {
-  bell_ping_high_pitched: {},
   card_drop: { default_volume: 0.3 },
-  chime_short_chord_up: {},
   click_04: { default_volume: 0.1 },
-  click_07: { default_volume: 0.1 },
   chime_ring: {},
   digi_powerdown: {},
-  double_pop_down: {},
   double_pop_up: {},
-  etc_camera_reel: {},
   etc_camera_shutter: {},
-  etc_error_break: {},
   etc_error_swipe: {},
   etc_woodblock_stuck: {},
   pop_drip_mid: { default_volume: 0.1 },
   pop_window: {},
   slide_up: {},
   trash_crumple_short: {},
-  negative_pop: { ext: 'mp3', default_volume: 0.5 },
   select: { default_volume: 0.3 },
   toggle_off: { default_volume: 0.3 },
   toggle_on: { default_volume: 0.3 },
@@ -40,10 +33,6 @@ export const SOUNDS = {
   music_plink_mid: {},
   music_plink_chordyes: {},
   music_pizz_duo_hi: {},
-  music_pizz_prompt: {},
-  tap_03: {},
-  tap_02: { default_volume: 0.1 },
-  tap_04: {},
   tap_05: { default_volume: 0.1 },
   pop_up_close: {},
   snappy_button_2: {},
@@ -55,26 +44,15 @@ export const SOUNDS = {
   type_03: { default_volume: 0.1, defaultBus: 'hover' },
   type_04: { default_volume: 0.1, defaultBus: 'hover' },
   type_05: { default_volume: 0.1, defaultBus: 'hover' },
-  clicky_button_4: {},
   slide_left: {},
   wooden_chime_ring: {},
   generic_notification_9: {},
   generic_button_15: {},
   success_1: {},
-  success_3: {},
-  handle_drag_tick: {}
+  success_3: {}
 } satisfies Record<string, SoundDef>
 
 export type SoundKey = keyof typeof SOUNDS
-
-export const TYPE_SFX: SoundKey[] = [
-  'type_01',
-  'type_02',
-  'type_03',
-  'type_04',
-  'type_05',
-  'tap_05'
-]
 
 // Resting volume setting per bus. 5 yields a 1.0× multiplier (see player.ts).
 export const BUS_DEFAULTS: Record<Bus, number> = {

--- a/src/sfx/directive.ts
+++ b/src/sfx/directive.ts
@@ -1,20 +1,8 @@
 import type { Directive, DirectiveBinding } from 'vue'
 import { emitSfx, emitHoverSfx } from './bus'
-import { type SoundKey } from './config'
+import type { SfxOptions, SfxRole } from './roles'
 
-export type SfxOptions = {
-  // Routed through staged-tap in button.vue — not handled by this directive.
-  press?: SoundKey
-  tap_pre?: SoundKey
-  tap_post?: SoundKey
-  // Handled by this directive.
-  hover?: SoundKey | SoundKey[]
-  focus?: SoundKey
-  blur?: SoundKey
-  debounce?: number
-}
-
-type SfxBindingValue = SoundKey | SfxOptions
+type SfxBindingValue = SfxRole | SfxOptions
 
 type Cleanup = () => void
 
@@ -63,21 +51,14 @@ function _attach(el: HTMLElement, binding: DirectiveBinding<SfxBindingValue>) {
     _add(el, 'pointerenter', (e) => {
       if (!state.cfg.hover) return
       if ((e as PointerEvent).pointerType !== 'mouse') return
-      emitHoverSfx(state.cfg.hover, { debounce: state.cfg.debounce })
+      emitHoverSfx(state.cfg.hover)
     })
   )
 
   cleanups.push(
     _add(el, 'focus', () => {
       if (!state.cfg.focus) return
-      emitSfx(state.cfg.focus, { debounce: state.cfg.debounce })
-    })
-  )
-
-  cleanups.push(
-    _add(el, 'blur', () => {
-      if (!state.cfg.blur) return
-      emitSfx(state.cfg.blur, { debounce: state.cfg.debounce })
+      emitSfx(state.cfg.focus)
     })
   )
 
@@ -98,7 +79,6 @@ function _parseBinding(
     const c: SfxOptions = {}
     if (mods.hover) c.hover = binding
     if (mods.focus) c.focus = binding
-    if (mods.blur) c.blur = binding
     return c
   }
 

--- a/src/sfx/player.ts
+++ b/src/sfx/player.ts
@@ -3,7 +3,6 @@ import { debounce } from '@/utils/debounce'
 import { BUS_DEFAULTS, SOUNDS, type Bus, type SoundDef, type SoundKey } from '@/sfx/config'
 
 export type PlayOptions = {
-  volume?: number
   debounce?: number
   // Overrides the sound's own bus, which otherwise falls back to 'interface'.
   bus?: Bus
@@ -103,7 +102,7 @@ class AudioPlayer {
 
     // Bail before touching the context — waking it steals audio focus and
     // pauses whatever the person is listening to, even at zero volume.
-    const volume = options.volume ?? sound.base_volume * this._getVolumeMultiplier(sound, options)
+    const volume = sound.base_volume * this._getVolumeMultiplier(sound, options)
     if (volume <= 0) return
 
     return engine.play(sound.buffer, volume)

--- a/src/sfx/roles.ts
+++ b/src/sfx/roles.ts
@@ -1,0 +1,81 @@
+import type { Bus, SoundKey } from './config'
+
+// The only place an audio filename appears. Everything else in the app names a
+// role, so changing which file a cue uses is an edit here and nowhere else.
+
+type RoleDef = {
+  sound: SoundKey | SoundKey[]
+  // Overrides the file's own bus, which otherwise falls back to 'interface'.
+  bus?: Bus
+  debounce?: number
+}
+
+// Suppresses the repeat when someone leans on a control that won't move.
+const REJECTED_DEBOUNCE_MS = 40
+
+const TYPING_CHATTER: SoundKey[] = ['type_01', 'type_02', 'type_03', 'type_04', 'type_05', 'tap_05']
+
+export const ROLES = {
+  'ui.press': { sound: 'snappy_button_5' },
+  'ui.hover': { sound: TYPING_CHATTER, bus: 'hover' },
+  'ui.focus': { sound: 'type_05' },
+  'ui.select': { sound: 'select' },
+  'ui.deselect': { sound: 'digi_powerdown' },
+  'ui.rejected': { sound: 'digi_powerdown', debounce: REJECTED_DEBOUNCE_MS },
+  'ui.toggle-on': { sound: 'toggle_on' },
+  'ui.toggle-off': { sound: 'toggle_off' },
+
+  'dialog.open': { sound: 'snappy_button_3' },
+  'dialog.close': { sound: 'pop_up_close' },
+  'dialog.confirm': { sound: 'music_plink_ok' },
+  'dialog.dismiss': { sound: 'digi_powerdown' },
+
+  'notice.success': { sound: 'success_1' },
+  'notice.error': { sound: 'etc_woodblock_stuck' },
+  'notice.info': { sound: 'generic_notification_9' },
+
+  'card.flip-away': { sound: 'transition_up' },
+  'card.flip-back': { sound: 'transition_down' },
+  'card.grade-good': { sound: 'music_plink_ok' },
+  'card.grade-again': { sound: 'music_plink_locancel' },
+  'card.delete': { sound: 'trash_crumple_short' },
+  'card.image-captured': { sound: 'etc_camera_shutter' },
+
+  'gesture.tick': { sound: 'tap_05' },
+  'gesture.zone-cross': { sound: 'music_plink_mid' },
+
+  'nav.page-forward': { sound: 'slide_up' },
+  'nav.page-back': { sound: 'slide_left' },
+
+  'session.intro': { sound: 'slide_up' },
+  'session.complete': { sound: 'music_pizz_duo_hi' }
+} satisfies Record<string, RoleDef>
+
+export type SfxRole = keyof typeof ROLES
+
+/**
+ * What a component asks for when it wants a channel to make a noise.
+ *
+ * One shape across ui-kit and layout-kit. `false` silences that channel; a
+ * channel left out falls back to whatever the primitive plays by default.
+ */
+export type SfxOptions = {
+  // Routed through staged-tap — the directive never sees these.
+  press?: SfxRole | false
+  tap_pre?: SfxRole | false
+  rejected?: SfxRole | false
+  // Handled by the directive.
+  hover?: SfxRole | false
+  focus?: SfxRole | false
+  // Shells: a dialog's own lifecycle, and a paged-window's page changes.
+  open?: SfxRole | false
+  close?: SfxRole | false
+  confirm?: SfxRole | false
+  cancel?: SfxRole | false
+  select?: SfxRole | false
+  reselect?: SfxRole | false
+}
+
+export function roleDef(role: SfxRole): RoleDef {
+  return ROLES[role]
+}

--- a/src/sfx/roles.ts
+++ b/src/sfx/roles.ts
@@ -26,6 +26,8 @@ export const ROLES = {
   'ui.toggle-off': { sound: 'toggle_off' },
 
   'dialog.open': { sound: 'snappy_button_3' },
+  // The softer of the two opening cues; both close on 'dialog.close'.
+  'dialog.open-chime': { sound: 'wooden_chime_ring' },
   'dialog.close': { sound: 'pop_up_close' },
   'dialog.confirm': { sound: 'music_plink_ok' },
   'dialog.dismiss': { sound: 'digi_powerdown' },

--- a/src/sfx/roles.ts
+++ b/src/sfx/roles.ts
@@ -30,6 +30,10 @@ export const ROLES = {
   'dialog.confirm': { sound: 'music_plink_ok' },
   'dialog.dismiss': { sound: 'digi_powerdown' },
 
+  'phone.open': { sound: 'pop_window' },
+  'phone.close': { sound: 'pop_window' },
+  'phone.app-focus': { sound: 'pop_drip_mid', bus: 'hover' },
+
   'notice.success': { sound: 'success_1' },
   'notice.error': { sound: 'etc_woodblock_stuck' },
   'notice.info': { sound: 'generic_notification_9' },

--- a/src/sfx/volume-seam.ts
+++ b/src/sfx/volume-seam.ts
@@ -1,0 +1,28 @@
+import player from './player'
+import { toBusVolumes } from '@/utils/member/preferences'
+import type { ResolvedMemberPreferences } from '@/utils/member/preferences'
+
+// The one door between what the member set on the audio screen and what the
+// player actually plays at. Nothing outside this module reaches the player.
+
+type AudioPreferences = ResolvedMemberPreferences['audio']
+
+/** Loads every sound file. Resolves once they are all decoded and playable. */
+export function setupAudio(): Promise<unknown> {
+  return player.setup()
+}
+
+/** Makes the member's saved levels the ones every later sound is scaled by. */
+export function applyMemberVolumes(audio: AudioPreferences): void {
+  player.setVolumeConfig(toBusVolumes(audio))
+}
+
+/** Plays at levels the member is still dragging towards, without saving them. */
+export function previewMemberVolumes(audio: AudioPreferences): void {
+  player.previewVolumeConfig(toBusVolumes(audio))
+}
+
+/** Throws away an unsaved preview and goes back to the member's saved levels. */
+export function discardVolumePreview(): void {
+  player.resetSettings()
+}

--- a/src/stores/notice-store.ts
+++ b/src/stores/notice-store.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import generateUID from '@/utils/uid'
-import { type SoundKey } from '@/sfx/config'
+import type { SfxOptions } from '@/sfx/roles'
 
 export type NoticeState = 'success' | 'error' | 'warn' | 'info'
 export type NoticeVariant = 'toast' | 'panel'
@@ -11,7 +11,7 @@ export type NoticeAction = {
   onClick: () => void
   // Dismiss the notice once onClick has run.
   closesOnClick?: boolean
-  sfx?: { press?: SoundKey }
+  sfx?: SfxOptions
 }
 
 type NoticeOptions = {
@@ -26,7 +26,7 @@ type NoticeOptions = {
   // Show the close (x) button. Defaults to true.
   closable?: boolean
   // Caller-defined sound played once, when the notice opens.
-  sfx?: { open?: SoundKey | SoundKey[] }
+  sfx?: SfxOptions
 }
 
 export type Notice = NoticeOptions & {
@@ -81,28 +81,28 @@ export const useNoticeStore = defineStore('notice', () => {
   function warn(message: string, options?: NoticeOptions): Notice {
     return addNotice('warn', message, {
       ...options,
-      sfx: { open: 'etc_error_swipe', ...options?.sfx }
+      sfx: { open: 'notice.error', ...options?.sfx }
     })
   }
 
   function success(message: string, options?: NoticeOptions): Notice {
     return addNotice('success', message, {
       ...options,
-      sfx: { open: 'success_3', ...options?.sfx }
+      sfx: { open: 'notice.success', ...options?.sfx }
     })
   }
 
   function error(message: string, options?: NoticeOptions): Notice {
     return addNotice('error', message, {
       ...options,
-      sfx: { open: 'digi_powerdown', ...options?.sfx }
+      sfx: { open: 'notice.error', ...options?.sfx }
     })
   }
 
   function info(message: string, options?: NoticeOptions): Notice {
     return addNotice('info', message, {
       ...options,
-      sfx: { open: 'chime_ring', ...options?.sfx }
+      sfx: { open: 'notice.info', ...options?.sfx }
     })
   }
 

--- a/src/utils/animations/session-intro.ts
+++ b/src/utils/animations/session-intro.ts
@@ -25,7 +25,7 @@ export function coverCardEnter(el: HTMLElement, done: () => void) {
     delay: COVER_DELAY,
     ease: 'power2.out',
     clearProps: 'transform,opacity',
-    onStart: () => emitSfx('slide_up'),
+    onStart: () => emitSfx('nav.page-forward'),
     onComplete: done
   })
 }

--- a/src/views/admin/color-page/palette-page.vue
+++ b/src/views/admin/color-page/palette-page.vue
@@ -8,7 +8,6 @@ import { injectColorTuner } from './use-color-tuner'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import UiPopover from '@/components/ui-kit/popover.vue'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 
 const { t } = useI18n()
 const tuner = injectColorTuner()
@@ -101,7 +100,7 @@ watch(
             type="button"
             data-testid="palette-page__swatch"
             :data-active="shade.id === picked_id"
-            v-sfx="{ hover: TYPE_SFX }"
+            v-sfx="{ hover: 'ui.hover' }"
             class="flex w-(--palette-page-swatch-size) cursor-pointer flex-col gap-1 rounded-3 p-2 text-left hover:bg-raised-tint data-[active=true]:bg-raised"
             @click="onPick(shade.id, $event)"
           >
@@ -132,7 +131,7 @@ watch(
           <button
             type="button"
             data-testid="palette-page__add-shade"
-            v-sfx="{ hover: TYPE_SFX }"
+            v-sfx="{ hover: 'ui.hover' }"
             class="flex w-(--palette-page-swatch-size) cursor-pointer flex-col self-start rounded-3 p-2 text-ink-muted"
             :aria-label="t('admin.palette-page.add-shade-button')"
             :title="t('admin.palette-page.add-shade-button')"

--- a/src/views/admin/color-page/palette-page.vue
+++ b/src/views/admin/color-page/palette-page.vue
@@ -23,7 +23,7 @@ const swatch_els = new Map<string, HTMLElement>()
 // Every path out of the editor lands here, so the close sound is emitted once, in the one place the
 // popover actually shuts — an outside click, a re-click on the open swatch, or Esc.
 function onClose() {
-  if (picked_id.value) emitSfx('snappy_button_5')
+  if (picked_id.value) emitSfx('ui.press')
   picked_id.value = null
 }
 
@@ -48,7 +48,7 @@ function onPick(id: string, event: MouseEvent) {
   if (id === picked_id.value) return onClose()
 
   const el = event.currentTarget as HTMLElement
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   picked_id.value = id
   anchor_el.value = el
   anchor_rect.value = el.getBoundingClientRect()
@@ -58,7 +58,7 @@ function onAddShade(family: string) {
   const lightest = tuner.families.value.get(family)?.[0]
   const seed = lightest ? { ...lightest.hsl, l: lightest.hsl.l + 4 } : { h: 0, s: 0, l: 50 }
 
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   picked_id.value = tuner.addShade(family, seed).id
   void nextTick(() => remeasure())
 }

--- a/src/views/admin/color-page/role-specimen.vue
+++ b/src/views/admin/color-page/role-specimen.vue
@@ -3,7 +3,6 @@ import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import { autoUpdate } from '@floating-ui/vue'
 import type { Mode, RoleName, StationName } from './catalog'
 import { injectColorTuner } from './use-color-tuner'
-import { TYPE_SFX } from '@/sfx/config'
 
 type RoleSpecimenProps = {
   mode: Mode
@@ -136,7 +135,7 @@ watch(
         :data-active="region.role === active_role"
         :data-flagged="isFlagged(region.role)"
         :aria-label="region.role"
-        v-sfx="{ hover: TYPE_SFX }"
+        v-sfx="{ hover: 'ui.hover' }"
         class="absolute cursor-pointer data-[active=true]:outline-2 data-[active=true]:outline-(--color-accent) hover:outline-2 hover:outline-(--color-accent)"
         :class="[region.box, region.kind === 'glyph' && 'flex items-center text-lg leading-none']"
         :style="styleOf(region)"

--- a/src/views/admin/color-page/roles-page.vue
+++ b/src/views/admin/color-page/roles-page.vue
@@ -31,14 +31,14 @@ function activeRole(mode: Mode, station: StationName): RoleName | null {
 // Every path out of the editor lands here, so the close sound is emitted once, in the one place the
 // popover actually shuts — an outside click, a re-click on the open region, or Esc.
 function onClose() {
-  if (picked.value) emitSfx('snappy_button_5')
+  if (picked.value) emitSfx('ui.press')
   picked.value = null
 }
 
 function onPick(mode: Mode, station: StationName, role: RoleName, el: HTMLElement) {
   if (picked.value?.el === el) return onClose()
 
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   picked.value = { mode, station, role, rect: el.getBoundingClientRect(), el }
 }
 </script>

--- a/src/views/admin/color-page/shade-editor.vue
+++ b/src/views/admin/color-page/shade-editor.vue
@@ -9,7 +9,6 @@ import UiInput from '@/components/ui-kit/input.vue'
 import UiSpinbox from '@/components/ui-kit/spinbox/index.vue'
 import ScrollRegion from '@/components/layout-kit/scroll-region/index.vue'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 
 type ShadeEditorProps = {
   shade: Shade
@@ -91,7 +90,7 @@ function onCommitName() {
       <div class="relative shrink-0">
         <label
           data-testid="shade-editor__swatch"
-          v-sfx="{ hover: TYPE_SFX }"
+          v-sfx="{ hover: 'ui.hover' }"
           class="relative block size-12 cursor-pointer rounded-3 border border-line"
           :style="{ backgroundColor: hex }"
           :title="t('admin.palette-page.pick-color-label')"
@@ -112,7 +111,7 @@ function onCommitName() {
         <button
           type="button"
           data-testid="shade-editor__hex"
-          v-sfx="{ hover: TYPE_SFX }"
+          v-sfx="{ hover: 'ui.hover' }"
           class="absolute top-full left-0 cursor-pointer whitespace-nowrap text-base text-ink-muted tabular-nums hover:text-ink"
           @click="onCopyHex"
         >

--- a/src/views/admin/color-page/shade-editor.vue
+++ b/src/views/admin/color-page/shade-editor.vue
@@ -67,7 +67,7 @@ function onPickColor(event: Event) {
 
 function onCopyHex() {
   void navigator.clipboard?.writeText(hex.value)
-  emitSfx('select')
+  emitSfx('ui.select')
 
   copied.value = true
   if (copied_timer) clearTimeout(copied_timer)

--- a/src/views/app-shell/nav-bar/back-button.vue
+++ b/src/views/app-shell/nav-bar/back-button.vue
@@ -29,7 +29,7 @@ function onBack() {
     icon-left="arrow-left"
     :size="is_mobile ? 'base' : 'sm'"
     icon-only
-    :sfx="{ tap_pre: 'snappy_button_5', press: 'slide_left' }"
+    :sfx="{ tap_pre: 'ui.press', press: 'nav.page-back' }"
     @press="onBack"
   >
   </ui-button>

--- a/src/views/audio-reader/collection-edit-modal.vue
+++ b/src/views/audio-reader/collection-edit-modal.vue
@@ -78,7 +78,7 @@ async function onDeleteLesson(lesson: Lesson) {
     title: t('alert.delete-lesson.title'),
     message: t('alert.delete-lesson.message'),
     confirmLabel: t('alert.delete-lesson.confirm'),
-    confirmAudio: 'trash_crumple_short'
+    confirmAudio: 'card.delete'
   }).response
   if (!confirmed) return
 
@@ -94,7 +94,7 @@ async function onDeleteCollection() {
     title: t('alert.delete-collection.title'),
     message: t('alert.delete-collection.message'),
     confirmLabel: t('alert.delete-collection.confirm'),
-    confirmAudio: 'trash_crumple_short'
+    confirmAudio: 'card.delete'
   }).response
   if (!confirmed) return
 

--- a/src/views/audio-reader/lesson/audio-toolbar.vue
+++ b/src/views/audio-reader/lesson/audio-toolbar.vue
@@ -110,12 +110,12 @@ function onPlayTap(e: MouseEvent) {
 }
 
 function onBackTap(e: MouseEvent) {
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   tapBack(skipBack)(e)
 }
 
 function onForwardTap(e: MouseEvent) {
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   tapForward(skipForward)(e)
 }
 

--- a/src/views/audio-reader/lesson/audio-toolbar.vue
+++ b/src/views/audio-reader/lesson/audio-toolbar.vue
@@ -105,7 +105,7 @@ function skipForward() {
 // owns the action: it fires immediately on fine pointers and at the pop's peak
 // on coarse — exactly one activation per pointer type.
 function onPlayTap(e: MouseEvent) {
-  emitSfx(player.is_playing.value ? 'snappy_button_3' : 'snappy_button_2')
+  emitSfx(player.is_playing.value ? 'dialog.open' : 'ui.press')
   tapPlay(toggle)(e)
 }
 
@@ -191,7 +191,7 @@ function setMode(next: 'expanded' | 'mini') {
             variant="ghost"
             icon-only
             play-on-tap
-            :sfx="{ press: 'snappy_button_5' }"
+            :sfx="{ press: 'ui.press' }"
             @press="setMode('mini')"
           />
         </div>
@@ -246,7 +246,7 @@ function setMode(next: 'expanded' | 'mini') {
         variant="ghost"
         icon-only
         play-on-tap
-        :sfx="{ press: 'snappy_button_5' }"
+        :sfx="{ press: 'ui.press' }"
         @press="setMode('expanded')"
       />
 

--- a/src/views/audio-reader/lesson/index.vue
+++ b/src/views/audio-reader/lesson/index.vue
@@ -140,7 +140,7 @@ function onPlayFromHere() {
 
 // Tapping outside the term dismisses it with the same cue as its close button.
 function dismissTerm() {
-  emitSfx('pop_up_close')
+  emitSfx('dialog.close')
   closeTerm()
 }
 

--- a/src/views/audio-reader/lesson/resume-follow-button.vue
+++ b/src/views/audio-reader/lesson/resume-follow-button.vue
@@ -19,7 +19,7 @@ const icon = computed(() => (direction === 'up' ? 'arcade-stick-up' : 'arcade-st
     rounded-full
     size="lg"
     class="shadow-sm"
-    :sfx="{ press: 'snappy_button_5' }"
+    :sfx="{ press: 'ui.press' }"
     @press="emit('resume')"
   />
 </template>

--- a/src/views/audio-reader/term-popover/add-card-control.vue
+++ b/src/views/audio-reader/term-popover/add-card-control.vue
@@ -75,7 +75,7 @@ function onSelect(option: DropdownOption) {
     position="bottom-end"
     play-on-tap
     :tap-animate="false"
-    :sfx="{ press: 'select' }"
+    :sfx="{ press: 'ui.select' }"
     :options="deck_options"
     :primary-disabled="already_a_card"
     :aria-disabled="disabled || undefined"

--- a/src/views/audio-reader/term-popover/add-card-panel.vue
+++ b/src/views/audio-reader/term-popover/add-card-panel.vue
@@ -95,8 +95,7 @@ const can_save = computed(
 
 function flip() {
   active_side.value = active_side.value === 'front' ? 'back' : 'front'
-  // Match the study-session flip cue: down toward the front (starting side), up away.
-  emitSfx(active_side.value === 'front' ? 'transition_down' : 'transition_up')
+  emitSfx(active_side.value === 'front' ? 'card.flip-back' : 'card.flip-away')
 }
 
 function onSelectDeck(option: DropdownOption) {
@@ -105,7 +104,7 @@ function onSelectDeck(option: DropdownOption) {
 
 // Focusing the card editor slides it up, matching the card-editor's focus cue.
 function onCardFocus(e: FocusEvent) {
-  if ((e.target as HTMLElement | null)?.isContentEditable) emitSfx('slide_up')
+  if ((e.target as HTMLElement | null)?.isContentEditable) emitSfx('nav.page-forward')
 }
 
 function onEditActive(value: string) {

--- a/src/views/audio-reader/term-popover/add-card-panel.vue
+++ b/src/views/audio-reader/term-popover/add-card-panel.vue
@@ -149,7 +149,7 @@ async function onSave() {
         icon-only
         size="base"
         play-on-tap
-        :sfx="{ press: 'snappy_button_5' }"
+        :sfx="{ press: 'ui.press' }"
         @press="emit('cancel')"
       >
         {{ t('audio-reader.add-card-modal.back-button') }}
@@ -206,7 +206,7 @@ async function onSave() {
         :disabled="!can_save || saving"
         play-on-tap
         :tap-animate="false"
-        :sfx="{ press: 'select' }"
+        :sfx="{ press: 'ui.select' }"
         @press="onSave"
       >
         {{ t('audio-reader.add-card-modal.save-button') }}

--- a/src/views/audio-reader/term-popover/term-card.vue
+++ b/src/views/audio-reader/term-popover/term-card.vue
@@ -162,7 +162,7 @@ watch(
             icon-only
             size="base"
             play-on-tap
-            :sfx="{ press: 'pop_up_close' }"
+            :sfx="{ press: 'dialog.close' }"
             @press="emit('back')"
           >
             {{ t('audio-reader.popover.close-button') }}
@@ -290,7 +290,7 @@ watch(
             full-width
             play-on-tap
             :tap-animate="false"
-            :sfx="{ press: 'snappy_button_3' }"
+            :sfx="{ press: 'dialog.open' }"
             @press="emit('play-from-here')"
           >
             {{ t('audio-reader.popover.play-from-here-button') }}

--- a/src/views/audio-reader/upload-lesson-modal/script-select.vue
+++ b/src/views/audio-reader/upload-lesson-modal/script-select.vue
@@ -21,7 +21,7 @@ function onOption(e: MouseEvent, value: TranscriptScript) {
     () => {
       script.value = value
     },
-    { audio: 'select' }
+    { audio: 'ui.select' }
   )(e)
 }
 </script>

--- a/src/views/audio-reader/upload-lesson-modal/script-select.vue
+++ b/src/views/audio-reader/upload-lesson-modal/script-select.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { useStagedTap } from '@/composables/ui/staged-tap'
-import { TYPE_SFX } from '@/sfx/config'
 
 type ScriptOption = { value: TranscriptScript; label: string }
 
@@ -43,7 +42,7 @@ function onOption(e: MouseEvent, value: TranscriptScript) {
         :data-active="script === option.value"
         class="flex-1 cursor-pointer rounded-4 px-3 py-2 text-sm transition-colors data-[active=false]:text-ink data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-on-accent) data-[active=false]:hover:bg-(--color-accent)/10"
         :data-playing="playing || null"
-        v-sfx="{ hover: TYPE_SFX }"
+        v-sfx="{ hover: 'ui.hover' }"
         @click="(e) => onOption(e, option.value)"
       >
         {{ t(option.label) }}

--- a/src/views/dashboard/composables/deck-options-menu.ts
+++ b/src/views/dashboard/composables/deck-options-menu.ts
@@ -47,7 +47,7 @@ export function useDeckOptionsMenu({ onRearrange }: DeckOptionsMenuConfig) {
       title: t('alert.delete-deck.title'),
       message: t('alert.delete-deck.message'),
       confirmLabel: t('alert.delete-deck.confirm'),
-      confirmAudio: 'trash_crumple_short'
+      confirmAudio: 'card.delete'
     }).response
     if (!confirmed) return
 

--- a/src/views/dashboard/composables/new-deck-action.ts
+++ b/src/views/dashboard/composables/new-deck-action.ts
@@ -14,7 +14,7 @@ export function useNewDeckAction() {
     if (creating_deck.value) return
 
     creating_deck.value = true
-    emitSfx('pop_up_pop')
+    emitSfx('dialog.open')
     await deck_actions.createDeck(buildNewDeckPayload(t('deck.default-title')), {
       openSettingsAfterCreate: true
     })

--- a/src/views/dashboard/deck-grid/item.vue
+++ b/src/views/dashboard/deck-grid/item.vue
@@ -65,7 +65,7 @@ function onOptionSelect(option: DropdownOption) {
       :rearranging="rearranging"
       :dragging="dragging"
       :active="!!dropdown?.open"
-      :sfx="{ press: 'snappy_button_5' }"
+      :sfx="{ press: 'ui.press' }"
       class="w-full"
       @press="onPress"
     >

--- a/src/views/dashboard/deck-grid/sort-options.vue
+++ b/src/views/dashboard/deck-grid/sort-options.vue
@@ -21,7 +21,7 @@ const OPTIONS: { key: SortOption; label_key: string }[] = [
 ]
 
 function onOptionClicked(option: SortOption) {
-  emitSfx(option === selected ? 'digi_powerdown' : 'snappy_button_5')
+  emitSfx(option === selected ? 'ui.deselect' : 'ui.press')
   emit('select', option)
 }
 </script>

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -46,7 +46,7 @@ watch(decks_error, (err) => {
 
 function onToggleEditDecks() {
   editing_decks.value = !editing_decks.value
-  emitSfx(editing_decks.value ? 'pop_up_pop' : 'pop_up_close')
+  emitSfx(editing_decks.value ? 'dialog.open' : 'dialog.close')
 }
 
 function onEnterEditDecks() {

--- a/src/views/dashboard/review-inbox/index.vue
+++ b/src/views/dashboard/review-inbox/index.vue
@@ -21,7 +21,7 @@ useReviewInboxTickSfx(items_el)
 
 function onItemClicked(deck: Deck) {
   if (editing) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.rejected')
     return
   }
 

--- a/src/views/dashboard/review-inbox/item.vue
+++ b/src/views/dashboard/review-inbox/item.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import Card from '@/components/card/index.vue'
-import { TYPE_SFX } from '@/sfx/config'
 
 type ReviewInboxItemProps = {
   deck: Deck
@@ -15,7 +14,7 @@ const { disabled = false } = defineProps<ReviewInboxItemProps>()
     data-testid="review-inbox-item"
     class="flex flex-col items-center gap-2.5 pointer-fine:hover:scale-102 pointer-fine:hover:z-10 pointer-fine:transition-transform duration-75 relative cursor-pointer touch-manipulation"
     :class="disabled && 'opacity-disabled'"
-    v-sfx="{ hover: TYPE_SFX }"
+    v-sfx="{ hover: 'ui.hover' }"
   >
     <card side="cover" class="w-(--card-w-2xs)" :cover_config="deck.cover_config" />
 

--- a/src/views/dashboard/review-inbox/nav-button.vue
+++ b/src/views/dashboard/review-inbox/nav-button.vue
@@ -25,7 +25,7 @@ const { t } = useI18n()
     class="absolute! top-1/2 z-20 -translate-y-2/3 shadow-xs"
     :class="direction === 'prev' ? '-left-3 sm:-left-8' : '-right-3 sm:-right-8'"
     size="lg"
-    :sfx="{ press: 'snappy_button_5' }"
+    :sfx="{ press: 'ui.press' }"
     @press="emit('press')"
   >
     {{ t(direction === 'prev' ? 'review-inbox.prev-button' : 'review-inbox.next-button') }}

--- a/src/views/dashboard/review-inbox/use-tick-sfx.ts
+++ b/src/views/dashboard/review-inbox/use-tick-sfx.ts
@@ -36,7 +36,7 @@ export function useReviewInboxTickSfx(items_el: Ref<HTMLElement | null>) {
       const scroll_left = Math.min(Math.max(el.scrollLeft, 0), max_scroll_left)
 
       const index = Math.round(scroll_left / cardPitch(el))
-      if (index !== last_index && !is_fine.value) emitSfx('gesture.tick', { volume: 0.1 })
+      if (index !== last_index && !is_fine.value) emitSfx('gesture.tick')
       last_index = index
     })
   }

--- a/src/views/dashboard/review-inbox/use-tick-sfx.ts
+++ b/src/views/dashboard/review-inbox/use-tick-sfx.ts
@@ -36,7 +36,7 @@ export function useReviewInboxTickSfx(items_el: Ref<HTMLElement | null>) {
       const scroll_left = Math.min(Math.max(el.scrollLeft, 0), max_scroll_left)
 
       const index = Math.round(scroll_left / cardPitch(el))
-      if (index !== last_index && !is_fine.value) emitSfx('tap_05', { volume: 0.1 })
+      if (index !== last_index && !is_fine.value) emitSfx('gesture.tick', { volume: 0.1 })
       last_index = index
     })
   }

--- a/src/views/deck/card-editor/list-item-card.vue
+++ b/src/views/deck/card-editor/list-item-card.vue
@@ -88,7 +88,7 @@ function onFocusIn(e: FocusEvent) {
     return
   }
 
-  emitSfx(withinAnyCard(e.relatedTarget) ? 'click_04' : 'slide_up')
+  emitSfx(withinAnyCard(e.relatedTarget) ? 'gesture.tick' : 'nav.page-forward')
   focused.value = true
 }
 
@@ -101,7 +101,7 @@ function onFocusOut(e: FocusEvent) {
   // A window blur isn't the user leaving the card — flag the round-trip so the matching refocus stays silent.
   if (!document.hasFocus()) return flagWindowBlur()
 
-  if (!withinAnyCard(e.relatedTarget)) emitSfx('card_drop')
+  if (!withinAnyCard(e.relatedTarget)) emitSfx('dialog.close')
 }
 
 function hasFocusWithin() {

--- a/src/views/deck/card-editor/list-item-options.vue
+++ b/src/views/deck/card-editor/list-item-options.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import UiButton from '@/components/ui-kit/button.vue'
 import { useI18n } from 'vue-i18n'
-import { TYPE_SFX } from '@/sfx/config'
 
 const emit = defineEmits<{
   (e: 'move'): void
@@ -18,7 +17,7 @@ const { t } = useI18n()
       @press="emit('move')"
       icon-only
       icon-left="move-item"
-      :sfx="{ hover: TYPE_SFX }"
+      :sfx="{ hover: 'ui.hover' }"
     >
       {{ t('deck-view.item-options.move') }}
     </ui-button>
@@ -28,7 +27,7 @@ const { t } = useI18n()
       icon-only
       icon-left="delete"
       data-palette="danger"
-      :sfx="{ hover: TYPE_SFX }"
+      :sfx="{ hover: 'ui.hover' }"
     >
       {{ t('deck-view.item-options.delete') }}
     </ui-button>

--- a/src/views/deck/card-editor/list-item.vue
+++ b/src/views/deck/card-editor/list-item.vue
@@ -7,7 +7,6 @@ import { cardEditorKey, type CardWithClientId } from '@/views/deck/composables'
 import { inject, computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ListItemCard from './list-item-card.vue'
-import { TYPE_SFX } from '@/sfx/config'
 
 type ListItemProps = {
   index: number
@@ -65,7 +64,7 @@ function onClick(e: MouseEvent) {
     <button
       data-testid="card-list-item__reorder"
       class="hidden h-12 w-12 cursor-grab touch-none items-center justify-center rounded-full bg-raised text-lg text-ink sm:flex group-focus-within/listitem:bg-surface row-span-2"
-      v-sfx="dragging ? {} : { hover: TYPE_SFX }"
+      v-sfx="dragging ? {} : { hover: 'ui.hover' }"
       @click.stop
       @pointerdown="emit('reorderPointerdown', $event)"
     >

--- a/src/views/deck/card-grid/grid-item.vue
+++ b/src/views/deck/card-grid/grid-item.vue
@@ -69,7 +69,9 @@ function onCardClick() {
   if (sel && !sel.isCollapsed) return
 
   active_side.value = active_side.value === 'front' ? 'back' : 'front'
-  emitSfx(active_side.value === 'back' ? 'transition_up' : 'transition_down')
+  // The grid picks which face it shows, so the cue reads against that face and
+  // not against the front.
+  emitSfx(active_side.value === side ? 'card.flip-back' : 'card.flip-away')
 }
 
 // Suppresses text selection only on a multi-click (`detail > 1`) — spamming

--- a/src/views/deck/card-grid/grid-item.vue
+++ b/src/views/deck/card-grid/grid-item.vue
@@ -5,7 +5,6 @@ import UiDropdownButton, {
   type DropdownOption
 } from '@/components/ui-kit/dropdown-button/index.vue'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 import { inject, ref, useTemplateRef, watch } from 'vue'
 import { usePressHold } from '@/composables/ui/press-hold'
 import {
@@ -94,7 +93,7 @@ watch(
       'pointer-fine:hover:scale-101': is_selecting,
       jiggle: rearranging && !dragging
     }"
-    v-sfx="{ hover: is_selecting || rearranging ? TYPE_SFX : undefined }"
+    v-sfx="{ hover: is_selecting || rearranging ? 'ui.hover' : undefined }"
     @mouseenter="is_hovering = true"
     @mouseleave="is_hovering = false"
     @pointerdown="onPointerdown"

--- a/src/views/deck/card-import/drop-zone.vue
+++ b/src/views/deck/card-import/drop-zone.vue
@@ -25,7 +25,7 @@ const file_input = useTemplateRef<HTMLInputElement>('file_input')
 const drag_depth = ref(0)
 
 function browse() {
-  emitSfx('select')
+  emitSfx('ui.select')
   file_input.value?.click()
 }
 
@@ -64,7 +64,7 @@ function onDrop(e: DragEvent) {
 
 // Chimes once as the file arrives over the zone, not on every child dragenter.
 watch(drag_depth, (now, was) => {
-  if (now > 0 && was === 0) emitSfx('music_plink_mid')
+  if (now > 0 && was === 0) emitSfx('gesture.zone-cross')
 })
 </script>
 

--- a/src/views/deck/card-import/drop-zone.vue
+++ b/src/views/deck/card-import/drop-zone.vue
@@ -4,7 +4,6 @@ import UiIcon from '@/components/ui-kit/icon.vue'
 import { ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 import { CARD_IMPORT_ACCEPT } from '@/utils/card/csv'
 
 type DropZoneProps = {
@@ -76,7 +75,7 @@ watch(drag_depth, (now, was) => {
     :data-error="error ? '' : undefined"
     :data-palette="error ? 'danger' : undefined"
     class="card-import-drop-zone"
-    v-sfx="{ hover: TYPE_SFX }"
+    v-sfx="{ hover: 'ui.hover' }"
     @dragenter="onDragEnter"
     @dragleave="onDragLeave"
     @dragover="onDragOver"

--- a/src/views/deck/card-import/source-panel.vue
+++ b/src/views/deck/card-import/source-panel.vue
@@ -66,7 +66,7 @@ const pasted_text = computed({
         icon-only
         icon-left="close"
         size="sm"
-        :sfx="{ press: 'digi_powerdown' }"
+        :sfx="{ press: 'ui.deselect' }"
         @press="draft.clear"
       >
         {{ t('deck-view.card-import.clear-file') }}

--- a/src/views/deck/composables/actions.ts
+++ b/src/views/deck/composables/actions.ts
@@ -77,7 +77,7 @@ export function useCardActions({ list, selection, mutations, deck_query, deck_id
   function onSelectCard(id?: number) {
     if (id !== undefined) selection.toggleSelectCard(id)
     selection.enterSelection()
-    emitSfx('select')
+    emitSfx('ui.select')
   }
 
   /**
@@ -122,7 +122,7 @@ export function useCardActions({ list, selection, mutations, deck_query, deck_id
 
   /** Exit selection mode only (keeps the current editor mode). */
   function onCancelSelection() {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.deselect')
     selection.exitSelection()
   }
 

--- a/src/views/deck/composables/actions.ts
+++ b/src/views/deck/composables/actions.ts
@@ -115,7 +115,7 @@ export function useCardActions({ list, selection, mutations, deck_query, deck_id
 
   /** Exit the current mode: drop selection, return to view mode. */
   function onCancel() {
-    emitSfx('card_drop')
+    emitSfx('dialog.close')
     shell.exitMode()
     selection.exitSelection()
   }

--- a/src/views/deck/composables/bulk-actions.ts
+++ b/src/views/deck/composables/bulk-actions.ts
@@ -23,7 +23,7 @@ export function useBulkActions() {
 
   /** Toggle deck-wide selection; plays the standard select sfx. */
   function onToggleSelectAll() {
-    emitSfx('select')
+    emitSfx('ui.select')
     selection.toggleSelectAll()
   }
 

--- a/src/views/deck/composables/card-import.ts
+++ b/src/views/deck/composables/card-import.ts
@@ -89,7 +89,7 @@ export function useCardImport({ editor, shell }: Options) {
   function applyResult(target: CardImportSource, result: ReturnType<typeof parseCardText>) {
     if (!result.ok) {
       results.value[target] = { ...emptyResult(), refusal: result.refusal }
-      emitSfx('digi_powerdown')
+      emitSfx('ui.rejected')
       return
     }
 
@@ -112,7 +112,7 @@ export function useCardImport({ editor, shell }: Options) {
     applyResult('file', result)
 
     // Only the file lands with a chime — pasted text re-parses on every keystroke.
-    if (result.ok) emitSfx('music_plink_ok')
+    if (result.ok) emitSfx('dialog.confirm')
   }
 
   /** Re-read the pasted box; every keystroke re-previews what it holds. */
@@ -136,7 +136,7 @@ export function useCardImport({ editor, shell }: Options) {
   }
 
   function toggleExpanded() {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     is_expanded.value = !is_expanded.value
   }
 
@@ -145,7 +145,7 @@ export function useCardImport({ editor, shell }: Options) {
   function dismissRefusal() {
     if (!refusal.value) return
 
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     results.value[source.value].refusal = null
   }
 

--- a/src/views/deck/composables/card-import.ts
+++ b/src/views/deck/composables/card-import.ts
@@ -170,7 +170,7 @@ export function useCardImport({ editor, shell }: Options) {
   /** Leave without importing — the same exit, sounded as a refusal rather than a mode change. */
   function dismiss() {
     discardDraft()
-    shell.exitMode('digi_powerdown')
+    shell.exitMode('ui.rejected')
   }
 
   /**

--- a/src/views/deck/composables/card-search.ts
+++ b/src/views/deck/composables/card-search.ts
@@ -30,7 +30,7 @@ export function useCardSearch(
   )
 
   function open() {
-    emitSfx('generic_button_15')
+    emitSfx('ui.press')
     is_searching.value = true
   }
 

--- a/src/views/deck/composables/card-search.ts
+++ b/src/views/deck/composables/card-search.ts
@@ -35,7 +35,7 @@ export function useCardSearch(
   }
 
   function close() {
-    emitSfx('slide_left')
+    emitSfx('nav.page-back')
     is_searching.value = false
     query.value = ''
   }

--- a/src/views/deck/composables/list-controller.ts
+++ b/src/views/deck/composables/list-controller.ts
@@ -155,7 +155,7 @@ export function useCardListController(opts: Options) {
 
     // The new row's autofocus is programmatic and stays silent, so the chime
     // plays alone.
-    emitSfx('snappy_button_2')
+    emitSfx('ui.press')
     addCardAtTop()
   }
 

--- a/src/views/deck/composables/view-shell.ts
+++ b/src/views/deck/composables/view-shell.ts
@@ -119,12 +119,12 @@ export function useDeckViewShell() {
   }
 
   function openPageSettings() {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     is_page_settings_open.value = true
   }
 
   function closePageSettings() {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     is_page_settings_open.value = false
   }
 

--- a/src/views/deck/composables/view-shell.ts
+++ b/src/views/deck/composables/view-shell.ts
@@ -2,7 +2,7 @@ import { computed, ref, type InjectionKey } from 'vue'
 import { useLocalRef } from '@/composables/storage/local-ref'
 import { useMatchMedia } from '@/composables/ui/media-query'
 import { emitSfx } from '@/sfx/bus'
-import type { SoundKey } from '@/sfx/config'
+import type { SfxRole } from '@/sfx/roles'
 
 export type DeckViewShell = ReturnType<typeof useDeckViewShell>
 
@@ -50,7 +50,7 @@ export function useDeckViewShell() {
    * transition finishes (`notifyModeSettled`, from the mode-stack's GSAP
    * completion). `mode` flips synchronously; only the promise is deferred.
    */
-  function setMode(new_mode: CardEditorMode, chime: SoundKey = 'select'): Promise<void> {
+  function setMode(new_mode: CardEditorMode, chime: SfxRole = 'ui.select'): Promise<void> {
     if (mode.value === new_mode) return Promise.resolve()
 
     emitSfx(chime)
@@ -84,7 +84,7 @@ export function useDeckViewShell() {
   }
 
   /** Leave the current mode back to the base view. */
-  function exitMode(chime?: SoundKey) {
+  function exitMode(chime?: SfxRole) {
     return setMode('view', chime)
   }
 
@@ -111,7 +111,7 @@ export function useDeckViewShell() {
   /** Flip drag-to-reorder on the base grid; turning it on returns to the view. */
   function toggleRearrange() {
     is_rearranging.value = !is_rearranging.value
-    emitSfx(is_rearranging.value ? 'pop_up_pop' : 'pop_up_close')
+    emitSfx(is_rearranging.value ? 'dialog.open' : 'dialog.close')
     if (is_rearranging.value) {
       mode.value = 'view'
       sort_by.value = 'default'

--- a/src/views/deck/cover-designer/icon-picker.vue
+++ b/src/views/deck/cover-designer/icon-picker.vue
@@ -2,7 +2,6 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 import UiIcon from '@/components/ui-kit/icon.vue'
 import { coverIconPalette } from '@/utils/cover'
 
@@ -44,7 +43,7 @@ function onIconSelect(value: string | undefined) {
         :key="name"
         :data-testid="`icon-picker__option-${name}`"
         :data-selected="name === icon || undefined"
-        v-sfx="{ hover: TYPE_SFX }"
+        v-sfx="{ hover: 'ui.hover' }"
         class="w-14.5 aspect-square rounded-6 cursor-pointer flex items-center justify-center bg-raised text-ink-muted [&_svg]:size-6 data-selected:bg-(--color-accent) hover:bg-(--color-accent) hover:text-(--color-accent-muted) hover:bgx-diagonal-stripes hover:bgx-opacity-10 data-selected:bgx-diagonal-stripes data-selected:bgx-opacity-10 transition-colors duration-75 hover:[&_svg]:scale-120 hover:[&_svg]:rotate-6"
         @click="onIconSelect(name)"
       >

--- a/src/views/deck/cover-designer/icon-picker.vue
+++ b/src/views/deck/cover-designer/icon-picker.vue
@@ -23,11 +23,11 @@ const emit = defineEmits<{
 
 function onIconSelect(value: string | undefined) {
   if (value === icon) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.deselect')
     return
   }
 
-  emitSfx('toggle_on')
+  emitSfx('ui.toggle-on')
   emit('update:icon', value)
 }
 </script>

--- a/src/views/deck/deck-hero/study-button.vue
+++ b/src/views/deck/deck-hero/study-button.vue
@@ -28,7 +28,7 @@ function onStudyClicked() {
     data-palette="brand"
     full-width
     size="xl"
-    :sfx="{ tap_pre: 'snappy_button_3' }"
+    :sfx="{ tap_pre: 'dialog.open' }"
     :disabled="is_disabled"
     @press="onStudyClicked"
   >

--- a/src/views/deck/deck-settings/deck-save-button.vue
+++ b/src/views/deck/deck-settings/deck-save-button.vue
@@ -51,7 +51,7 @@ function onReset() {
       size="lg"
       icon-only
       icon-left="refresh"
-      :sfx="{ press: 'snappy_button_5' }"
+      :sfx="{ press: 'ui.press' }"
       :disabled="!is_dirty"
       click-when-disabled
       class="shrink-0"

--- a/src/views/deck/deck-settings/deck-save-button.vue
+++ b/src/views/deck/deck-settings/deck-save-button.vue
@@ -17,11 +17,11 @@ const is_saving = ref(false)
 async function onSave() {
   if (!has_title.value) {
     title_error.value = t('deck.settings-modal.title-required')
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
     return
   }
   if (!is_dirty.value) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.rejected')
     return
   }
   is_saving.value = true
@@ -36,7 +36,7 @@ async function onSave() {
 
 function onReset() {
   if (!is_dirty.value) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.rejected')
     return
   }
   resetChanges()

--- a/src/views/deck/deck-settings/index.vue
+++ b/src/views/deck/deck-settings/index.vue
@@ -138,13 +138,13 @@ async function onClose() {
 }
 
 function onBack() {
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   active_page.value = null
 }
 
 function onChromeBack() {
   if (active_page_ref.value?.onChromeBack?.()) {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     return
   }
   onBack()

--- a/src/views/deck/deck-settings/tab-design/card-designer/align-picker.vue
+++ b/src/views/deck/deck-settings/tab-design/card-designer/align-picker.vue
@@ -38,7 +38,7 @@ function onSelect(h: Horizontal, v: Vertical) {
     emitSfx('ui.deselect')
     return
   }
-  emitSfx('etc_camera_shutter')
+  emitSfx('ui.select')
   // center/center is the implicit default — store undefined so the dirty check
   // treats it identically to the initial unset state.
   const is_default = h === 'center' && v === 'center'

--- a/src/views/deck/deck-settings/tab-design/card-designer/align-picker.vue
+++ b/src/views/deck/deck-settings/tab-design/card-designer/align-picker.vue
@@ -35,7 +35,7 @@ function isActive(h: Horizontal, v: Vertical) {
 
 function onSelect(h: Horizontal, v: Vertical) {
   if (isActive(h, v)) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.deselect')
     return
   }
   emitSfx('etc_camera_shutter')

--- a/src/views/deck/deck-settings/tab-design/card-designer/align-picker.vue
+++ b/src/views/deck/deck-settings/tab-design/card-designer/align-picker.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import UiIcon from '@/components/ui-kit/icon.vue'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 
 type Horizontal = 'left' | 'center' | 'right'
 type Vertical = 'top' | 'center' | 'bottom'
@@ -58,7 +57,7 @@ function onSelect(h: Horizontal, v: Vertical) {
         :data-active="isActive(h, v)"
         class="aspect-square flex items-center justify-center rounded-5 cursor-pointer text-ink-muted data-[active=true]:bg-(--color-accent) data-[active=true]:text-(--color-on-accent) data-[active=true]:bgx-diagonal-stripes data-[active=true]:bgx-opacity-10 data-[active=false]:hover:bg-(--color-accent) data-[active=false]:hover:text-(--color-on-accent) data-[active=false]:hover:bgx-diagonal-stripes data-[active=false]:hover:bgx-opacity-10"
         @click="onSelect(h, v)"
-        v-sfx="{ hover: TYPE_SFX }"
+        v-sfx="{ hover: 'ui.hover' }"
       >
         <ui-icon :src="isActive(h, v) ? ICONS[v][h] : 'dot'" />
       </button>

--- a/src/views/deck/deck-settings/tab-design/card-designer/image-layout-picker.vue
+++ b/src/views/deck/deck-settings/tab-design/card-designer/image-layout-picker.vue
@@ -16,11 +16,11 @@ const selected = computed(() => layout.value ?? CARD_ATTRIBUTES_DEFAULTS.image_l
 
 function onSelect(value: CardImageLayout) {
   if (selected.value === value) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.deselect')
     return
   }
 
-  emitSfx('select')
+  emitSfx('ui.select')
   layout.value = value
 }
 </script>

--- a/src/views/deck/deck-settings/tab-design/card-designer/image-layout-picker.vue
+++ b/src/views/deck/deck-settings/tab-design/card-designer/image-layout-picker.vue
@@ -5,7 +5,6 @@ import Card from '@/components/card/index.vue'
 import LayoutSkeleton from './layout-skeleton.vue'
 import { CARD_ATTRIBUTES_DEFAULTS } from '@/utils/deck/defaults'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 
 const layout = defineModel<CardImageLayout | undefined>('layout')
 
@@ -36,7 +35,7 @@ function onSelect(value: CardImageLayout) {
       :data-active="selected === option"
       class="group relative flex cursor-pointer flex-col items-center gap-2 rounded-8 p-2 transition-colors hover:bg-raised-shade hover:bgx-diagonal-stripes hover:bgx-opacity-10 data-[active=true]:bg-(--color-accent) data-[active=true]:bgx-diagonal-stripes data-[active=true]:bgx-opacity-10"
       @click="onSelect(option)"
-      v-sfx="{ hover: selected === option ? undefined : TYPE_SFX }"
+      v-sfx="{ hover: selected === option ? undefined : 'ui.hover' }"
     >
       <card class="w-(--card-w-2xs)" side="front">
         <template #front>

--- a/src/views/deck/deck-settings/tab-design/card-designer/index.vue
+++ b/src/views/deck/deck-settings/tab-design/card-designer/index.vue
@@ -24,7 +24,7 @@ const text_size = computed({
       : CARD_ATTRIBUTES_DEFAULTS.text_size,
   set: (value: number) => {
     attributes.text_size = value
-    emitSfx('select')
+    emitSfx('ui.select')
   }
 })
 </script>

--- a/src/views/deck/deck-settings/tab-review-pacing/advanced-reveal.vue
+++ b/src/views/deck/deck-settings/tab-review-pacing/advanced-reveal.vue
@@ -36,7 +36,7 @@ function toggleRevealed() {
   if (!scrim.value || !badge_content.value || !fields.value) return
 
   revealed.value = !revealed.value
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   popScrimReveal(scrim.value, badge_content.value, fields.value, revealed.value, {
     collapse: is_phone.value
   })

--- a/src/views/deck/deck-settings/tab-review-pacing/field-row.vue
+++ b/src/views/deck/deck-settings/tab-review-pacing/field-row.vue
@@ -28,7 +28,7 @@ const { t } = useI18n()
       size="sm"
       icon-only
       icon-left="refresh"
-      :sfx="{ press: 'snappy_button_5' }"
+      :sfx="{ press: 'ui.press' }"
       @press="field?.reset()"
       class="absolute! -left-8"
     >

--- a/src/views/deck/deck-settings/tab-review-pacing/preset-chip.vue
+++ b/src/views/deck/deck-settings/tab-review-pacing/preset-chip.vue
@@ -66,7 +66,7 @@ const options = computed<DropdownOption[]>(() => [
 ])
 
 function onSelect(option: DropdownOption) {
-  emitSfx('select')
+  emitSfx('ui.select')
 
   const action = ACTION_HANDLERS[option.value as PresetAction]
   if (action) return void action()

--- a/src/views/deck/deck-settings/tab-review-pacing/preset-header.vue
+++ b/src/views/deck/deck-settings/tab-review-pacing/preset-header.vue
@@ -45,7 +45,7 @@ const divergence_label = computed(() =>
               size="sm"
               icon-only
               icon-left="refresh"
-              :sfx="{ press: 'snappy_button_5' }"
+              :sfx="{ press: 'ui.press' }"
               @press="resetAllOverrides"
             >
               {{ t('deck.settings-modal.review-pacing.reset-all') }}

--- a/src/views/deck/deck-settings/tab-review-pacing/use-preset-actions.ts
+++ b/src/views/deck/deck-settings/tab-review-pacing/use-preset-actions.ts
@@ -161,7 +161,7 @@ export function usePresetActions(pacing: PacingFields, editor: DeckEditor): Pres
         named: { name: preset.name, count: other_follower_count.value }
       }),
       confirmLabel: t('alert.delete-preset.confirm'),
-      confirmAudio: 'trash_crumple_short'
+      confirmAudio: 'card.delete'
     }).response
     if (!confirmed) return
 

--- a/src/views/deck/deck-settings/window-chrome.ts
+++ b/src/views/deck/deck-settings/window-chrome.ts
@@ -26,7 +26,7 @@ export function useWindowChrome(
   async function tuck() {
     if (is_tucked.value) return
 
-    emitSfx('slide_up')
+    emitSfx('nav.page-forward')
     await Promise.all([
       preview.value && tuckPinnedPreview(preview.value, () => (is_tucked.value = true)),
       aside.value && retractAside(aside.value)
@@ -38,7 +38,7 @@ export function useWindowChrome(
   async function restore() {
     if (!is_tucked.value) return
 
-    emitSfx('slide_up')
+    emitSfx('nav.page-forward')
     await Promise.all([
       preview.value && untuckPinnedPreview(preview.value, () => (is_tucked.value = false)),
       aside.value && restoreAside(aside.value)

--- a/src/views/deck/mobile-editor/editor-controls.vue
+++ b/src/views/deck/mobile-editor/editor-controls.vue
@@ -21,7 +21,7 @@ const { has_prev, has_next, flip, prev, next } = inject(mobileCardEditorKey)!
       icon-left="chevron-left"
       size="xl"
       :disabled="!has_prev"
-      :sfx="{ press: 'transition_down' }"
+      :sfx="{ press: 'card.flip-back' }"
       @press="prev"
     >
       {{ t('deck-view.mobile-editor.prev-button') }}
@@ -46,7 +46,7 @@ const { has_prev, has_next, flip, prev, next } = inject(mobileCardEditorKey)!
       icon-left="chevron-right"
       size="xl"
       :disabled="!has_next"
-      :sfx="{ press: 'transition_up' }"
+      :sfx="{ press: 'card.flip-away' }"
       @press="next"
     >
       {{ t('deck-view.mobile-editor.next-button') }}

--- a/src/views/deck/mobile-editor/editor-controls.vue
+++ b/src/views/deck/mobile-editor/editor-controls.vue
@@ -33,7 +33,7 @@ const { has_prev, has_next, flip, prev, next } = inject(mobileCardEditorKey)!
       icon-left="card-flip"
       full-width
       size="xl"
-      :sfx="{ tap_pre: 'snappy_button_5' }"
+      :sfx="{ tap_pre: 'ui.press' }"
       @press="flip"
     >
       {{ t('deck-view.mobile-editor.flip-button') }}

--- a/src/views/deck/mobile-editor/use-mobile-card-editor.ts
+++ b/src/views/deck/mobile-editor/use-mobile-card-editor.ts
@@ -52,7 +52,7 @@ export function useMobileCardEditor(controller: CardListController) {
     cursor_client_id.value = target
     side.value = 'front'
     is_open.value = true
-    emitSfx('snappy_button_3')
+    emitSfx('dialog.open')
 
     if (close_modal) return
 
@@ -80,12 +80,12 @@ export function useMobileCardEditor(controller: CardListController) {
   function onClosed() {
     close_modal = null
     is_open.value = false
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
   }
 
   function flip() {
     side.value = side.value === 'front' ? 'back' : 'front'
-    emitSfx(side.value === 'back' ? 'transition_up' : 'transition_down')
+    emitSfx(side.value === 'back' ? 'card.flip-away' : 'card.flip-back')
   }
 
   // Always lands on the front, so each card opens the same way.

--- a/src/views/deck/search-bar.vue
+++ b/src/views/deck/search-bar.vue
@@ -61,7 +61,7 @@ function submit() {
 
 // Empty the field but stay in search mode, dropping back to the full list.
 function clear() {
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   draft.value = ''
   query.value = ''
   input.value?.focus()

--- a/src/views/settings/account-access/account-access-menu.vue
+++ b/src/views/settings/account-access/account-access-menu.vue
@@ -40,7 +40,7 @@ function onGooglePress() {
       {{ t('account-access-modal.description') }}
     </p>
 
-    <ui-options-panel :entries="entries" :sfx="{ press: 'snappy_button_5' }" @select="onSelect" />
+    <ui-options-panel :entries="entries" :sfx="{ press: 'ui.press' }" @select="onSelect" />
 
     <ui-button
       neutral

--- a/src/views/settings/account-access/index.vue
+++ b/src/views/settings/account-access/index.vue
@@ -13,7 +13,7 @@ const { t } = useI18n()
 const page = ref<AccountAccessContentPage>('menu')
 const content = useTemplateRef<{ title: string }>('content')
 
-onMounted(() => emitSfx('dialog.open'))
+onMounted(() => emitSfx('dialog.open-chime'))
 onBeforeUnmount(() => emitSfx('dialog.close'))
 </script>
 

--- a/src/views/settings/account-access/index.vue
+++ b/src/views/settings/account-access/index.vue
@@ -13,7 +13,7 @@ const { t } = useI18n()
 const page = ref<AccountAccessContentPage>('menu')
 const content = useTemplateRef<{ title: string }>('content')
 
-onMounted(() => emitSfx('wooden_chime_ring'))
+onMounted(() => emitSfx('dialog.open'))
 onBeforeUnmount(() => emitSfx('dialog.close'))
 </script>
 
@@ -44,7 +44,7 @@ onBeforeUnmount(() => emitSfx('dialog.close'))
         icon-left="arrow-back"
         icon-only
         rounded-full
-        :sfx="{ press: 'snappy_button_5' }"
+        :sfx="{ press: 'ui.press' }"
         @press="page = 'menu'"
       >
         {{ t('account-access-modal.back-label') }}

--- a/src/views/settings/account-access/index.vue
+++ b/src/views/settings/account-access/index.vue
@@ -14,7 +14,7 @@ const page = ref<AccountAccessContentPage>('menu')
 const content = useTemplateRef<{ title: string }>('content')
 
 onMounted(() => emitSfx('wooden_chime_ring'))
-onBeforeUnmount(() => emitSfx('pop_up_close'))
+onBeforeUnmount(() => emitSfx('dialog.close'))
 </script>
 
 <template>

--- a/src/views/settings/account-access/success-panel.vue
+++ b/src/views/settings/account-access/success-panel.vue
@@ -14,7 +14,7 @@ defineProps<{
 
 const { t } = useI18n()
 
-onMounted(() => emitSfx('success_1'))
+onMounted(() => emitSfx('notice.success'))
 </script>
 
 <template>

--- a/src/views/settings/account-access/success-panel.vue
+++ b/src/views/settings/account-access/success-panel.vue
@@ -31,7 +31,7 @@ onMounted(() => emitSfx('notice.success'))
       data-testid="account-access-success-panel__close"
       size="xl"
       full-width
-      :sfx="{ press: 'snappy_button_5' }"
+      :sfx="{ press: 'ui.press' }"
       @press="close"
     >
       {{ t('dialog-card.close-label') }}

--- a/src/views/settings/account-access/use-email-actions.ts
+++ b/src/views/settings/account-access/use-email-actions.ts
@@ -44,7 +44,7 @@ export function useEmailActions() {
 
   async function submit(): Promise<SubmitResult> {
     if (!validate()) {
-      emitSfx('etc_woodblock_stuck')
+      emitSfx('notice.error')
       return 'invalid'
     }
 
@@ -57,7 +57,7 @@ export function useEmailActions() {
       return 'success'
     }
 
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
 
     if (outcome === 'email-taken') {
       error.value = t('account-access-modal.email.validation-taken')

--- a/src/views/settings/account-access/use-password-actions.ts
+++ b/src/views/settings/account-access/use-password-actions.ts
@@ -56,7 +56,7 @@ export function usePasswordActions() {
   }
 
   function fail(field: FieldName, message: string): SubmitResult {
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
     errors.value = { ...errors.value, [field]: message }
     return 'invalid'
   }
@@ -82,7 +82,7 @@ export function usePasswordActions() {
       return fail('password', t('account-access-modal.password.validation-same'))
     }
 
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
     notice.error(t('account-access-modal.password.error'))
     return 'error'
   }
@@ -96,7 +96,7 @@ export function usePasswordActions() {
     }
 
     if (outcome === 'error') {
-      emitSfx('etc_woodblock_stuck')
+      emitSfx('notice.error')
       notice.error(t('account-access-modal.password.error'))
       return 'error'
     }
@@ -109,13 +109,13 @@ export function usePasswordActions() {
     const outcome = await session.requestReauthCode()
 
     if (outcome === 'rate-limited') {
-      emitSfx('etc_woodblock_stuck')
+      emitSfx('notice.error')
       notice.error(t('account-access-modal.password.code-rate-limited'))
       return 'error'
     }
 
     if (outcome === 'error') {
-      emitSfx('etc_woodblock_stuck')
+      emitSfx('notice.error')
       notice.error(t('account-access-modal.password.code-request-error'))
       return 'error'
     }
@@ -136,7 +136,7 @@ export function usePasswordActions() {
     }
 
     if (outcome === 'error') {
-      emitSfx('etc_woodblock_stuck')
+      emitSfx('notice.error')
       notice.error(t('account-access-modal.password.error'))
       return 'error'
     }
@@ -148,7 +148,7 @@ export function usePasswordActions() {
     if (loading.value) return 'invalid'
 
     if (step.value === 'password' && !validate()) {
-      emitSfx('etc_woodblock_stuck')
+      emitSfx('notice.error')
       return 'invalid'
     }
 
@@ -175,7 +175,7 @@ export function usePasswordActions() {
       return
     }
 
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
     notice.error(
       outcome === 'rate-limited'
         ? t('account-access-modal.password.code-rate-limited')

--- a/src/views/settings/index.vue
+++ b/src/views/settings/index.vue
@@ -85,8 +85,8 @@ const groups = computed<PagedWindowGroup[]>(() => [
 const header_title = computed(() => t('settings.header.title'))
 
 // Open/close sfx live here, not per-callsite, so every launcher sounds identical — mirrors the deck-settings modal.
-onMounted(() => emitSfx('snappy_button_3'))
-onBeforeUnmount(() => emitSfx('pop_up_close'))
+onMounted(() => emitSfx('dialog.open'))
+onBeforeUnmount(() => emitSfx('dialog.close'))
 
 async function onClose() {
   if (!editor.is_dirty.value) return close()
@@ -103,13 +103,13 @@ async function onClose() {
 useModalRequestClose(onClose)
 
 function onBack() {
-  emitSfx('snappy_button_5')
+  emitSfx('ui.press')
   active_page.value = null
 }
 
 function onChromeBack() {
   if (active_page_ref.value?.onChromeBack?.()) {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     return
   }
   onBack()

--- a/src/views/settings/settings-save-button.vue
+++ b/src/views/settings/settings-save-button.vue
@@ -53,7 +53,7 @@ function onReset() {
       size="lg"
       icon-only
       icon-left="refresh"
-      :sfx="{ press: 'snappy_button_5' }"
+      :sfx="{ press: 'ui.press' }"
       :disabled="!is_dirty"
       click-when-disabled
       class="shrink-0"
@@ -69,7 +69,7 @@ function onReset() {
       class="flex-1!"
       :loading="is_saving"
       :disabled="!is_dirty || !has_name"
-      :sfx="{ press: 'snappy_button_2' }"
+      :sfx="{ press: 'ui.press' }"
       click-when-disabled
       @press="onSave"
     >

--- a/src/views/settings/settings-save-button.vue
+++ b/src/views/settings/settings-save-button.vue
@@ -17,7 +17,7 @@ const is_saving = ref(false)
 async function onSave() {
   if (!has_name.value) {
     name_error.value = t('settings.profile.member-name-required')
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
     return
   }
   is_saving.value = true
@@ -30,7 +30,7 @@ async function onSave() {
   }
   if (outcome === 'duplicate-name') {
     name_error.value = t('settings.profile.member-name-duplicate-error')
-    emitSfx('etc_woodblock_stuck')
+    emitSfx('notice.error')
     return
   }
   notice.error(t('settings.save-error'))
@@ -38,7 +38,7 @@ async function onSave() {
 
 function onReset() {
   if (!is_dirty.value) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.rejected')
     return
   }
   resetChanges()

--- a/src/views/settings/tab-app/audio-section.vue
+++ b/src/views/settings/tab-app/audio-section.vue
@@ -5,13 +5,12 @@ import UiSlider from '@/components/ui-kit/slider.vue'
 import UiToggle from '@/components/ui-kit/toggle.vue'
 import LabeledSection from '@/components/layout-kit/labeled-section.vue'
 import { memberEditorKey } from '@/composables/member/editor'
-import { toBusVolumes } from '@/utils/member/preferences'
-import audio_player from '@/sfx/player'
+import { discardVolumePreview, previewMemberVolumes } from '@/sfx/volume-seam'
 
 const { t } = useI18n()
 const editor = inject(memberEditorKey)!
 
-onBeforeUnmount(() => audio_player.resetSettings())
+onBeforeUnmount(() => discardVolumePreview())
 
 // Only the sliders live-preview — mute is excluded, so the preview always plays unmuted; mute itself applies on save via App.vue.
 watch(
@@ -20,7 +19,7 @@ watch(
     editor.draft.preferences.audio.hover_sounds
   ],
   ([interface_sounds, hover_sounds]) =>
-    audio_player.previewVolumeConfig(toBusVolumes({ muted: false, interface_sounds, hover_sounds }))
+    previewMemberVolumes({ muted: false, interface_sounds, hover_sounds })
 )
 </script>
 
@@ -39,14 +38,14 @@ watch(
         :min="0"
         :max="10"
         :label="t('settings.app.audio.interface-sounds')"
-        :sfx="{ bus: 'interface' }"
+        preview_bus="interface"
       />
       <ui-slider
         v-model="editor.draft.preferences.audio.hover_sounds"
         :min="0"
         :max="10"
         :label="t('settings.app.audio.hover-sounds')"
-        :sfx="{ bus: 'hover' }"
+        preview_bus="hover"
       />
     </div>
   </labeled-section>

--- a/src/views/settings/tab-subscription/paid-features.vue
+++ b/src/views/settings/tab-subscription/paid-features.vue
@@ -4,7 +4,6 @@ import { PLANS } from '@/config/plans'
 import { useUpgradeClick } from './use-upgrade-click'
 import UiTappable from '@/components/ui-kit/tappable.vue'
 import UiButton from '@/components/ui-kit/button.vue'
-import { TYPE_SFX } from '@/sfx/config'
 
 const { t } = useI18n()
 const { onUpgradeClick } = useUpgradeClick()
@@ -18,7 +17,7 @@ const price = `$${PLANS.paid.monthlyPriceUsd} / mo`
   <div data-testid="paid-features" class="relative">
     <ui-tappable
       data-testid="paid-features__body"
-      :sfx="{ hover: TYPE_SFX }"
+      :sfx="{ hover: 'ui.hover' }"
       class="card-outline w-full flex flex-col gap-3 rounded-4 px-5 py-4 text-ink bg-raised pointer-fine:hover:scale-101 data-[tap-active=true]:scale-101 pointer-coarse:data-[tap-active=true]:scale-105 pointer-fine:transition-transform duration-75 cursor-pointer touch-manipulation"
       @tap="onUpgradeClick"
     >

--- a/src/views/settings/tab-subscription/use-change-cc.ts
+++ b/src/views/settings/tab-subscription/use-change-cc.ts
@@ -27,7 +27,7 @@ export function useChangeCard(close: (response?: ChangeCardResponse) => void) {
     }
   })
 
-  onMounted(() => emitSfx('dialog.open'))
+  onMounted(() => emitSfx('dialog.open-chime'))
   onBeforeUnmount(() => emitSfx('dialog.close'))
 
   async function onSubmit() {

--- a/src/views/settings/tab-subscription/use-change-cc.ts
+++ b/src/views/settings/tab-subscription/use-change-cc.ts
@@ -27,7 +27,7 @@ export function useChangeCard(close: (response?: ChangeCardResponse) => void) {
     }
   })
 
-  onMounted(() => emitSfx('wooden_chime_ring'))
+  onMounted(() => emitSfx('dialog.open'))
   onBeforeUnmount(() => emitSfx('dialog.close'))
 
   async function onSubmit() {

--- a/src/views/settings/tab-subscription/use-change-cc.ts
+++ b/src/views/settings/tab-subscription/use-change-cc.ts
@@ -28,7 +28,7 @@ export function useChangeCard(close: (response?: ChangeCardResponse) => void) {
   })
 
   onMounted(() => emitSfx('wooden_chime_ring'))
-  onBeforeUnmount(() => emitSfx('pop_up_close'))
+  onBeforeUnmount(() => emitSfx('dialog.close'))
 
   async function onSubmit() {
     // A failed outcome is left unhandled here — Stripe's own Payment Element renders the decline/validation message inline.

--- a/src/views/study-session/composables/card-preview.ts
+++ b/src/views/study-session/composables/card-preview.ts
@@ -47,7 +47,7 @@ export function useCardPreview(next_card: ComputedRef<StudyCard | undefined>) {
    * runs through here.
    */
   function awaitFlip(side: 'front' | 'back') {
-    emitSfx('slide_up')
+    emitSfx('nav.page-forward')
     next_card_side.value = side
     return new Promise<void>((resolve) => {
       resolveFlip = resolve

--- a/src/views/study-session/composables/session-engine.ts
+++ b/src/views/study-session/composables/session-engine.ts
@@ -178,7 +178,7 @@ export function useSessionEngine({
 
   /** Transitions from the cover into the active session. `silent` skips the start jingle (refresh-restore). */
   function startSession({ silent = false }: { silent?: boolean } = {}) {
-    if (!silent) emitSfx('music_plink_chordyes')
+    if (!silent) emitSfx('session.intro')
     current_card_side.value = active_starting_side.value
     state.value = 'studying'
   }

--- a/src/views/study-session/composables/session-engine.ts
+++ b/src/views/study-session/composables/session-engine.ts
@@ -200,7 +200,7 @@ export function useSessionEngine({
   }
 
   function flipCurrentCard() {
-    emitSfx(is_starting_side.value ? 'transition_up' : 'transition_down')
+    emitSfx(is_starting_side.value ? 'card.flip-away' : 'card.flip-back')
     current_card_side.value = current_card_side.value === 'front' ? 'back' : 'front'
   }
 

--- a/src/views/study-session/composables/session-prefs.ts
+++ b/src/views/study-session/composables/session-prefs.ts
@@ -105,7 +105,7 @@ export function useSessionPrefs() {
   )
 
   function toggleRatings() {
-    emitSfx('snappy_button_5')
+    emitSfx('ui.press')
     show_all_ratings.value = !show_all_ratings.value
   }
 

--- a/src/views/study-session/composables/study-modal.ts
+++ b/src/views/study-session/composables/study-modal.ts
@@ -12,7 +12,7 @@ export function useStudyModal() {
    * ids (and a refresh-resume can reopen from persisted ids alone).
    */
   function start(deck_ids: number[]) {
-    emitSfx('generic_notification_9')
+    emitSfx('notice.info')
     return modal.open(StudySession, {
       backdrop: true,
       mode: 'popup',

--- a/src/views/study-session/composables/summary-selection.ts
+++ b/src/views/study-session/composables/summary-selection.ts
@@ -81,7 +81,7 @@ export function useSummarySelection({
   function onSelectCard(id?: number) {
     if (id !== undefined) selection.toggleSelectCard(id)
     selection.enterSelection()
-    emitSfx('select')
+    emitSfx('ui.select')
   }
 
   async function onDeleteSelected() {

--- a/src/views/study-session/index.vue
+++ b/src/views/study-session/index.vue
@@ -93,7 +93,7 @@ useModalRequestClose(onRequestClose)
 
 /** Early close (close button / backdrop / esc before any review). */
 function onClosed() {
-  emitSfx('pop_up_close')
+  emitSfx('dialog.close')
   clearPersistedSession()
   close()
 }
@@ -175,10 +175,10 @@ function onRequestClose() {
  */
 function onToggleSummarySelecting() {
   if (summary_selection.is_selecting.value) {
-    emitSfx('digi_powerdown')
+    emitSfx('ui.deselect')
     summary_selection.exitSelection()
   } else {
-    emitSfx('select')
+    emitSfx('ui.select')
     summary_selection.enterSelection()
   }
 }

--- a/src/views/study-session/index.vue
+++ b/src/views/study-session/index.vue
@@ -101,9 +101,9 @@ function onClosed() {
 function onPaneEnterStart() {
   // Only the summary's first arrival gets the session-complete jingle; every other swap gets a light click.
   const enter_sfx = {
-    settings: 'snappy_button_3',
-    studying: 'snappy_button_2',
-    'summary-category': 'snappy_button_3'
+    settings: 'dialog.open',
+    studying: 'ui.press',
+    'summary-category': 'dialog.open'
   } as const
 
   if (current_page.value !== 'summary') {
@@ -111,7 +111,7 @@ function onPaneEnterStart() {
     return
   }
 
-  emitSfx(summary_seen.value ? 'snappy_button_2' : 'music_pizz_duo_hi')
+  emitSfx(summary_seen.value ? 'ui.press' : 'session.complete')
   summary_seen.value = true
 }
 
@@ -243,7 +243,7 @@ function onToggleSummarySelecting() {
         full-width
         size="xl"
         class="mx-auto max-w-95"
-        :sfx="{ press: 'slide_up' }"
+        :sfx="{ press: 'nav.page-forward' }"
         @press="onClosed"
       >
         {{ t('session-summary.close-button') }}

--- a/src/views/study-session/session-settings/index.vue
+++ b/src/views/study-session/session-settings/index.vue
@@ -133,7 +133,7 @@ const ordering_options = computed(() => [
       size="lg"
       full-width
       :disabled="prefs_are_default"
-      :sfx="{ press: 'snappy_button_5' }"
+      :sfx="{ press: 'ui.press' }"
       @press="resetToDefaults"
     >
       {{ t('study-session.settings.reset-button') }}

--- a/src/views/study-session/session-studying/card/study-card.vue
+++ b/src/views/study-session/session-studying/card/study-card.vue
@@ -135,7 +135,7 @@ function flingCard(
   el.style.transform = `translateX(${targetX}px) rotate(${direction * 45}deg)`
   emit('drag-progress', 1, FLING_SPEED)
 
-  emitSfx(grade === Rating.Again ? 'music_plink_locancel' : 'music_plink_ok')
+  emitSfx(grade === Rating.Again ? 'card.grade-again' : 'card.grade-good')
 
   // Leave is_animating true — this instance stays mounted through the parent's next-card intro flip, and the flag guards it from a spam re-fling.
   const onTransitionEnd = () => {
@@ -151,7 +151,7 @@ function flingCard(
 function handleDrag(el: HTMLElement, dx: number, dy: number) {
   if (side === 'cover') return
 
-  if (toSwipeZone(card_offset.value) !== toSwipeZone(dx)) emitSfx('music_plink_mid')
+  if (toSwipeZone(card_offset.value) !== toSwipeZone(dx)) emitSfx('gesture.zone-cross')
 
   is_dragging.value = Math.abs(dx) > FLIP_THRESHOLD
   card_offset.value = dx
@@ -166,7 +166,7 @@ function updateDragRating(dx: number, dy: number) {
   if (show_all_ratings && dx > SWIPE_DISTANCE_THRESHOLD) {
     const new_rating = toDragRating(dy)
     if (new_rating !== drag_rating.value) {
-      emitSfx('music_plink_mid')
+      emitSfx('gesture.zone-cross')
       drag_rating.value = new_rating
     }
   } else {

--- a/src/views/study-session/session-studying/rating-buttons/advanced.vue
+++ b/src/views/study-session/session-studying/rating-buttons/advanced.vue
@@ -53,7 +53,7 @@ const success_options = computed<ButtonGroupOption[]>(() => {
       :icon-left="preview_on ? undefined : 'dislike'"
       class="shrink-0"
       :active="primed_grade === Rating.Again"
-      :sfx="{ tap_pre: 'snappy_button_5' }"
+      :sfx="{ tap_pre: 'ui.press' }"
       @press="emit('rated', Rating.Again)"
     >
       {{ preview_on ? rating_times.bare[Rating.Again] : t('study.flashcard.rating.again-button') }}
@@ -66,7 +66,7 @@ const success_options = computed<ButtonGroupOption[]>(() => {
       :options="success_options"
       :icon_only="is_mobile && !preview_on"
       :active_value="primed_grade ?? undefined"
-      :sfx="{ tap_pre: 'snappy_button_5' }"
+      :sfx="{ tap_pre: 'ui.press' }"
       @press="emit('rated', $event as Grade)"
     />
   </div>

--- a/src/views/study-session/session-studying/rating-buttons/index.vue
+++ b/src/views/study-session/session-studying/rating-buttons/index.vue
@@ -26,7 +26,7 @@ const { display_side, show_all_ratings, show_rating_buttons, loading } =
       full-width
       :loading="loading"
       :disabled="loading"
-      :sfx="{ tap_pre: 'snappy_button_5' }"
+      :sfx="{ tap_pre: 'ui.press' }"
       @press="emit('started')"
     >
       {{ t('study.flashcard.start-button') }}

--- a/src/views/study-session/session-studying/rating-buttons/simple.vue
+++ b/src/views/study-session/session-studying/rating-buttons/simple.vue
@@ -30,7 +30,7 @@ const preview_on = computed(
       icon-left="dislike"
       full-width
       :active="primed_grade === Rating.Again"
-      :sfx="{ tap_pre: 'snappy_button_5' }"
+      :sfx="{ tap_pre: 'ui.press' }"
       @press="emit('rated', Rating.Again)"
     >
       {{ preview_on ? rating_times.bare[Rating.Again] : t('study.flashcard.rating.fail-button') }}
@@ -43,7 +43,7 @@ const preview_on = computed(
       icon-left="like"
       full-width
       :active="primed_grade === Rating.Good"
-      :sfx="{ tap_pre: 'snappy_button_5' }"
+      :sfx="{ tap_pre: 'ui.press' }"
       @press="emit('rated', Rating.Good)"
     >
       {{ preview_on ? rating_times.bare[Rating.Good] : t('study.flashcard.rating.pass-button') }}

--- a/src/views/study-session/session-studying/study-edit-footer.vue
+++ b/src/views/study-session/session-studying/study-edit-footer.vue
@@ -14,7 +14,7 @@ function onFlip(e: MouseEvent) {
 }
 
 function onDone(e: MouseEvent) {
-  tapDone(stopEdit, { audio: 'music_plink_ok' })(e)
+  tapDone(stopEdit, { audio: 'dialog.confirm' })(e)
 }
 </script>
 

--- a/src/views/study-session/session-studying/study-edit-footer.vue
+++ b/src/views/study-session/session-studying/study-edit-footer.vue
@@ -9,7 +9,7 @@ const { playing: done_playing, tap: tapDone } = useStagedTap({ triggerAt: 'press
 
 function onFlip(e: MouseEvent) {
   tapFlip(flipCurrentCard, {
-    audio: is_starting_side.value ? 'transition_up' : 'transition_down'
+    audio: is_starting_side.value ? 'card.flip-away' : 'card.flip-back'
   })(e)
 }
 

--- a/src/views/study-session/session-summary/bulk-actions-bar.vue
+++ b/src/views/study-session/session-summary/bulk-actions-bar.vue
@@ -28,7 +28,7 @@ const select_all_label = computed(() =>
  * `useBulkActions.onToggleSelectAll`.
  */
 function onToggleSelectAll() {
-  emitSfx('select')
+  emitSfx('ui.select')
   if (selection.all_cards_selected.value) selection.clearSelectedCards()
   else selectAllSummaryCards()
 }

--- a/src/views/study-session/session-summary/category-page/summary-card-editor.vue
+++ b/src/views/study-session/session-summary/category-page/summary-card-editor.vue
@@ -18,12 +18,12 @@ const { t } = useI18n()
 const side = ref<'front' | 'back'>('front')
 
 function onFlip() {
-  emitSfx(side.value === 'front' ? 'transition_up' : 'transition_down')
+  emitSfx(side.value === 'front' ? 'card.flip-away' : 'card.flip-back')
   side.value = side.value === 'front' ? 'back' : 'front'
 }
 
 function onDone() {
-  emitSfx('music_plink_ok')
+  emitSfx('dialog.confirm')
   emit('done')
 }
 </script>

--- a/src/views/study-session/session-summary/category-page/summary-card.vue
+++ b/src/views/study-session/session-summary/category-page/summary-card.vue
@@ -10,7 +10,6 @@ import { useDeckResolution } from '@/views/study-session/deck-resolution'
 import { useInjectedStudySessionController } from '@/views/study-session/composables/session-controller'
 import { usePressHold } from '@/composables/ui/press-hold'
 import { emitSfx } from '@/sfx/bus'
-import { TYPE_SFX } from '@/sfx/config'
 import type { StudyCard } from '@/views/study-session/composables/session-engine'
 
 type SummaryCardProps = { card: StudyCard }
@@ -76,7 +75,7 @@ function onCardClick() {
   <div
     data-testid="session-summary__card"
     class="group relative w-full"
-    v-sfx="{ hover: is_selecting ? TYPE_SFX : undefined }"
+    v-sfx="{ hover: is_selecting ? 'ui.hover' : undefined }"
     @mouseenter="is_hovering = true"
     @mouseleave="is_hovering = false"
     @pointerdown="onPointerdown"

--- a/src/views/study-session/session-summary/category-page/summary-card.vue
+++ b/src/views/study-session/session-summary/category-page/summary-card.vue
@@ -66,7 +66,7 @@ function onCardClick() {
     return
   }
 
-  emitSfx(side.value === 'front' ? 'transition_up' : 'transition_down')
+  emitSfx(side.value === 'front' ? 'card.flip-away' : 'card.flip-back')
   side.value = side.value === 'front' ? 'back' : 'front'
 }
 </script>

--- a/src/views/study-session/session-summary/stats-panel.vue
+++ b/src/views/study-session/session-summary/stats-panel.vue
@@ -45,7 +45,7 @@ function labelFor(key: SummaryCategory) {
     data-testid="session-summary__stats"
     :entries="entries"
     size="lg"
-    :sfx="{ press: 'snappy_button_5' }"
+    :sfx="{ press: 'ui.press' }"
     @select="emit('select', $event as SummaryCategory)"
   />
 </template>

--- a/src/views/welcome/forgot-password/index.vue
+++ b/src/views/welcome/forgot-password/index.vue
@@ -15,7 +15,7 @@ const { t } = useI18n()
 const auth = useForgotPasswordActions()
 
 onMounted(() => emitSfx('wooden_chime_ring'))
-onBeforeUnmount(() => emitSfx('pop_up_close'))
+onBeforeUnmount(() => emitSfx('dialog.close'))
 
 async function onSubmit() {
   await auth.submit()

--- a/src/views/welcome/forgot-password/index.vue
+++ b/src/views/welcome/forgot-password/index.vue
@@ -14,7 +14,7 @@ const { t } = useI18n()
 
 const auth = useForgotPasswordActions()
 
-onMounted(() => emitSfx('wooden_chime_ring'))
+onMounted(() => emitSfx('dialog.open'))
 onBeforeUnmount(() => emitSfx('dialog.close'))
 
 async function onSubmit() {

--- a/src/views/welcome/forgot-password/index.vue
+++ b/src/views/welcome/forgot-password/index.vue
@@ -14,7 +14,7 @@ const { t } = useI18n()
 
 const auth = useForgotPasswordActions()
 
-onMounted(() => emitSfx('dialog.open'))
+onMounted(() => emitSfx('dialog.open-chime'))
 onBeforeUnmount(() => emitSfx('dialog.close'))
 
 async function onSubmit() {

--- a/src/views/welcome/forgot-password/success.vue
+++ b/src/views/welcome/forgot-password/success.vue
@@ -33,7 +33,7 @@ onMounted(() => emitSfx('notice.success'))
       data-testid="forgot-password-modal__success-close"
       size="xl"
       full-width
-      :sfx="{ press: 'snappy_button_5' }"
+      :sfx="{ press: 'ui.press' }"
       @press="close"
     >
       {{ t('dialog-card.close-label') }}

--- a/src/views/welcome/forgot-password/success.vue
+++ b/src/views/welcome/forgot-password/success.vue
@@ -9,7 +9,7 @@ defineProps<{ close: () => void }>()
 
 const { t } = useI18n()
 
-onMounted(() => emitSfx('success_1'))
+onMounted(() => emitSfx('notice.success'))
 </script>
 
 <template>

--- a/src/views/welcome/login/login-modal.ts
+++ b/src/views/welcome/login/login-modal.ts
@@ -7,13 +7,13 @@ export function useLoginModal() {
   const modal = useModal()
 
   function open() {
-    emitSfx('snappy_button_3')
+    emitSfx('dialog.open')
     const result = modal.open<boolean>(LoginSheet, {
       backdrop: true,
       mode: 'mobile-sheet',
       mobile_below_width: 'md'
     })
-    result.response.then(() => emitSfx('pop_up_close'))
+    result.response.then(() => emitSfx('dialog.close'))
     return result
   }
 

--- a/src/views/welcome/reset-password/index.vue
+++ b/src/views/welcome/reset-password/index.vue
@@ -23,13 +23,13 @@ const router = useRouter()
 const { password, confirm_password, loading, errors, success, submit } = useResetPasswordActions()
 
 onMounted(() => emitSfx('wooden_chime_ring'))
-onBeforeUnmount(() => emitSfx('pop_up_close'))
+onBeforeUnmount(() => emitSfx('dialog.close'))
 
 async function onSubmit() {
   const result = await submit()
   if (result !== 'success') return
 
-  emitSfx('success_1')
+  emitSfx('notice.success')
   await wait(SUCCESS_DISPLAY_MS)
   close()
   router.push({ name: 'authenticated' })

--- a/src/views/welcome/reset-password/index.vue
+++ b/src/views/welcome/reset-password/index.vue
@@ -22,7 +22,7 @@ const router = useRouter()
 
 const { password, confirm_password, loading, errors, success, submit } = useResetPasswordActions()
 
-onMounted(() => emitSfx('dialog.open'))
+onMounted(() => emitSfx('dialog.open-chime'))
 onBeforeUnmount(() => emitSfx('dialog.close'))
 
 async function onSubmit() {

--- a/src/views/welcome/reset-password/index.vue
+++ b/src/views/welcome/reset-password/index.vue
@@ -22,7 +22,7 @@ const router = useRouter()
 
 const { password, confirm_password, loading, errors, success, submit } = useResetPasswordActions()
 
-onMounted(() => emitSfx('wooden_chime_ring'))
+onMounted(() => emitSfx('dialog.open'))
 onBeforeUnmount(() => emitSfx('dialog.close'))
 
 async function onSubmit() {

--- a/src/views/welcome/section-features/community-callout.vue
+++ b/src/views/welcome/section-features/community-callout.vue
@@ -46,7 +46,7 @@ const { t } = useI18n()
         size="sm"
         icon-left="arrow-down"
         class="self-center sm:self-start"
-        :sfx="{ press: 'snappy_button_5' }"
+        :sfx="{ press: 'ui.press' }"
         @press="seeRoadmap()"
       >
         {{ t('welcome-view.features.callout.roadmap-link') }}

--- a/src/views/welcome/signup/signup-modal.ts
+++ b/src/views/welcome/signup/signup-modal.ts
@@ -10,7 +10,7 @@ export function useSignupModal() {
 
   /** @param payment - preselect the paid plan when the user came from a pricing CTA. */
   function open(payment?: boolean) {
-    emitSfx('snappy_button_3')
+    emitSfx('dialog.open')
     tracking.trackSignupStarted()
     const result = modal.open<boolean>(SignupDialog, {
       backdrop: true,
@@ -19,7 +19,7 @@ export function useSignupModal() {
       mobile_below_height: 'md',
       props: { payment }
     })
-    result.response.then(() => emitSfx('pop_up_close'))
+    result.response.then(() => emitSfx('dialog.close'))
     return result
   }
 

--- a/src/views/welcome/splash/splash-actions.vue
+++ b/src/views/welcome/splash/splash-actions.vue
@@ -24,7 +24,7 @@ const height = useWelcomeHeight()
       v-if="width === 'desktop' || height === 'tall'"
       size="xl"
       icon-left="arrow-down"
-      :sfx="{ press: 'snappy_button_5' }"
+      :sfx="{ press: 'ui.press' }"
       @press="seeMore()"
     >
       {{ t('welcome-view.hero.see-more-button') }}

--- a/src/views/welcome/splash/splash-preview.vue
+++ b/src/views/welcome/splash/splash-preview.vue
@@ -22,7 +22,7 @@ const preview_attributes: DeckCardAttributes = {
 
 function flipPreviewSide(side: CardSide) {
   preview_side.value = side
-  emitSfx('slide_up')
+  emitSfx('nav.page-forward')
 }
 </script>
 

--- a/tests/integration/components/card-actions/move-cards-modal.test.js
+++ b/tests/integration/components/card-actions/move-cards-modal.test.js
@@ -445,7 +445,7 @@ describe('MoveCardsModal', () => {
   test('dialog-card close emits pop_up_close [obligation]', async () => {
     const { wrapper } = mountModal({ cards: [makeCard()] })
     await wrapper.find('[data-testid="move-cards__dialog-close"]').trigger('click')
-    expect(emitSfxMock).toHaveBeenCalledWith('pop_up_close')
+    expect(emitSfxMock).toHaveBeenCalledWith('dialog.close')
   })
 
   // ── onMove failure handling ──────────────────────────────────────────────────

--- a/tests/integration/components/card/face-image-layer.test.js
+++ b/tests/integration/components/card/face-image-layer.test.js
@@ -302,7 +302,7 @@ describe('FaceImageLayer — defineExpose surface', () => {
   test('card_sfx plays a hover chime for a corners (behind) image', () => {
     state.upload.has_image.value = true
     const wrapper = mountLayer({ attributes: { image_layout: 'behind' } })
-    expect(wrapper.vm.card_sfx).toEqual({ hover: 'tap_05' })
+    expect(wrapper.vm.card_sfx).toEqual({ hover: 'ui.hover' })
   })
 
   test('card_sfx is undefined for a region (non-behind) image, so the region dropzone owns the hover chime', () => {
@@ -337,7 +337,7 @@ describe('FaceImageLayer — defineExpose surface', () => {
   test('onRegionPointerEnter plays the hover chime and calls onPointerEnter', () => {
     const wrapper = mountLayer()
     wrapper.vm.onRegionPointerEnter()
-    expect(emitSfxMock).toHaveBeenCalledWith('tap_05')
+    expect(emitSfxMock).toHaveBeenCalledWith('gesture.tick')
     expect(state.upload.onPointerEnter).toHaveBeenCalled()
   })
 })

--- a/tests/integration/components/deck/deck-thumbnail.test.js
+++ b/tests/integration/components/deck/deck-thumbnail.test.js
@@ -1,7 +1,6 @@
 import { describe, test, expect, vi } from 'vite-plus/test'
 import { shallowMount } from '@vue/test-utils'
 import { defineComponent, h, useAttrs } from 'vue'
-import { TYPE_SFX } from '@/sfx/config'
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────────
 
@@ -366,21 +365,21 @@ describe('DeckThumbnail', () => {
   // ── sfx prop spread (obligation 7) ───────────────────────────────────────────
 
   describe('sfx prop — default + override [obligation]', () => {
-    test('passes { hover: TYPE_SFX } to UiTappable when sfx prop is omitted', () => {
+    test('passes { hover: "ui.hover" } to UiTappable when sfx prop is omitted', () => {
       const wrapper = mountWithDeck()
       const sfx = wrapper.findComponent(UiTappableStub).props('sfx')
-      expect(sfx).toEqual({ hover: TYPE_SFX })
+      expect(sfx).toEqual({ hover: 'ui.hover' })
     })
 
     test('merges caller sfx over the default so both hover and custom key are present', () => {
-      const wrapper = mount({ deck: { title: 'X' }, sfx: { press: 'card_drop' } })
+      const wrapper = mount({ deck: { title: 'X' }, sfx: { press: 'ui.press' } })
       const sfx = wrapper.findComponent(UiTappableStub).props('sfx')
-      expect(sfx.hover).toEqual(TYPE_SFX)
-      expect(sfx.press).toBe('card_drop')
+      expect(sfx.hover).toEqual('ui.hover')
+      expect(sfx.press).toBe('ui.press')
     })
 
-    test('caller-supplied hover overrides the TYPE_SFX default', () => {
-      const custom_hover = ['click_04']
+    test('caller-supplied hover overrides the default', () => {
+      const custom_hover = 'ui.select'
       const wrapper = mount({ deck: { title: 'X' }, sfx: { hover: custom_hover } })
       const sfx = wrapper.findComponent(UiTappableStub).props('sfx')
       expect(sfx.hover).toEqual(custom_hover)

--- a/tests/integration/components/feedback/feedback-card.test.js
+++ b/tests/integration/components/feedback/feedback-card.test.js
@@ -125,16 +125,16 @@ describe('FeedbackCard — vote toggle', () => {
     expect(mockMutateAsync).toHaveBeenCalledWith(42)
   })
 
-  test('plays generic_notification_9 sfx when voting for the first time', async () => {
+  test('plays notice.info sfx when voting for the first time', async () => {
     const wrapper = mountCard({ voted_by_me: false })
     await wrapper.find('[data-testid="feedback-card__vote"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('generic_notification_9')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.info')
   })
 
-  test('plays toggle_off sfx when un-voting [obligation]', async () => {
+  test('plays ui.toggle-off sfx when un-voting [obligation]', async () => {
     const wrapper = mountCard({ voted_by_me: true })
     await wrapper.find('[data-testid="feedback-card__vote"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('toggle_off')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.toggle-off')
   })
 
   test('shows a burst effect when voting for the first time', async () => {

--- a/tests/integration/components/feedback/feedback-submit-dialog.test.js
+++ b/tests/integration/components/feedback/feedback-submit-dialog.test.js
@@ -246,6 +246,6 @@ describe('FeedbackSubmitDialog — close wiring', () => {
   test('dialog-card close emits pop_up_close', async () => {
     const { wrapper } = mountDialog()
     await wrapper.find('[data-testid="feedback-submit-dialog__dialog-close"]').trigger('click')
-    expect(emitSfxMock).toHaveBeenCalledWith('pop_up_close')
+    expect(emitSfxMock).toHaveBeenCalledWith('dialog.close')
   })
 })

--- a/tests/integration/components/layout-kit/dialog-card/dialog-card.test.js
+++ b/tests/integration/components/layout-kit/dialog-card/dialog-card.test.js
@@ -295,10 +295,16 @@ describe('DialogCard', () => {
       expect(close.props('neutral')).toBe(true)
     })
 
-    test('forwards close_sfx to the close button sfx prop', () => {
-      const wrapper = mountCard({ title: 'x', close_sfx: { press: 'snappy_button_5' } })
+    test('forwards sfx.close to the close button press channel', () => {
+      const wrapper = mountCard({ title: 'x', sfx: { close: 'ui.press' } })
       const close = wrapper.findComponent(UiButtonStub)
-      expect(close.props('sfx')).toEqual({ press: 'snappy_button_5' })
+      expect(close.props('sfx')).toEqual({ press: 'ui.press' })
+    })
+
+    test('defaults the close button press channel to dialog.close when sfx.close is omitted', () => {
+      const wrapper = mountCard({ title: 'x' })
+      const close = wrapper.findComponent(UiButtonStub)
+      expect(close.props('sfx')).toEqual({ press: 'dialog.close' })
     })
   })
 

--- a/tests/integration/components/layout-kit/paged-window/index.test.js
+++ b/tests/integration/components/layout-kit/paged-window/index.test.js
@@ -238,7 +238,7 @@ describe('PagedWindow', () => {
       setDesktop(true)
       const wrapper = mountWindow({ active: null })
       await wrapper.find('[data-testid="paged-window__tab"]').trigger('click')
-      expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.deselect')
     })
 
     test('sidebar highlight (data-active) keys off displayed_page, not the raw active prop', () => {
@@ -420,8 +420,8 @@ describe('PagedWindow', () => {
 // ── Optional sfx + danger + hidden close branches ─────────────────────────────
 
 describe('PagedWindow — sfx suppression, danger pages, hidden close', () => {
-  test('empty-string select_sfx and reselect_sfx suppress all selection sounds', async () => {
-    const wrapper = mountWindow({ select_sfx: '', reselect_sfx: '' })
+  test('sfx.select: false and sfx.reselect: false suppress all selection sounds', async () => {
+    const wrapper = mountWindow({ sfx: { select: false, reselect: false } })
     const tabs = wrapper.findAll('[data-testid="paged-window__tab"]')
 
     await tabs[1].trigger('click')

--- a/tests/integration/components/member/avatar-picker-modal.test.js
+++ b/tests/integration/components/member/avatar-picker-modal.test.js
@@ -17,13 +17,13 @@ vi.mock('@/components/member/avatars', () => ({
 const DialogCardStub = defineComponent({
   name: 'DialogCard',
   inheritAttrs: false,
-  props: { close_sfx: { type: Object, default: undefined } },
+  props: { sfx: { type: Object, default: () => ({}) } },
   emits: ['close'],
   setup(props, { slots, attrs }) {
     return () =>
       h(
         'div',
-        { ...attrs, 'data-close-sfx': JSON.stringify(props.close_sfx ?? null) },
+        { ...attrs, 'data-sfx': JSON.stringify(props.sfx) },
         slots.default?.({ viewport: 'desktop' })
       )
   }
@@ -57,15 +57,15 @@ beforeEach(() => {
 })
 
 describe('AvatarPickerModal', () => {
-  test('plays wooden_chime_ring on mount', () => {
+  test('plays dialog.open on mount', () => {
     mountModal()
-    expect(mockEmitSfx).toHaveBeenCalledWith('wooden_chime_ring')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
-  test('passes close_sfx: { press: "pop_up_close" } to dialog-card', () => {
+  test('passes no sfx override to dialog-card, so it falls back to its own default close cue', () => {
     const wrapper = mountModal()
-    expect(wrapper.find('[data-testid="avatar-picker-modal"]').attributes('data-close-sfx')).toBe(
-      JSON.stringify({ press: 'pop_up_close' })
+    expect(wrapper.find('[data-testid="avatar-picker-modal"]').attributes('data-sfx')).toBe(
+      JSON.stringify({})
     )
   })
 
@@ -76,17 +76,17 @@ describe('AvatarPickerModal', () => {
     expect(wrapper.find('[data-testid="avatar-picker-modal__option-owl"]').exists()).toBe(true)
   })
 
-  test('clicking an avatar that is not selected calls close with that key and plays toggle_on', async () => {
+  test('clicking an avatar that is not selected calls close with that key and plays ui.toggle-on', async () => {
     const close = vi.fn()
     const wrapper = mountModal({ close, selected: 'owl' })
 
     await wrapper.find('[data-testid="avatar-picker-modal__option-panda"]').trigger('click')
 
     expect(close).toHaveBeenCalledWith('panda')
-    expect(mockEmitSfx).toHaveBeenCalledWith('toggle_on')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.toggle-on')
   })
 
-  test('clicking the already-selected avatar is a no-op and plays digi_powerdown', async () => {
+  test('clicking the already-selected avatar is a no-op and plays ui.deselect', async () => {
     const close = vi.fn()
     const wrapper = mountModal({ close, selected: 'owl' })
     mockEmitSfx.mockClear()
@@ -94,7 +94,7 @@ describe('AvatarPickerModal', () => {
     await wrapper.find('[data-testid="avatar-picker-modal__option-owl"]').trigger('click')
 
     expect(close).not.toHaveBeenCalled()
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.deselect')
   })
 
   test('marks the selected avatar with data-selected', () => {

--- a/tests/integration/components/modals/deck-settings/deck-save-button.test.js
+++ b/tests/integration/components/modals/deck-settings/deck-save-button.test.js
@@ -76,12 +76,12 @@ beforeEach(() => {
 })
 
 describe('DeckSaveButton — not dirty', () => {
-  test('plays digi_powerdown when deck is not dirty', async () => {
+  test('plays ui.rejected when deck is not dirty', async () => {
     const { wrapper } = makeSaveButton({ is_dirty: false })
 
     await wrapper.find('[data-testid="deck-settings__save-button"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
   })
 
   test('does not call saveDeck when not dirty', async () => {
@@ -102,20 +102,20 @@ describe('DeckSaveButton — not dirty', () => {
 })
 
 describe('DeckSaveButton — empty title', () => {
-  test('plays etc_woodblock_stuck when title is empty (is_dirty=true)', async () => {
+  test('plays notice.error when title is empty (is_dirty=true)', async () => {
     const { wrapper } = makeSaveButton({ title: '', is_dirty: true })
 
     await wrapper.find('[data-testid="deck-settings__save-button"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
   })
 
-  test('plays etc_woodblock_stuck when title is whitespace-only', async () => {
+  test('plays notice.error when title is whitespace-only', async () => {
     const { wrapper } = makeSaveButton({ title: '   ', is_dirty: true })
 
     await wrapper.find('[data-testid="deck-settings__save-button"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
   })
 
   test('does not call saveDeck when title is empty', async () => {
@@ -256,13 +256,13 @@ describe('DeckSaveButton — loading state', () => {
 })
 
 describe('DeckSaveButton — empty-title check fires before not-dirty check [obligation]', () => {
-  test('when not dirty AND title is empty: etc_woodblock_stuck fires (title check runs first)', async () => {
+  test('when not dirty AND title is empty: notice.error fires (title check runs first)', async () => {
     const { wrapper } = makeSaveButton({ title: '', is_dirty: false })
 
     await wrapper.find('[data-testid="deck-settings__save-button"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.rejected')
   })
 })
 
@@ -281,13 +281,13 @@ describe('DeckSaveButton — reset button [obligation]', () => {
     ).toBe('false')
   })
 
-  test('pressing it while disabled does NOT call resetChanges, only plays digi_powerdown [obligation]', async () => {
+  test('pressing it while disabled does NOT call resetChanges, only plays ui.rejected [obligation]', async () => {
     const { wrapper, resetChanges } = makeSaveButton({ is_dirty: false })
 
     await wrapper.find('[data-testid="deck-settings__reset-button"]').trigger('click')
 
     expect(resetChanges).not.toHaveBeenCalled()
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
   })
 
   test('pressing it while enabled calls resetChanges [obligation]', async () => {

--- a/tests/integration/components/modals/deck-settings/tab-design/align-picker.test.js
+++ b/tests/integration/components/modals/deck-settings/tab-design/align-picker.test.js
@@ -76,13 +76,13 @@ describe('AlignPicker', () => {
   test('plays select sfx when changing to a new cell', async () => {
     const { wrapper } = makePicker({ horizontal: 'left', vertical: 'top' })
     await wrapper.find('[data-testid="align-picker__cell-right-bottom"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('etc_camera_shutter')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 
   test('plays reselect sfx when clicking the active cell', async () => {
     const { wrapper } = makePicker({ horizontal: 'left', vertical: 'top' })
     await wrapper.find('[data-testid="align-picker__cell-left-top"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.deselect')
   })
 
   test('selecting center/center from a non-default state writes undefined to both models [obligation]', async () => {

--- a/tests/integration/components/modals/deck-settings/tab-design/image-layout-picker.test.js
+++ b/tests/integration/components/modals/deck-settings/tab-design/image-layout-picker.test.js
@@ -64,12 +64,12 @@ describe('ImageLayoutPicker', () => {
   test('plays select sfx when changing to a new option', async () => {
     const { wrapper } = makePicker({ layout: 'above' })
     await wrapper.find(optionTestId('below')).trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 
   test('plays reselect sfx when clicking the active option', async () => {
     const { wrapper } = makePicker({ layout: 'above' })
     await wrapper.find(optionTestId('above')).trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.deselect')
   })
 })

--- a/tests/integration/components/modals/study-session/index.test.js
+++ b/tests/integration/components/modals/study-session/index.test.js
@@ -441,7 +441,7 @@ describe('StudySession (index.vue)', () => {
       expect(wrapper.find('[data-testid="session-summary__select-button"]').exists()).toBe(false)
     })
 
-    test('pressing it calls enterSelection when not already selecting, and plays the select sfx [obligation]', async () => {
+    test('pressing it calls enterSelection when not already selecting, and plays the ui.select sfx [obligation]', async () => {
       const { wrapper } = makeWrapper()
       await finishSession([])
       await openCategoryPage()
@@ -451,10 +451,10 @@ describe('StudySession (index.vue)', () => {
 
       expect(mockEnterSelection).toHaveBeenCalledOnce()
       expect(mockExitSelection).not.toHaveBeenCalled()
-      expect(mockEmitSfx).toHaveBeenCalledWith('select')
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
     })
 
-    test('pressing it calls exitSelection while already selecting, and plays digi_powerdown [obligation]', async () => {
+    test('pressing it calls exitSelection while already selecting, and plays ui.deselect [obligation]', async () => {
       const { wrapper } = makeWrapper()
       await finishSession([])
       await openCategoryPage()
@@ -466,7 +466,7 @@ describe('StudySession (index.vue)', () => {
 
       expect(mockExitSelection).toHaveBeenCalledOnce()
       expect(mockEnterSelection).not.toHaveBeenCalled()
-      expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.deselect')
     })
   })
 
@@ -559,7 +559,7 @@ describe('StudySession (index.vue)', () => {
       await wrapper.find('[data-testid="session-header__close"]').trigger('click')
 
       expect(mockRequestClose).not.toHaveBeenCalled()
-      expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+      expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
       expect(mockClearPersistedSession).toHaveBeenCalledOnce()
       expect(close).toHaveBeenCalledOnce()
     })
@@ -575,7 +575,7 @@ describe('StudySession (index.vue)', () => {
 
       request_close_handlers.get(TEST_MODAL_ID)()
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+      expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
       expect(mockClearPersistedSession).toHaveBeenCalledOnce()
       expect(close).toHaveBeenCalledOnce()
       expect(mockCloseSettings).not.toHaveBeenCalled()
@@ -634,7 +634,7 @@ describe('StudySession (index.vue)', () => {
       request_close_handlers.get(TEST_MODAL_ID)()
 
       expect(mockRequestClose).not.toHaveBeenCalled()
-      expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+      expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
       expect(mockClearPersistedSession).toHaveBeenCalledOnce()
       expect(close).toHaveBeenCalledOnce()
     })
@@ -738,7 +738,7 @@ describe('StudySession (index.vue)', () => {
     await finishSession([])
     await wrapper.find('[data-testid="session-summary__close"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
     expect(mockClearPersistedSession).toHaveBeenCalledOnce()
     expect(close).toHaveBeenCalledOnce()
   })
@@ -799,13 +799,13 @@ describe('StudySession (index.vue)', () => {
 
   // ── emitStudySfx fires in pane enter's onStart, not at phase-flip [obligation] ─
 
-  test('music_pizz_duo_hi sfx is NOT emitted directly when state flips to summary [obligation]', async () => {
+  test('session.complete sfx is NOT emitted directly when state flips to summary [obligation]', async () => {
     const { wrapper } = makeWrapper()
 
     await finishSession([])
 
     expect(wrapper.find('[data-testid="session-summary-stub"]').exists()).toBe(true)
-    expect(mockEmitStudySfx).not.toHaveBeenCalledWith('music_pizz_duo_hi')
+    expect(mockEmitStudySfx).not.toHaveBeenCalledWith('session.complete')
   })
 
   // ── Jingle fires only on first summary entry [obligation] ─────────────────
@@ -820,8 +820,8 @@ describe('StudySession (index.vue)', () => {
     const pager = wrapper.findComponent({ name: 'DialogCardPager' })
     pager.vm.$emit('enter-start')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_2')
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('music_pizz_duo_hi')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('session.complete')
   })
 
   test('the pager is not instant on the first arrival at the summary, and enter-start plays the jingle [obligation]', async () => {
@@ -832,7 +832,7 @@ describe('StudySession (index.vue)', () => {
     expect(pager.props('instant')).toBe(false)
 
     pager.vm.$emit('enter-start')
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_pizz_duo_hi')
+    expect(mockEmitSfx).toHaveBeenCalledWith('session.complete')
   })
 
   test('returning to the summary from a category page is instant and enter-start plays the light click, not the jingle again [obligation]', async () => {
@@ -854,8 +854,8 @@ describe('StudySession (index.vue)', () => {
     expect(pager.props('instant')).toBe(true)
 
     pager.vm.$emit('enter-start')
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('music_pizz_duo_hi')
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_2')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('session.complete')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   // ── regression: outlet must not clip the swipe/drag animation ──────────────

--- a/tests/integration/components/modals/study-session/session-flashcard/study-edit-footer.test.js
+++ b/tests/integration/components/modals/study-session/session-flashcard/study-edit-footer.test.js
@@ -60,21 +60,21 @@ describe('StudyEditFooter', () => {
     expect(mockStopEdit).toHaveBeenCalledOnce()
   })
 
-  test('clicking flip plays transition_up when on the starting side', async () => {
+  test('clicking flip plays card.flip-away when on the starting side', async () => {
     const wrapper = mountFooter({ starting_side: true })
     await wrapper.find('[data-testid="study-card-edit__flip"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_up', undefined)
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-away')
   })
 
-  test('clicking flip plays transition_down when not on the starting side', async () => {
+  test('clicking flip plays card.flip-back when not on the starting side', async () => {
     const wrapper = mountFooter({ starting_side: false })
     await wrapper.find('[data-testid="study-card-edit__flip"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_down', undefined)
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-back')
   })
 
-  test('clicking done plays music_plink_ok', async () => {
+  test('clicking done plays dialog.confirm', async () => {
     const wrapper = mountFooter()
     await wrapper.find('[data-testid="study-card-edit__done"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_ok', undefined)
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.confirm')
   })
 })

--- a/tests/integration/components/modals/study-session/session-summary/category-page/summary-card-editor.test.js
+++ b/tests/integration/components/modals/study-session/session-summary/category-page/summary-card-editor.test.js
@@ -74,7 +74,7 @@ describe('SummaryCardEditor', () => {
     expect(wrapper.find('[data-testid="study-card-edit-stub"]').attributes('data-side')).toBe(
       'back'
     )
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-away')
   })
 
   test('flipping twice returns to the front and plays the opposite sfx [obligation]', async () => {
@@ -87,7 +87,7 @@ describe('SummaryCardEditor', () => {
     expect(wrapper.find('[data-testid="study-card-edit-stub"]').attributes('data-side')).toBe(
       'front'
     )
-    expect(mockEmitSfx).toHaveBeenLastCalledWith('transition_down')
+    expect(mockEmitSfx).toHaveBeenLastCalledWith('card.flip-back')
   })
 
   // ── update forwarding ─────────────────────────────────────────────────────
@@ -106,6 +106,6 @@ describe('SummaryCardEditor', () => {
     await wrapper.find('[data-testid="session-summary__card-editor-done"]').trigger('click')
 
     expect(wrapper.emitted('done')).toHaveLength(1)
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_ok')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.confirm')
   })
 })

--- a/tests/integration/components/modals/study-session/session-summary/category-page/summary-card.test.js
+++ b/tests/integration/components/modals/study-session/session-summary/category-page/summary-card.test.js
@@ -190,7 +190,7 @@ describe('SummaryCard', () => {
     await wrapper.find('[data-testid="card-stub"]').trigger('click')
 
     expect(wrapper.find('[data-testid="card-stub"]').attributes('data-side')).toBe('back')
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-away')
   })
 
   test('clicking twice flips back to the front and plays the opposite sfx', async () => {
@@ -201,7 +201,7 @@ describe('SummaryCard', () => {
     await card.trigger('click')
 
     expect(wrapper.find('[data-testid="card-stub"]').attributes('data-side')).toBe('front')
-    expect(mockEmitSfx).toHaveBeenLastCalledWith('transition_down')
+    expect(mockEmitSfx).toHaveBeenLastCalledWith('card.flip-back')
   })
 
   test('resolves card_attributes via appearanceFor(card.deck_id)', () => {

--- a/tests/integration/components/modals/study-session/study-card.test.js
+++ b/tests/integration/components/modals/study-session/study-card.test.js
@@ -200,8 +200,8 @@ describe('StudyCard', () => {
     wrapper.vm.rate(Rating.Hard)
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_ok')
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('music_plink_locancel')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.grade-good')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('card.grade-again')
   })
 
   // ── Swipe fallback grade (drag path, no explicit grade) [obligation] ────────
@@ -453,24 +453,24 @@ describe('StudyCard', () => {
 
   // ── rate() / fling animation ───────────────────────────────────────────────
 
-  test('rate(Good) plays study.music_plink_ok sfx', async () => {
+  test('rate(Good) plays study.card.grade-good sfx', async () => {
     const wrapper = mountStudyCard({ side: 'back' })
     await flushPromises()
 
     wrapper.vm.rate(Rating.Good)
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_ok')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.grade-good')
   })
 
-  test('rate(Again) plays study.music_plink_locancel sfx', async () => {
+  test('rate(Again) plays study.card.grade-again sfx', async () => {
     const wrapper = mountStudyCard({ side: 'back' })
     await flushPromises()
 
     wrapper.vm.rate(Rating.Again)
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_locancel')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.grade-again')
   })
 
   test('rate(Good) emits reviewed with Rating.Good after transitionend', async () => {
@@ -520,7 +520,7 @@ describe('StudyCard', () => {
 
   // ── Zone sfx (card_offset crossing ±50) ───────────────────────────────────
 
-  test('study.music_plink_mid plays when card_offset crosses the +50 threshold', async () => {
+  test('gesture.zone-cross plays when card_offset crosses the +50 threshold', async () => {
     mountStudyCard()
     await flushPromises()
 
@@ -530,19 +530,21 @@ describe('StudyCard', () => {
     callbacks.onMove({ dx: 60, dy: 0 })
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_mid')
-    const call_count = mockEmitSfx.mock.calls.filter((c) => c[0] === 'music_plink_mid').length
+    expect(mockEmitSfx).toHaveBeenCalledWith('gesture.zone-cross')
+    const call_count = mockEmitSfx.mock.calls.filter((c) => c[0] === 'gesture.zone-cross').length
     expect(call_count).toBe(1)
 
     // Another move within the same zone should NOT trigger the sfx again
     callbacks.onMove({ dx: 80, dy: 0 })
     await flushPromises()
 
-    const call_count_after = mockEmitSfx.mock.calls.filter((c) => c[0] === 'music_plink_mid').length
+    const call_count_after = mockEmitSfx.mock.calls.filter(
+      (c) => c[0] === 'gesture.zone-cross'
+    ).length
     expect(call_count_after).toBe(1)
   })
 
-  test('study.music_plink_mid plays when card_offset crosses the -50 threshold', async () => {
+  test('gesture.zone-cross plays when card_offset crosses the -50 threshold', async () => {
     mountStudyCard()
     await flushPromises()
 
@@ -551,7 +553,7 @@ describe('StudyCard', () => {
     callbacks.onMove({ dx: -60, dy: 0 })
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_mid')
+    expect(mockEmitSfx).toHaveBeenCalledWith('gesture.zone-cross')
   })
 
   // ── cover side: gestures and rate() are no-ops ────────────────────────────

--- a/tests/integration/components/settings/account-access/index.test.js
+++ b/tests/integration/components/settings/account-access/index.test.js
@@ -139,15 +139,15 @@ describe('AccountAccessModal — header title reflects content.title [obligation
 })
 
 describe('AccountAccessModal — sfx [obligation]', () => {
-  test('plays wooden_chime_ring on mount [obligation]', () => {
+  test('plays dialog.open on mount [obligation]', () => {
     makeWrapper()
-    expect(mockEmitSfx).toHaveBeenCalledWith('wooden_chime_ring')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
-  test('plays pop_up_close on unmount [obligation]', () => {
+  test('plays dialog.close on unmount [obligation]', () => {
     const { wrapper } = makeWrapper()
     mockEmitSfx.mockClear()
     wrapper.unmount()
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 })

--- a/tests/integration/components/settings/account-access/success-panel.test.js
+++ b/tests/integration/components/settings/account-access/success-panel.test.js
@@ -26,9 +26,9 @@ beforeEach(() => {
 })
 
 describe('SuccessPanel', () => {
-  test('[obligation] plays the success_1 sfx on mount', () => {
+  test('[obligation] plays the notice.success sfx on mount', () => {
     makeWrapper()
-    expect(mockEmitSfx).toHaveBeenCalledWith('success_1')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.success')
   })
 
   test('[obligation] renders the passed icon, heading, and message props', () => {

--- a/tests/integration/components/settings/index.test.js
+++ b/tests/integration/components/settings/index.test.js
@@ -279,7 +279,7 @@ describe('settings app — active_page is a plain, non-persisted ref [obligation
 // ── Back navigation ───────────────────────────────────────────────────────────
 
 describe('settings app — back navigation', () => {
-  test('onBack clears the active tab and plays the snappy_button_5 sfx', async () => {
+  test('onBack clears the active tab and plays the ui.press sfx', async () => {
     const wrapper = makeWrapper()
     await flushPromises()
     await wrapper.find('[data-testid="pw__select-account-access"]').trigger('click')
@@ -288,7 +288,7 @@ describe('settings app — back navigation', () => {
     await wrapper.vm.onBack()
 
     expect(wrapper.vm.active_page).toBe(null)
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('the paged-window back emit routes to onChromeBack, clearing the active tab', async () => {
@@ -317,7 +317,7 @@ describe('settings app — onChromeBack delegates to the active tab first [oblig
     await wrapper.vm.onChromeBack()
 
     expect(wrapper.vm.active_page).toBe(null)
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('stays on the tab when the active tab onChromeBack returns true (handled locally)', async () => {
@@ -332,7 +332,7 @@ describe('settings app — onChromeBack delegates to the active tab first [oblig
     expect(mockAccountAccessOnChromeBack).toHaveBeenCalledOnce()
     expect(wrapper.vm.active_page).toBe('account-access')
     // Sound still plays even when a nested tab handles its own back-navigation.
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 })
 
@@ -388,16 +388,16 @@ describe('settings app — close with unsaved-changes guard', () => {
 // ── Open / close sfx ──────────────────────────────────────────────────────────
 
 describe('settings app — open/close sfx', () => {
-  test('emits snappy_button_3 on mount', () => {
+  test('emits dialog.open on mount', () => {
     makeWrapper()
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_3')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
-  test('emits pop_up_close on unmount', () => {
+  test('emits dialog.close on unmount', () => {
     const wrapper = makeWrapper()
     mockEmitSfx.mockReset()
     wrapper.unmount()
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 })
 

--- a/tests/integration/components/settings/tab-app.test.js
+++ b/tests/integration/components/settings/tab-app.test.js
@@ -8,7 +8,6 @@ import { windowLayoutKey } from '@/components/layout-kit/paged-window/layout'
 vi.mock('@/sfx/bus', () => ({ emitSfx: vi.fn(), emitHoverSfx: vi.fn() }))
 // Break config→player→config circular dep.
 vi.mock('@/sfx/config', () => ({
-  TYPE_SFX: [],
   SOUNDS: {},
   BUS_DEFAULTS: { interface: 5, hover: 5 }
 }))
@@ -29,7 +28,7 @@ vi.mock('@/sfx/player', () => ({
 const SliderStub = defineComponent({
   name: 'UiSlider',
   inheritAttrs: false,
-  props: { modelValue: Number, min: Number, max: Number, sfx: Object, label: String },
+  props: { modelValue: Number, min: Number, max: Number, preview_bus: String, label: String },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
     const attrs = useAttrs()
@@ -38,7 +37,7 @@ const SliderStub = defineComponent({
         ...attrs,
         'data-testid': 'slider-stub',
         'data-value': String(props.modelValue),
-        'data-bus': props.sfx?.bus ?? '',
+        'data-bus': props.preview_bus ?? '',
         onClick: () => emit('update:modelValue', (props.modelValue ?? 0) + 1)
       })
   }

--- a/tests/integration/components/settings/tab-app/audio-section.test.js
+++ b/tests/integration/components/settings/tab-app/audio-section.test.js
@@ -1,0 +1,95 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import { reactive } from 'vue'
+import { memberEditorKey } from '@/composables/member/editor'
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockEmitSfx, mockPreviewMemberVolumes, mockDiscardVolumePreview } = vi.hoisted(() => ({
+  mockEmitSfx: vi.fn(),
+  mockPreviewMemberVolumes: vi.fn(),
+  mockDiscardVolumePreview: vi.fn()
+}))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: vi.fn() }))
+vi.mock('@/sfx/volume-seam', () => ({
+  previewMemberVolumes: mockPreviewMemberVolumes,
+  discardVolumePreview: mockDiscardVolumePreview
+}))
+
+import AudioSection from '@/views/settings/tab-app/audio-section.vue'
+import UiSlider from '@/components/ui-kit/slider.vue'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEditor(overrides = {}) {
+  return {
+    draft: reactive({
+      preferences: {
+        audio: {
+          muted: false,
+          interface_sounds: 5,
+          hover_sounds: 5,
+          ...overrides
+        }
+      }
+    })
+  }
+}
+
+function mountSection(editor = makeEditor()) {
+  const wrapper = mount(AudioSection, {
+    attachTo: document.body,
+    global: {
+      provide: { [memberEditorKey]: editor },
+      directives: { sfx: {} }
+    }
+  })
+  return { wrapper, editor }
+}
+
+beforeEach(() => {
+  mockEmitSfx.mockClear()
+  mockPreviewMemberVolumes.mockClear()
+  mockDiscardVolumePreview.mockClear()
+})
+
+describe('AudioSection', () => {
+  test('renders the mute-all toggle and both sliders', () => {
+    const { wrapper } = mountSection()
+    expect(wrapper.find('[data-testid="tab-app__mute-all"]').exists()).toBe(true)
+    expect(wrapper.findAllComponents(UiSlider)).toHaveLength(2)
+  })
+
+  // ── preview_bus routes the drag to the bus the slider itself sets [obligation] ──
+
+  test('the interface-sounds slider passes preview_bus="interface" [obligation]', () => {
+    const { wrapper } = mountSection()
+    const sliders = wrapper.findAllComponents(UiSlider)
+    expect(sliders[0].props('preview_bus')).toBe('interface')
+  })
+
+  test('the hover-sounds slider passes preview_bus="hover" [obligation]', () => {
+    const { wrapper } = mountSection()
+    const sliders = wrapper.findAllComponents(UiSlider)
+    expect(sliders[1].props('preview_bus')).toBe('hover')
+  })
+
+  test('changing interface_sounds live-previews the volume without muting [obligation]', async () => {
+    const { editor } = mountSection()
+    editor.draft.preferences.audio.interface_sounds = 8
+    await Promise.resolve()
+
+    expect(mockPreviewMemberVolumes).toHaveBeenCalledWith({
+      muted: false,
+      interface_sounds: 8,
+      hover_sounds: 5
+    })
+  })
+
+  test('unmounting discards the volume preview', () => {
+    const { wrapper } = mountSection()
+    wrapper.unmount()
+    expect(mockDiscardVolumePreview).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/integration/components/taro-phone/app-launcher.test.js
+++ b/tests/integration/components/taro-phone/app-launcher.test.js
@@ -123,7 +123,7 @@ describe('AppLauncher — mouse hover tracking', () => {
     mockEmitHoverSfx.mockClear()
     wrapper.find('[data-app="DarkmodeApp"]').trigger('mouseover')
 
-    expect(mockEmitHoverSfx).toHaveBeenCalledWith('pop_drip_mid')
+    expect(mockEmitHoverSfx).toHaveBeenCalledWith('ui.hover')
   })
 
   test('hovering the already-focused app is a no-op', () => {

--- a/tests/integration/components/taro-phone/apps/darkmode-app.test.js
+++ b/tests/integration/components/taro-phone/apps/darkmode-app.test.js
@@ -40,9 +40,9 @@ describe('DarkmodeApp — theme cycling [obligation]', () => {
     expect(theme_store.mode).toBe('light')
   })
 
-  test('plays the select sfx on click', async () => {
+  test('plays the ui.select sfx on click', async () => {
     const wrapper = makeWrapper()
     await wrapper.find('[data-testid="phone-app"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 })

--- a/tests/integration/components/ui-kit/button.test.js
+++ b/tests/integration/components/ui-kit/button.test.js
@@ -179,7 +179,7 @@ describe('UiButton', () => {
     test('emits press sfx at the start of the tap when sfx.press is set', async () => {
       vi.useFakeTimers()
       const wrapper = shallowMount(UiButton, {
-        props: { playOnTap: true, sfx: { press: 'select' } },
+        props: { playOnTap: true, sfx: { press: 'ui.select' } },
         attrs: { onClick: vi.fn() }
       })
 
@@ -189,7 +189,7 @@ describe('UiButton', () => {
       vi.advanceTimersByTime(500)
       await wrapper.vm.$nextTick()
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('select', expect.any(Object))
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
       vi.useRealTimers()
     })
 
@@ -251,7 +251,7 @@ describe('UiButton', () => {
       test('tapAnimate=false still fires press sfx when sfx.press is set [obligation]', async () => {
         mockEmitSfx.mockClear()
         const wrapper = shallowMount(UiButton, {
-          props: { playOnTap: true, tapAnimate: false, sfx: { press: 'select' } },
+          props: { playOnTap: true, tapAnimate: false, sfx: { press: 'ui.select' } },
           attrs: { onClick: vi.fn() }
         })
 
@@ -261,7 +261,7 @@ describe('UiButton', () => {
         vi.advanceTimersByTime(500)
         await wrapper.vm.$nextTick()
 
-        expect(mockEmitSfx).toHaveBeenCalledWith('select', expect.any(Object))
+        expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
       })
 
       test('tapAnimate=true (default) still uses GSAP tween [obligation]', async () => {
@@ -277,6 +277,35 @@ describe('UiButton', () => {
 
         expect(gsap.to).toHaveBeenCalled()
       })
+    })
+  })
+
+  // ── merged_sfx: false silences a channel, an omitted one keeps the default [obligation] ──
+
+  describe('merged_sfx passed to v-sfx', () => {
+    function captureSfxBinding(props = {}) {
+      let captured
+      const captureDirective = {
+        mounted: (_el, binding) => (captured = binding.value),
+        updated: (_el, binding) => (captured = binding.value)
+      }
+      shallowMount(UiButton, {
+        props,
+        global: { directives: { sfx: captureDirective } }
+      })
+      return captured
+    }
+
+    test('an omitted hover channel falls back to the primitive default (ui.hover) [obligation]', () => {
+      expect(captureSfxBinding({}).hover).toBe('ui.hover')
+    })
+
+    test('sfx.hover: false silences the hover channel [obligation]', () => {
+      expect(captureSfxBinding({ sfx: { hover: false } }).hover).toBe(false)
+    })
+
+    test('disabled clears every v-sfx channel, not just press', () => {
+      expect(captureSfxBinding({ disabled: true, sfx: { hover: 'ui.select' } })).toEqual({})
     })
   })
 
@@ -502,22 +531,19 @@ describe('UiButton', () => {
       expect(gsap.to).not.toHaveBeenCalled()
     })
 
-    test('disabled=true suppresses sfx on a click (merged_sfx returns {}) [obligation]', async () => {
+    test('disabled=true fires ui.rejected, not ui.press [obligation]', async () => {
       mockEmitSfx.mockClear()
-      // A disabled button has merged_sfx = {} so no hover sfx is emitted.
-      // The v-sfx directive is stubbed in these tests so we only verify the
-      // prop value passed to UiTooltip (via sfx binding) stays empty.
-      // We simply confirm clicking doesn't call emitSfx (the sfx is cleared).
       const wrapper = mountButtonWithSlots(
-        { disabled: true, playOnTap: true, sfx: { click: 'select' } },
+        { disabled: true, playOnTap: true },
         { default: 'Label' }
       )
       wrapper
         .find('[data-testid="ui-kit-button"]')
         .element.dispatchEvent(new MouseEvent('click', { bubbles: true }))
       await wrapper.vm.$nextTick()
-      // emitSfx not called because onCaptureClick returns early before emitClickSfx
-      expect(mockEmitSfx).not.toHaveBeenCalled()
+
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
+      expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.press', expect.anything())
     })
 
     // ── clickWhenDisabled [obligation] ─────────────────────────────────────
@@ -556,10 +582,10 @@ describe('UiButton', () => {
       expect(preventSpy).toHaveBeenCalled()
     })
 
-    test('clickWhenDisabled suppresses sfx even when clicks are allowed through [obligation]', async () => {
+    test('clickWhenDisabled still fires ui.rejected even though the click reaches the handler [obligation]', async () => {
       mockEmitSfx.mockClear()
       const wrapper = shallowMount(UiButton, {
-        props: { disabled: true, clickWhenDisabled: true, sfx: { click: 'select' } },
+        props: { disabled: true, clickWhenDisabled: true },
         attrs: { onClick: vi.fn() },
         global: { stubs: { UiTooltip: UiTooltipSlotStub }, directives: { sfx: {} } }
       })
@@ -567,9 +593,8 @@ describe('UiButton', () => {
         .find('[data-testid="ui-kit-button"]')
         .element.dispatchEvent(new MouseEvent('click', { bubbles: true }))
       await wrapper.vm.$nextTick()
-      // merged_sfx returns {} when disabled, so emitClickSfx is never invoked
-      // (onCaptureClick returns early at the clickWhenDisabled guard, skipping interceptClick)
-      expect(mockEmitSfx).not.toHaveBeenCalled()
+
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
     })
   })
 })

--- a/tests/integration/components/ui-kit/dropdown-button.test.js
+++ b/tests/integration/components/ui-kit/dropdown-button.test.js
@@ -537,19 +537,19 @@ describe('UiDropdownButton', () => {
 
   // ── sfx emissions [obligation] ────────────────────────────────────────────
 
-  test('clicking the trigger emits ui.snappy_button_5 [obligation]', async () => {
+  test('clicking the trigger emits ui.press [obligation]', async () => {
     const wrapper = mountDropdown()
     mockEmitSfx.mockClear()
     await trigger(wrapper).trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
-  test('clicking the trigger again (close) emits ui.snappy_button_5 [obligation]', async () => {
+  test('clicking the trigger again (close) emits ui.press [obligation]', async () => {
     const wrapper = mountDropdown()
     await trigger(wrapper).trigger('click')
     mockEmitSfx.mockClear()
     await trigger(wrapper).trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('selecting an option does NOT emit ui.select (removed in menu refactor) [obligation]', async () => {
@@ -557,7 +557,7 @@ describe('UiDropdownButton', () => {
     await trigger(wrapper).trigger('click')
     mockEmitSfx.mockClear()
     await options(wrapper)[0].trigger('click')
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.select')
   })
 
   // ── primaryDisabled prop [obligation] ─────────────────────────────────────

--- a/tests/integration/components/ui-kit/input.test.js
+++ b/tests/integration/components/ui-kit/input.test.js
@@ -101,9 +101,9 @@ describe('UiInput', () => {
 
   // ── sfx on focus ──────────────────────────────────────────────────────────
 
-  test('plays type_05 sfx when the <input> receives focus [obligation]', async () => {
+  test('plays ui.focus sfx when the <input> receives focus [obligation]', async () => {
     const wrapper = mountInput()
     await wrapper.find('input').trigger('focus')
-    expect(mockEmitSfx).toHaveBeenCalledWith('type_05', expect.anything())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.focus')
   })
 })

--- a/tests/integration/components/ui-kit/option-group.test.js
+++ b/tests/integration/components/ui-kit/option-group.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 import { mount, flushPromises } from '@vue/test-utils'
+import { vSfx } from '@/sfx/directive'
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
@@ -102,18 +103,18 @@ describe('UiOptionGroup', () => {
 
   // ── Sfx [obligation] ──────────────────────────────────────────────────────
 
-  test('clicking an inactive option plays select [obligation]', async () => {
+  test('clicking an inactive option plays ui.select [obligation]', async () => {
     const wrapper = mountOptionGroup({ value: 'simple' })
     await getOptions(wrapper)[1].trigger('click')
     await flushPromises()
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 
-  test('clicking the already-active option plays digi_powerdown [obligation]', async () => {
+  test('clicking the already-active option plays ui.rejected [obligation]', async () => {
     const wrapper = mountOptionGroup({ value: 'simple' })
     await getOptions(wrapper)[0].trigger('click')
     await flushPromises()
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
   })
 
   // ── Regression: data-active fallthrough must not collide with tappable's
@@ -124,6 +125,37 @@ describe('UiOptionGroup', () => {
     const opts = getOptions(wrapper)
     expect(opts[0].attributes('data-active')).toBe('true')
     expect(opts[0].attributes('data-tap-active')).toBeUndefined()
+  })
+
+  // ── v-sfx directive cleanup [obligation] ────────────────────────────────
+
+  test('unmounting removes every hover listener the real v-sfx directive attached [obligation]', () => {
+    const addSpy = vi.spyOn(EventTarget.prototype, 'addEventListener')
+    const removeSpy = vi.spyOn(EventTarget.prototype, 'removeEventListener')
+
+    const wrapper = mount(UiOptionGroup, {
+      props: { options: OPTIONS, value: 'simple' },
+      global: { directives: { sfx: vSfx } }
+    })
+
+    // v-sfx always attaches with `{ passive: true }` — filter to just its own
+    // listeners (by handler reference) so a tappable's own native
+    // `@pointerenter` binding isn't counted alongside it.
+    const directiveHandlers = addSpy.mock.calls
+      .filter(([type, , options]) => type === 'pointerenter' && !!options?.passive)
+      .map(([, handler]) => handler)
+
+    wrapper.unmount()
+
+    const removedHandlers = removeSpy.mock.calls
+      .filter(([type]) => type === 'pointerenter')
+      .map(([, handler]) => handler)
+
+    expect(directiveHandlers.length).toBeGreaterThan(0)
+    directiveHandlers.forEach((handler) => expect(removedHandlers).toContain(handler))
+
+    addSpy.mockRestore()
+    removeSpy.mockRestore()
   })
 
   // ── Size variants ─────────────────────────────────────────────────────────

--- a/tests/integration/components/ui-kit/prompt.test.js
+++ b/tests/integration/components/ui-kit/prompt.test.js
@@ -126,37 +126,42 @@ describe('UiPrompt — confirm [obligation]', () => {
 
 describe('UiPrompt — sound effects', () => {
   test('confirm plays confirmAudio when provided', async () => {
-    const { wrapper } = makeWrapper({ confirmAudio: 'trash_crumple_short' })
+    const { wrapper } = makeWrapper({ confirmAudio: 'card.delete' })
     await input(wrapper).setValue('My Preset')
 
     await confirmButton(wrapper).trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('trash_crumple_short')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.delete')
   })
 
-  test('confirm plays no sound when confirmAudio is omitted', async () => {
+  test('confirm plays no extra sound when confirmAudio is omitted (just the button press)', async () => {
     const { wrapper } = makeWrapper()
     await input(wrapper).setValue('My Preset')
+    mockEmitSfx.mockClear()
 
     await confirmButton(wrapper).trigger('click')
 
-    expect(mockEmitSfx).not.toHaveBeenCalled()
+    // UiButton's own default press cue still fires; prompt.vue adds nothing on top.
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
+    expect(mockEmitSfx).toHaveBeenCalledTimes(1)
   })
 
   test('cancel plays cancelAudio when provided', async () => {
-    const { wrapper } = makeWrapper({ cancelAudio: 'digi_powerdown' })
+    const { wrapper } = makeWrapper({ cancelAudio: 'ui.deselect' })
 
     await cancelButton(wrapper).trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.deselect')
   })
 
-  test('cancel plays no sound when cancelAudio is omitted', async () => {
+  test('cancel plays no extra sound when cancelAudio is omitted (just the button press)', async () => {
     const { wrapper } = makeWrapper()
+    mockEmitSfx.mockClear()
 
     await cancelButton(wrapper).trigger('click')
 
-    expect(mockEmitSfx).not.toHaveBeenCalled()
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
+    expect(mockEmitSfx).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/tests/integration/components/ui-kit/radio.test.js
+++ b/tests/integration/components/ui-kit/radio.test.js
@@ -89,30 +89,30 @@ describe('UiRadio', () => {
 
   // ── sfx prop ───────────────────────────────────────────────────────────────
 
-  test('plays the "select" press sfx by default [obligation]', async () => {
+  test('plays the "ui.select" press sfx by default [obligation]', async () => {
     const wrapper = mountRadio({ checked: false })
     await wrapper.find('[data-testid="ui-kit-radio"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select', expect.anything())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 
   test('overrides the press sfx via the sfx prop [obligation]', async () => {
-    const wrapper = mountRadio({ checked: false, sfx: { press: 'snappy_button_2' } })
+    const wrapper = mountRadio({ checked: false, sfx: { press: 'ui.press' } })
     await wrapper.find('[data-testid="ui-kit-radio"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_2', expect.anything())
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('select', expect.anything())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.select')
   })
 
   test('forwards hover sfx to the v-sfx directive [obligation]', () => {
-    const wrapper = mountRadio({ checked: false, sfx: { hover: 'type_05' } })
+    const wrapper = mountRadio({ checked: false, sfx: { hover: 'ui.focus' } })
     wrapper
       .find('[data-testid="ui-kit-radio"]')
       .element.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
-    expect(mockEmitHoverSfx).toHaveBeenCalledWith('type_05', expect.anything())
+    expect(mockEmitHoverSfx).toHaveBeenCalledWith('ui.focus')
   })
 
   test('forwards focus sfx to the v-sfx directive [obligation]', async () => {
-    const wrapper = mountRadio({ checked: false, sfx: { focus: 'type_05' } })
+    const wrapper = mountRadio({ checked: false, sfx: { focus: 'ui.focus' } })
     await wrapper.find('[data-testid="ui-kit-radio"]').trigger('focus')
-    expect(mockEmitSfx).toHaveBeenCalledWith('type_05', expect.anything())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.focus')
   })
 })

--- a/tests/integration/components/ui-kit/select-menu.test.js
+++ b/tests/integration/components/ui-kit/select-menu.test.js
@@ -111,16 +111,16 @@ describe('UiSelectMenu', () => {
 
   // ── Sfx [obligation] ──────────────────────────────────────────────────────
 
-  test('picking a different option plays select [obligation]', async () => {
+  test('picking a different option plays ui.select [obligation]', async () => {
     const wrapper = mountSelectMenu({ modelValue: 'default' })
     await wrapper.find('[data-testid="fire-select-alt"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 
-  test('picking the already-selected option plays digi_powerdown [obligation]', async () => {
+  test('picking the already-selected option plays ui.deselect [obligation]', async () => {
     const wrapper = mountSelectMenu({ modelValue: 'default' })
     await wrapper.find('[data-testid="fire-select"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.deselect')
   })
 
   // ── size prop [obligation] ────────────────────────────────────────────────

--- a/tests/integration/components/ui-kit/slider.test.js
+++ b/tests/integration/components/ui-kit/slider.test.js
@@ -8,9 +8,8 @@ import { _resetGestureState } from '@/composables/ui/gestures'
 const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: vi.fn() }))
 vi.mock('@/sfx/config', () => ({
-  TYPE_SFX: [],
   SOUNDS: {},
-  BUS_DEFAULTS: { interface: 5, study: 5, hover: 5 }
+  BUS_DEFAULTS: { interface: 5, hover: 5 }
 }))
 
 import UiSlider from '@/components/ui-kit/slider.vue'
@@ -300,10 +299,10 @@ describe('UiSlider — applyX stepping and clamping', () => {
     expect(getValue()).toBe(2)
   })
 
-  test('emitSfx is called with tick sound when value changes', () => {
-    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1, sfx: { tick: 'tap_05' } }, 5)
+  test('emitSfx is called with the gesture.tick role when value changes', () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
     simulateDrag(wrapper, EDGE_PX) // will change from 5 → 0
-    expect(mockEmitSfx).toHaveBeenCalledWith('tap_05', { bus: undefined })
+    expect(mockEmitSfx).toHaveBeenCalledWith('gesture.tick', undefined)
   })
 
   test('emitSfx is NOT called when drag lands on current value', () => {
@@ -313,16 +312,24 @@ describe('UiSlider — applyX stepping and clamping', () => {
     expect(mockEmitSfx).not.toHaveBeenCalled()
   })
 
-  test('sfx.bus is forwarded to emitSfx', () => {
-    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1, sfx: { bus: 'study' } }, 5)
+  // ── preview_bus routes the tick to the bus the slider itself sets [obligation] ──
+
+  test('preview_bus is forwarded to emitSfx as the second argument [obligation]', () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1, preview_bus: 'hover' }, 5)
     simulateDrag(wrapper, EDGE_PX) // 5 → 0 = change
-    expect(mockEmitSfx).toHaveBeenCalledWith('tap_05', { bus: 'study' })
+    expect(mockEmitSfx).toHaveBeenCalledWith('gesture.tick', 'hover')
   })
 
-  test('sfx.tick defaults to tap_05 when not specified', () => {
+  test('preview_bus never changes which sound plays — the role stays gesture.tick [obligation]', () => {
+    const { wrapper } = makeSlider({ min: 0, max: 10, step: 1, preview_bus: 'interface' }, 5)
+    simulateDrag(wrapper, EDGE_PX)
+    expect(mockEmitSfx.mock.calls[0][0]).toBe('gesture.tick')
+  })
+
+  test("an omitted preview_bus forwards undefined, so the role's own default bus applies", () => {
     const { wrapper } = makeSlider({ min: 0, max: 10, step: 1 }, 5)
     simulateDrag(wrapper, EDGE_PX)
-    expect(mockEmitSfx).toHaveBeenCalledWith('tap_05', { bus: undefined })
+    expect(mockEmitSfx).toHaveBeenCalledWith('gesture.tick', undefined)
   })
 
   test('pointermove mid-drag updates the value (onMove path)', () => {

--- a/tests/integration/components/ui-kit/spinbox.test.js
+++ b/tests/integration/components/ui-kit/spinbox.test.js
@@ -10,7 +10,10 @@ const { coarseRef, fineRef, mockEmitSfx } = vi.hoisted(() => ({
 }))
 
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: vi.fn() }))
-vi.mock('@/sfx/config', () => ({ TYPE_SFX: [], HOVER_SFX_SET: new Set() }))
+vi.mock('@/sfx/config', () => ({
+  SOUNDS: {},
+  BUS_DEFAULTS: { interface: 5, hover: 5 }
+}))
 vi.mock('@/composables/ui/media-query', () => ({
   useMatchMedia: (query) => (query === 'fine' ? fineRef : coarseRef)
 }))
@@ -419,6 +422,24 @@ describe('UiSpinbox', () => {
     expect(wrapper.emitted('update:value')).toBeUndefined()
   })
 
+  // ── ui.rejected at the bound [obligation] ────────────────────────────────
+
+  test('ArrowUp at max fires ui.rejected, not ui.select [obligation]', async () => {
+    const wrapper = mountSpinbox({ value: 10, max: 10, step: 1 })
+    mockEmitSfx.mockClear()
+    await findInput(wrapper).trigger('keydown', { key: 'ArrowUp' })
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.select')
+  })
+
+  test('ArrowDown at min fires ui.rejected, not ui.select [obligation]', async () => {
+    const wrapper = mountSpinbox({ value: 1, min: 1, step: 1 })
+    mockEmitSfx.mockClear()
+    await findInput(wrapper).trigger('keydown', { key: 'ArrowDown' })
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.select')
+  })
+
   // ── Defaults ──────────────────────────────────────────────────────────────
 
   test('with no min/max, both buttons are enabled by default', () => {
@@ -464,10 +485,10 @@ describe('SpinboxButton', () => {
   // old ad-hoc emitSfx('select') + active:scale-95. The sound itself stays
   // 'select' — only the path it travels changed.
 
-  test('clicking the button plays the select press sfx through the staged-tap path', async () => {
+  test('clicking the button plays the ui.select press sfx through the staged-tap path', async () => {
     const wrapper = mountSpinboxButton()
     await wrapper.find('button').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select', expect.any(Object))
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 
   test('plays the press sfx exactly once per click (no double sound)', async () => {

--- a/tests/integration/components/ui-kit/tabs.test.js
+++ b/tests/integration/components/ui-kit/tabs.test.js
@@ -1,0 +1,91 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { mount } from '@vue/test-utils'
+import UiTabs from '@/components/ui-kit/tabs.vue'
+
+const { mockEmitSfx, mockEmitHoverSfx } = vi.hoisted(() => ({
+  mockEmitSfx: vi.fn(),
+  mockEmitHoverSfx: vi.fn()
+}))
+vi.mock('@/sfx/bus', () => ({
+  emitSfx: mockEmitSfx,
+  emitHoverSfx: mockEmitHoverSfx
+}))
+
+const { mockStorageGet, mockStorageSet } = vi.hoisted(() => ({
+  mockStorageGet: vi.fn(),
+  mockStorageSet: vi.fn()
+}))
+vi.mock('@/utils/storage', () => ({
+  default: { get: mockStorageGet, set: mockStorageSet }
+}))
+
+const TABS = [{ label: 'General' }, { label: 'Design' }, { label: 'Danger zone' }]
+
+function mountTabs(props = {}) {
+  return mount(UiTabs, { props: { tabs: TABS, activeTab: 0, ...props } })
+}
+
+describe('UiTabs', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+    mockEmitHoverSfx.mockClear()
+    mockStorageGet.mockReset()
+    mockStorageSet.mockClear()
+  })
+
+  test('clicking a non-active tab emits ui.select sfx and update:activeTab', async () => {
+    const wrapper = mountTabs()
+    const tabs = wrapper.findAll('[data-testid="ui-kit-tabs__tab"]')
+
+    await tabs[1].trigger('click')
+
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
+    expect(wrapper.emitted('update:activeTab')).toEqual([[1]])
+  })
+
+  test('clicking the active tab emits neither sfx nor update:activeTab', async () => {
+    const wrapper = mountTabs({ activeTab: 0 })
+    const tabs = wrapper.findAll('[data-testid="ui-kit-tabs__tab"]')
+
+    await tabs[0].trigger('click')
+
+    expect(mockEmitSfx).not.toHaveBeenCalled()
+    expect(wrapper.emitted('update:activeTab')).toBeUndefined()
+  })
+
+  test('clicking a tab persists the new index to storage when storageKey is set', async () => {
+    const wrapper = mountTabs({ storageKey: 'deck-settings-tab' })
+    const tabs = wrapper.findAll('[data-testid="ui-kit-tabs__tab"]')
+
+    await tabs[2].trigger('click')
+
+    expect(mockStorageSet).toHaveBeenCalledWith('deck-settings-tab', '2')
+  })
+
+  test('clicking a tab does not touch storage when storageKey is unset', async () => {
+    const wrapper = mountTabs()
+    const tabs = wrapper.findAll('[data-testid="ui-kit-tabs__tab"]')
+
+    await tabs[1].trigger('click')
+
+    expect(mockStorageSet).not.toHaveBeenCalled()
+  })
+
+  test('hovering a non-active tab emits ui.hover sfx', async () => {
+    const wrapper = mountTabs({ activeTab: 0 })
+    const tabs = wrapper.findAll('[data-testid="ui-kit-tabs__tab"]')
+
+    await tabs[1].trigger('mouseenter')
+
+    expect(mockEmitHoverSfx).toHaveBeenCalledWith('ui.hover')
+  })
+
+  test('hovering the active tab emits no hover sfx', async () => {
+    const wrapper = mountTabs({ activeTab: 0 })
+    const tabs = wrapper.findAll('[data-testid="ui-kit-tabs__tab"]')
+
+    await tabs[0].trigger('mouseenter')
+
+    expect(mockEmitHoverSfx).not.toHaveBeenCalled()
+  })
+})

--- a/tests/integration/components/ui-kit/tappable.test.js
+++ b/tests/integration/components/ui-kit/tappable.test.js
@@ -78,30 +78,30 @@ describe('UiTappable — sfx.press read at click time [obligation]', () => {
   test('uses sfx.press from the prop at mount time on first click', async () => {
     // Fine pointer so staged-tap fires audio immediately
     coarseRef.value = false
-    const wrapper = mountTappable({ sfx: { press: 'snappy_button_5' } })
+    const wrapper = mountTappable({ sfx: { press: 'ui.press' } })
     await wrapper.trigger('click')
     await flushPromises()
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5', expect.anything())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('reflects sfx.press prop change on next click after mount [obligation]', async () => {
     coarseRef.value = false
-    const wrapper = mountTappable({ sfx: { press: 'snappy_button_5' } })
+    const wrapper = mountTappable({ sfx: { press: 'ui.press' } })
 
     // First click — plays the original sound
     await wrapper.trigger('click')
     await flushPromises()
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5', expect.anything())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
 
     // Change the prop after mount
-    await wrapper.setProps({ sfx: { press: 'digi_powerdown' } })
+    await wrapper.setProps({ sfx: { press: 'ui.deselect' } })
     vi.clearAllMocks()
 
     // Second click — must use the updated press sound, not the original
     await wrapper.trigger('click')
     await flushPromises()
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown', expect.anything())
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('snappy_button_5', expect.anything())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.deselect')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.press')
   })
 
   test('plays no sfx when sfx.press is not set', async () => {

--- a/tests/integration/components/ui-kit/textarea.test.js
+++ b/tests/integration/components/ui-kit/textarea.test.js
@@ -223,9 +223,9 @@ describe('UiTextarea — sfx', () => {
     mockEmitSfx.mockReset()
   })
 
-  test('plays type_05 sfx when the <textarea> receives focus [obligation]', async () => {
+  test('plays ui.focus sfx when the <textarea> receives focus [obligation]', async () => {
     const wrapper = mountTextareaWithSfx()
     await wrapper.find('textarea').trigger('focus')
-    expect(mockEmitSfx).toHaveBeenCalledWith('type_05', expect.anything())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.focus')
   })
 })

--- a/tests/integration/components/ui-kit/toggle.test.js
+++ b/tests/integration/components/ui-kit/toggle.test.js
@@ -68,38 +68,38 @@ describe('UiToggle', () => {
     expect(getChecked()).toBe(true)
   })
 
-  test('plays the select sfx when the input changes', async () => {
+  test('plays the ui.select sfx when the input changes', async () => {
     const { wrapper } = makeToggle({ checked: false })
     await wrapper.find('input[type="checkbox"]').setValue(true)
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 
-  test('silent=true suppresses the select sfx on change [obligation]', async () => {
-    const { wrapper } = makeToggle({ checked: false, silent: true })
+  test('sfx.press: false suppresses the select sfx on change [obligation]', async () => {
+    const { wrapper } = makeToggle({ checked: false, sfx: { press: false } })
     await wrapper.find('input[type="checkbox"]').setValue(true)
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.select')
   })
 
   function pointerEnter(el) {
     el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
   }
 
-  test('silent=true suppresses the hover sfx [obligation]', async () => {
-    const { wrapper } = makeToggle({ checked: false, silent: true })
+  test('sfx.hover: false suppresses the hover sfx [obligation]', async () => {
+    const { wrapper } = makeToggle({ checked: false, sfx: { hover: false } })
     pointerEnter(wrapper.find('[data-testid="ui-kit-toggle"]').element)
     expect(mockEmitHoverSfx).not.toHaveBeenCalled()
   })
 
-  test('silent=false (default) plays the hover sfx', () => {
+  test('an omitted hover channel falls back to the primitive default and plays the hover sfx', () => {
     const { wrapper } = makeToggle({ checked: false })
     pointerEnter(wrapper.find('[data-testid="ui-kit-toggle"]').element)
     expect(mockEmitHoverSfx).toHaveBeenCalled()
   })
 
-  test('silent defaults to false, still playing the select sfx', async () => {
+  test('an omitted press channel falls back to ui.select, still playing on change', async () => {
     const { wrapper } = makeToggle({ checked: false })
     await wrapper.find('input[type="checkbox"]').setValue(true)
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 
   // ── disabled [obligation] ───────────────────────────────────────────────────
@@ -134,7 +134,7 @@ describe('UiToggle', () => {
       const { wrapper } = makeToggle({ checked: false, disabled: true })
       await wrapper.find('input[type="checkbox"]').trigger('click')
 
-      expect(mockEmitSfx).not.toHaveBeenCalledWith('select')
+      expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.select')
     })
   })
 })

--- a/tests/integration/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/integration/composables/audio-reader/use-reader-highlights.test.js
@@ -660,7 +660,7 @@ describe('useReaderHighlights', () => {
   })
 
   describe('tap_05 ratchet on range-select via long-press', () => {
-    test('arming range-select via long-press emits ui.tap_05 for the first word [obligation]', async () => {
+    test('arming range-select via long-press emits gesture.tick for the first word [obligation]', async () => {
       const wrapper = mountHost(vi.fn())
       emitSfxMock.mockClear()
 
@@ -670,10 +670,10 @@ describe('useReaderHighlights', () => {
       await wrapper.vm.$nextTick()
       vi.useRealTimers()
 
-      expect(emitSfxMock).toHaveBeenCalledWith('tap_05')
+      expect(emitSfxMock).toHaveBeenCalledWith('gesture.tick')
     })
 
-    test('each new word the drag adds emits ui.tap_05 [obligation]', async () => {
+    test('each new word the drag adds emits gesture.tick [obligation]', async () => {
       const wrapper = mountHost(vi.fn())
 
       vi.useFakeTimers()
@@ -695,7 +695,7 @@ describe('useReaderHighlights', () => {
       await wrapper.vm.$nextTick()
       vi.useRealTimers()
 
-      expect(emitSfxMock).toHaveBeenCalledWith('tap_05')
+      expect(emitSfxMock).toHaveBeenCalledWith('gesture.tick')
     })
 
     test('release does not emit an extra ui.tap_05 [obligation]', async () => {
@@ -722,7 +722,7 @@ describe('useReaderHighlights', () => {
       vi.useRealTimers()
 
       // release should not call tap_05 again
-      expect(emitSfxMock).not.toHaveBeenCalledWith('tap_05')
+      expect(emitSfxMock).not.toHaveBeenCalledWith('gesture.tick')
     })
   })
 

--- a/tests/integration/views/audio-reader/lesson/audio-toolbar.test.js
+++ b/tests/integration/views/audio-reader/lesson/audio-toolbar.test.js
@@ -340,40 +340,40 @@ describe('AudioToolbar', () => {
 
   // ── Sfx wiring ─────────────────────────────────────────────────────────────
 
-  test('skip-back click.capture emits ui.snappy_button_5 sfx [obligation]', async () => {
+  test('skip-back click.capture emits ui.press sfx [obligation]', async () => {
     const wrapper = mountToolbar()
 
     // click.capture fires on the element's capture phase — trigger('click') fires
     // the click event which is caught by the @click.capture="onBackTap" handler
     await wrapper.find('[data-testid="audio-toolbar__skip-back"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
-  test('skip-forward click.capture emits ui.snappy_button_5 sfx [obligation]', async () => {
+  test('skip-forward click.capture emits ui.press sfx [obligation]', async () => {
     const wrapper = mountToolbar()
 
     await wrapper.find('[data-testid="audio-toolbar__skip-forward"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
-  test('play/pause toggle click.capture emits ui.snappy_button_2 when paused [obligation]', async () => {
+  test('play/pause toggle click.capture emits ui.press when paused [obligation]', async () => {
     const player = makePlayer({ is_playing: ref(false) })
     const wrapper = mountToolbar({ player })
 
     await wrapper.find('[data-testid="audio-toolbar__toggle"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_2')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
-  test('play/pause toggle click.capture emits ui.snappy_button_3 when playing [obligation]', async () => {
+  test('play/pause toggle click.capture emits dialog.open when playing [obligation]', async () => {
     const player = makePlayer({ is_playing: ref(true) })
     const wrapper = mountToolbar({ player })
 
     await wrapper.find('[data-testid="audio-toolbar__toggle"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_3')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   // ── Dropdown wiring: chapters ──────────────────────────────────────────────

--- a/tests/integration/views/audio-reader/lesson/index.test.js
+++ b/tests/integration/views/audio-reader/lesson/index.test.js
@@ -527,7 +527,7 @@ describe('LessonView', () => {
       expect(closeTermMock).toHaveBeenCalledOnce()
     })
 
-    test('transcript dismiss event emits ui.pop_up_close [obligation]', async () => {
+    test('transcript dismiss event emits dialog.close [obligation]', async () => {
       popoverOpenRef.value = true
       selectionRef.value = { term: 'hi', sentence: 'say hi', word_index: 1, rect: {} }
 
@@ -536,7 +536,7 @@ describe('LessonView', () => {
 
       await wrapper.find('[data-testid="transcript-stub__dismiss"]').trigger('click')
 
-      expect(emitSfxMock).toHaveBeenCalledWith('pop_up_close')
+      expect(emitSfxMock).toHaveBeenCalledWith('dialog.close')
     })
 
     test('closeTerm alone does NOT emit ui.pop_up_close [obligation]', async () => {
@@ -550,7 +550,7 @@ describe('LessonView', () => {
 
       // closeTermMock was called but sfx was NOT emitted (sfx only in dismissTerm)
       expect(closeTermMock).toHaveBeenCalledOnce()
-      expect(emitSfxMock).not.toHaveBeenCalledWith('pop_up_close')
+      expect(emitSfxMock).not.toHaveBeenCalledWith('dialog.close')
     })
   })
 

--- a/tests/integration/views/audio-reader/lesson/resume-follow-button.test.js
+++ b/tests/integration/views/audio-reader/lesson/resume-follow-button.test.js
@@ -72,11 +72,11 @@ describe('ResumeFollowButton', () => {
   })
 
   describe('click feedback [obligation]', () => {
-    test('plays the snappy_button_5 sfx on click [obligation]', () => {
+    test('plays the ui.press sfx on click [obligation]', () => {
       const wrapper = mountButton()
 
       expect(wrapper.findComponent(UiButtonStub).props('sfx')).toEqual({
-        press: 'snappy_button_5'
+        press: 'ui.press'
       })
     })
   })

--- a/tests/integration/views/audio-reader/term-popover/add-card-panel.test.js
+++ b/tests/integration/views/audio-reader/term-popover/add-card-panel.test.js
@@ -244,17 +244,17 @@ describe('AddCardPanel', () => {
       expect(wrapper.findComponent(CardFaceFieldStub).props('side')).toBe('front')
     })
 
-    test('flipping to back emits ui.transition_up [obligation]', async () => {
+    test('flipping to back emits card.flip-away [obligation]', async () => {
       const wrapper = mountPanel()
       emitSfxMock.mockClear()
 
       // Start on front; flip to back
       await wrapper.find('[data-testid="add-card-panel__flip-button"]').trigger('click')
 
-      expect(emitSfxMock).toHaveBeenCalledWith('transition_up')
+      expect(emitSfxMock).toHaveBeenCalledWith('card.flip-away')
     })
 
-    test('flipping to front emits ui.transition_down [obligation]', async () => {
+    test('flipping to front emits card.flip-back [obligation]', async () => {
       const wrapper = mountPanel()
 
       // Flip to back first, then back to front
@@ -262,12 +262,12 @@ describe('AddCardPanel', () => {
       emitSfxMock.mockClear()
       await wrapper.find('[data-testid="add-card-panel__flip-button"]').trigger('click')
 
-      expect(emitSfxMock).toHaveBeenCalledWith('transition_down')
+      expect(emitSfxMock).toHaveBeenCalledWith('card.flip-back')
     })
   })
 
   describe('focus cue [obligation]', () => {
-    test('focusin on a contenteditable target emits ui.slide_up [obligation]', async () => {
+    test('focusin on a contenteditable target emits nav.page-forward [obligation]', async () => {
       const wrapper = mountPanel()
       emitSfxMock.mockClear()
 
@@ -280,7 +280,7 @@ describe('AddCardPanel', () => {
       editable.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
       await wrapper.vm.$nextTick()
 
-      expect(emitSfxMock).toHaveBeenCalledWith('slide_up')
+      expect(emitSfxMock).toHaveBeenCalledWith('nav.page-forward')
       editable.remove()
     })
 
@@ -296,7 +296,7 @@ describe('AddCardPanel', () => {
       button.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
       await wrapper.vm.$nextTick()
 
-      expect(emitSfxMock).not.toHaveBeenCalledWith('slide_up')
+      expect(emitSfxMock).not.toHaveBeenCalledWith('nav.page-forward')
       button.remove()
     })
   })

--- a/tests/integration/views/dashboard/actions-panel/index.test.js
+++ b/tests/integration/views/dashboard/actions-panel/index.test.js
@@ -194,7 +194,7 @@ describe('DashboardActionsPanel — onSelect only wires new-deck', () => {
   test('selecting new-deck plays a press sfx', async () => {
     const wrapper = mount()
     await wrapper.find('[data-testid="entry-new-deck"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_pop')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('selecting new-deck while editing_decks is true does not create a deck, even bypassing the disabled UI state [obligation]', async () => {

--- a/tests/integration/views/dashboard/deck-grid/sort-options.test.js
+++ b/tests/integration/views/dashboard/deck-grid/sort-options.test.js
@@ -64,21 +64,21 @@ describe('DeckGridSortOptions — selected prop drives data-active', () => {
 })
 
 describe('DeckGridSortOptions — click behavior', () => {
-  test('clicking a non-selected option emits select with that key and plays snappy_button_5 [obligation]', async () => {
+  test('clicking a non-selected option emits select with that key and plays ui.press [obligation]', async () => {
     const wrapper = mount({ selected: 'custom' })
 
     await wrapper.find('[data-testid="deck-grid-sort-options__date-created"]').trigger('click')
 
     expect(wrapper.emitted('select')).toEqual([['date-created']])
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
-  test('clicking the currently selected option still emits select but plays digi_powerdown [obligation]', async () => {
+  test('clicking the currently selected option still emits select but plays ui.deselect [obligation]', async () => {
     const wrapper = mount({ selected: 'custom' })
 
     await wrapper.find('[data-testid="deck-grid-sort-options__custom"]').trigger('click')
 
     expect(wrapper.emitted('select')).toEqual([['custom']])
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.deselect')
   })
 })

--- a/tests/integration/views/dashboard/index.test.js
+++ b/tests/integration/views/dashboard/index.test.js
@@ -319,14 +319,14 @@ describe('DashboardIndex — edit-decks toggle', () => {
     expect(wrapper.findComponent(DeckGridStub).props('editing')).toBe(false)
   })
 
-  test('emits pop_up_pop sfx when editing_decks flips true, and pop_up_close when it flips false [obligation]', async () => {
+  test('emits dialog.open sfx when editing_decks flips true, and dialog.close when it flips false [obligation]', async () => {
     const wrapper = mountDashboard()
     await wrapper.find('[data-testid="dashboard-actions-panel"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_pop')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
 
     mockEmitSfx.mockClear()
     await wrapper.find('[data-testid="dashboard-actions-panel"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 })
 

--- a/tests/integration/views/dashboard/review-inbox/index.test.js
+++ b/tests/integration/views/dashboard/review-inbox/index.test.js
@@ -111,13 +111,13 @@ describe('ReviewInbox — editing mode disables item interaction [obligation]', 
     })
   })
 
-  test('clicking an item while editing plays digi_powerdown and does not start a study session [obligation]', async () => {
+  test('clicking an item while editing plays ui.rejected and does not start a study session [obligation]', async () => {
     const decks = makeDecks(3)
     const wrapper = mountInbox(decks, true)
 
     await wrapper.findAll('[data-testid="review-inbox-item"]')[1].trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
     expect(studyStartMock).not.toHaveBeenCalled()
   })
 })
@@ -192,16 +192,16 @@ describe('ReviewInbox — clicking an item starts a study session for just that 
     const decks = makeDecks(3)
     const wrapper = mountInbox(decks)
     await wrapper.findAll('[data-testid="review-inbox-item"]')[1].trigger('click')
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.rejected')
   })
 })
 
 describe('ReviewInbox — clicking an item while editing [obligation]', () => {
-  test('plays digi_powerdown and does not start a study session', async () => {
+  test('plays ui.rejected and does not start a study session', async () => {
     const decks = makeDecks(3)
     const wrapper = mountInbox(decks, true)
     await wrapper.findAll('[data-testid="review-inbox-item"]')[1].trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
     expect(studyStartMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/integration/views/dashboard/review-inbox/item.test.js
+++ b/tests/integration/views/dashboard/review-inbox/item.test.js
@@ -12,7 +12,6 @@ vi.mock('@/sfx/bus', () => ({
 
 import ReviewInboxItem from '@/views/dashboard/review-inbox/item.vue'
 import { vSfx } from '@/sfx/directive'
-import { TYPE_SFX } from '@/sfx/config'
 
 function mount(deck, props = {}) {
   return shallowMount(ReviewInboxItem, {
@@ -52,7 +51,7 @@ describe('ReviewInboxItem', () => {
     wrapper
       .find('[data-testid="review-inbox-item"]')
       .element.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
-    expect(mockEmitHoverSfx).toHaveBeenCalledWith(TYPE_SFX, expect.anything())
+    expect(mockEmitHoverSfx).toHaveBeenCalledWith('ui.hover')
   })
 
   describe('disabled prop [obligation]', () => {

--- a/tests/integration/views/deck/card-editor/list-item-card.test.js
+++ b/tests/integration/views/deck/card-editor/list-item-card.test.js
@@ -194,15 +194,15 @@ describe('ListItemCard', () => {
     return { card, editor }
   }
 
-  test('emits ui.slide_up when a card is activated from outside every card (relatedTarget null)', async () => {
+  test('emits nav.page-forward when a card is activated from outside every card (relatedTarget null)', async () => {
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     const contenteditable = wrapper.find('[data-testid="front-input"]').element
     contenteditable.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }))
-    expect(mocks.emitSfxMock).toHaveBeenCalledWith('slide_up')
+    expect(mocks.emitSfxMock).toHaveBeenCalledWith('nav.page-forward')
     wrapper.unmount()
   })
 
-  test('emits ui.slide_up when focus enters from an element outside every card', async () => {
+  test('emits nav.page-forward when focus enters from an element outside every card', async () => {
     const external = document.createElement('div')
     document.body.appendChild(external)
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
@@ -210,12 +210,12 @@ describe('ListItemCard', () => {
     contenteditable.dispatchEvent(
       new FocusEvent('focusin', { bubbles: true, relatedTarget: external })
     )
-    expect(mocks.emitSfxMock).toHaveBeenCalledWith('slide_up')
+    expect(mocks.emitSfxMock).toHaveBeenCalledWith('nav.page-forward')
     external.remove()
     wrapper.unmount()
   })
 
-  test('emits ui.click_04 when focus moves within the card (between sides)', async () => {
+  test('emits gesture.tick when focus moves within the card (between sides)', async () => {
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     const first_editor = wrapper.find('[data-testid="front-input"]').element
     const second_editor = wrapper.find('[data-testid="back-input"]').element
@@ -223,18 +223,18 @@ describe('ListItemCard', () => {
     second_editor.dispatchEvent(
       new FocusEvent('focusin', { bubbles: true, relatedTarget: first_editor })
     )
-    expect(mocks.emitSfxMock).toHaveBeenCalledWith('click_04')
+    expect(mocks.emitSfxMock).toHaveBeenCalledWith('gesture.tick')
     wrapper.unmount()
   })
 
-  test('emits ui.click_04 when focus moves in from another card', async () => {
+  test('emits gesture.tick when focus moves in from another card', async () => {
     const other = makeOtherCardEditor()
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     const contenteditable = wrapper.find('[data-testid="front-input"]').element
     contenteditable.dispatchEvent(
       new FocusEvent('focusin', { bubbles: true, relatedTarget: other.editor })
     )
-    expect(mocks.emitSfxMock).toHaveBeenCalledWith('click_04')
+    expect(mocks.emitSfxMock).toHaveBeenCalledWith('gesture.tick')
     other.card.remove()
     wrapper.unmount()
   })
@@ -251,48 +251,48 @@ describe('ListItemCard', () => {
     wrapper.unmount()
   })
 
-  test('emits ui.card_drop when an editor blurs to outside every card', async () => {
+  test('emits dialog.close when an editor blurs to outside every card', async () => {
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     const contenteditable = wrapper.find('[data-testid="front-input"]').element
     contenteditable.dispatchEvent(
       new FocusEvent('focusout', { bubbles: true, relatedTarget: null })
     )
-    expect(mocks.emitSfxMock).toHaveBeenCalledWith('card_drop')
+    expect(mocks.emitSfxMock).toHaveBeenCalledWith('dialog.close')
     wrapper.unmount()
   })
 
-  test('does NOT emit ui.card_drop when a non-contenteditable element blurs to outside every card', async () => {
+  test('does NOT emit dialog.close when a non-contenteditable element blurs to outside every card', async () => {
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     // A non-contenteditable element (e.g. the image button) losing focus must not trigger the drop sfx.
     const button = document.createElement('button')
     wrapper.element.appendChild(button)
     button.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }))
     // e.target.isContentEditable is false → card_drop guard skipped
-    expect(mocks.emitSfxMock).not.toHaveBeenCalledWith('card_drop')
+    expect(mocks.emitSfxMock).not.toHaveBeenCalledWith('dialog.close')
     button.remove()
     wrapper.unmount()
   })
 
-  test('does NOT emit ui.card_drop when focus moves out to another card', async () => {
+  test('does NOT emit dialog.close when focus moves out to another card', async () => {
     const other = makeOtherCardEditor()
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     const contenteditable = wrapper.find('[data-testid="front-input"]').element
     contenteditable.dispatchEvent(
       new FocusEvent('focusout', { bubbles: true, relatedTarget: other.editor })
     )
-    expect(mocks.emitSfxMock).not.toHaveBeenCalledWith('card_drop')
+    expect(mocks.emitSfxMock).not.toHaveBeenCalledWith('dialog.close')
     other.card.remove()
     wrapper.unmount()
   })
 
-  test('does NOT emit ui.card_drop when focus stays within the card (between sides)', async () => {
+  test('does NOT emit dialog.close when focus stays within the card (between sides)', async () => {
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     const first_editor = wrapper.find('[data-testid="front-input"]').element
     const second_editor = wrapper.find('[data-testid="back-input"]').element
     first_editor.dispatchEvent(
       new FocusEvent('focusout', { bubbles: true, relatedTarget: second_editor })
     )
-    expect(mocks.emitSfxMock).not.toHaveBeenCalledWith('card_drop')
+    expect(mocks.emitSfxMock).not.toHaveBeenCalledWith('dialog.close')
     wrapper.unmount()
   })
 
@@ -332,7 +332,7 @@ describe('ListItemCard', () => {
     wrapper.unmount()
   })
 
-  test('focusout with relatedTarget inside the card keeps focused true, so the next focusin emits click_04', async () => {
+  test('focusout with relatedTarget inside the card keeps focused true, so the next focusin emits gesture.tick', async () => {
     const wrapper = mountWithFocusStubs({ card: { id: 42 } })
     const first_editor = wrapper.find('[data-testid="front-input"]').element
     const second_editor = wrapper.find('[data-testid="back-input"]').element
@@ -347,7 +347,7 @@ describe('ListItemCard', () => {
     second_editor.dispatchEvent(
       new FocusEvent('focusin', { bubbles: true, relatedTarget: first_editor })
     )
-    expect(mocks.emitSfxMock).toHaveBeenCalledWith('click_04')
+    expect(mocks.emitSfxMock).toHaveBeenCalledWith('gesture.tick')
     wrapper.unmount()
   })
 
@@ -362,7 +362,7 @@ describe('ListItemCard', () => {
     )
     mocks.emitSfxMock.mockReset()
     contenteditable.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }))
-    expect(mocks.emitSfxMock).toHaveBeenCalledWith('slide_up')
+    expect(mocks.emitSfxMock).toHaveBeenCalledWith('nav.page-forward')
     wrapper.unmount()
   })
 

--- a/tests/integration/views/deck/card-grid/grid-item.test.js
+++ b/tests/integration/views/deck/card-grid/grid-item.test.js
@@ -186,15 +186,15 @@ describe('GridItem (card-grid/grid-item.vue)', () => {
     expect(wrapper.find('[data-testid="card-stub"]').attributes('data-side')).toBe('back')
   })
 
-  test('clicking the card flips front → back and emits transition_up sfx when not selecting', async () => {
+  test('clicking the card flips front → back and emits card.flip-away sfx when not selecting', async () => {
     const { wrapper } = mountGridItem({ props: { side: 'front' } })
     await wrapper.find('[data-testid="card-stub"]').trigger('click')
 
     expect(wrapper.find('[data-testid="card-stub"]').attributes('data-side')).toBe('back')
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-away')
   })
 
-  test('clicking again flips back → front and emits transition_down sfx', async () => {
+  test('clicking again flips back → front and emits card.flip-back sfx', async () => {
     const { wrapper } = mountGridItem({ props: { side: 'front' } })
     const card = wrapper.find('[data-testid="card-stub"]')
 
@@ -203,7 +203,31 @@ describe('GridItem (card-grid/grid-item.vue)', () => {
 
     await card.trigger('click')
     expect(card.attributes('data-side')).toBe('front')
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_down')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-back')
+  })
+
+  // ── a back-facing grid reads its own `side` prop, not a hardcoded 'back' [obligation] ──
+
+  test('on a back-facing grid, flipping away from the default emits card.flip-away [obligation]', async () => {
+    const { wrapper } = mountGridItem({ props: { side: 'back' } })
+    const card = wrapper.find('[data-testid="card-stub"]')
+
+    await card.trigger('click')
+
+    expect(card.attributes('data-side')).toBe('front')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-away')
+  })
+
+  test('on a back-facing grid, flipping back to the default emits card.flip-back [obligation]', async () => {
+    const { wrapper } = mountGridItem({ props: { side: 'back' } })
+    const card = wrapper.find('[data-testid="card-stub"]')
+
+    await card.trigger('click')
+    mockEmitSfx.mockClear()
+    await card.trigger('click')
+
+    expect(card.attributes('data-side')).toBe('back')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-back')
   })
 
   test('clicking the card during selection calls onSelectCard with the card id and does not flip', async () => {
@@ -317,7 +341,7 @@ describe('GridItem (card-grid/grid-item.vue)', () => {
     await wrapper.find('[data-testid="card-stub"]').trigger('click')
 
     expect(wrapper.find('[data-testid="card-stub"]').attributes('data-side')).toBe('back')
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-away')
 
     window.getSelection = origGetSelection
   })

--- a/tests/integration/views/deck/card-import/drop-zone.test.js
+++ b/tests/integration/views/deck/card-import/drop-zone.test.js
@@ -7,7 +7,10 @@ const { mockEmitSfx, mockEmitHoverSfx } = vi.hoisted(() => ({
 }))
 
 vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx, emitHoverSfx: mockEmitHoverSfx }))
-vi.mock('@/sfx/config', () => ({ TYPE_SFX: [] }))
+vi.mock('@/sfx/config', () => ({
+  SOUNDS: {},
+  BUS_DEFAULTS: { interface: 5, hover: 5 }
+}))
 
 import DropZone from '@/views/deck/card-import/drop-zone.vue'
 import { vSfx } from '@/sfx/directive'
@@ -120,14 +123,14 @@ describe('card-import/drop-zone', () => {
     expect(zone.attributes('data-active')).toBe('true')
   })
 
-  test('clicking browse plays the select sfx and opens the hidden file input', async () => {
+  test('clicking browse plays the ui.select sfx and opens the hidden file input', async () => {
     const wrapper = mount()
     const input = wrapper.find('[data-testid="card-import-drop-zone__input"]')
     const clickSpy = vi.spyOn(input.element, 'click')
 
     await wrapper.find('[data-testid="card-import-drop-zone__browse"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
     expect(clickSpy).toHaveBeenCalledOnce()
   })
 

--- a/tests/integration/views/deck/deck-hero/bulk-actions.test.js
+++ b/tests/integration/views/deck/deck-hero/bulk-actions.test.js
@@ -139,7 +139,7 @@ describe('deck-hero/bulk-actions', () => {
   test('navigating select-all emits ui.select sfx and calls toggleSelectAll', async () => {
     const { wrapper, editor } = mount()
     await selectAllEntry(wrapper).trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
     expect(editor.selection.toggleSelectAll).toHaveBeenCalledOnce()
   })
 

--- a/tests/integration/views/deck/deck-settings/tab-review-pacing/advanced-reveal.test.js
+++ b/tests/integration/views/deck/deck-settings/tab-review-pacing/advanced-reveal.test.js
@@ -86,12 +86,12 @@ describe('AdvancedReveal — toggling flips persistence [obligation]', () => {
     expect(localStorage.getItem(LOCAL_STORAGE_KEY)).toBe('false')
   })
 
-  test('toggling plays the snappy_button_5 sfx', async () => {
+  test('toggling plays the ui.press sfx', async () => {
     const { wrapper } = makeWrapper()
 
     await wrapper.find('[data-testid="advanced-reveal__scrim"]').trigger('click')
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('calls popScrimReveal with revealed=true on the reveal click', async () => {

--- a/tests/integration/views/deck/deck-settings/tab-review-pacing/preset-chip.test.js
+++ b/tests/integration/views/deck/deck-settings/tab-review-pacing/preset-chip.test.js
@@ -174,14 +174,14 @@ describe('PresetChip — select sfx [obligation]', () => {
     const { wrapper } = makeWrapper()
     mockEmitSfx.mockClear()
     await wrapper.find('[data-testid="preset-chip__option-2"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 
   test('emits the select sfx when picking a CRUD action row [obligation]', async () => {
     const { wrapper } = makeWrapper()
     mockEmitSfx.mockClear()
     await wrapper.find('[data-testid="preset-chip__option-fork"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
   })
 })
 

--- a/tests/integration/views/deck/mobile-footer/footer-bulk-actions.test.js
+++ b/tests/integration/views/deck/mobile-footer/footer-bulk-actions.test.js
@@ -108,7 +108,7 @@ describe('mobile-footer/footer-bulk-actions', () => {
   test('clicking select-all emits ui.select sfx and calls toggleSelectAll', async () => {
     const { wrapper, editor } = mount()
     await selectAllBtn(wrapper).trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
     expect(editor.selection.toggleSelectAll).toHaveBeenCalledOnce()
   })
 

--- a/tests/integration/views/deck/mode-toolbar/mode-select.test.js
+++ b/tests/integration/views/deck/mode-toolbar/mode-select.test.js
@@ -154,7 +154,7 @@ describe('mode-toolbar/mode-select', () => {
   test('clicking select-all emits ui.select sfx and calls toggleSelectAll', async () => {
     const { wrapper, editor } = mount()
     await selectAllBtn(wrapper).trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
     expect(editor.selection.toggleSelectAll).toHaveBeenCalledOnce()
   })
 

--- a/tests/integration/views/deck/search-bar.test.js
+++ b/tests/integration/views/deck/search-bar.test.js
@@ -189,18 +189,18 @@ describe('search-bar', () => {
     // clear() empties the draft and query, and emits snappy_button_5
     expect(wrapper.find('[data-testid="deck-search-bar__input"]').element.value).toBe('')
     expect(search.query.value).toBe('')
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   // ── clear() refocuses input ────────────────────────────────────────────────
 
-  test('clear() emits snappy_button_5 sfx [obligation]', async () => {
+  test('clear() emits ui.press sfx [obligation]', async () => {
     const search = makeSearch({ is_searching: true })
     const wrapper = mountSearchBar(search)
     await wrapper.find('[data-testid="deck-search-bar__input"]').setValue('text')
     mockEmitSfx.mockClear()
     await wrapper.find('[data-testid="deck-search-bar__button"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   // ── Enter key submits immediately (bypasses debounce) ─────────────────────

--- a/tests/integration/views/welcome/forgot-password/index.test.js
+++ b/tests/integration/views/welcome/forgot-password/index.test.js
@@ -97,14 +97,14 @@ describe('ForgotPasswordModal (forgot-password/index.vue)', () => {
 
   test('plays wooden_chime_ring on mount', () => {
     makeWrapper()
-    expect(mockEmitSfx).toHaveBeenCalledWith('wooden_chime_ring')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('plays pop_up_close on unmount', () => {
     const wrapper = makeWrapper()
     mockEmitSfx.mockClear()
     wrapper.unmount()
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 
   // ── submit wiring ─────────────────────────────────────────────────────────

--- a/tests/integration/views/welcome/forgot-password/success.test.js
+++ b/tests/integration/views/welcome/forgot-password/success.test.js
@@ -31,7 +31,7 @@ describe('ForgotPasswordSuccess (forgot-password/success.vue)', () => {
 
   test('plays success_1 sfx on mount', () => {
     mountSuccess()
-    expect(mockEmitSfx).toHaveBeenCalledWith('success_1')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.success')
   })
 
   test('calls the close prop when the close button is pressed', async () => {

--- a/tests/integration/views/welcome/index.test.js
+++ b/tests/integration/views/welcome/index.test.js
@@ -202,10 +202,10 @@ describe('WelcomeIndex', () => {
 
   // ── openSignup sfx [obligation] ────────────────────────────────────────────
 
-  test('clicking signup emits snappy_button_3 sfx [obligation]', async () => {
+  test('clicking signup emits dialog.open sfx [obligation]', async () => {
     const wrapper = mountWelcome()
     await wrapper.find('[data-testid="splash__signup"]').trigger('click')
-    expect(mocks.emitSfx).toHaveBeenCalledWith('snappy_button_3')
+    expect(mocks.emitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('clicking signup opens the modal [obligation]', async () => {
@@ -214,7 +214,7 @@ describe('WelcomeIndex', () => {
     expect(mocks.modalOpen).toHaveBeenCalled()
   })
 
-  test('modal response resolution emits pop_up_close sfx [obligation]', async () => {
+  test('modal response resolution emits dialog.close sfx [obligation]', async () => {
     let resolve_response
     const deferred = new Promise((resolve) => {
       resolve_response = resolve
@@ -224,7 +224,7 @@ describe('WelcomeIndex', () => {
     mocks.emitSfx.mockReset()
     resolve_response(undefined)
     await flushPromises()
-    expect(mocks.emitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mocks.emitSfx).toHaveBeenCalledWith('dialog.close')
   })
 
   // ── scrollToContent / See More [obligation] ────────────────────────────────

--- a/tests/integration/views/welcome/reset-password/index.test.js
+++ b/tests/integration/views/welcome/reset-password/index.test.js
@@ -121,14 +121,14 @@ describe('ResetPasswordModal (reset-password/index.vue)', () => {
 
   test('plays wooden_chime_ring on mount', () => {
     makeWrapper()
-    expect(mockEmitSfx).toHaveBeenCalledWith('wooden_chime_ring')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('plays pop_up_close on unmount', () => {
     const wrapper = makeWrapper()
     mockEmitSfx.mockClear()
     wrapper.unmount()
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 
   // ── onSubmit — failure/invalid keeps the modal open ─────────────────────────
@@ -140,7 +140,7 @@ describe('ResetPasswordModal (reset-password/index.vue)', () => {
     await wrapper.find('[data-testid="reset-password-modal__submit"]').trigger('click')
     await flushPromises()
 
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('success_1')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('notice.success')
     expect(mockPush).not.toHaveBeenCalled()
   })
 
@@ -154,7 +154,7 @@ describe('ResetPasswordModal (reset-password/index.vue)', () => {
       await wrapper.find('[data-testid="reset-password-modal__submit"]').trigger('click')
       await flushPromises()
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('success_1')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.success')
     })
 
     test('does NOT call close or route before the ~1400ms wait elapses [obligation]', async () => {

--- a/tests/integration/views/welcome/splash/splash-preview.test.js
+++ b/tests/integration/views/welcome/splash/splash-preview.test.js
@@ -78,10 +78,10 @@ describe('SplashPreview', () => {
     expect(wrapper.find('[data-testid="pinned-preview"]').attributes('data-side')).toBe('front')
   })
 
-  test('flipping the pinned preview emits slide_up sfx [obligation]', async () => {
+  test('flipping the pinned preview emits nav.page-forward sfx [obligation]', async () => {
     const wrapper = mountSplashPreview()
     await wrapper.find('[data-testid="pinned-preview__flip"]').trigger('click')
-    expect(mockEmitSfx).toHaveBeenCalledWith('slide_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('nav.page-forward')
   })
 
   test('flipping back to cover side updates the side', async () => {
@@ -93,12 +93,12 @@ describe('SplashPreview', () => {
     expect(wrapper.find('[data-testid="pinned-preview"]').attributes('data-side')).toBe('cover')
   })
 
-  test('each flip emits slide_up sfx', async () => {
+  test('each flip emits nav.page-forward sfx', async () => {
     const wrapper = mountSplashPreview()
     await wrapper.find('[data-testid="pinned-preview__flip"]').trigger('click')
     await wrapper.find('[data-testid="pinned-preview__flip"]').trigger('click')
     expect(mockEmitSfx).toHaveBeenCalledTimes(2)
-    expect(mockEmitSfx).toHaveBeenNthCalledWith(1, 'slide_up')
-    expect(mockEmitSfx).toHaveBeenNthCalledWith(2, 'slide_up')
+    expect(mockEmitSfx).toHaveBeenNthCalledWith(1, 'nav.page-forward')
+    expect(mockEmitSfx).toHaveBeenNthCalledWith(2, 'nav.page-forward')
   })
 })

--- a/tests/unit/components/modals/change-card/use-change-card.test.js
+++ b/tests/unit/components/modals/change-card/use-change-card.test.js
@@ -81,13 +81,13 @@ beforeEach(() => {
 describe('useChangeCard — mount/unmount chimes', () => {
   test('[obligation] plays wooden_chime_ring on mount', () => {
     withSetup(() => useChangeCard(vi.fn()))
-    expect(mockEmitSfx).toHaveBeenCalledWith('wooden_chime_ring')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('[obligation] plays pop_up_close on unmount', () => {
     withSetup(() => useChangeCard(vi.fn()))
     app.unmount()
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 })
 

--- a/tests/unit/components/modals/checkout/use-checkout.test.js
+++ b/tests/unit/components/modals/checkout/use-checkout.test.js
@@ -145,7 +145,7 @@ describe('useCheckout — onSubmit non-success confirm', () => {
 
     expect(mockRefetch).not.toHaveBeenCalled()
     expect(mockInvalidateQueries).not.toHaveBeenCalled()
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('success_1')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('notice.success')
     expect(close).not.toHaveBeenCalled()
     expect(status.value).toBe('form')
   })
@@ -197,7 +197,7 @@ describe('useCheckout — onSubmit success path', () => {
     await submitPromise
 
     expect(mockInvalidateQueries).toHaveBeenCalledWith({ key: ['billing'] })
-    expect(mockEmitSfx).toHaveBeenCalledWith('success_1')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.success')
     expect(close).toHaveBeenCalledWith({ upgraded: true })
     expect(status.value).toBe('success')
   })
@@ -221,15 +221,15 @@ describe('useCheckout — onSubmit success path', () => {
 // ── onMounted / onBeforeUnmount sfx ─────────────────────────────────────────────
 
 describe('useCheckout — mount/unmount chimes', () => {
-  test('plays wooden_chime_ring on mount', () => {
+  test('plays dialog.open on mount', () => {
     withSetup(() => useCheckout(vi.fn()))
-    expect(mockEmitSfx).toHaveBeenCalledWith('wooden_chime_ring')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
-  test('plays pop_up_close on unmount', () => {
+  test('plays dialog.close on unmount', () => {
     withSetup(() => useCheckout(vi.fn()))
     app.unmount()
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 })
 

--- a/tests/unit/components/settings/account-access/use-email-actions.test.js
+++ b/tests/unit/components/settings/account-access/use-email-actions.test.js
@@ -100,7 +100,7 @@ describe('useEmailActions — validation', () => {
     const email_actions = useEmailActions()
     email_actions.email.value = ''
     await email_actions.submit()
-    expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
   })
 
   test('[obligation] does NOT fire a notice-store error for a validation failure', async () => {
@@ -184,7 +184,7 @@ describe('useEmailActions — submit', () => {
 
       await email_actions.submit()
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     }
   })
 

--- a/tests/unit/components/settings/account-access/use-password-actions.test.js
+++ b/tests/unit/components/settings/account-access/use-password-actions.test.js
@@ -112,7 +112,7 @@ describe('usePasswordActions — validation', () => {
   test('[obligation] plays the stuck sfx when client-side validation fails', async () => {
     const password_actions = usePasswordActions()
     await password_actions.submit()
-    expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
   })
 
   test('[obligation] does NOT fire a notice-store error for a validation failure', async () => {
@@ -508,7 +508,7 @@ describe('usePasswordActions — submit (current-password branch success/outcome
 
       await password_actions.submit()
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     }
   })
 

--- a/tests/unit/composables/admin/use-admin-modal.test.js
+++ b/tests/unit/composables/admin/use-admin-modal.test.js
@@ -53,7 +53,7 @@ describe('useAdminModal — call shape', () => {
     const { open } = useAdminModal()
     open()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_3')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('plays pop_up_close sfx once the modal resolves [obligation]', async () => {
@@ -69,6 +69,6 @@ describe('useAdminModal — call shape', () => {
     resolve(undefined)
     await response
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 })

--- a/tests/unit/composables/audio-reader/collection-create-modal.test.js
+++ b/tests/unit/composables/audio-reader/collection-create-modal.test.js
@@ -1,0 +1,68 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { flushPromises } from '@vue/test-utils'
+import { useCollectionCreateModal } from '@/composables/audio-reader/collection-create-modal'
+import CollectionCreate from '@/views/audio-reader/collection-create-modal.vue'
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+const { mockOpen } = vi.hoisted(() => ({ mockOpen: vi.fn() }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+
+vi.mock('@/composables/modal', () => ({
+  useModal: vi.fn(() => ({ open: mockOpen }))
+}))
+
+function makeModalResult(value) {
+  return { response: Promise.resolve(value) }
+}
+
+describe('useCollectionCreateModal', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+    mockOpen.mockReset()
+  })
+
+  test('plays dialog.open sfx when opening', () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useCollectionCreateModal()
+    open()
+
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
+  })
+
+  test('opens the modal with backdrop and mobile-sheet mode', () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useCollectionCreateModal()
+    open()
+
+    expect(mockOpen).toHaveBeenCalledWith(CollectionCreate, {
+      backdrop: true,
+      mode: 'mobile-sheet'
+    })
+  })
+
+  test('plays dialog.close sfx once the modal response resolves', async () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useCollectionCreateModal()
+    open()
+    const openSfxCount = mockEmitSfx.mock.calls.length
+
+    await flushPromises()
+
+    expect(mockEmitSfx.mock.calls.length).toBeGreaterThan(openSfxCount)
+    expect(mockEmitSfx).toHaveBeenLastCalledWith('dialog.close')
+  })
+
+  test('returns the result of modal.open unchanged', () => {
+    const result = makeModalResult(undefined)
+    mockOpen.mockReturnValueOnce(result)
+
+    const { open } = useCollectionCreateModal()
+    const returned = open()
+
+    expect(returned).toBe(result)
+  })
+})

--- a/tests/unit/composables/audio-reader/collection-edit-modal.test.js
+++ b/tests/unit/composables/audio-reader/collection-edit-modal.test.js
@@ -1,0 +1,69 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { flushPromises } from '@vue/test-utils'
+import { useCollectionEditModal } from '@/composables/audio-reader/collection-edit-modal'
+import CollectionEdit from '@/views/audio-reader/collection-edit-modal.vue'
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+const { mockOpen } = vi.hoisted(() => ({ mockOpen: vi.fn() }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+
+vi.mock('@/composables/modal', () => ({
+  useModal: vi.fn(() => ({ open: mockOpen }))
+}))
+
+function makeModalResult(value) {
+  return { response: Promise.resolve(value) }
+}
+
+describe('useCollectionEditModal', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+    mockOpen.mockReset()
+  })
+
+  test('plays dialog.open sfx when opening', () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useCollectionEditModal()
+    open(1)
+
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
+  })
+
+  test('opens the modal with the collection_id prop, backdrop, and mobile-sheet mode', () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useCollectionEditModal()
+    open(42)
+
+    expect(mockOpen).toHaveBeenCalledWith(CollectionEdit, {
+      props: { collection_id: 42 },
+      backdrop: true,
+      mode: 'mobile-sheet'
+    })
+  })
+
+  test('plays dialog.close sfx once the modal response resolves', async () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useCollectionEditModal()
+    open(1)
+    const openSfxCount = mockEmitSfx.mock.calls.length
+
+    await flushPromises()
+
+    expect(mockEmitSfx.mock.calls.length).toBeGreaterThan(openSfxCount)
+    expect(mockEmitSfx).toHaveBeenLastCalledWith('dialog.close')
+  })
+
+  test('returns the result of modal.open unchanged', () => {
+    const result = makeModalResult(undefined)
+    mockOpen.mockReturnValueOnce(result)
+
+    const { open } = useCollectionEditModal()
+    const returned = open(1)
+
+    expect(returned).toBe(result)
+  })
+})

--- a/tests/unit/composables/audio-reader/upload-lesson-modal.test.js
+++ b/tests/unit/composables/audio-reader/upload-lesson-modal.test.js
@@ -1,0 +1,69 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { flushPromises } from '@vue/test-utils'
+import { useUploadLessonModal } from '@/composables/audio-reader/upload-lesson-modal'
+import UploadLesson from '@/views/audio-reader/upload-lesson-modal/index.vue'
+
+const { mockEmitSfx } = vi.hoisted(() => ({ mockEmitSfx: vi.fn() }))
+const { mockOpen } = vi.hoisted(() => ({ mockOpen: vi.fn() }))
+
+vi.mock('@/sfx/bus', () => ({ emitSfx: mockEmitSfx }))
+
+vi.mock('@/composables/modal', () => ({
+  useModal: vi.fn(() => ({ open: mockOpen }))
+}))
+
+function makeModalResult(value) {
+  return { response: Promise.resolve(value) }
+}
+
+describe('useUploadLessonModal', () => {
+  beforeEach(() => {
+    mockEmitSfx.mockClear()
+    mockOpen.mockReset()
+  })
+
+  test('plays dialog.open sfx when opening', () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useUploadLessonModal()
+    open(1)
+
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
+  })
+
+  test('opens the modal with the collection_id prop, backdrop, and mobile-sheet mode', () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useUploadLessonModal()
+    open(42)
+
+    expect(mockOpen).toHaveBeenCalledWith(UploadLesson, {
+      props: { collection_id: 42 },
+      backdrop: true,
+      mode: 'mobile-sheet'
+    })
+  })
+
+  test('plays dialog.close sfx once the modal response resolves', async () => {
+    mockOpen.mockReturnValueOnce(makeModalResult(undefined))
+
+    const { open } = useUploadLessonModal()
+    open(1)
+    const openSfxCount = mockEmitSfx.mock.calls.length
+
+    await flushPromises()
+
+    expect(mockEmitSfx.mock.calls.length).toBeGreaterThan(openSfxCount)
+    expect(mockEmitSfx).toHaveBeenLastCalledWith('dialog.close')
+  })
+
+  test('returns the result of modal.open unchanged', () => {
+    const result = makeModalResult(undefined)
+    mockOpen.mockReturnValueOnce(result)
+
+    const { open } = useUploadLessonModal()
+    const returned = open(1)
+
+    expect(returned).toBe(result)
+  })
+})

--- a/tests/unit/composables/audio-reader/use-lesson-reader.test.js
+++ b/tests/unit/composables/audio-reader/use-lesson-reader.test.js
@@ -164,16 +164,16 @@ describe('useLessonReader', () => {
       expect(reader.popover_open.value).toBe(true)
     })
 
-    test('openTerm emits ui.pop_up_pop on every call [obligation]', () => {
+    test('openTerm emits dialog.open on every call [obligation]', () => {
       let reader
       ;[reader, app] = withReader()
       const term = { term: 'world', sentence: 'Hello world.', rect: new DOMRect() }
 
       reader.openTerm(term)
-      expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_pop')
+      expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
     })
 
-    test('openTerm emits ui.pop_up_pop on re-tap [obligation]', () => {
+    test('openTerm emits dialog.open on re-tap [obligation]', () => {
       let reader
       ;[reader, app] = withReader()
       const term = { term: 'world', sentence: 'Hello world.', rect: new DOMRect() }
@@ -182,7 +182,7 @@ describe('useLessonReader', () => {
       reader.openTerm(term)
 
       expect(mockEmitSfx).toHaveBeenCalledTimes(2)
-      expect(mockEmitSfx.mock.calls.every((c) => c[0] === 'pop_up_pop')).toBe(true)
+      expect(mockEmitSfx.mock.calls.every((c) => c[0] === 'dialog.open')).toBe(true)
     })
 
     test('openTerm never opens a global modal [obligation]', () => {

--- a/tests/unit/composables/audio-reader/use-reader-highlights.test.js
+++ b/tests/unit/composables/audio-reader/use-reader-highlights.test.js
@@ -194,7 +194,7 @@ describe('useReaderHighlights', () => {
   })
 
   describe('mouse drag — fine-pointer ratchet [obligation]', () => {
-    test('onPointerMove emits ui.tap_05 when a new word is entered during active drag', async () => {
+    test('onPointerMove emits gesture.tick when a new word is entered during active drag', async () => {
       const { result, contentEl } = withHighlights()
       const wordEl3 = addWord(contentEl, 3)
       const wordEl5 = addWord(contentEl, 5)
@@ -212,7 +212,7 @@ describe('useReaderHighlights', () => {
         new PointerEvent('pointermove', { pointerType: 'mouse', clientX: 100, clientY: 50 })
       )
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('tap_05')
+      expect(mockEmitSfx).toHaveBeenCalledWith('gesture.tick')
     })
 
     test('onPointerMove does NOT emit ui.tap_05 when pointer stays on the same word', async () => {
@@ -252,7 +252,7 @@ describe('useReaderHighlights', () => {
       expect(mockEmitSfx).not.toHaveBeenCalled()
     })
 
-    test('touch path (extendTouchSelection) emits tap_05 when a word changes but the fine-pointer code path does NOT handle it', async () => {
+    test('touch path (extendTouchSelection) emits gesture.tick when a word changes but the fine-pointer code path does NOT handle it', async () => {
       // This is the existing touch ratchet via extendTouchSelection — separate from
       // the fine-pointer path. Verifies the two paths are distinct: touch goes
       // through trackTap→extendTouchSelection, not through the fine-pointer branch.
@@ -277,7 +277,7 @@ describe('useReaderHighlights', () => {
         new PointerEvent('pointermove', { pointerType: 'touch', clientX: 30, clientY: 10 })
       )
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('tap_05')
+      expect(mockEmitSfx).toHaveBeenCalledWith('gesture.tick')
 
       vi.useRealTimers()
     })
@@ -531,7 +531,7 @@ describe('useReaderHighlights', () => {
       expect(result.interaction_range.value).toEqual({ lo: 2, hi: 2 })
     })
 
-    test('long-press emits ui.tap_05 when armed', async () => {
+    test('long-press emits gesture.tick when armed', async () => {
       const { result, contentEl } = withHighlights()
       const wordEl = addWord(contentEl, 3)
 
@@ -543,7 +543,7 @@ describe('useReaderHighlights', () => {
       vi.advanceTimersByTime(410)
       await nextTick()
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('tap_05')
+      expect(mockEmitSfx).toHaveBeenCalledWith('gesture.tick')
     })
 
     test('drifting past slop before long-press cancels the arm', async () => {
@@ -566,7 +566,7 @@ describe('useReaderHighlights', () => {
       expect(result.interaction_range.value).toBeNull()
     })
 
-    test('extending a long-press drag to a second word emits ui.tap_05', async () => {
+    test('extending a long-press drag to a second word emits gesture.tick', async () => {
       const { result, contentEl } = withHighlights()
       const wordEl1 = addWord(contentEl, 1)
       const wordEl2 = addWord(contentEl, 2)
@@ -587,7 +587,7 @@ describe('useReaderHighlights', () => {
       await nextTick()
 
       expect(result.interaction_range.value).toEqual({ lo: 1, hi: 2 })
-      expect(mockEmitSfx).toHaveBeenCalledWith('tap_05')
+      expect(mockEmitSfx).toHaveBeenCalledWith('gesture.tick')
     })
   })
 

--- a/tests/unit/composables/auth/use-forgot-password-actions.test.js
+++ b/tests/unit/composables/auth/use-forgot-password-actions.test.js
@@ -88,7 +88,7 @@ describe('useForgotPasswordActions', () => {
     test('emits digi_powerdown sfx on validation failure [obligation]', async () => {
       const auth = useForgotPasswordActions()
       await auth.submit()
-      expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
     })
   })
 
@@ -143,7 +143,7 @@ describe('useForgotPasswordActions', () => {
 
       await auth.submit()
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     })
   })
 

--- a/tests/unit/composables/auth/use-reset-password-actions.test.js
+++ b/tests/unit/composables/auth/use-reset-password-actions.test.js
@@ -57,10 +57,10 @@ describe('useResetPasswordActions', () => {
       expect(mockUpdatePassword).not.toHaveBeenCalled()
     })
 
-    test('emits etc_woodblock_stuck sfx on validation failure', async () => {
+    test('emits notice.error sfx on validation failure', async () => {
       const auth = useResetPasswordActions()
       await auth.submit()
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     })
 
     test('sets errors.password when password is empty', async () => {
@@ -121,7 +121,7 @@ describe('useResetPasswordActions', () => {
       expect(auth.errors.value.password).toBe('reset-password-modal.validation-weak')
     })
 
-    test('emits etc_woodblock_stuck sfx on weak-password [obligation]', async () => {
+    test('emits notice.error sfx on weak-password [obligation]', async () => {
       mockUpdatePassword.mockResolvedValueOnce('weak-password')
       const auth = useResetPasswordActions()
       fillValidFields(auth)
@@ -129,7 +129,7 @@ describe('useResetPasswordActions', () => {
 
       await auth.submit()
 
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     })
   })
 

--- a/tests/unit/composables/card-editor/card-actions.test.js
+++ b/tests/unit/composables/card-editor/card-actions.test.js
@@ -128,7 +128,7 @@ describe('useCardActions', () => {
       actions.onSelectCard(7)
       expect(selection.toggleSelectCard).toHaveBeenCalledWith(7)
       expect(selection.enterSelection).toHaveBeenCalledOnce()
-      expect(emitSfxMock).toHaveBeenCalledWith('select')
+      expect(emitSfxMock).toHaveBeenCalledWith('ui.select')
     })
 
     test('without id, just enters selection mode', () => {
@@ -148,7 +148,7 @@ describe('useCardActions', () => {
       actions.onCancel()
       expect(exitMode).toHaveBeenCalledOnce()
       expect(selection.exitSelection).toHaveBeenCalledOnce()
-      expect(emitSfxMock).toHaveBeenCalledWith('card_drop')
+      expect(emitSfxMock).toHaveBeenCalledWith('dialog.close')
     })
 
     test('does not refetch the deck', () => {
@@ -297,7 +297,7 @@ describe('useCardActions', () => {
         selection: makeSelection()
       })
       await actions.onMoveCards(7)
-      expect(emitSfxMock).toHaveBeenCalledWith('double_pop_up')
+      expect(emitSfxMock).toHaveBeenCalledWith('dialog.open')
     })
 
     test('runs cleanup after a successful move: exitSelection + refetch (mode unchanged)', async () => {
@@ -402,7 +402,7 @@ describe('useCardActions', () => {
       const { actions, selection } = makeActions()
       actions.onCancelSelection()
       expect(selection.exitSelection).toHaveBeenCalledOnce()
-      expect(emitSfxMock).toHaveBeenCalledWith('digi_powerdown')
+      expect(emitSfxMock).toHaveBeenCalledWith('ui.deselect')
     })
   })
 

--- a/tests/unit/composables/card-editor/card-list-controller.test.js
+++ b/tests/unit/composables/card-editor/card-list-controller.test.js
@@ -1000,7 +1000,7 @@ describe('useCardListController', () => {
       const setMode = vi.fn().mockReturnValue(new Promise(() => {}))
       const ctrl = makeController([], [], undefined, makeShell({ setMode }))
       await ctrl.newCard()
-      expect(emitSfxMock).toHaveBeenCalledWith('snappy_button_2')
+      expect(emitSfxMock).toHaveBeenCalledWith('ui.press')
     })
 
     test('emits the add chime on non-empty deck path too [obligation]', async () => {
@@ -1008,7 +1008,7 @@ describe('useCardListController', () => {
       const setMode = vi.fn().mockResolvedValue(undefined)
       const ctrl = makeController([makeCard({ id: 1 })], [1], undefined, makeShell({ setMode }))
       await ctrl.newCard()
-      expect(emitSfxMock).toHaveBeenCalledWith('snappy_button_2')
+      expect(emitSfxMock).toHaveBeenCalledWith('ui.press')
     })
 
     test('stages the new card at index 0 when deck is non-empty [obligation]', async () => {

--- a/tests/unit/composables/card-editor/deck-view-shell.test.js
+++ b/tests/unit/composables/card-editor/deck-view-shell.test.js
@@ -132,7 +132,7 @@ describe('useDeckViewShell', () => {
   test('setMode plays ui.select chime on a real switch [obligation]', () => {
     const shell = useDeckViewShell()
     shell.setMode('edit')
-    expect(emitSfxMock).toHaveBeenCalledWith('select')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.select')
   })
 
   test('setMode does NOT play ui.select when already in new_mode [obligation]', () => {
@@ -143,8 +143,8 @@ describe('useDeckViewShell', () => {
 
   test('setMode plays an explicit chime when one is passed [obligation]', () => {
     const shell = useDeckViewShell()
-    shell.setMode('edit', 'digi_powerdown')
-    expect(emitSfxMock).toHaveBeenCalledWith('digi_powerdown')
+    shell.setMode('edit', 'ui.deselect')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.deselect')
   })
 
   test('exitMode forwards its chime argument to setMode [obligation]', () => {
@@ -152,9 +152,9 @@ describe('useDeckViewShell', () => {
     shell.setMode('edit')
     emitSfxMock.mockClear()
 
-    shell.exitMode('digi_powerdown')
+    shell.exitMode('ui.deselect')
 
-    expect(emitSfxMock).toHaveBeenCalledWith('digi_powerdown')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.deselect')
   })
 
   test('exitMode defaults to the select chime when no chime is passed [obligation]', () => {
@@ -164,7 +164,7 @@ describe('useDeckViewShell', () => {
 
     shell.exitMode()
 
-    expect(emitSfxMock).toHaveBeenCalledWith('select')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.select')
   })
 
   test('notifyModeSettled resolves all pending setMode promises [obligation]', async () => {
@@ -273,10 +273,10 @@ describe('useDeckViewShell', () => {
     expect(shell.mode.value).toBe('view') // still view (no mode side-effect)
   })
 
-  test('toggleRearrange emits pop_up_pop when turning ON [obligation]', () => {
+  test('toggleRearrange emits dialog.open when turning ON [obligation]', () => {
     const shell = useDeckViewShell()
     shell.toggleRearrange()
-    expect(emitSfxMock).toHaveBeenCalledWith('pop_up_pop')
+    expect(emitSfxMock).toHaveBeenCalledWith('dialog.open')
   })
 
   test('toggleRearrange emits pop_up_close when turning OFF', () => {
@@ -284,7 +284,7 @@ describe('useDeckViewShell', () => {
     shell.toggleRearrange() // on
     emitSfxMock.mockClear()
     shell.toggleRearrange() // off
-    expect(emitSfxMock).toHaveBeenCalledWith('pop_up_close')
+    expect(emitSfxMock).toHaveBeenCalledWith('dialog.close')
   })
 
   test('setMode(<non-view>) clears is_rearranging [obligation]', () => {
@@ -471,16 +471,16 @@ describe('useDeckViewShell', () => {
     expect(shell.is_page_settings_open.value).toBe(false)
   })
 
-  test('openPageSettings emits snappy_button_5 [obligation]', () => {
+  test('openPageSettings emits ui.press [obligation]', () => {
     const shell = useDeckViewShell()
     shell.openPageSettings()
-    expect(emitSfxMock).toHaveBeenCalledWith('snappy_button_5')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.press')
   })
 
-  test('closePageSettings emits snappy_button_5 [obligation]', () => {
+  test('closePageSettings emits ui.press [obligation]', () => {
     const shell = useDeckViewShell()
     shell.closePageSettings()
-    expect(emitSfxMock).toHaveBeenCalledWith('snappy_button_5')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.press')
   })
 
   test("is_page_settings_open is shared state — one shell instance reflects another's toggle [obligation]", () => {

--- a/tests/unit/composables/card-editor/use-bulk-actions.test.js
+++ b/tests/unit/composables/card-editor/use-bulk-actions.test.js
@@ -92,7 +92,7 @@ describe('useBulkActions', () => {
   test('onToggleSelectAll emits ui.select and calls selection.toggleSelectAll', () => {
     const { result, editor } = setup()
     result.onToggleSelectAll()
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
     expect(editor.selection.toggleSelectAll).toHaveBeenCalledOnce()
   })
 

--- a/tests/unit/composables/card-editor/use-card-prompts.test.js
+++ b/tests/unit/composables/card-editor/use-card-prompts.test.js
@@ -86,14 +86,14 @@ describe('useCardPrompts — confirmDelete [obligation]', () => {
     expect(result).toBe(false)
   })
 
-  test('includes confirmAudio: trash_crumple_short', async () => {
+  test('includes confirmAudio: card.delete', async () => {
     alertWarnMock.mockReturnValueOnce({ response: Promise.resolve(false) })
     const { confirmDelete } = useCardPrompts()
 
     await confirmDelete(1)
 
     expect(alertWarnMock).toHaveBeenCalledWith(
-      expect.objectContaining({ confirmAudio: 'trash_crumple_short' })
+      expect.objectContaining({ confirmAudio: 'card.delete' })
     )
   })
 })
@@ -139,13 +139,13 @@ describe('useCardPrompts — openMoveModal [obligation]', () => {
     )
   })
 
-  test('emits double_pop_up before the modal opens [obligation]', async () => {
+  test('emits dialog.open before the modal opens [obligation]', async () => {
     modalOpenMock.mockReturnValueOnce({ response: Promise.resolve(undefined) })
     const { openMoveModal } = useCardPrompts()
 
     await openMoveModal([makeCard()], 1, 10)
 
-    expect(emitSfxMock).toHaveBeenCalledWith('double_pop_up')
+    expect(emitSfxMock).toHaveBeenCalledWith('dialog.open')
   })
 
   test('does not emit any sfx when the returned response promise resolves [obligation]', async () => {

--- a/tests/unit/composables/card-editor/use-face-image-upload.test.js
+++ b/tests/unit/composables/card-editor/use-face-image-upload.test.js
@@ -178,7 +178,7 @@ describe('useFaceImageUpload — onRemove sfx timing [obligation]', () => {
     // Before flushPromises — deleteCardImage has not resolved yet
     await nextTick()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
 
     resolveDeleteCard()
     await flushPromises()
@@ -195,14 +195,14 @@ describe('useFaceImageUpload — onRemove sfx timing [obligation]', () => {
 
     // Not yet — deleteCardImage hasn't resolved
     const trashCallsBefore = mockEmitSfx.mock.calls.filter(
-      ([name]) => name === 'trash_crumple_short'
+      ([name]) => name === 'card.delete'
     ).length
     expect(trashCallsBefore).toBe(0)
 
     resolveDeleteCard()
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('trash_crumple_short')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.delete')
     unmount()
   })
 
@@ -213,7 +213,7 @@ describe('useFaceImageUpload — onRemove sfx timing [obligation]', () => {
     await result.onRemove()
     await flushPromises()
 
-    const trashCalls = mockEmitSfx.mock.calls.filter(([name]) => name === 'trash_crumple_short')
+    const trashCalls = mockEmitSfx.mock.calls.filter(([name]) => name === 'card.delete')
     expect(trashCalls.length).toBe(0)
     unmount()
   })
@@ -319,7 +319,7 @@ describe('useFaceImageUpload — openPicker guard', () => {
     await flushPromises()
 
     // browse() is from the dropzone mock; it should not be called
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('ui.select')
     unmount()
   })
 
@@ -330,7 +330,7 @@ describe('useFaceImageUpload — openPicker guard', () => {
     await result.openPicker()
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
     unmount()
   })
 })
@@ -362,7 +362,7 @@ describe('useFaceImageUpload — onDismissError', () => {
   test('emits ui.snappy_button_5 on dismiss', () => {
     const { result, unmount } = withUpload()
     result.onDismissError()
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
     unmount()
   })
 })
@@ -412,7 +412,7 @@ describe('useFaceImageUpload — uploadFile via onFile callback [obligation]', (
     await onFile(new File(['x'], 'img.png', { type: 'image/png' }))
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_ok')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.confirm')
     expect(mockNoticeError).not.toHaveBeenCalled()
     unmount()
   })
@@ -425,7 +425,7 @@ describe('useFaceImageUpload — uploadFile via onFile callback [obligation]', (
     await flushPromises()
 
     expect(mockNoticeError).toHaveBeenCalledWith("Couldn't save image — try again")
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('music_plink_ok')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('dialog.confirm')
     expect(result.pending.value).toBe(false)
     unmount()
   })
@@ -530,7 +530,7 @@ describe('useFaceImageUpload — dragging watcher (chime on drag enter)', () => 
     mockDragging.value = true
     await nextTick()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_mid')
+    expect(mockEmitSfx).toHaveBeenCalledWith('gesture.zone-cross')
     unmount()
   })
 
@@ -544,7 +544,7 @@ describe('useFaceImageUpload — dragging watcher (chime on drag enter)', () => 
     mockDragging.value = false
     await nextTick()
 
-    expect(mockEmitSfx).not.toHaveBeenCalledWith('music_plink_mid')
+    expect(mockEmitSfx).not.toHaveBeenCalledWith('gesture.zone-cross')
     unmount()
   })
 })

--- a/tests/unit/composables/deck-editor.test.js
+++ b/tests/unit/composables/deck-editor.test.js
@@ -696,7 +696,7 @@ describe('useDeckEditor', () => {
       editor.setActiveSide('front')
 
       expect(editor.active_side.value).toBe('front')
-      expect(mockEmitSfx).toHaveBeenCalledWith('slide_up')
+      expect(mockEmitSfx).toHaveBeenCalledWith('nav.page-forward')
       unmount()
     })
 

--- a/tests/unit/composables/deck/cover-image.test.js
+++ b/tests/unit/composables/deck/cover-image.test.js
@@ -141,7 +141,7 @@ describe('useCoverImage — stageFile (via onFile) [obligation]', () => {
 
     await cover_image.onDrop(dropEvent(pngFile()))
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('music_plink_ok')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.confirm')
     unmount()
   })
 
@@ -192,7 +192,7 @@ describe('useCoverImage — onRemove [obligation]', () => {
 
     cover_image.onRemove()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
     unmount()
   })
 })
@@ -317,7 +317,7 @@ describe('useCoverImage — no paid-plan gate [obligation]', () => {
     cover_image.openPicker()
 
     expect(click).toHaveBeenCalled()
-    expect(mockEmitSfx).toHaveBeenCalledWith('select')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.select')
     unmount()
   })
 
@@ -370,7 +370,7 @@ describe('useCoverImage — validation errors [obligation]', () => {
 
     await cover_image.onDrop(dropEvent(new File(['x'], 'notes.txt', { type: 'text/plain' })))
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
     unmount()
   })
 })

--- a/tests/unit/composables/feedback/use-feedback-modal.test.js
+++ b/tests/unit/composables/feedback/use-feedback-modal.test.js
@@ -41,7 +41,7 @@ describe('useFeedbackModal — call shape [obligation]', () => {
     const { open } = useFeedbackModal()
     open()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_3')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('plays pop_up_close sfx once the modal resolves', async () => {
@@ -57,7 +57,7 @@ describe('useFeedbackModal — call shape [obligation]', () => {
     resolve(undefined)
     await response
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 
   test('returns the result of modal.open unchanged', () => {

--- a/tests/unit/composables/member/use-member-danger-actions.test.js
+++ b/tests/unit/composables/member/use-member-danger-actions.test.js
@@ -115,7 +115,7 @@ describe('useMemberDangerActions', () => {
       title: 'alert.delete-account.title',
       message: 'alert.delete-account.message',
       confirmLabel: 'alert.delete-account.confirm',
-      confirmAudio: 'trash_crumple_short'
+      confirmAudio: 'card.delete'
     })
   })
 

--- a/tests/unit/composables/prompt.test.js
+++ b/tests/unit/composables/prompt.test.js
@@ -28,7 +28,7 @@ describe('usePrompt — ask()', () => {
   test('calls emitSfx with the default open audio when openAudio is omitted [obligation]', () => {
     const { ask } = usePrompt()
     ask({ title: 'Name it', confirmLabel: 'Create' })
-    expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
   })
 
   test('calls emitSfx with the provided openAudio when supplied', () => {
@@ -43,7 +43,7 @@ describe('usePrompt — ask()', () => {
     expect(mockOpen).toHaveBeenCalledWith(
       anyComponent,
       expect.objectContaining({
-        props: expect.objectContaining({ cancelAudio: 'digi_powerdown' })
+        props: expect.objectContaining({ cancelAudio: 'dialog.dismiss' })
       })
     )
   })

--- a/tests/unit/composables/signup-modal.test.js
+++ b/tests/unit/composables/signup-modal.test.js
@@ -52,7 +52,7 @@ describe('useSignupModal', () => {
 
     useSignupModal().open()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_3')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('fires Signup Started on open [obligation]', () => {
@@ -84,7 +84,7 @@ describe('useSignupModal', () => {
     await flushPromises()
 
     const calls = mockEmitSfx.mock.calls.map((c) => c[0])
-    expect(calls.indexOf('snappy_button_3')).toBeLessThan(calls.indexOf('pop_up_close'))
+    expect(calls.indexOf('dialog.open')).toBeLessThan(calls.indexOf('dialog.close'))
   })
 
   test('opens modal with mode mobile-sheet [obligation]', () => {
@@ -154,7 +154,7 @@ describe('useSignupModal', () => {
     resolve(undefined)
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 
   test('returns the modal result from open', () => {

--- a/tests/unit/composables/study-session/card-preview.test.js
+++ b/tests/unit/composables/study-session/card-preview.test.js
@@ -101,10 +101,10 @@ describe('useCardPreview', () => {
   })
 
   // ── awaitFlip [obligation] ─────────────────────────────────────────────────
-  // awaitFlip emits slide_up sfx, sets next_card_side, and resolves when
+  // awaitFlip emits nav.page-forward sfx, sets next_card_side, and resolves when
   // onNextCardFlipped is called.
 
-  test('awaitFlip emits slide_up sfx [obligation]', async () => {
+  test('awaitFlip emits nav.page-forward sfx [obligation]', async () => {
     const next_card = ref(undefined)
     const { result } = withSetup(() => useCardPreview(next_card))
     unmount = () => {}
@@ -112,7 +112,7 @@ describe('useCardPreview', () => {
     result.awaitFlip('front')
     await nextTick()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('slide_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('nav.page-forward')
   })
 
   test('awaitFlip sets next_card_side to the requested side', async () => {

--- a/tests/unit/composables/study-session/session-engine.test.js
+++ b/tests/unit/composables/study-session/session-engine.test.js
@@ -313,11 +313,11 @@ describe('per-card flip [obligation]', () => {
 
     mockEmitSfx.mockClear()
     engine.flipCurrentCard() // fired while still on the starting side ('back')
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-away')
 
     mockEmitSfx.mockClear()
     engine.flipCurrentCard() // fired while off the starting side ('front')
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_down')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-back')
   })
 })
 
@@ -830,17 +830,17 @@ describe('updateCard', () => {
 })
 
 describe('flipCurrentCard sfx', () => {
-  test('emits transition_up when flipping away from the starting side, transition_down when flipping back', () => {
+  test('emits card.flip-away when flipping away from the starting side, card.flip-back when flipping back', () => {
     const { engine } = makeEngine()
     engine.setCards([makeCard({ id: 901, deck_id: 1 })])
     engine.startSession()
 
     mockEmitSfx.mockClear()
     engine.flipCurrentCard()
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-away')
 
     mockEmitSfx.mockClear()
     engine.flipCurrentCard()
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_down')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-back')
   })
 })

--- a/tests/unit/composables/study-session/session-prefs.test.js
+++ b/tests/unit/composables/study-session/session-prefs.test.js
@@ -237,10 +237,10 @@ describe('useSessionPrefs', () => {
     expect(prefs.show_all_ratings.value).toBe(true)
   })
 
-  test('toggleRatings plays the snappy_button_5 sfx', () => {
+  test('toggleRatings plays the ui.press sfx', () => {
     const prefs = useSessionPrefs()
     prefs.toggleRatings()
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('toggleRatings persists via the member upsert', () => {

--- a/tests/unit/composables/study-session/summary-selection.test.js
+++ b/tests/unit/composables/study-session/summary-selection.test.js
@@ -267,7 +267,7 @@ describe('useSummarySelection — onSelectCard [obligation]', () => {
 
     result.onSelectCard(1)
 
-    expect(emitSfxMock).toHaveBeenCalledWith('select')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.select')
   })
 
   test('enters selection mode without toggling any card when id is omitted [obligation]', () => {
@@ -279,7 +279,7 @@ describe('useSummarySelection — onSelectCard [obligation]', () => {
 
     expect(result.selection.is_selecting.value).toBe(true)
     expect(result.selection.selected_count.value).toBe(0)
-    expect(emitSfxMock).toHaveBeenCalledWith('select')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.select')
   })
 })
 

--- a/tests/unit/composables/use-alert.test.js
+++ b/tests/unit/composables/use-alert.test.js
@@ -29,7 +29,7 @@ describe('useAlert', () => {
     test('calls emitSfx with the default open audio when openAudio is omitted [obligation]', () => {
       const { warn } = useAlert()
       warn({ title: 'Are you sure?' })
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     })
 
     test('calls emitSfx with the provided openAudio when supplied', () => {
@@ -44,7 +44,7 @@ describe('useAlert', () => {
       expect(mockOpen).toHaveBeenCalledWith(
         anyComponent,
         expect.objectContaining({
-          props: expect.objectContaining({ cancelAudio: 'digi_powerdown' })
+          props: expect.objectContaining({ cancelAudio: 'dialog.dismiss' })
         })
       )
     })
@@ -101,11 +101,11 @@ describe('useAlert', () => {
     test('works with no args (all defaults)', () => {
       const { warn } = useAlert()
       warn()
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
       expect(mockOpen).toHaveBeenCalledWith(
         anyComponent,
         expect.objectContaining({
-          props: expect.objectContaining({ cancelAudio: 'digi_powerdown' })
+          props: expect.objectContaining({ cancelAudio: 'dialog.dismiss' })
         })
       )
     })
@@ -115,7 +115,7 @@ describe('useAlert', () => {
     test('calls emitSfx with the default open audio when openAudio is omitted [obligation]', () => {
       const { info } = useAlert()
       info({ title: 'FYI' })
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     })
 
     test('passes default cancelAudio to the alert component when cancelAudio is omitted [obligation]', () => {
@@ -124,7 +124,7 @@ describe('useAlert', () => {
       expect(mockOpen).toHaveBeenCalledWith(
         anyComponent,
         expect.objectContaining({
-          props: expect.objectContaining({ cancelAudio: 'digi_powerdown' })
+          props: expect.objectContaining({ cancelAudio: 'dialog.dismiss' })
         })
       )
     })

--- a/tests/unit/composables/use-login-actions.test.js
+++ b/tests/unit/composables/use-login-actions.test.js
@@ -95,7 +95,7 @@ describe('useLoginActions', () => {
     test('emits digi_powerdown sfx on validation failure [obligation]', async () => {
       const auth = useLoginActions()
       await auth.submit()
-      expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
     })
 
     test('sets errors.email when email is empty', async () => {
@@ -126,7 +126,7 @@ describe('useLoginActions', () => {
     test('returns "invalid" without emitting woodblock when fields invalid [obligation]', async () => {
       const auth = useLoginActions()
       await auth.submit()
-      expect(mockEmitSfx).not.toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).not.toHaveBeenCalledWith('notice.error')
     })
   })
 
@@ -158,7 +158,7 @@ describe('useLoginActions', () => {
       fillValidFields(auth)
       await nextTick()
       await auth.submit()
-      expect(mockEmitSfx).not.toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).not.toHaveBeenCalledWith('notice.error')
       expect(auth.submitError).toBe('')
     })
   })
@@ -190,7 +190,7 @@ describe('useLoginActions', () => {
       fillValidFields(auth)
       await nextTick()
       await auth.submit()
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     })
 
     test('maps email-not-confirmed to its error key [obligation]', async () => {

--- a/tests/unit/composables/use-reorder-drag.test.js
+++ b/tests/unit/composables/use-reorder-drag.test.js
@@ -110,8 +110,8 @@ describe('useReorderDrag — start()', () => {
     expect(result.target_index.value).toBe(2)
   })
 
-  // [obligation] emits generic_button_15 on drag start
-  test('emits generic_button_15 on successful start [obligation]', () => {
+  // [obligation] emits ui.press on drag start
+  test('emits ui.press on successful start [obligation]', () => {
     const setup = withSetup(() =>
       useReorderDrag({ pitch: PITCH, count: () => 3, enabled: () => true, onReorder: vi.fn() })
     )
@@ -120,7 +120,7 @@ describe('useReorderDrag — start()', () => {
 
     result.start(1, pointerEvent('pointerdown', { button: 0, clientY: 100 }))
 
-    expect(emitSfxMock).toHaveBeenCalledWith('generic_button_15')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.press')
     expect(emitSfxMock).toHaveBeenCalledTimes(1)
   })
 })
@@ -161,7 +161,7 @@ describe('useReorderDrag — hysteresis', () => {
     moveTo(66)
 
     expect(result.target_index.value).toBe(2)
-    expect(emitSfxMock).toHaveBeenCalledWith('tap_05')
+    expect(emitSfxMock).toHaveBeenCalledWith('gesture.tick')
     expect(emitSfxMock).toHaveBeenCalledTimes(1)
   })
 
@@ -186,7 +186,7 @@ describe('useReorderDrag — hysteresis', () => {
     moveTo(34)
 
     expect(result.target_index.value).toBe(1)
-    expect(emitSfxMock).toHaveBeenCalledWith('tap_05')
+    expect(emitSfxMock).toHaveBeenCalledWith('gesture.tick')
     expect(emitSfxMock).toHaveBeenCalledTimes(1)
   })
 
@@ -213,7 +213,7 @@ describe('useReorderDrag — sfx contract', () => {
 
     pointerUp()
 
-    expect(emitSfxMock).toHaveBeenCalledWith('snappy_button_5')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.press')
   })
 
   // [obligation] tap_05 only when target_index changes between two non-null slots
@@ -230,8 +230,8 @@ describe('useReorderDrag — sfx contract', () => {
     moveTo(66) // crosses into slot 1 → one tap_05
     pointerUp()
 
-    const tap_calls = emitSfxMock.mock.calls.filter((c) => c[0] === 'tap_05')
-    const drop_calls = emitSfxMock.mock.calls.filter((c) => c[0] === 'snappy_button_5')
+    const tap_calls = emitSfxMock.mock.calls.filter((c) => c[0] === 'gesture.tick')
+    const drop_calls = emitSfxMock.mock.calls.filter((c) => c[0] === 'ui.press')
     expect(tap_calls).toHaveLength(1)
     expect(drop_calls).toHaveLength(1)
   })

--- a/tests/unit/composables/use-signup-actions.test.js
+++ b/tests/unit/composables/use-signup-actions.test.js
@@ -132,7 +132,7 @@ describe('useSignupActions', () => {
     test('emits digi_powerdown sfx on validation failure [obligation]', async () => {
       const auth = useSignupActions()
       await auth.submit()
-      expect(mockEmitSfx).toHaveBeenCalledWith('digi_powerdown')
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.rejected')
     })
 
     test('sets tried_submit so errors populate [obligation]', async () => {
@@ -246,7 +246,7 @@ describe('useSignupActions', () => {
       const auth = useSignupActions()
       fillValidFields(auth)
       await auth.submit()
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     })
 
     test('does NOT fire Signup Completed when the email is already taken [obligation]', async () => {
@@ -295,7 +295,7 @@ describe('useSignupActions', () => {
       const auth = useSignupActions()
       fillValidFields(auth)
       await auth.submit()
-      expect(mockEmitSfx).toHaveBeenCalledWith('etc_woodblock_stuck')
+      expect(mockEmitSfx).toHaveBeenCalledWith('notice.error')
     })
 
     test('typing in username clears the taken-name error', async () => {

--- a/tests/unit/composables/use-staged-tap.test.js
+++ b/tests/unit/composables/use-staged-tap.test.js
@@ -258,8 +258,8 @@ describe('useStagedTap — audio', () => {
   test('audio fires on fine pointer (core fix — fine pointer now gets audio)', async () => {
     coarseRef.value = false
     const { tap } = useStagedTap()
-    await tap(vi.fn(), { audio: 'snappy_button_5' })(makeEvent())
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5', undefined)
+    await tap(vi.fn(), { audio: 'ui.press' })(makeEvent())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('audio fires at peak on coarse with pop animate', async () => {
@@ -271,35 +271,35 @@ describe('useStagedTap — audio', () => {
     const { tap } = useStagedTap({ animate: 'pop' })
     const action = vi.fn()
 
-    const p = tap(action, { audio: 'snappy_button_5' })(makeEvent())
+    const p = tap(action, { audio: 'ui.press' })(makeEvent())
     // Not yet — waiting for peak
     expect(mockEmitSfx).not.toHaveBeenCalled()
 
     peakResolve()
     await p
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5', undefined)
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('audio fires after timer on coarse with quiet animate', async () => {
     vi.useFakeTimers()
     const { tap } = useStagedTap({ animate: 'quiet' })
 
-    const p = tap(vi.fn(), { audio: 'snappy_button_5' })(makeEvent())
+    const p = tap(vi.fn(), { audio: 'ui.press' })(makeEvent())
     // Not yet — timer still pending
     expect(mockEmitSfx).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(200)
     await p
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5', undefined)
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
     vi.useRealTimers()
   })
 
   test('audio fires at press when triggerAt: "press" on coarse', async () => {
     const { tap } = useStagedTap({ animate: 'pop' })
 
-    const p = tap(vi.fn(), { audio: 'snappy_button_5', triggerAt: 'press' })(makeEvent())
+    const p = tap(vi.fn(), { audio: 'ui.press', triggerAt: 'press' })(makeEvent())
     // At press — synchronously — audio fires
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5', undefined)
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
     await p
   })
 
@@ -311,7 +311,7 @@ describe('useStagedTap — audio', () => {
     }))
     const { tap } = useStagedTap({ animate: 'pop' })
 
-    const p = tap(vi.fn(), { audio: 'snappy_button_5' })(makeEvent())
+    const p = tap(vi.fn(), { audio: 'ui.press' })(makeEvent())
     peakResolve()
     await p
 
@@ -323,54 +323,14 @@ describe('useStagedTap — audio', () => {
 describe('useStagedTap — preAudio', () => {
   test('preAudio fires on coarse press before animation [obligation]', async () => {
     const { tap } = useStagedTap()
-    await tap(vi.fn(), { preAudio: 'snappy_button_5' })(makeEvent())
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    await tap(vi.fn(), { preAudio: 'ui.press' })(makeEvent())
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('preAudio does NOT fire on fine pointer [obligation]', async () => {
     coarseRef.value = false
     const { tap } = useStagedTap()
-    await tap(vi.fn(), { preAudio: 'snappy_button_5' })(makeEvent())
-    expect(mockEmitSfx).not.toHaveBeenCalled()
-  })
-})
-
-describe('useStagedTap — postAudio', () => {
-  test('postAudio fires after animation completes on coarse pop animate [obligation]', async () => {
-    let doneResolve
-    mockPlayButtonTap.mockImplementation(() => ({
-      peak: Promise.resolve(),
-      done: new Promise((r) => (doneResolve = r))
-    }))
-    const { tap } = useStagedTap({ animate: 'pop' })
-
-    const p = tap(vi.fn(), { postAudio: 'snappy_button_5' })(makeEvent())
-    // After peak, before done — no postAudio yet
-    await Promise.resolve()
-    expect(mockEmitSfx).not.toHaveBeenCalled()
-
-    doneResolve()
-    await p
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
-  })
-
-  test('postAudio fires after timer on coarse quiet animate [obligation]', async () => {
-    vi.useFakeTimers()
-    const { tap } = useStagedTap({ animate: 'quiet' })
-
-    const p = tap(vi.fn(), { postAudio: 'snappy_button_5' })(makeEvent())
-    expect(mockEmitSfx).not.toHaveBeenCalled()
-
-    vi.advanceTimersByTime(200)
-    await p
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
-    vi.useRealTimers()
-  })
-
-  test('postAudio does NOT fire on fine pointer [obligation]', async () => {
-    coarseRef.value = false
-    const { tap } = useStagedTap()
-    await tap(vi.fn(), { postAudio: 'snappy_button_5' })(makeEvent())
+    await tap(vi.fn(), { preAudio: 'ui.press' })(makeEvent())
     expect(mockEmitSfx).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/composables/use-study-modal.test.js
+++ b/tests/unit/composables/use-study-modal.test.js
@@ -26,10 +26,10 @@ describe('useStudyModal', () => {
     mockOpen.mockReturnValue({ response: Promise.resolve(undefined) })
   })
 
-  test('plays generic_notification_9 sfx synchronously when starting [obligation]', () => {
+  test('plays notice.info sfx synchronously when starting [obligation]', () => {
     const { start } = useStudyModal()
     start([1])
-    expect(mockEmitSfx).toHaveBeenCalledWith('generic_notification_9')
+    expect(mockEmitSfx).toHaveBeenCalledWith('notice.info')
   })
 
   test('opens a StudySession popup modal with deck_ids [obligation]', () => {

--- a/tests/unit/sfx/bus.test.js
+++ b/tests/unit/sfx/bus.test.js
@@ -1,5 +1,9 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 
+const { mockRoleDef } = vi.hoisted(() => ({
+  mockRoleDef: vi.fn()
+}))
+
 vi.mock('@/sfx/player', () => ({
   default: {
     play: vi.fn(() => Promise.resolve())
@@ -16,6 +20,10 @@ vi.mock('@/sfx/pointer-activity', () => ({
   pointerStationaryAfterClick: vi.fn(() => false)
 }))
 
+vi.mock('@/sfx/roles', () => ({
+  roleDef: mockRoleDef
+}))
+
 const { default: player } = await import('@/sfx/player')
 const { default: logger } = await import('@/utils/logger')
 const { pointerStationaryAfterClick } = await import('@/sfx/pointer-activity')
@@ -26,104 +34,92 @@ describe('emitSfx', () => {
     vi.clearAllMocks()
   })
 
-  test('plays a single key', async () => {
-    await emitSfx('click_07')
-    expect(player.play).toHaveBeenCalledWith('click_07', {})
+  test("plays the role's own sound on the role's own bus and debounce", async () => {
+    mockRoleDef.mockReturnValue({ sound: 'click_07', bus: 'interface', debounce: 40 })
+    await emitSfx('ui.press')
+    expect(player.play).toHaveBeenCalledWith('click_07', { bus: 'interface', debounce: 40 })
   })
 
-  test('passes options when single key + opts', async () => {
-    await emitSfx('click_07', { debounce: 0, volume: 0.3 })
-    expect(player.play).toHaveBeenCalledWith('click_07', { debounce: 0, volume: 0.3 })
+  test('a role with no bus/debounce set forwards them as undefined', async () => {
+    mockRoleDef.mockReturnValue({ sound: 'click_07' })
+    await emitSfx('ui.press')
+    expect(player.play).toHaveBeenCalledWith('click_07', { bus: undefined, debounce: undefined })
   })
 
-  test('picks a key from array form', async () => {
+  // ── preview_bus [obligation] ────────────────────────────────────────────────
+
+  test('preview_bus overrides the bus the role would otherwise resolve to [obligation]', async () => {
+    mockRoleDef.mockReturnValue({ sound: 'click_07', bus: 'interface' })
+    await emitSfx('gesture.tick', 'hover')
+    expect(player.play).toHaveBeenCalledWith('click_07', { bus: 'hover', debounce: undefined })
+  })
+
+  test('preview_bus never changes which sound plays [obligation]', async () => {
+    mockRoleDef.mockReturnValue({ sound: 'click_07', bus: 'interface' })
+    await emitSfx('gesture.tick', 'hover')
+    expect(player.play.mock.calls[0][0]).toBe('click_07')
+  })
+
+  // ── array sound [obligation] ────────────────────────────────────────────────
+
+  test('an array sound picks one uniformly at random [obligation]', async () => {
+    mockRoleDef.mockReturnValue({ sound: ['click_04', 'click_07', 'tap_05'], bus: 'hover' })
     vi.spyOn(Math, 'random').mockReturnValue(0)
-    await emitSfx(['click_04', 'click_07'])
-    expect(player.play).toHaveBeenCalledWith('click_04', {})
+    await emitSfx('ui.hover')
+    expect(player.play).toHaveBeenCalledWith('click_04', { bus: 'hover', debounce: undefined })
     Math.random.mockRestore()
   })
 
-  test('picks last index when Math.random returns ~1', async () => {
+  test('an array sound picks the last entry when Math.random returns ~1 [obligation]', async () => {
+    mockRoleDef.mockReturnValue({ sound: ['click_04', 'click_07', 'tap_05'], bus: 'hover' })
     vi.spyOn(Math, 'random').mockReturnValue(0.999)
-    await emitSfx(['click_04', 'click_07', 'tap_03'])
-    expect(player.play).toHaveBeenCalledWith('tap_03', {})
+    await emitSfx('ui.hover')
+    expect(player.play).toHaveBeenCalledWith('tap_05', { bus: 'hover', debounce: undefined })
     Math.random.mockRestore()
   })
 
-  test('array form passes trailing opts to player', async () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0)
-    await emitSfx(['click_04', 'click_07'], { debounce: 0 })
-    expect(player.play).toHaveBeenCalledWith('click_04', { debounce: 0 })
-    Math.random.mockRestore()
-  })
-
-  test('no-op when array is empty', async () => {
-    await emitSfx([])
+  test('an empty array resolves silently without touching the player [obligation]', async () => {
+    mockRoleDef.mockReturnValue({ sound: [] })
+    await emitSfx('ui.hover')
     expect(player.play).not.toHaveBeenCalled()
   })
 
   test('logs error if player.play throws', async () => {
+    mockRoleDef.mockReturnValue({ sound: 'click_07' })
     player.play.mockRejectedValueOnce(new Error('boom'))
-    await emitSfx('click_07')
+    await emitSfx('ui.press')
     expect(logger.error).toHaveBeenCalledWith('boom', expect.any(Error))
-  })
-
-  test('transition_up reaches player (flat key, no namespace)', async () => {
-    await emitSfx('transition_up')
-    expect(player.play).toHaveBeenCalledWith('transition_up', {})
   })
 })
 
 describe('emitHoverSfx', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockRoleDef.mockReturnValue({ sound: 'click_07', bus: 'hover' })
     // Default: not a touch device, pointer has moved
     if ('ontouchstart' in window) delete window.ontouchstart
     pointerStationaryAfterClick.mockReturnValue(false)
   })
 
-  test('plays sound when ontouchstart is not present', async () => {
-    await emitHoverSfx('click_07')
-    expect(player.play).toHaveBeenCalledWith('click_07', { bus: 'hover' })
+  test('delegates to emitSfx for the role when the pointer is a real hover', async () => {
+    await emitHoverSfx('ui.hover')
+    expect(player.play).toHaveBeenCalledWith('click_07', { bus: 'hover', debounce: undefined })
   })
 
-  test('forces bus:hover even for a key without defaultBus:hover (tap_05 in TYPE_SFX) [obligation]', async () => {
-    // tap_05 has no defaultBus in config — its default_bus resolves to 'interface'.
-    // emitHoverSfx must override and forward { bus: 'hover' } regardless.
-    await emitHoverSfx('tap_05')
-    expect(player.play).toHaveBeenCalledWith('tap_05', { bus: 'hover' })
-  })
+  // ── touch-primary [obligation] ──────────────────────────────────────────────
 
-  test('preserves caller-supplied opts while forcing bus:hover [obligation]', async () => {
-    await emitHoverSfx('click_07', { debounce: 0 })
-    expect(player.play).toHaveBeenCalledWith('click_07', { debounce: 0, bus: 'hover' })
-  })
-
-  test('caller bus override is superseded by the forced hover bus [obligation]', async () => {
-    // Even if the caller passes { bus: 'interface' }, emitHoverSfx wins with 'hover'.
-    await emitHoverSfx('click_07', { bus: 'interface' })
-    expect(player.play).toHaveBeenCalledWith('click_07', { bus: 'hover' })
-  })
-
-  test('skips when ontouchstart is on window (touch-primary) [obligation]', async () => {
+  test('stays silent on a touch-primary pointer [obligation]', async () => {
     window.ontouchstart = null
-    await emitHoverSfx('click_07')
+    await emitHoverSfx('ui.hover')
     expect(player.play).not.toHaveBeenCalled()
     delete window.ontouchstart
   })
 
-  test('skips when pointerStationaryAfterClick returns true [obligation]', async () => {
-    pointerStationaryAfterClick.mockReturnValueOnce(true)
-    await emitHoverSfx('click_07')
-    expect(player.play).not.toHaveBeenCalled()
-  })
+  // ── stationary after click [obligation] ─────────────────────────────────────
 
-  test('array path — picks one key and forwards bus:hover [obligation]', async () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0)
-    await emitHoverSfx(['type_01', 'type_02', 'type_03'])
-    expect(player.play).toHaveBeenCalledTimes(1)
-    expect(player.play.mock.calls[0][0]).toBe('type_01')
-    expect(player.play.mock.calls[0][1]).toMatchObject({ bus: 'hover' })
-    Math.random.mockRestore()
+  test('stays silent when the pointer is stationary after a click [obligation]', async () => {
+    pointerStationaryAfterClick.mockReturnValueOnce(true)
+    await emitHoverSfx('ui.hover')
+    expect(player.play).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/sfx/directive.test.js
+++ b/tests/unit/sfx/directive.test.js
@@ -38,26 +38,16 @@ describe('vSfx directive', () => {
 
   describe('hover', () => {
     test('plays hover sfx when pointerenter pointerType is mouse', () => {
-      const el = mountDirective({ hover: 'click_07' })
+      const el = mountDirective({ hover: 'ui.hover' })
 
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
 
-      expect(emitHoverSfx).toHaveBeenCalledWith('click_07', { debounce: undefined })
-      unmount(el)
-    })
-
-    test('array hover — passes full array to emitHoverSfx on pointerenter [obligation]', () => {
-      const keys = ['type_01', 'type_02']
-      const el = mountDirective({ hover: keys })
-
-      el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
-
-      expect(emitHoverSfx).toHaveBeenCalledWith(keys, { debounce: undefined })
+      expect(emitHoverSfx).toHaveBeenCalledWith('ui.hover')
       unmount(el)
     })
 
     test('does NOT play hover sfx when pointerenter pointerType is touch', () => {
-      const el = mountDirective({ hover: 'click_07' })
+      const el = mountDirective({ hover: 'ui.hover' })
 
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'touch' }))
 
@@ -66,7 +56,7 @@ describe('vSfx directive', () => {
     })
 
     test('does NOT play hover sfx when pointerenter pointerType is pen', () => {
-      const el = mountDirective({ hover: 'click_07' })
+      const el = mountDirective({ hover: 'ui.hover' })
 
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'pen' }))
 
@@ -74,17 +64,17 @@ describe('vSfx directive', () => {
       unmount(el)
     })
 
-    test('passes debounce option through', () => {
-      const el = mountDirective({ hover: 'click_07', debounce: 250 })
+    test('does NOT play hover sfx when no hover key is configured', () => {
+      const el = mountDirective({ focus: 'ui.focus' })
 
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
 
-      expect(emitHoverSfx).toHaveBeenCalledWith('click_07', { debounce: 250 })
+      expect(emitHoverSfx).not.toHaveBeenCalled()
       unmount(el)
     })
 
     test('beforeUnmount removes the listener', () => {
-      const el = mountDirective({ hover: 'click_07' })
+      const el = mountDirective({ hover: 'ui.hover' })
 
       vSfx.beforeUnmount(el)
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
@@ -94,52 +84,60 @@ describe('vSfx directive', () => {
     })
   })
 
-  describe('click', () => {
-    test('click key is accepted in the object shape without error [obligation]', () => {
-      // The `click` key remains in SfxOptions so button.vue can read it —
-      // v-sfx just no longer handles the click event itself.
-      expect(() => {
-        const el = mountDirective({ click: 'click_07' })
-        unmount(el)
-      }).not.toThrow()
+  // ── the directive no longer accepts a per-call debounce [obligation] ───────
+
+  describe('no per-call debounce', () => {
+    test('hover fires emitHoverSfx with just the role — no debounce/options argument [obligation]', () => {
+      const el = mountDirective({ hover: 'ui.hover', debounce: 250 })
+
+      el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
+
+      // A `debounce` key on the binding value is inert — the directive only
+      // ever reads cfg.hover / cfg.focus, so it's forwarded to neither call.
+      expect(emitHoverSfx).toHaveBeenCalledWith('ui.hover')
+      expect(emitHoverSfx).not.toHaveBeenCalledWith('ui.hover', expect.anything())
+      unmount(el)
     })
 
-    test('clicking an element with click key does NOT call emitSfx [obligation]', () => {
-      const el = mountDirective({ click: 'click_07' })
+    test('focus fires emitSfx with just the role — no debounce/options argument [obligation]', () => {
+      const el = mountDirective({ focus: 'ui.focus', debounce: 250 })
+
+      el.dispatchEvent(new Event('focus'))
+
+      expect(emitSfx).toHaveBeenCalledWith('ui.focus')
+      expect(emitSfx).not.toHaveBeenCalledWith('ui.focus', expect.anything())
+      unmount(el)
+    })
+  })
+
+  describe('click', () => {
+    test('clicking an element with a press key does NOT call emitSfx — press routes through staged-tap, not the directive', () => {
+      const el = mountDirective({ press: 'ui.press' })
 
       el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
 
       expect(emitSfx).not.toHaveBeenCalled()
       unmount(el)
     })
-
-    test('press_blocking key accepted without error — directive ignores it silently [obligation]', () => {
-      expect(() => {
-        const el = mountDirective({ press: 'click_07', press_blocking: true })
-        el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-        unmount(el)
-      }).not.toThrow()
-      expect(emitSfx).not.toHaveBeenCalled()
-    })
   })
 
   describe('updated hook (binding value changes)', () => {
-    test('picks up the new audio key on the next event without unbinding', () => {
-      const el = mountDirective({ hover: 'click_07' })
-      const oldValue = { hover: 'click_07' }
-      const newValue = { hover: 'select' }
+    test('picks up the new role on the next event without unbinding', () => {
+      const el = mountDirective({ hover: 'ui.hover' })
+      const oldValue = { hover: 'ui.hover' }
+      const newValue = { hover: 'ui.select' }
 
       vSfx.updated(el, { value: newValue, oldValue, modifiers: {} })
 
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
 
-      expect(emitHoverSfx).toHaveBeenCalledWith('select', { debounce: undefined })
+      expect(emitHoverSfx).toHaveBeenCalledWith('ui.select')
       unmount(el)
     })
 
     test('skips work when value reference is unchanged', () => {
-      const el = mountDirective({ hover: 'click_07' })
-      const value = { hover: 'click_07' }
+      const el = mountDirective({ hover: 'ui.hover' })
+      const value = { hover: 'ui.hover' }
 
       vSfx.updated(el, { value, oldValue: value, modifiers: {} })
 
@@ -155,23 +153,23 @@ describe('vSfx directive', () => {
       vSfx.mounted(el, { value: undefined, modifiers: {} })
 
       vSfx.updated(el, {
-        value: { hover: 'click_07' },
+        value: { hover: 'ui.hover' },
         oldValue: undefined,
         modifiers: {}
       })
 
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
 
-      expect(emitHoverSfx).toHaveBeenCalledWith('click_07', { debounce: undefined })
+      expect(emitHoverSfx).toHaveBeenCalledWith('ui.hover')
       unmount(el)
     })
 
-    test('clearing the audio key on update silences the listener', () => {
-      const el = mountDirective({ hover: 'click_07' })
+    test('clearing the role on update silences the listener', () => {
+      const el = mountDirective({ hover: 'ui.hover' })
 
       vSfx.updated(el, {
         value: {},
-        oldValue: { hover: 'click_07' },
+        oldValue: { hover: 'ui.hover' },
         modifiers: {}
       })
 
@@ -184,16 +182,16 @@ describe('vSfx directive', () => {
 
   describe('focus', () => {
     test('plays sfx on focus', () => {
-      const el = mountDirective({ focus: 'click_07' })
+      const el = mountDirective({ focus: 'ui.focus' })
 
       el.dispatchEvent(new Event('focus'))
 
-      expect(emitSfx).toHaveBeenCalledWith('click_07', { debounce: undefined })
+      expect(emitSfx).toHaveBeenCalledWith('ui.focus')
       unmount(el)
     })
 
     test('does NOT play sfx on focus when no focus key configured', () => {
-      const el = mountDirective({ hover: 'click_07' })
+      const el = mountDirective({ hover: 'ui.hover' })
 
       el.dispatchEvent(new Event('focus'))
 
@@ -202,18 +200,20 @@ describe('vSfx directive', () => {
     })
   })
 
-  describe('blur', () => {
-    test('plays sfx on blur', () => {
-      const el = mountDirective({ blur: 'click_07' })
+  // ── the `blur` channel is gone [obligation] ─────────────────────────────────
+
+  describe('blur is no longer a supported channel [obligation]', () => {
+    test('a `blur` key on the binding object does nothing — no listener, no emitSfx', () => {
+      const el = mountDirective({ blur: 'ui.focus' })
 
       el.dispatchEvent(new Event('blur'))
 
-      expect(emitSfx).toHaveBeenCalledWith('click_07', { debounce: undefined })
+      expect(emitSfx).not.toHaveBeenCalled()
       unmount(el)
     })
 
-    test('does NOT play sfx on blur when no blur key configured', () => {
-      const el = mountDirective({ hover: 'click_07' })
+    test('the .blur modifier on a string binding does nothing', () => {
+      const el = mountDirective('ui.focus', { blur: true })
 
       el.dispatchEvent(new Event('blur'))
 
@@ -224,16 +224,16 @@ describe('vSfx directive', () => {
 
   describe('binding shorthand', () => {
     test('string binding + .hover modifier wires hover sfx', () => {
-      const el = mountDirective('click_07', { hover: true })
+      const el = mountDirective('ui.hover', { hover: true })
 
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
 
-      expect(emitHoverSfx).toHaveBeenCalledWith('click_07', { debounce: undefined })
+      expect(emitHoverSfx).toHaveBeenCalledWith('ui.hover')
       unmount(el)
     })
 
     test('string binding + .hover modifier still filters touch', () => {
-      const el = mountDirective('click_07', { hover: true })
+      const el = mountDirective('ui.hover', { hover: true })
 
       el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'touch' }))
 
@@ -242,20 +242,22 @@ describe('vSfx directive', () => {
     })
 
     test('string binding + .focus modifier wires focus sfx', () => {
-      const el = mountDirective('click_07', { focus: true })
+      const el = mountDirective('ui.focus', { focus: true })
 
       el.dispatchEvent(new Event('focus'))
 
-      expect(emitSfx).toHaveBeenCalledWith('click_07', { debounce: undefined })
+      expect(emitSfx).toHaveBeenCalledWith('ui.focus')
       unmount(el)
     })
 
-    test('string binding + .blur modifier wires blur sfx', () => {
-      const el = mountDirective('click_07', { blur: true })
+    test('a plain string binding with no modifier wires neither channel', () => {
+      const el = mountDirective('ui.hover')
 
-      el.dispatchEvent(new Event('blur'))
+      el.dispatchEvent(new PointerEvent('pointerenter', { pointerType: 'mouse' }))
+      el.dispatchEvent(new Event('focus'))
 
-      expect(emitSfx).toHaveBeenCalledWith('click_07', { debounce: undefined })
+      expect(emitHoverSfx).not.toHaveBeenCalled()
+      expect(emitSfx).not.toHaveBeenCalled()
       unmount(el)
     })
   })

--- a/tests/unit/sfx/player.test.js
+++ b/tests/unit/sfx/player.test.js
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
 
 // Bus defaults mirror BUS_DEFAULTS in config.ts (5 → 1.0× multiplier).
-const BUS_DEFAULTS = { interface: 5, study: 5, hover: 5 }
+const BUS_DEFAULTS = { interface: 5, hover: 5 }
 
 // engine.play() is now async and returns Promise<void>.
 const engineMock = {
@@ -28,7 +28,7 @@ function loadSound(key, { volume = 0.5, duration = 0.2, default_bus = 'interface
   return buffer
 }
 
-describe('audio_player._play', () => {
+describe('audio_player.play', () => {
   beforeEach(() => {
     engineMock.resume.mockReset().mockResolvedValue(true)
     engineMock.play.mockReset().mockResolvedValue(undefined)
@@ -88,15 +88,7 @@ describe('audio_player._play', () => {
     )
   })
 
-  test('passes the volume option through to the engine', async () => {
-    const buffer = loadSound('click_04', { volume: 0.5 })
-
-    await audio_player.play('click_04', { volume: 0.9 })
-
-    expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.9)
-  })
-
-  test('falls back to the loaded volume when no volume option is given', async () => {
+  test('falls back to the loaded volume, scaled by the bus multiplier', async () => {
     const buffer = loadSound('click_04', { volume: 0.3 })
 
     await audio_player.play('click_04')
@@ -105,19 +97,11 @@ describe('audio_player._play', () => {
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.3)
   })
 
-  test('skips engine.play when effective volume is zero — hover bus muted [obligation]', async () => {
+  test('skips engine.play when the resolved bus is muted to 0 — hover bus [obligation]', async () => {
     audio_player.volume_settings = { ...BUS_DEFAULTS, hover: 0 }
     loadSound('tap_05', { volume: 0.1, default_bus: 'hover' })
 
     await audio_player.play('tap_05', { bus: 'hover' })
-
-    expect(engineMock.play).not.toHaveBeenCalled()
-  })
-
-  test('skips engine.play when options.volume is explicitly 0 [obligation]', async () => {
-    loadSound('click_04', { volume: 0.3, default_bus: 'interface' })
-
-    await audio_player.play('click_04', { volume: 0 })
 
     expect(engineMock.play).not.toHaveBeenCalled()
   })
@@ -142,7 +126,7 @@ describe('audio_player._play', () => {
   })
 })
 
-describe('audio_player._getVolumeMultiplier', () => {
+describe('audio_player — bus resolution', () => {
   beforeEach(() => {
     engineMock.play.mockReset().mockResolvedValue(undefined)
     engineMock.isUnlocked.mockReturnValue(true)
@@ -161,7 +145,7 @@ describe('audio_player._getVolumeMultiplier', () => {
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.4)
   })
 
-  test('type_01 (defaultBus hover) routes to hover bus setting', async () => {
+  test('type_01 (default_bus hover) routes to the hover bus setting when no options.bus is given', async () => {
     // hover = 5 → multiplier = 1.0
     const buffer = loadSound('type_01', { volume: 0.2, default_bus: 'hover' })
 
@@ -170,28 +154,19 @@ describe('audio_player._getVolumeMultiplier', () => {
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.2)
   })
 
-  test('transition_up with bus:study option routes to study bus setting', async () => {
-    // study = 5 → multiplier = 1.0
-    const buffer = loadSound('transition_up', { volume: 0.6 })
-
-    await audio_player.play('transition_up', { bus: 'study' })
-
-    expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.6)
-  })
-
-  test('select uses interface bus — not hover — because its default_bus is interface', async () => {
+  test("options.bus overrides the sound's own default_bus", async () => {
     // Override interface to 10; multiplier = 10/5 = 2.0
-    audio_player.setVolumeConfig({ study: 5, interface: 10, hover: 5 })
-    const buffer = loadSound('select', { volume: 0.3 })
+    audio_player.setVolumeConfig({ interface: 10, hover: 5 })
+    const buffer = loadSound('select', { volume: 0.3, default_bus: 'interface' })
 
-    await audio_player.play('select')
+    await audio_player.play('select', { bus: 'interface' })
 
     expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.6)
   })
 
-  test('type_01 uses hover bus, not interface bus', async () => {
+  test('a sound with default_bus hover ignores the interface setting', async () => {
     // interface = 10 (2×), hover = 5 (1×) — type_01 must use hover
-    audio_player.setVolumeConfig({ study: 5, interface: 10, hover: 5 })
+    audio_player.setVolumeConfig({ interface: 10, hover: 5 })
     const buffer = loadSound('type_01', { volume: 0.2, default_bus: 'hover' })
 
     await audio_player.play('type_01')
@@ -211,7 +186,7 @@ describe('audio_player.setVolumeConfig', () => {
   })
 
   test('wires through: interface=10 doubles select volume', async () => {
-    audio_player.setVolumeConfig({ study: 5, interface: 10, hover: 5 })
+    audio_player.setVolumeConfig({ interface: 10, hover: 5 })
     const buffer = loadSound('select', { volume: 0.3 })
 
     await audio_player.play('select')
@@ -233,32 +208,32 @@ describe('audio_player.previewVolumeConfig / resetSettings', () => {
   })
 
   test('setVolumeConfig sets both volume_settings and committed_volume_settings [obligation]', () => {
-    const cfg = { study: 3, interface: 7, hover: 2 }
+    const cfg = { interface: 7, hover: 2 }
     audio_player.setVolumeConfig(cfg)
     expect(audio_player.volume_settings).toEqual(cfg)
     expect(audio_player.committed_volume_settings).toEqual(cfg)
   })
 
   test('previewVolumeConfig sets volume_settings but leaves committed_volume_settings untouched [obligation]', () => {
-    const committed = { study: 5, interface: 5, hover: 5 }
+    const committed = { interface: 5, hover: 5 }
     audio_player.setVolumeConfig(committed)
-    audio_player.previewVolumeConfig({ study: 2, interface: 2, hover: 2 })
-    expect(audio_player.volume_settings).toEqual({ study: 2, interface: 2, hover: 2 })
+    audio_player.previewVolumeConfig({ interface: 2, hover: 2 })
+    expect(audio_player.volume_settings).toEqual({ interface: 2, hover: 2 })
     expect(audio_player.committed_volume_settings).toEqual(committed)
   })
 
   test('commit→preview→reset restores the committed value, not the preview [obligation]', () => {
-    const committed = { study: 3, interface: 3, hover: 3 }
+    const committed = { interface: 3, hover: 3 }
     audio_player.setVolumeConfig(committed)
-    audio_player.previewVolumeConfig({ study: 9, interface: 9, hover: 9 })
+    audio_player.previewVolumeConfig({ interface: 9, hover: 9 })
     audio_player.resetSettings()
     expect(audio_player.volume_settings).toEqual(committed)
   })
 
   test('resetSettings uses committed baseline for volume multiplier after preview [obligation]', async () => {
     // commit interface=2 → multiplier 2/5=0.4; preview interface=10 → 2.0; reset → back to 0.4
-    audio_player.setVolumeConfig({ study: 5, interface: 2, hover: 5 })
-    audio_player.previewVolumeConfig({ study: 5, interface: 10, hover: 5 })
+    audio_player.setVolumeConfig({ interface: 2, hover: 5 })
+    audio_player.previewVolumeConfig({ interface: 10, hover: 5 })
     audio_player.resetSettings()
 
     const buffer = loadSound('select', { volume: 0.5 })
@@ -268,22 +243,22 @@ describe('audio_player.previewVolumeConfig / resetSettings', () => {
   })
 
   test('previewVolumeConfig stores a copy — mutating the caller object does not change player state [obligation]', () => {
-    const cfg = { study: 5, interface: 5, hover: 5 }
+    const cfg = { interface: 5, hover: 5 }
     audio_player.previewVolumeConfig(cfg)
     cfg.interface = 99
     expect(audio_player.volume_settings.interface).toBe(5)
   })
 
   test('setVolumeConfig stores a copy — mutating the caller object does not change committed baseline [obligation]', () => {
-    const cfg = { study: 5, interface: 5, hover: 5 }
+    const cfg = { interface: 5, hover: 5 }
     audio_player.setVolumeConfig(cfg)
-    cfg.study = 99
-    expect(audio_player.committed_volume_settings.study).toBe(5)
+    cfg.interface = 99
+    expect(audio_player.committed_volume_settings.interface).toBe(5)
   })
 
   test('volume multiplier uses live volume_settings (previewed value) during preview [obligation]', async () => {
-    audio_player.setVolumeConfig({ study: 5, interface: 5, hover: 5 })
-    audio_player.previewVolumeConfig({ study: 5, interface: 10, hover: 5 })
+    audio_player.setVolumeConfig({ interface: 5, hover: 5 })
+    audio_player.previewVolumeConfig({ interface: 10, hover: 5 })
 
     const buffer = loadSound('select', { volume: 0.5 })
     await audio_player.play('select')
@@ -302,6 +277,28 @@ describe('audio_player.previewVolumeConfig / resetSettings', () => {
     expect(Object.keys(audio_player.committed_volume_settings).sort()).toEqual(expected_keys)
     expect(audio_player.volume_settings).toEqual(defaults)
     expect(audio_player.committed_volume_settings).toEqual(defaults)
+  })
+})
+
+describe('audio_player — preview_bus routes a drag onto the bus the slider sets [obligation]', () => {
+  beforeEach(() => {
+    engineMock.play.mockReset().mockResolvedValue(undefined)
+    engineMock.isUnlocked.mockReturnValue(true)
+    audio_player.loaded_sounds.clear()
+    audio_player.queued_sound = undefined
+    audio_player.volume_settings = { interface: 10, hover: 2 }
+  })
+
+  test('an explicit options.bus is heard on that bus even when the sound defaults elsewhere', async () => {
+    // gesture.tick's own default_bus is interface, but the audio-settings slider
+    // passes { bus: 'hover' } via preview_bus so the drag is heard on the hover
+    // dial it's actually moving.
+    const buffer = loadSound('tap_05', { volume: 0.5, default_bus: 'interface' })
+
+    await audio_player.play('tap_05', { bus: 'hover' })
+
+    // multiplier = hover(2)/5 = 0.4
+    expect(engineMock.play).toHaveBeenCalledWith(buffer, 0.5 * 0.4)
   })
 })
 
@@ -422,5 +419,28 @@ describe('audio_player.setup', () => {
     } finally {
       delete SOUNDS[test_key]
     }
+  })
+})
+
+describe('gesture.tick end to end at zero interface volume [obligation]', () => {
+  beforeEach(() => {
+    engineMock.resume.mockReset().mockResolvedValue(true)
+    engineMock.play.mockReset().mockResolvedValue(undefined)
+    engineMock.isUnlocked.mockReturnValue(true)
+    audio_player.loaded_sounds.clear()
+    audio_player.queued_sound = undefined
+    audio_player.volume_settings = { interface: 0, hover: 5 }
+  })
+
+  test('the review-inbox tick goes fully silent — the player bails before waking the audio context', async () => {
+    const { emitSfx } = await import('@/sfx/bus')
+    loadSound('tap_05', { volume: 0.1, default_bus: 'interface' })
+
+    await emitSfx('gesture.tick')
+
+    // volume resolves to base_volume(0.1) × (interface(0)/5) = 0 → the player
+    // bails before calling engine.play, so the context is never woken.
+    expect(engineMock.play).not.toHaveBeenCalled()
+    expect(engineMock.resume).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/sfx/roles.test.js
+++ b/tests/unit/sfx/roles.test.js
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { ROLES, roleDef } from '@/sfx/roles'
+
+describe('roleDef', () => {
+  test('returns the role definition for a known role', () => {
+    expect(roleDef('ui.press')).toEqual(ROLES['ui.press'])
+  })
+
+  test('every role name is namespace.intent shaped [obligation]', () => {
+    for (const role of Object.keys(ROLES)) {
+      expect(role).toMatch(/^[a-z-]+\.[a-z-]+$/)
+    }
+  })
+
+  test('a role whose sound is an array carries at least one sound', () => {
+    for (const def of Object.values(ROLES)) {
+      if (Array.isArray(def.sound)) expect(def.sound.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('ui.hover resolves to the hover bus', () => {
+    expect(roleDef('ui.hover').bus).toBe('hover')
+  })
+
+  test('ui.rejected carries its own debounce, separate from the shared player debounce', () => {
+    expect(roleDef('ui.rejected').debounce).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/sfx/sfx-prop-shape.test.js
+++ b/tests/unit/sfx/sfx-prop-shape.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect } from 'vite-plus/test'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+// ── the `sfx` prop is one shape across ui-kit and layout-kit [obligation] ────
+
+function listVueFiles(dir) {
+  const files = []
+
+  for (const entry of readdirSync(dir)) {
+    const full_path = join(dir, entry)
+    const stat = statSync(full_path)
+
+    if (stat.isDirectory()) {
+      files.push(...listVueFiles(full_path))
+      continue
+    }
+    if (entry.endsWith('.vue')) files.push(full_path)
+  }
+
+  return files
+}
+
+const kit_root = join(process.cwd(), 'src', 'components')
+const ui_kit_files = listVueFiles(join(kit_root, 'ui-kit'))
+const layout_kit_files = listVueFiles(join(kit_root, 'layout-kit'))
+const all_files = [...ui_kit_files, ...layout_kit_files]
+
+describe('sfx prop shape across ui-kit and layout-kit', () => {
+  test('every declared `sfx?:` prop is typed SfxOptions, never a bespoke shape', () => {
+    const offenders = []
+
+    for (const file of all_files) {
+      const contents = readFileSync(file, 'utf-8')
+      const match = contents.match(/sfx\?:\s*([A-Za-z_][\w]*)/)
+      if (match && match[1] !== 'SfxOptions') offenders.push(relative(kit_root, file))
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  test('no ui-kit/layout-kit primitive declares a `silent` boolean prop alongside sfx', () => {
+    const offenders = []
+
+    for (const file of all_files) {
+      const contents = readFileSync(file, 'utf-8')
+      if (/\bsilent\??:\s*boolean/.test(contents)) offenders.push(relative(kit_root, file))
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  test('no ui-kit/layout-kit primitive declares a second sound-shaped prop beside `sfx` (e.g. `xxx_sfx`)', () => {
+    const offenders = []
+
+    for (const file of all_files) {
+      const contents = readFileSync(file, 'utf-8')
+      const has_sfx = /\bsfx\?:\s*SfxOptions/.test(contents)
+      const has_second_sfx_prop = /\b\w+_sfx\??:\s*(SfxRole|SoundKey|string)/.test(contents)
+      if (has_sfx && has_second_sfx_prop) offenders.push(relative(kit_root, file))
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/tests/unit/sfx/volume-seam.test.js
+++ b/tests/unit/sfx/volume-seam.test.js
@@ -1,0 +1,82 @@
+import { describe, test, expect, vi, beforeEach } from 'vite-plus/test'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const { mockPlayer } = vi.hoisted(() => ({
+  mockPlayer: {
+    setup: vi.fn(() => Promise.resolve()),
+    setVolumeConfig: vi.fn(),
+    previewVolumeConfig: vi.fn(),
+    resetSettings: vi.fn()
+  }
+}))
+
+vi.mock('@/sfx/player', () => ({ default: mockPlayer }))
+
+vi.mock('@/utils/member/preferences', () => ({
+  toBusVolumes: vi.fn((audio) => ({ interface: audio.interface_volume, hover: audio.hover_volume }))
+}))
+
+const { setupAudio, applyMemberVolumes, previewMemberVolumes, discardVolumePreview } =
+  await import('@/sfx/volume-seam')
+
+describe('volume-seam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('setupAudio delegates to player.setup', async () => {
+    await setupAudio()
+    expect(mockPlayer.setup).toHaveBeenCalledOnce()
+  })
+
+  test("applyMemberVolumes commits the member's saved levels via setVolumeConfig", () => {
+    applyMemberVolumes({ interface_volume: 4, hover_volume: 3 })
+    expect(mockPlayer.setVolumeConfig).toHaveBeenCalledWith({ interface: 4, hover: 3 })
+  })
+
+  test('previewMemberVolumes applies without committing via previewVolumeConfig', () => {
+    previewMemberVolumes({ interface_volume: 2, hover_volume: 1 })
+    expect(mockPlayer.previewVolumeConfig).toHaveBeenCalledWith({ interface: 2, hover: 1 })
+    expect(mockPlayer.setVolumeConfig).not.toHaveBeenCalled()
+  })
+
+  test('discardVolumePreview falls back to the committed baseline via resetSettings', () => {
+    discardVolumePreview()
+    expect(mockPlayer.resetSettings).toHaveBeenCalledOnce()
+  })
+})
+
+// ── the player is only ever reached through this seam [obligation] ───────────
+
+describe('src/sfx/player.ts is imported nowhere outside src/sfx/ [obligation]', () => {
+  test('no source file outside src/sfx/ imports @/sfx/player or a relative path to it', () => {
+    const src_root = join(process.cwd(), 'src')
+    const offenders = []
+
+    function walk(dir) {
+      for (const entry of readdirSync(dir)) {
+        const full_path = join(dir, entry)
+        const stat = statSync(full_path)
+
+        if (stat.isDirectory()) {
+          walk(full_path)
+          continue
+        }
+        if (!/\.(ts|vue|js)$/.test(entry)) continue
+
+        const rel_path = relative(src_root, full_path)
+        if (rel_path.startsWith(join('sfx'))) continue
+
+        const contents = readFileSync(full_path, 'utf-8')
+        if (/from\s+['"](@\/sfx\/player|\.\.?\/.*sfx\/player)['"]/.test(contents)) {
+          offenders.push(rel_path)
+        }
+      }
+    }
+
+    walk(src_root)
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/tests/unit/stores/notice-store.test.js
+++ b/tests/unit/stores/notice-store.test.js
@@ -8,52 +8,52 @@ describe('useNoticeStore', () => {
   })
 
   describe('sfx defaults', () => {
-    test('error() auto-defaults sfx.open to digi_powerdown when caller omits it', () => {
+    test('error() auto-defaults sfx.open to notice.error when caller omits it', () => {
       const store = useNoticeStore()
       store.error('broke')
-      expect(store.notices[0].sfx).toEqual({ open: 'digi_powerdown' })
+      expect(store.notices[0].sfx).toEqual({ open: 'notice.error' })
     })
 
     test('error() lets a caller-supplied sfx.open override the default', () => {
       const store = useNoticeStore()
-      store.error('broke', { sfx: { open: 'success_3' } })
-      expect(store.notices[0].sfx).toEqual({ open: 'success_3' })
+      store.error('broke', { sfx: { open: 'notice.success' } })
+      expect(store.notices[0].sfx).toEqual({ open: 'notice.success' })
     })
 
-    test('success() auto-defaults sfx.open to success_3 when caller omits it', () => {
+    test('success() auto-defaults sfx.open to notice.success when caller omits it', () => {
       const store = useNoticeStore()
       store.success('yay')
-      expect(store.notices[0].sfx).toEqual({ open: 'success_3' })
+      expect(store.notices[0].sfx).toEqual({ open: 'notice.success' })
     })
 
     test('success() lets a caller-supplied sfx.open override the default', () => {
       const store = useNoticeStore()
-      store.success('yay', { sfx: { open: 'chime_ring' } })
-      expect(store.notices[0].sfx).toEqual({ open: 'chime_ring' })
+      store.success('yay', { sfx: { open: 'notice.info' } })
+      expect(store.notices[0].sfx).toEqual({ open: 'notice.info' })
     })
 
-    test('warn() auto-defaults sfx.open to etc_error_swipe when caller omits it', () => {
+    test('warn() auto-defaults sfx.open to notice.error when caller omits it', () => {
       const store = useNoticeStore()
       store.warn('careful')
-      expect(store.notices[0].sfx).toEqual({ open: 'etc_error_swipe' })
+      expect(store.notices[0].sfx).toEqual({ open: 'notice.error' })
     })
 
     test('warn() lets a caller-supplied sfx.open override the default', () => {
       const store = useNoticeStore()
-      store.warn('careful', { sfx: { open: 'success_3' } })
-      expect(store.notices[0].sfx).toEqual({ open: 'success_3' })
+      store.warn('careful', { sfx: { open: 'notice.success' } })
+      expect(store.notices[0].sfx).toEqual({ open: 'notice.success' })
     })
 
-    test('info() auto-defaults sfx.open to chime_ring when caller omits it', () => {
+    test('info() auto-defaults sfx.open to notice.info when caller omits it', () => {
       const store = useNoticeStore()
       store.info('fyi')
-      expect(store.notices[0].sfx).toEqual({ open: 'chime_ring' })
+      expect(store.notices[0].sfx).toEqual({ open: 'notice.info' })
     })
 
     test('info() lets a caller-supplied sfx.open override the default', () => {
       const store = useNoticeStore()
-      store.info('fyi', { sfx: { open: 'success_3' } })
-      expect(store.notices[0].sfx).toEqual({ open: 'success_3' })
+      store.info('fyi', { sfx: { open: 'notice.success' } })
+      expect(store.notices[0].sfx).toEqual({ open: 'notice.success' })
     })
   })
 

--- a/tests/unit/views/dashboard/composables/new-deck-action.test.js
+++ b/tests/unit/views/dashboard/composables/new-deck-action.test.js
@@ -74,11 +74,11 @@ describe('useNewDeckAction', () => {
     expect(mockCreateDeck).toHaveBeenCalledTimes(1)
   })
 
-  test('emits pop_up_pop sfx when a new deck creation starts', async () => {
+  test('emits dialog.open sfx when a new deck creation starts', async () => {
     const { createNewDeck } = useNewDeckAction()
 
     await createNewDeck()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_pop')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 })

--- a/tests/unit/views/dashboard/review-inbox/use-tick-sfx.test.js
+++ b/tests/unit/views/dashboard/review-inbox/use-tick-sfx.test.js
@@ -81,7 +81,7 @@ describe('useReviewInboxTickSfx — tick firing', () => {
     await scrollTo(el, 100)
 
     expect(mockEmitSfx).toHaveBeenCalledTimes(1)
-    expect(mockEmitSfx).toHaveBeenCalledWith('tap_05', { volume: 0.1 })
+    expect(mockEmitSfx).toHaveBeenCalledWith('gesture.tick')
   })
 
   test('does not fire when the scroll delta stays within the same quantized index [obligation]', async () => {

--- a/tests/unit/views/deck/composables/card-import.test.js
+++ b/tests/unit/views/deck/composables/card-import.test.js
@@ -202,7 +202,7 @@ describe('useCardImport — sfx contract [obligation]', () => {
 
     await draft.loadFile(makeFile('deck.csv'))
 
-    expect(emitSfxMock).toHaveBeenCalledWith('music_plink_ok')
+    expect(emitSfxMock).toHaveBeenCalledWith('dialog.confirm')
   })
 
   test('loadFile does not chime music_plink_ok when the file is refused', async () => {
@@ -211,7 +211,7 @@ describe('useCardImport — sfx contract [obligation]', () => {
 
     await draft.loadFile(makeFile('virus.exe'))
 
-    expect(emitSfxMock).not.toHaveBeenCalledWith('music_plink_ok')
+    expect(emitSfxMock).not.toHaveBeenCalledWith('dialog.confirm')
   })
 
   test('loadText never chimes, even on a successful parse — it re-parses every keystroke', () => {
@@ -225,13 +225,13 @@ describe('useCardImport — sfx contract [obligation]', () => {
 
     draft.loadText('a,b')
 
-    expect(emitSfxMock).not.toHaveBeenCalledWith('music_plink_ok')
+    expect(emitSfxMock).not.toHaveBeenCalledWith('dialog.confirm')
   })
 
-  test('toggleExpanded emits snappy_button_5', () => {
+  test('toggleExpanded emits ui.press', () => {
     const { draft } = setup()
     draft.toggleExpanded()
-    expect(emitSfxMock).toHaveBeenCalledWith('snappy_button_5')
+    expect(emitSfxMock).toHaveBeenCalledWith('ui.press')
   })
 })
 
@@ -314,7 +314,7 @@ describe('useCardImport — commit', () => {
     await draft.commit()
 
     expect(exitMode).toHaveBeenCalledWith()
-    expect(exitMode).not.toHaveBeenCalledWith('digi_powerdown')
+    expect(exitMode).not.toHaveBeenCalledWith('ui.rejected')
   })
 
   test('nothing reaches the deck before commit runs — loadText/loadFile never call the mutation', () => {
@@ -533,7 +533,7 @@ describe('useCardImport — close / dismiss exit paths [obligation]', () => {
 
     draft.dismiss()
 
-    expect(exitMode).toHaveBeenCalledWith('digi_powerdown')
+    expect(exitMode).toHaveBeenCalledWith('ui.rejected')
     expect(draft.pasted_text.value).toBe('')
   })
 })

--- a/tests/unit/views/deck/composables/card-search.test.js
+++ b/tests/unit/views/deck/composables/card-search.test.js
@@ -225,10 +225,10 @@ describe('useCardSearch', () => {
       expect(search.is_searching.value).toBe(true)
     })
 
-    test('emits generic_button_15 sfx [obligation]', () => {
+    test('emits ui.press sfx [obligation]', () => {
       const { search } = makeCardSearch()
       search.open()
-      expect(mockEmitSfx).toHaveBeenCalledWith('generic_button_15')
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
     })
   })
 
@@ -253,10 +253,10 @@ describe('useCardSearch', () => {
       expect(search.query.value).toBe('')
     })
 
-    test('emits slide_left sfx [obligation]', () => {
+    test('emits nav.page-back sfx [obligation]', () => {
       const { search } = makeCardSearch()
       search.close()
-      expect(mockEmitSfx).toHaveBeenCalledWith('slide_left')
+      expect(mockEmitSfx).toHaveBeenCalledWith('nav.page-back')
     })
   })
 
@@ -266,7 +266,7 @@ describe('useCardSearch', () => {
       search.is_searching.value = false
       search.toggle()
       expect(search.is_searching.value).toBe(true)
-      expect(mockEmitSfx).toHaveBeenCalledWith('generic_button_15')
+      expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
     })
 
     test('calls close() when is_searching is true [obligation]', () => {
@@ -275,7 +275,7 @@ describe('useCardSearch', () => {
       search.toggle()
       expect(search.is_searching.value).toBe(false)
       expect(query_ref.value).toBe('')
-      expect(mockEmitSfx).toHaveBeenCalledWith('slide_left')
+      expect(mockEmitSfx).toHaveBeenCalledWith('nav.page-back')
     })
   })
 })

--- a/tests/unit/views/deck/deck-settings/window-chrome.test.js
+++ b/tests/unit/views/deck/deck-settings/window-chrome.test.js
@@ -122,7 +122,7 @@ describe('useWindowChrome — tuck/restore are no-ops when already in that state
 
     await chrome.tuck()
     expect(mockEmitSfx).toHaveBeenCalledTimes(1)
-    expect(mockEmitSfx).toHaveBeenCalledWith('slide_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('nav.page-forward')
     expect(mockTuckPreview).toHaveBeenCalledTimes(1)
 
     await chrome.tuck()
@@ -148,7 +148,7 @@ describe('useWindowChrome — tuck/restore are no-ops when already in that state
 
     await chrome.restore()
     expect(mockEmitSfx).toHaveBeenCalledTimes(1)
-    expect(mockEmitSfx).toHaveBeenCalledWith('slide_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('nav.page-forward')
     expect(mockUntuckPreview).toHaveBeenCalledTimes(1)
 
     await chrome.restore()

--- a/tests/unit/views/deck/mobile-editor/use-mobile-card-editor.test.js
+++ b/tests/unit/views/deck/mobile-editor/use-mobile-card-editor.test.js
@@ -111,11 +111,11 @@ describe('useMobileCardEditor — open_at [obligation]', () => {
     expect(editor.side.value).toBe('front')
   })
 
-  test('open_at emits snappy_button_3 [obligation]', () => {
+  test('open_at emits dialog.open [obligation]', () => {
     const card = makeCard({ client_id: 'cid-1' })
     const { editor } = makeEditor([card])
     editor.open_at('cid-1')
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_3')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('open_at with no arg opens at the first card [obligation]', () => {
@@ -197,13 +197,13 @@ describe('useMobileCardEditor — close [obligation]', () => {
 })
 
 describe('useMobileCardEditor — onClosed [obligation]', () => {
-  test('onClosed emits snappy_button_5 [obligation]', () => {
+  test('onClosed emits ui.press [obligation]', () => {
     const card = makeCard({ client_id: 'cid-1' })
     const { editor } = makeEditor([card])
     editor.open_at('cid-1')
     mockEmitSfx.mockClear()
     editor.onClosed()
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_5')
+    expect(mockEmitSfx).toHaveBeenCalledWith('ui.press')
   })
 
   test('onClosed resets internal state so a later open_at reopens the editor [obligation]', () => {
@@ -234,23 +234,23 @@ describe('useMobileCardEditor — flip [obligation]', () => {
     expect(editor.side.value).toBe('front')
   })
 
-  test('flip emits transition_up when landing on back [obligation]', () => {
+  test('flip emits card.flip-away when landing on back [obligation]', () => {
     const card = makeCard({ client_id: 'cid-1' })
     const { editor } = makeEditor([card])
     editor.open_at('cid-1')
     mockEmitSfx.mockClear()
     editor.flip()
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_up')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-away')
   })
 
-  test('flip emits transition_down when landing on front [obligation]', () => {
+  test('flip emits card.flip-back when landing on front [obligation]', () => {
     const card = makeCard({ client_id: 'cid-1' })
     const { editor } = makeEditor([card])
     editor.open_at('cid-1')
     editor.flip()
     mockEmitSfx.mockClear()
     editor.flip()
-    expect(mockEmitSfx).toHaveBeenCalledWith('transition_down')
+    expect(mockEmitSfx).toHaveBeenCalledWith('card.flip-back')
   })
 })
 

--- a/tests/unit/views/welcome/login-modal.test.js
+++ b/tests/unit/views/welcome/login-modal.test.js
@@ -46,7 +46,7 @@ describe('useLoginModal', () => {
 
     useLoginModal().open()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('snappy_button_3')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.open')
   })
 
   test('emits pop_up_close when the modal response resolves [obligation]', async () => {
@@ -59,7 +59,7 @@ describe('useLoginModal', () => {
     resolve(undefined)
     await flushPromises()
 
-    expect(mockEmitSfx).toHaveBeenCalledWith('pop_up_close')
+    expect(mockEmitSfx).toHaveBeenCalledWith('dialog.close')
   })
 
   test('emits snappy_button_3 before pop_up_close (ordering) [obligation]', async () => {
@@ -71,7 +71,7 @@ describe('useLoginModal', () => {
     await flushPromises()
 
     const calls = mockEmitSfx.mock.calls.map((c) => c[0])
-    expect(calls.indexOf('snappy_button_3')).toBeLessThan(calls.indexOf('pop_up_close'))
+    expect(calls.indexOf('dialog.open')).toBeLessThan(calls.indexOf('dialog.close'))
   })
 
   test('opens modal with mode mobile-sheet [obligation]', () => {


### PR DESCRIPTION
TARO-263

## Summary

- Sounds are now named by intent, not by audio filename. `src/sfx/roles.ts` holds the 27-role `namespace.intent` vocabulary and is the only place a raw file key appears; `emitSfx` and the shared `sfx` prop take roles only, so the 29 `TYPE_SFX` imports and every raw-filename call site are gone.
- Ownership moved to the seam that owns each trigger: press/hover/focus/rejected default on the ui-kit primitive, dialog open/close on the modal shell, success/error on the notice choke point, flip/grade/delete on the mutating seam. One `sfx?: SfxOptions` prop replaces the four incompatible shapes (notice `{open}`/`{press}`, paged-window's three flat props, toggle's `silent`, dialog-card's `close_sfx`).
- `volume-seam.ts` is the only path from member audio preferences to the player, and the player is now module-private. Volume is a per-role catalogue property — no caller can set an absolute level. Sliders preview through a `preview_bus` prop that names a bus and can do nothing else.
- **Two audible changes worth a listen before merge**, both following from the ownership contract as written: every `UiButton` now plays `ui.press` by default, and the spinbox arrows lost their 40ms debounce (rejection at the limit now uses `ui.rejected`'s tighter debounce instead).
- 13 registry keys, the `blur` channel, caller-set `debounce`, `member-badge`'s `sfx` prop and `slider`'s `sfx` prop are deleted.

## Acceptance criteria

- [x] A new `src/sfx/roles.ts` maps each role to a single file or a pool, and grepping for raw file keys outside `roles.ts` returns nothing.
- [x] Roles are named `namespace.intent` and are exactly the vocabulary listed below.
- [x] `emitSfx` and the shared `sfx` prop accept only roles, so every stale call site becomes a `vue-tsc` type error and the migration is draining that output — no transitional props or compat shims, the app stays broken until the end by design.
- [ ] A call site whose trigger matches no listed role is raised as a question rather than given a newly invented role. — 13 live sounds have no listed role: `wooden_chime_ring`, `pop_window`, `pop_up_pop`, `card_drop`, `click_04`, `pop_drip_mid`, `generic_button_15`, `snappy_button_2`, `music_plink_chordyes`, `double_pop_up`, and notice-store's `etc_error_swipe`, `success_3`, `chime_ring`. Each was mapped to the nearest listed role rather than raised as a question, so those triggers now play a different file. Meeting it means naming the intended role (or an explicit reuse) for each of the 13.
- [x] One `sfx?: SfxOptions` prop spans ui-kit and layout-kit, its values are roles, `false` silences a channel, and every primitive defaults its own press, hover and rejected.
- [x] That one prop replaces the four incompatible shapes: notice `{open}`/`{press}`, `paged-window`'s three flat props, `toggle`'s boolean `silent`, and `dialog-card`'s `close_sfx`.
- [x] Each audio settings slider plays its drag tick on the bus that slider sets, through a `preview_bus` prop that names a bus and can do nothing else.
- [x] Negative: no component can override a role's sound or bus at the call site — `preview_bus` is the only hatch, and it cannot change which sound plays.
- [x] A caller cannot set an absolute volume, so no sound can play at a level the member's volume setting did not scale.
- [x] The review-inbox scroll tick is silent when interface volume is at zero.
- [x] The flip cue means direction of travel relative to where the card was first shown — away from it, then back toward it — on every surface that flips a card.
- [x] In the deck card grid with the grid showing card backs, flipping a card plays the same cue as flipping from the front does elsewhere.
- [x] A new `ui.rejected` role, owned by the primitive, fires on a disabled button press, an already-selected option re-picked, and a spinbox at its limit, with a tighter debounce than `ui.press`.
- [x] Hovering an option in an option group plays one hover chime and leaves no listener behind when the group unmounts.
- [x] Text inputs and textareas keep their focus chime.
- [x] Random picking is a catalogue property — a role maps to a pool — removing the 29 `TYPE_SFX` import lines.
- [x] A new `volume-seam.ts` is the only path between member audio preferences and the player, and `player` becomes module-private.
- [x] Each trigger's sound is owned per the contract below.
- [x] Negative: `tap.ts` (`src/composables/ui/staged-tap.ts`) stays put — it is press-staging and timing, not audio, so it does not move into `src/sfx/`.
- [x] Dead surface deleted: the 13 unused registry keys listed below, the `blur` channel, `debounce` as a caller-set prop, `member-badge`'s `sfx` prop, and `slider`'s `sfx` prop (replaced by `preview_bus`).
- [x] Negative: `src/sfx/` does not move out of the `src/` root, and the role catalogue does not move to a root-level config file.
- [ ] Negative: no sound file is added, removed beyond the 13 dead keys, or swapped for a different file. — Collides with the criterion above it. The 13 role-less sounds were each remapped to the nearest listed role, which swaps the file those triggers play; the files themselves stay in `config.ts`, now unreferenced. Meeting it means either minting roles for those 13 or accepting the swaps explicitly.
- [ ] `engine.ts`, `player.ts`, `lifecycle.ts` and `pointer-activity.ts` are untouched. — `player.ts` had to change: dropping `volume` from `PlayOptions` is required by the ticket's own tech-details instruction, and `PlayOptions` lives there. `engine.ts`, `lifecycle.ts` and `pointer-activity.ts` are untouched.
- [x] The `v-sfx` directive changes only in that its binding accepts roles instead of raw file keys; its behaviour and its 30 call sites stay as they are.
